### PR TITLE
added %* for allowing parameters to be passed down to java

### DIFF
--- a/javatraverser/traverser.bat
+++ b/javatraverser/traverser.bat
@@ -1,1 +1,1 @@
-start javaw -cp "%MDSPLUS_DIR%\Java\Classes\jTraverser.jar" jTraverser
+start javaw -cp "%MDSPLUS_DIR%\Java\Classes\jTraverser.jar" jTraverser %*


### PR DESCRIPTION
otherwise one cannot use treename and shotnumber as parameters using the
batch script shortcut
