### PR TITLE
Add DESTDIR to install locations

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -104,12 +104,12 @@ $(install_DIRS):
 
 .PHONY: install
 install: $(install_DIRS)
-	$(MKDIR_P) $(prefix)/local/tdi
-	$(MKDIR_P) $(prefix)/java
-	tar cf - $(MISC_PARTS) | (cd $(exec_prefix); tar xf -)
-	if [ ! -z "$$MDSPLUS_VERSION" ]; then echo "mdsplus_version='$$MDSPLUS_VERSION'" > $(exec_prefix)/mdsobjects/python/mdsplus_version.py; fi
-	$(INSTALL) MDSplus-License.txt MDSplus-License.rtf $(exec_prefix)
-	(cd $(exec_prefix); chmod -R 755 $(MISC_PARTS))
+	$(MKDIR_P) $(DESTDIR)$(prefix)/local/tdi
+	$(MKDIR_P) $(DESTDIR)$(prefix)/java
+	tar cf - $(MISC_PARTS) | (cd $(DESTDIR)$(exec_prefix); tar xf -)
+	if [ ! -z "$$MDSPLUS_VERSION" ]; then echo "mdsplus_version='$$MDSPLUS_VERSION'" > $(DESTDIR)$(exec_prefix)/mdsobjects/python/mdsplus_version.py; fi
+	$(INSTALL) MDSplus-License.txt MDSplus-License.rtf $(DESTDIR)$(exec_prefix)
+	(cd $(DESTDIR)$(exec_prefix); chmod -R 755 $(MISC_PARTS))
 
 # Interdependent directories:
 actions: mdsshr tdishr treeshr xmdsshr mdstcpip servershr

--- a/Makefile.inc.in
+++ b/Makefile.inc.in
@@ -73,7 +73,7 @@ top_srcdir = @abs_top_srcdir@
 tooldir = $(exec_prefix)/$(target_alias)
 
 
-$(sort @MAKEBINDIR@ @MAKELIBDIR@ @MAKESHLIBDIR@ @MAKEETCDIR@ @MAKEUIDDIR@ @uiddir@ $(bindir) $(libdir) $(sysconfdir)):
+$(sort @MAKEBINDIR@ @MAKELIBDIR@ @MAKESHLIBDIR@ @MAKEETCDIR@ @MAKEUIDDIR@ $(DESTDIR)@uiddir@ $(DESTDIR)$(bindir) $(DESTDIR)$(libdir) $(DESTDIR)$(sysconfdir)):
 	$(MKDIR_P) $@
 
 .DEFAULT_GOAL := all

--- a/camshr/Makefile.in
+++ b/camshr/Makefile.in
@@ -68,12 +68,12 @@ clean:
 depend:
 	 - @makedepend -- $(CFLAGS) -- $(SOURCES) 2>/dev/null
 
-install: $(libdir) $(bindir)
+install: $(DESTDIR)$(libdir) $(DESTDIR)$(bindir)
 	$(INSTALL) -m 755 @MAKEBINDIR@mdscts $(bindir)
-	$(INSTALL) -m 755 @MAKESHLIBDIR@@LIBPRE@cts_commands@SHARETYPE@ $(libdir)
-	$(INSTALL) -m 755 $(SHLIB_BUILD).$(MAJOR).$(MINOR) $(libdir)
-	ln -sf $(SHLIB).$(MAJOR).$(MINOR) $(libdir)/$(SHLIB).$(MAJOR)
-	ln -sf $(SHLIB).$(MAJOR) $(libdir)/$(SHLIB)
+	$(INSTALL) -m 755 @MAKESHLIBDIR@@LIBPRE@cts_commands@SHARETYPE@ $(DESTDIR)$(libdir)
+	$(INSTALL) -m 755 $(SHLIB_BUILD).$(MAJOR).$(MINOR) $(DESTDIR)$(libdir)
+	ln -sf $(SHLIB).$(MAJOR).$(MINOR) $(DESTDIR)$(libdir)/$(SHLIB).$(MAJOR)
+	ln -sf $(SHLIB).$(MAJOR) $(DESTDIR)$(libdir)/$(SHLIB)
 
 @MAKEBINDIR@mdscts: cts
 	cp $< $@

--- a/ccl/Makefile.in
+++ b/ccl/Makefile.in
@@ -17,10 +17,10 @@ clean:
 depend:
 	 - @makedepend -- $(CFLAGS) -- $(SOURCES) 2>/dev/null
 
-install: $(libdir) $(bindir)
-	$(INSTALL) -m 755  @MAKESHLIBDIR@@LIBPRE@ccl_commands@SHARETYPE@ $(libdir)
-	@MINGW_FALSE@ $(INSTALL) -m 755  @MAKEBINDIR@mdsccl $(bindir)
-	@MINGW_TRUE@ $(INSTALL) -m 755 @MAKEBINDIR@mdsccl.bat $(bindir)
+install: $(DESTDIR)$(libdir) $(DESTDIR)$(bindir)
+	$(INSTALL) -m 755  @MAKESHLIBDIR@@LIBPRE@ccl_commands@SHARETYPE@ $(DESTDIR)$(libdir)
+	@MINGW_FALSE@ $(INSTALL) -m 755  @MAKEBINDIR@mdsccl $(DESTDIR)$(bindir)
+	@MINGW_TRUE@ $(INSTALL) -m 755 @MAKEBINDIR@mdsccl.bat $(DESTDIR)$(bindir)
 
 cdudir = $(top_builddir)/cdu
 CDU = $(cdudir)/cdu

--- a/d3dshr/Makefile.in
+++ b/d3dshr/Makefile.in
@@ -15,8 +15,8 @@ clean :
 	@ $(RM) $(OBJECTS)
 	@ $(RM) @MAKELIBDIR@libMdsD3D@SHARETYPE@
 
-install: $(libdir)
-	$(INSTALL) -m 755  @MAKELIBDIR@libMdsD3D@SHARETYPE@ @libdir@
+install: $(DESTDIR)$(libdir)
+	$(INSTALL) -m 755  @MAKELIBDIR@libMdsD3D@SHARETYPE@ $(DESTDIR)@libdir@
 
 @MAKELIBDIR@libMdsD3D@SHARETYPE@ : $(OBJECTS) 
 	$(LD) -o $@ @LINKSHARED@ $(OBJECTS)  $(D3DLIB) -ld3 $(LIBS) @FOR_LDFLAGS@ 

--- a/examples/demoadc/Makefile.in
+++ b/examples/demoadc/Makefile.in
@@ -24,13 +24,13 @@ depend:
 	 @makedepend -- $(CFLAGS) -- $(SOURCES)
 
 install:
-	if [ ! -d @libdir@ ] ; then \
-                mkdir @libdir@; \
-                chmod 755 @libdir@; \
+	if [ ! -d $(DESTDIR)@libdir@ ] ; then \
+                mkdir $(DESTDIR)@libdir@; \
+                chmod 755 $(DESTDIR)@libdir@; \
         fi;
-	$(INSTALL) -m 755  @MAKESHLIBDIR@libDemoAdcShr@SHARETYPE@ @libdir@
+	$(INSTALL) -m 755  @MAKESHLIBDIR@libDemoAdcShr@SHARETYPE@ $(DESTDIR)@libdir@
 	if test @SHARETYPE@ != .a ; then \
-		$(INSTALL) -m 644  @MAKELIBDIR@libDemoAdcShr.a @libdir@; \
+		$(INSTALL) -m 644  @MAKELIBDIR@libDemoAdcShr.a $(DESTDIR)@libdir@; \
 	fi;
 
 

--- a/hdf5/Makefile.in
+++ b/hdf5/Makefile.in
@@ -26,13 +26,13 @@ clean :
 	@ $(RM) @MAKEBINDIR@hdf5ToMds
 	@ $(RM) @MAKEBINDIR@MDSplus2HDF5
 
-install: $(libdir) $(bindir)
-	$(INSTALL) -m 755  @MAKESHLIBDIR@libhdf5tdi@SHARETYPE@ @libdir@
+install: $(DESTDIR)$(libdir) $(DESTDIR)$(bindir)
+	$(INSTALL) -m 755  @MAKESHLIBDIR@libhdf5tdi@SHARETYPE@ $(DESTDIR)@libdir@
 	if (test @SHARETYPE@ != .a) then \
-		$(INSTALL) -m 644  @MAKELIBDIR@libhdf5tdi.a @libdir@; \
+		$(INSTALL) -m 644  @MAKELIBDIR@libhdf5tdi.a $(DESTDIR)@libdir@; \
 	fi;
-	$(INSTALL) -m 755  @MAKEBINDIR@hdf5ToMds @bindir@
-	$(INSTALL) -m 755  @MAKEBINDIR@MDSplus2HDF5 @bindir@
+	$(INSTALL) -m 755  @MAKEBINDIR@hdf5ToMds $(DESTDIR)@bindir@
+	$(INSTALL) -m 755  @MAKEBINDIR@MDSplus2HDF5 $(DESTDIR)@bindir@
 
 @MAKESHLIBDIR@libhdf5tdi@SHARETYPE@ : hdf5tdi.o @EXPORTS_FILE@
 	$(LD) -o $@ @LINKSHARED@ hdf5tdi.o $(LIBS) $(LD_FLAGS)

--- a/idlmdsevent/Makefile.in
+++ b/idlmdsevent/Makefile.in
@@ -28,9 +28,9 @@ clean:
 depend:
 	 @makedepend -- $(CFLAGS) -- $(SOURCES)
 
-install: $(libdir)
-	$(INSTALL) -m 644  @MAKELIBDIR@libIdlMdsEvent.a @libdir@
-	$(INSTALL) -m 755  @MAKELIBDIR@libIdlMdsEvent@SHARETYPEMOD@ @libdir@
+install: $(DESTDIR)$(libdir)
+	$(INSTALL) -m 644  @MAKELIBDIR@libIdlMdsEvent.a $(DESTDIR)@libdir@
+	$(INSTALL) -m 755  @MAKELIBDIR@libIdlMdsEvent@SHARETYPEMOD@ $(DESTDIR)@libdir@
 
 @MAKELIBDIR@libIdlMdsEvent@SHARETYPEMOD@ : $(OBJECTS) $(DEF)
 	$(LINK.c) -o $@ @LINKMODULE@ $(OBJECTS) $(DEF) -L@MAKELIBDIR@ $(LDFLAGS) $(LIBS)

--- a/idlmdswidgets/Makefile.in
+++ b/idlmdswidgets/Makefile.in
@@ -31,9 +31,9 @@ depend:
 	 @makedepend -- $(CFLAGS) -- $(SOURCES)
 
 install:
-	$(INSTALL) -m 644  @MAKELIBDIR@libIdlMdsWidgets.a @libdir@
-	$(INSTALL) -m 755  @MAKELIBDIR@libIdlMdsWidgets@SHARETYPEMOD@ @libdir@
-	$(INSTALL) -m 644 @MAKEUIDDIR@cw_wvedit.uid @uiddir@
+	$(INSTALL) -m 644  @MAKELIBDIR@libIdlMdsWidgets.a $(DESTDIR)@libdir@
+	$(INSTALL) -m 755  @MAKELIBDIR@libIdlMdsWidgets@SHARETYPEMOD@ $(DESTDIR)@libdir@
+	$(INSTALL) -m 644 @MAKEUIDDIR@cw_wvedit.uid $(DESTDIR)@uiddir@
 
 @MAKELIBDIR@libIdlMdsWidgets@SHARETYPEMOD@ : $(OBJECTS) 
 	$(LINK.c) -o $@ @LINKMODULE@ $(OBJECTS) -L@MAKELIBDIR@ $(LDFLAGS)  $(LIBS) $(X_LIBS) $(MOTIF_LIBS) $(LIBS) -lXmdsShr

--- a/javamds/Makefile.in
+++ b/javamds/Makefile.in
@@ -17,8 +17,8 @@ clean:
 	@ $(RM) $(OBJECTS)
 	@ $(RM) @MAKELIBDIR@@LIBPRE@JavaMds@SHARETYPEJNI@
 
-install: $(libdir)
-	$(INSTALL) -m 755  @MAKELIBDIR@@LIBPRE@JavaMds@SHARETYPEJNI@ @libdir@
+install: $(DESTDIR)$(libdir)
+	$(INSTALL) -m 755  @MAKELIBDIR@@LIBPRE@JavaMds@SHARETYPEJNI@ $(DESTDIR)@libdir@
 
 @MAKELIBDIR@@LIBPRE@JavaMds@SHARETYPEJNI@ : $(OBJECTS) $(DEF)
 	$(LINK.c) $(OUTPUT_OPTION) @LINKJNI@ $(THREAD) $^ -L@MAKELIBDIR@ -lMdsShr -lMdsIpShr -lTreeShr -lTdiShr $(LIBS)

--- a/math/Makefile.in
+++ b/math/Makefile.in
@@ -73,8 +73,8 @@ $(LIBRARIES): $(OBJECTS)  $(DEF)
 depend:
 	@makedepend -- $(CFLAGS) -- $(SOURCES)
 
-install: $(libdir)
-	$(INSTALL) -m 755 $(@LIBPRE@MdsMath) $(libdir)
+install: $(DESTDIR)$(libdir)
+	$(INSTALL) -m 755 $(@LIBPRE@MdsMath) $(DESTDIR)$(libdir)
 
 clean:
 	$(RM) $(OBJECTS) $(OBJECTS_i386)

--- a/mdsdcl/Makefile.in
+++ b/mdsdcl/Makefile.in
@@ -26,9 +26,9 @@ clean:
 depend: 
 	 @makedepend -- $(CFLAGS) -- $(SOURCES) mdsdcl.c ocldToXml.c
 
-install: $(libdir) $(bindir)
-	$(INSTALL) -m 755 @MAKEBINDIR@mdsdcl$(EXE) $(bindir)
-	$(INSTALL) -m 755 @MAKESHLIBDIR@@LIBPRE@Mdsdcl@SHARETYPE@ $(IMPLIB) $(libdir)
+install: $(DESTDIR)$(libdir) $(DESTDIR)$(bindir)
+	$(INSTALL) -m 755 @MAKEBINDIR@mdsdcl$(EXE) $(DESTDIR)$(bindir)
+	$(INSTALL) -m 755 @MAKESHLIBDIR@@LIBPRE@Mdsdcl@SHARETYPE@ $(IMPLIB) $(DESTDIR)$(libdir)
 
 @MAKELIBDIR@@LIBPRE@Mdsdcl.a: $(OBJECTS)
 		$(AR) -cr $@ $^

--- a/mdslib/Makefile.in
+++ b/mdslib/Makefile.in
@@ -30,10 +30,10 @@ clean:
 	@ $(RM) @MAKESHLIBDIR@@LIBPRE@MdsLib@SHARETYPE@ @MAKESHLIBDIR@@LIBPRE@MdsLib_client@SHARETYPE@ $(IMPLIB_MdsLib) $(IMPLIB_MdsLib_client)
 	@ $(RM) @MAKEBINDIR@dtype_test @MAKEBINDIR@mdslib_*test
 
-install: $(libdir)
-	$(MKDIR_P) $(libdir)
-	$(INSTALL) -m 644  @MAKELIBDIR@@LIBPRE@MdsLib.a @MAKELIBDIR@@LIBPRE@MdsLib_client.a $(libdir)
-	$(INSTALL) -m 755  @MAKESHLIBDIR@@LIBPRE@MdsLib@SHARETYPE@ @MAKESHLIBDIR@@LIBPRE@MdsLib_client@SHARETYPE@ $(IMPLIB_MdsLib) $(IMPLIB_MdsLib_client) $(libdir)
+install: $(DESTDIR)$(libdir)
+	$(MKDIR_P) $(DESTDIR)$(libdir)
+	$(INSTALL) -m 644  @MAKELIBDIR@@LIBPRE@MdsLib.a @MAKELIBDIR@@LIBPRE@MdsLib_client.a $(DESTDIR)$(libdir)
+	$(INSTALL) -m 755  @MAKESHLIBDIR@@LIBPRE@MdsLib@SHARETYPE@ @MAKESHLIBDIR@@LIBPRE@MdsLib_client@SHARETYPE@ $(IMPLIB_MdsLib) $(IMPLIB_MdsLib_client) $(DESTDIR)$(libdir)
 
 MdsLib = @MAKESHLIBDIR@@LIBPRE@MdsLib@SHARETYPE@ $(IMPLIB_MdsLib)
 

--- a/mdslibidl/Makefile.in
+++ b/mdslibidl/Makefile.in
@@ -17,5 +17,5 @@ clean :
 depend:
 	 @makedepend -- $(CFLAGS) -- $(SOURCES)
 
-install: $(libdir)
-	$(INSTALL) -m 755  @MAKESHLIBDIR@@LIBPRE@MdsLibIdl@SHARETYPEMOD@ $(libdir)
+install: $(DESTDIR)$(libdir)
+	$(INSTALL) -m 755  @MAKESHLIBDIR@@LIBPRE@MdsLibIdl@SHARETYPEMOD@ $(DESTDIR)$(libdir)

--- a/mdsmisc/Makefile.in
+++ b/mdsmisc/Makefile.in
@@ -36,10 +36,10 @@ clean :
 	@ $(RM) @MAKELIBDIR@@LIBPRE@MdsMisc.a 
 	@ $(RM) @MAKESHLIBDIR@@LIBPRE@MdsMisc@SHARETYPE@ 
 
-install: $(libdir)
-	$(INSTALL) -m 755  @MAKESHLIBDIR@@LIBPRE@MdsMisc@SHARETYPE@ @libdir@
+install: $(DESTDIR)$(libdir)
+	$(INSTALL) -m 755  @MAKESHLIBDIR@@LIBPRE@MdsMisc@SHARETYPE@ $(DESTDIR)@libdir@
 	if (test @SHARETYPE@ != .a) then \
-		$(INSTALL) -m 644  @MAKELIBDIR@@LIBPRE@MdsMisc.a @libdir@; \
+		$(INSTALL) -m 644  @MAKELIBDIR@@LIBPRE@MdsMisc.a $(DESTDIR)@libdir@; \
 	fi;
 
 @MAKESHLIBDIR@@LIBPRE@MdsMisc@SHARETYPE@ : $(OBJECTS) $(DEF) @EXPORTS_FILE@

--- a/mdsobjects/cpp/Makefile.in
+++ b/mdsobjects/cpp/Makefile.in
@@ -27,11 +27,11 @@ clean:
 depend:
 	 @makedepend -- $(CFLAGS) -- $(SOURCES)
 
-install: $(libdir)
-	$(INSTALL) -m 755  @MAKESHLIBDIR@@LIBPRE@MdsObjectsCppShr@SHARETYPE@ $(IMPLIB) $(libdir)
-	@VS_TRUE@ $(INSTALL) -m 755 @MAKELIBDIR@MdsObjectsCppShr-VS.dll @MAKESHLIBDIR@*.lib $(libdir)
+install: $(DESTDIR)$(libdir)
+	$(INSTALL) -m 755  @MAKESHLIBDIR@@LIBPRE@MdsObjectsCppShr@SHARETYPE@ $(IMPLIB) $(DESTDIR)$(libdir)
+	@VS_TRUE@ $(INSTALL) -m 755 @MAKELIBDIR@MdsObjectsCppShr-VS.dll @MAKESHLIBDIR@*.lib $(DESTDIR)$(libdir)
 	if test @SHARETYPE@ != .a ; then \
-		$(INSTALL) -m 644  @MAKELIBDIR@@LIBPRE@MdsObjectsCppShr.a $(libdir); \
+		$(INSTALL) -m 644  @MAKELIBDIR@@LIBPRE@MdsObjectsCppShr.a $(DESTDIR)$(libdir); \
 	fi;
 
 @MINGW_TRUE@ MAKE_IMPLIB=-Wl,--out-implib,$(IMPLIB)

--- a/mdsobjects/labview/Makefile.in
+++ b/mdsobjects/labview/Makefile.in
@@ -32,14 +32,14 @@ clean:
 depend:
 	 @makedepend -- $(CFLAGS) -- $(SOURCES)
 
-install: $(libdir)
-	$(MKDIR_P) $(exec_prefix)/LabView
-	tar cf - MDSplus | (cd ${exec_prefix}/LabView; tar xf -)
-	tar cf - MDSplus_LV2012 | (cd ${exec_prefix}/LabView; tar xf -)
-	$(INSTALL) -m 755  @MAKESHLIBDIR@@LIBPRE@MDSobjectsLVShr@SHARETYPE@ @libdir@
-@MINGW_FALSE@	$(INSTALL) -m 755  @MAKESHLIBDIR@@LIBPRE@MDSobjectsLVShr @libdir@
-@MINGW_FALSE@	$(INSTALL) -m 755  @MAKESHLIBDIR@MDSobjectsLVShr @libdir@
-@MINGW_FALSE@	$(INSTALL) -m 755  @MAKESHLIBDIR@@LIBPRE@LV@SHARETYPE@ @libdir@
+install: $(DESTDIR)$(libdir)
+	$(MKDIR_P) $(DESTDIR)$(exec_prefix)/LabView
+	tar cf - MDSplus | (cd $(DESTDIR)${exec_prefix}/LabView; tar xf -)
+	tar cf - MDSplus_LV2012 | (cd $(DESTDIR)${exec_prefix}/LabView; tar xf -)
+	$(INSTALL) -m 755  @MAKESHLIBDIR@@LIBPRE@MDSobjectsLVShr@SHARETYPE@ $(DESTDIR)@libdir@
+@MINGW_FALSE@	$(INSTALL) -m 755  @MAKESHLIBDIR@@LIBPRE@MDSobjectsLVShr $(DESTDIR)@libdir@
+@MINGW_FALSE@	$(INSTALL) -m 755  @MAKESHLIBDIR@MDSobjectsLVShr $(DESTDIR)@libdir@
+@MINGW_FALSE@	$(INSTALL) -m 755  @MAKESHLIBDIR@@LIBPRE@LV@SHARETYPE@ $(DESTDIR)@libdir@
 
 @MAKESHLIBDIR@@LIBPRE@LV@SHARETYPE@: $(COBJECTS) @EXPORTS_FILE@
 	$(LD) -o $@ $(CFLAGS) @LINKSHARED@ $(COBJECTS) $(CLIBS) $(LIBS) $(CXXFLAGS)

--- a/mdsshr/Makefile.in
+++ b/mdsshr/Makefile.in
@@ -43,8 +43,8 @@ clean:
 	@ $(RM) $(OBJECTS)
 	@ $(RM) $(libs)
 
-install: $(libdir)
-	$(INSTALL) -m 755 $(libs) $(libdir)
+install: $(DESTDIR)$(libdir)
+	$(INSTALL) -m 755 $(libs) $(DESTDIR)$(libdir)
 
 @MINGW_TRUE@ MAKE_IMPLIB=-Wl,--out-implib,$(IMPLIB)
 @MAKELIBDIR@%.dll @MAKELIBDIR@%.dll.a: $(OBJECTS) $(DEF)

--- a/mdssql/Makefile.in
+++ b/mdssql/Makefile.in
@@ -25,9 +25,9 @@ clean:
 depend:
 	 @makedepend -- $(CFLAGS) -- $(SOURCES)
 
-install: $(libdir)
-	$(INSTALL) -m 644  @MAKELIBDIR@@LIBPRE@MdsSql.a @libdir@
-	$(INSTALL) -m 755  @MAKELIBDIR@@LIBPRE@MdsSql@SHARETYPE@ @libdir@
+install: $(DESTDIR)$(libdir)
+	$(INSTALL) -m 644  @MAKELIBDIR@@LIBPRE@MdsSql.a $(DESTDIR)@libdir@
+	$(INSTALL) -m 755  @MAKELIBDIR@@LIBPRE@MdsSql@SHARETYPE@ $(DESTDIR)@libdir@
 
 @MAKELIBDIR@@LIBPRE@MdsSql@SHARETYPE@ : $(OBJECTS) $(DEF)
 	$(LINK.c) -o $@ @LINKSHARED@ $(OBJECTS) $(DEF) -L@MAKELIBDIR@ $(LDFLAGS) $(LIBS)

--- a/mdstcpip/Makefile.in
+++ b/mdstcpip/Makefile.in
@@ -152,24 +152,24 @@ clean :
 	@ $(RM) $(MDSIPSD)
         endif
 
-install: $(bindir) $(libdir) $(sysconfdir)
-	$(INSTALL) -m 755 $(PROGRAMS) @bindir@
-	$(INSTALL) -m 755 $(MdsIpShr) @libdir@
+install: $(DESTDIR)$(bindir) $(DESTDIR)$(libdir) $(DESTDIR)$(sysconfdir)
+	$(INSTALL) -m 755 $(PROGRAMS) $(DESTDIR)@bindir@
+	$(INSTALL) -m 755 $(MdsIpShr) $(DESTDIR)@libdir@
         ifdef modules
-		$(INSTALL) -m 755  @MAKESHLIBDIR@@LIBPRE@MdsIpShr@SHARETYPEMOD@ @libdir@
+		$(INSTALL) -m 755  @MAKESHLIBDIR@@LIBPRE@MdsIpShr@SHARETYPEMOD@ $(DESTDIR)@libdir@
         endif
 	if test "@SHARETYPE@" != ".a" ; then \
-		$(INSTALL) -m 644  @MAKELIBDIR@@LIBPRE@MdsIpShr.a @libdir@; \
+		$(INSTALL) -m 644  @MAKELIBDIR@@LIBPRE@MdsIpShr.a $(DESTDIR)@libdir@; \
 	fi;
-	$(INSTALL) -m 755  @MAKEETCDIR@mdsip.hosts $(sysconfdir)
-	$(INSTALL) -m 755 $(MdsIpSrvShr) @libdir@
-	$(INSTALL) -m 755 $(MdsIpTunnel) @libdir@
-	$(INSTALL) -m 755 $(MdsIpTCP) @libdir@
-@MINGW_FALSE@	$(INSTALL) -m 755 $(IPV6_UDT) @libdir@
-	$(INSTALL) -m 755 $(MdsIpSSH) @libdir@
-	$(INSTALL) -m 755 $(MdsIpHTTP) @libdir@
+	$(INSTALL) -m 755  @MAKEETCDIR@mdsip.hosts $(DESTDIR)$(sysconfdir)
+	$(INSTALL) -m 755 $(MdsIpSrvShr) $(DESTDIR)@libdir@
+	$(INSTALL) -m 755 $(MdsIpTunnel) $(DESTDIR)@libdir@
+	$(INSTALL) -m 755 $(MdsIpTCP) $(DESTDIR)@libdir@
+@MINGW_FALSE@	$(INSTALL) -m 755 $(IPV6_UDT) $(DESTDIR)@libdir@
+	$(INSTALL) -m 755 $(MdsIpSSH) $(DESTDIR)@libdir@
+	$(INSTALL) -m 755 $(MdsIpHTTP) $(DESTDIR)@libdir@
         ifdef MdsIpGSI
-		$(INSTALL) -m 755 $(MdsIpGSI) @libdir@
+		$(INSTALL) -m 755 $(MdsIpGSI) $(DESTDIR)@libdir@
         endif
 
 .PHONY: docs

--- a/mdsvme/Makefile.in
+++ b/mdsvme/Makefile.in
@@ -19,10 +19,10 @@ clean :
 	@ $(RM) @MAKELIBDIR@libMdsVme.a
 	@ $(RM) @MAKESHLIBDIR@libMdsVme@SHARETYPE@
 
-install: $(libdir)
-	$(INSTALL) -m 755  @MAKESHLIBDIR@libMdsVme@SHARETYPE@ @libdir@
+install: $(DESTDIR)$(libdir)
+	$(INSTALL) -m 755  @MAKESHLIBDIR@libMdsVme@SHARETYPE@ $(DESTDIR)@libdir@
 	if (test @SHARETYPE@ != .a) then \
-		$(INSTALL) -m 644  @MAKELIBDIR@libMdsVme.a @libdir@; \
+		$(INSTALL) -m 644  @MAKELIBDIR@libMdsVme.a $(DESTDIR)@libdir@; \
 	fi;
 
 @MAKESHLIBDIR@libMdsVme@SHARETYPE@ : $(OBJECTS) @EXPORTS_FILE@

--- a/mitdevices/Makefile.in
+++ b/mitdevices/Makefile.in
@@ -239,26 +239,26 @@ clean:
 	@ $(RM) @DC1394_SUPPORT@ @DC1394_SUPPORT2@
 
 
-install: $(bindir) $(libdir)
-	$(INSTALL) -m 644 $(UIDS) @uiddir@
-	$(INSTALL) -m 755  @MAKESHLIBDIR@libMitDevices@SHARETYPE@ @libdir@
+install: $(DESTDIR)$(bindir) $(DESTDIR)$(libdir)
+	$(INSTALL) -m 644 $(UIDS) $(DESTDIR)@uiddir@
+	$(INSTALL) -m 755  @MAKESHLIBDIR@libMitDevices@SHARETYPE@ $(DESTDIR)@libdir@
 	if [ -x @MAKESHLIBDIR@libMitDevicesIO@SHARETYPE@ ] ; then \
-		$(INSTALL) -m 755  @MAKESHLIBDIR@libMitDevicesIO@SHARETYPE@ @libdir@ ;\
+		$(INSTALL) -m 755  @MAKESHLIBDIR@libMitDevicesIO@SHARETYPE@ $(DESTDIR)@libdir@ ;\
 	fi;
-	$(INSTALL) -m 755  @MAKESHLIBDIR@libMitDevicesMsg@SHARETYPE@ @libdir@
-	ln -sf libMitDevices@SHARETYPE@ @libdir@/libMIT\$$DEVICES@SHARETYPE@
+	$(INSTALL) -m 755  @MAKESHLIBDIR@libMitDevicesMsg@SHARETYPE@ $(DESTDIR)@libdir@
+	ln -sf libMitDevices@SHARETYPE@ $(DESTDIR)@libdir@/libMIT\$$DEVICES@SHARETYPE@
 	if (test @SHARETYPE@ != .a) then \
-	  $(INSTALL) -m 644  @MAKELIBDIR@libMitDevices.a @libdir@; \
+	  $(INSTALL) -m 644  @MAKELIBDIR@libMitDevices.a $(DESTDIR)@libdir@; \
 	fi;
-	$(INSTALL) -m 755  @MAKEBINDIR@reboot_dtaq_satelite @bindir@
-	$(INSTALL) -m 755  @MAKEBINDIR@dtaq_update_board.sh @bindir@
-	$(INSTALL) -m 755  @MAKESHLIBDIR@acq_root_filesystem.tgz @libdir@
-	$(INSTALL) -m 755  @MAKESHLIBDIR@acq_root_filesystem.tgz_ffs @libdir@
+	$(INSTALL) -m 755  @MAKEBINDIR@reboot_dtaq_satelite $(DESTDIR)@bindir@
+	$(INSTALL) -m 755  @MAKEBINDIR@dtaq_update_board.sh $(DESTDIR)@bindir@
+	$(INSTALL) -m 755  @MAKESHLIBDIR@acq_root_filesystem.tgz $(DESTDIR)@libdir@
+	$(INSTALL) -m 755  @MAKESHLIBDIR@acq_root_filesystem.tgz_ffs $(DESTDIR)@libdir@
 ifneq "@DC1394_SUPPORT@" ""
-	$(INSTALL) -m 755 @DC1394_SUPPORT@ @libdir@
+	$(INSTALL) -m 755 @DC1394_SUPPORT@ $(DESTDIR)@libdir@
 endif
 ifneq "@DC1394_SUPPORT2@" ""
-	$(INSTALL) -m 755 @DC1394_SUPPORT2@ @libdir@
+	$(INSTALL) -m 755 @DC1394_SUPPORT2@ $(DESTDIR)@libdir@
 endif
 
 l8590_mem.c: l8590_sclr_gen.c

--- a/remcam/Makefile.in
+++ b/remcam/Makefile.in
@@ -20,5 +20,5 @@ clean:
 depend:
 	 @makedepend -- $(CFLAGS) -- $(SOURCES)
 
-install: $(libdir)
-	$(INSTALL) -m 755  @MAKESHLIBDIR@@LIBPRE@@REMCAMLIB@@SHARETYPE@ @libdir@
+install: $(DESTDIR)$(libdir)
+	$(INSTALL) -m 755  @MAKESHLIBDIR@@LIBPRE@@REMCAMLIB@@SHARETYPE@ $(DESTDIR)@libdir@

--- a/roam/Makefile.in
+++ b/roam/Makefile.in
@@ -36,16 +36,16 @@ clean:
 	@ $(RM) @MAKEBINDIR@roam_check_access
 
 
-install: $(bindir) $(libdir)
-	$(INSTALL) -m 755  @MAKESHLIBDIR@libRoam_@GLOBUS_FLAVOR@@SHARETYPE@ $(libdir)
-	ln -sf libRoam_@GLOBUS_FLAVOR@@SHARETYPE@ $(libdir)/libRoam@SHARETYPE@
-	chmod 755 $(libdir)/libRoam@SHARETYPE@
-	$(INSTALL) -m 755  @MAKEBINDIR@roam_check_access $(bindir)
+install: $(DESTDIR)$(bindir) $(DESTDIR)$(libdir)
+	$(INSTALL) -m 755  @MAKESHLIBDIR@libRoam_@GLOBUS_FLAVOR@@SHARETYPE@ $(DESTDIR)$(libdir)
+	ln -sf libRoam_@GLOBUS_FLAVOR@@SHARETYPE@ $(DESTDIR)$(libdir)/libRoam@SHARETYPE@
+	chmod 755 $(DESTDIR)$(libdir)/libRoam@SHARETYPE@
+	$(INSTALL) -m 755  @MAKEBINDIR@roam_check_access $(DESTDIR)$(bindir)
         ifdef modules
-		$(INSTALL) -m 755  @MAKESHLIBDIR@libRoam_@GLOBUS_FLAVOR@@SHARETYPEMOD@ $(libdir)
+		$(INSTALL) -m 755  @MAKESHLIBDIR@libRoam_@GLOBUS_FLAVOR@@SHARETYPEMOD@ $(DESTDIR)$(libdir)
         endif
 	if test "@SHARETYPE@" != ".a" ; then \
-		$(INSTALL) -m 644  @MAKELIBDIR@libRoam_@GLOBUS_FLAVOR@.a $(libdir); \
+		$(INSTALL) -m 644  @MAKELIBDIR@libRoam_@GLOBUS_FLAVOR@.a $(DESTDIR)$(libdir); \
 	fi;
 
 

--- a/servershr/Makefile.in
+++ b/servershr/Makefile.in
@@ -37,10 +37,10 @@ clean:
 depend:
 	 @makedepend -- $(CFLAGS) -- $(SOURCES)
 
-install: $(libdir)
-	$(INSTALL) -m 755  @MAKESHLIBDIR@@LIBPRE@MdsServerShr@SHARETYPE@ $(IMPLIB) $(libdir)
+install: $(DESTDIR)$(libdir)
+	$(INSTALL) -m 755  @MAKESHLIBDIR@@LIBPRE@MdsServerShr@SHARETYPE@ $(IMPLIB) $(DESTDIR)$(libdir)
 	if test "@SHARETYPE@" != ".a" ; then \
-		$(INSTALL) -m 644  @MAKELIBDIR@@LIBPRE@MdsServerShr.a $(libdir); \
+		$(INSTALL) -m 644  @MAKELIBDIR@@LIBPRE@MdsServerShr.a $(DESTDIR)$(libdir); \
 	fi;
 
 @MINGW_TRUE@ MAKE_IMPLIB=-Wl,--out-implib,$(IMPLIB)

--- a/tcl/Makefile.in
+++ b/tcl/Makefile.in
@@ -56,9 +56,9 @@ clean:
 	@ $(RM) @MAKEBINDIR@$(MDSTCL)
 	@ $(RM) @MAKESHLIBDIR@@LIBPRE@tcl_commands@SHARETYPE@
 
-install: $(libdir) $(bindir)
-	$(INSTALL) -m 755 @MAKESHLIBDIR@@LIBPRE@tcl_commands@SHARETYPE@ $(libdir)
-	$(INSTALL) -m 755 @MAKEBINDIR@$(MDSTCL) $(bindir)
+install: $(DESTDIR)$(libdir) $(DESTDIR)$(bindir)
+	$(INSTALL) -m 755 @MAKESHLIBDIR@@LIBPRE@tcl_commands@SHARETYPE@ $(DESTDIR)$(libdir)
+	$(INSTALL) -m 755 @MAKEBINDIR@$(MDSTCL) $(DESTDIR)$(bindir)
 
 @MAKEBINDIR@$(MDSTCL): $(MDSTCL)
 	$(INSTALL) -m 755 $< $@

--- a/tdic/Makefile.in
+++ b/tdic/Makefile.in
@@ -23,12 +23,12 @@ clean :
 	@ $(RM) @MAKESHLIBDIR@@LIBPRE@TdiShrExt@SHARETYPE@
 	@ $(RM) @MAKEBINDIR@tdic
 
-install: $(libdir) $(bindir)
-	$(INSTALL) -m 755  @MAKESHLIBDIR@@LIBPRE@TdiShrExt@SHARETYPE@ $(libdir)
+install: $(DESTDIR)$(libdir) $(DESTDIR)$(bindir)
+	$(INSTALL) -m 755  @MAKESHLIBDIR@@LIBPRE@TdiShrExt@SHARETYPE@ $(DESTDIR)$(libdir)
 	if (test @SHARETYPE@ != .a) then \
-		$(INSTALL) -m 644  @MAKELIBDIR@@LIBPRE@TdiShrExt.a $(libdir); \
+		$(INSTALL) -m 644  @MAKELIBDIR@@LIBPRE@TdiShrExt.a $(DESTDIR)$(libdir); \
 	fi;
-	$(INSTALL) -m 755  @MAKEBINDIR@tdic$(EXE) $(bindir)
+	$(INSTALL) -m 755  @MAKEBINDIR@tdic$(EXE) $(DESTDIR)$(bindir)
 
 @MAKESHLIBDIR@@LIBPRE@TdiShrExt@SHARETYPE@ : $(OBJECTS) $(DEF) @EXPORTS_FILE@
 	$(LINK.c) $(OUTPUT_OPTION) @LINKSHARED@ $(OBJECTS) $(LIBS)

--- a/tdishr/Makefile.in
+++ b/tdishr/Makefile.in
@@ -99,10 +99,10 @@ clean:
 	@ $(RM) @MAKESHLIBDIR@@LIBPRE@TdiShr@SHARETYPE@ $(IMPLIB)
 	@ $(RM) @MAKELIBDIR@@LIBPRE@TdiShr.a
 
-install: $(libdir)
-	$(INSTALL) -m 755  @MAKESHLIBDIR@@LIBPRE@TdiShr@SHARETYPE@ $(IMPLIB) @libdir@
+install: $(DESTDIR)$(libdir)
+	$(INSTALL) -m 755  @MAKESHLIBDIR@@LIBPRE@TdiShr@SHARETYPE@ $(IMPLIB) $(DESTDIR)@libdir@
 	if test "@SHARETYPE@" != ".a" ; then \
-		$(INSTALL) -m 644  @MAKELIBDIR@@LIBPRE@TdiShr.a @libdir@; \
+		$(INSTALL) -m 644  @MAKELIBDIR@@LIBPRE@TdiShr.a $(DESTDIR)@libdir@; \
 	fi;
 
 ifneq "@PYTHON_INCLUDE_DIR@" ""

--- a/tditest/Makefile.in
+++ b/tditest/Makefile.in
@@ -9,8 +9,8 @@ all : @MAKEBINDIR@ @MAKEBINDIR@tditest$(EXE)
 depend:
 	@makedepend -- $(CFLAGS) -- $(SOURCES)
 
-install: $(bindir)
-	$(INSTALL) -m 755  @MAKEBINDIR@tditest$(EXE) $(bindir)
+install: $(DESTDIR)$(bindir)
+	$(INSTALL) -m 755  @MAKEBINDIR@tditest$(EXE) $(DESTDIR)$(bindir)
 
 clean :
 	@ $(RM) @MAKEBINDIR@tditest$(EXE)

--- a/traverser/Makefile.in
+++ b/traverser/Makefile.in
@@ -34,9 +34,9 @@ clean :
 	@ $(RM) @MAKEUIDDIR@traverser.uid
 
 
-install: $(bindir) @uiddir@
-	$(INSTALL) -m 644  @MAKEUIDDIR@traverser.uid @uiddir@
-	$(INSTALL) -m 755  @MAKEBINDIR@traverser @bindir@
+install: $(DESTDIR)$(bindir) $(DESTDIR)@uiddir@
+	$(INSTALL) -m 644  @MAKEUIDDIR@traverser.uid $(DESTDIR)@uiddir@
+	$(INSTALL) -m 755  @MAKEBINDIR@traverser $(DESTDIR)@bindir@
 
 
 @MAKEBINDIR@traverser : $(OBJECTS)

--- a/treeshr/Makefile.in
+++ b/treeshr/Makefile.in
@@ -50,10 +50,10 @@ clean:
 depend:
 	 @makedepend -- $(CFLAGS) -- $(SOURCES)
 
-install: $(libdir)
-	$(INSTALL) -m 755  @MAKESHLIBDIR@@LIBPRE@TreeShr@SHARETYPE@ $(IMPLIB) @libdir@
+install: $(DESTDIR)$(libdir)
+	$(INSTALL) -m 755  @MAKESHLIBDIR@@LIBPRE@TreeShr@SHARETYPE@ $(IMPLIB) $(DESTDIR)@libdir@
 	if test @SHARETYPE@ != .a ; then \
-		$(INSTALL) -m 644  @MAKELIBDIR@@LIBPRE@TreeShr.a @libdir@; \
+		$(INSTALL) -m 644  @MAKELIBDIR@@LIBPRE@TreeShr.a $(DESTDIR)@libdir@; \
 	fi;
 
 

--- a/xmdsshr/Makefile.in
+++ b/xmdsshr/Makefile.in
@@ -64,14 +64,14 @@ clean :
 	@ $(RM) @MAKEUIDDIR@XmdsXdBox.uid
 
 
-install: $(libdir) @uiddir@
-	$(INSTALL) -m 644  @MAKEUIDDIR@xmds_usage_icons.uid @uiddir@
-	$(INSTALL) -m 644  @MAKEUIDDIR@XmdsDigChans.uid @uiddir@
-	$(INSTALL) -m 644  @MAKEUIDDIR@XmdsInput.uid @uiddir@
-	$(INSTALL) -m 644  @MAKEUIDDIR@XmdsXdBox.uid @uiddir@
-	$(INSTALL) -m 755  @MAKESHLIBDIR@libXmdsShr@SHARETYPE@ @libdir@
+install: $(DESTDIR)$(libdir) $(DESTDIR)@uiddir@
+	$(INSTALL) -m 644  @MAKEUIDDIR@xmds_usage_icons.uid $(DESTDIR)@uiddir@
+	$(INSTALL) -m 644  @MAKEUIDDIR@XmdsDigChans.uid $(DESTDIR)@uiddir@
+	$(INSTALL) -m 644  @MAKEUIDDIR@XmdsInput.uid $(DESTDIR)@uiddir@
+	$(INSTALL) -m 644  @MAKEUIDDIR@XmdsXdBox.uid $(DESTDIR)@uiddir@
+	$(INSTALL) -m 755  @MAKESHLIBDIR@libXmdsShr@SHARETYPE@ $(DESTDIR)@libdir@
 	if test "@SHARETYPE@" != ".a" ; then \
-		$(INSTALL) -m 644  @MAKELIBDIR@libXmdsShr.a @libdir@; \
+		$(INSTALL) -m 644  @MAKELIBDIR@libXmdsShr.a $(DESTDIR)@libdir@; \
 	fi;
 
 @MAKEUIDDIR@xmds_usage_icons.uid: xmds_usage_icons.uil

--- a/xtreeshr/Makefile.in
+++ b/xtreeshr/Makefile.in
@@ -24,10 +24,10 @@ clean:
 depend:
 	@makedepend -- $(CFLAGS) -- $(SOURCES)
 
-install: $(libdir)
-	$(INSTALL) -m 755  @MAKESHLIBDIR@@LIBPRE@XTreeShr@SHARETYPE@ $(IMPLIB) $(libdir)
+install: $(DESTDIR)$(libdir)
+	$(INSTALL) -m 755  @MAKESHLIBDIR@@LIBPRE@XTreeShr@SHARETYPE@ $(IMPLIB) $(DESTDIR)$(libdir)
 	if test @SHARETYPE@ != .a ; then \
-		$(INSTALL) -m 644 @MAKELIBDIR@@LIBPRE@XTreeShr.a $(libdir); \
+		$(INSTALL) -m 644 @MAKELIBDIR@@LIBPRE@XTreeShr.a $(DESTDIR)$(libdir); \
 	fi;
 
 @MINGW_TRUE@ MAKE_IMPLIB=-Wl,--out-implib,$(IMPLIB)


### PR DESCRIPTION
Per https://www.gnu.org/prep/standards/html_node/DESTDIR.html , installations should handle a `DESTDIR` prefix to installed files.  This pull request fulfills that standard.
