### PR TITLE
support for non-ansii TEXT data in python (2.7)

### DIFF
--- a/mdsobjects/python/_descriptor.py
+++ b/mdsobjects/python/_descriptor.py
@@ -354,7 +354,7 @@ class descriptor(_C.Structure):
                 if self.length == 0:
                     return _scalar.makeScalar('')
                 else:
-                    return(_scalar.makeScalar(str(_N.array(_C.cast(self.pointer,_C.POINTER((_C.c_byte*self.length))).contents[:],dtype=_N.uint8).tostring().decode())))
+                    return(_scalar.makeScalar(_N.array(_C.cast(self.pointer,_C.POINTER((_C.c_byte*self.length))).contents[:],dtype=_N.uint8).tostring()))
             if (self.dtype == _dtypes.DTYPE_FSC):
                 ans=_C.cast(self.pointer,_C.POINTER((_C.c_float*2))).contents
                 return _scalar.makeScalar(_N.complex64(complex(ans[0],ans[1])))

--- a/mdsobjects/python/_treeshr.py
+++ b/mdsobjects/python/_treeshr.py
@@ -718,10 +718,10 @@ def TreeGetDbi(tree,itemname):
     if not (status & 1):
         raise TreeException(_mdsshr.MdsGetMsg(status))
     if item[1]==str:
-        if isinstance(ans.value,str):
-          return ans.value
-        else:
+        try:
           return ans.value.decode()
+        except:
+          return ans.value
     else:
         return item[1](ans.value)
 

--- a/mdsobjects/python/mdsscalar.py
+++ b/mdsobjects/python/mdsscalar.py
@@ -36,7 +36,7 @@ def makeScalar(value):
             return Int64(value)
     if isinstance(value,float):
         return Float32(value)
-    if isinstance(value,str):
+    if isinstance(value,basestring):
         return String(value)
     if isinstance(value,bytes):
         return String(value.decode())
@@ -226,7 +226,11 @@ class String(Scalar):
         """String: x.__str__() <==> str(x)
         @rtype: String"""
         if len(self._value) > 0:
-            return str(self.value.tostring().decode())
+            valstr = self.value.tostring()
+            try:
+                return valstr.decode()
+            except:
+                return valstr
         else:
             return ''
     def __len__(self):


### PR DESCRIPTION
Encloses decode() in try..except and returns un-decoded value if it fails.
Before, it returned EmptyData when the error is caught by the outer
try..except structure.
The error occurred when a TEXT node contained non-ansii chars (e.g. äöü..)
