### PR TITLE
preserve the tree name and shot at tree-open (clean pull-request)

### DIFF
--- a/javatraverser/Tree.java
+++ b/javatraverser/Tree.java
@@ -284,12 +284,17 @@ public class Tree extends JScrollPane implements TreeSelectionListener,
 	    open_exp.addKeyListener(this);
 	    open_dialog.pack();
 	    open_dialog.setLocation(curr_origin);
+	    if (curr_experiment != null)
+	        try {
+		       open_exp.setText(curr_experiment.getName());
+	           open_shot.setText(new Integer(curr_experiment.getShot()).toString());
+	        }catch(Exception exc){}
 	    open_dialog.setVisible(true);
 	}
 	else
 	{
-	    open_exp.setText("");
-	    open_shot.setText("");
+//	    open_exp.setText("");
+//	    open_shot.setText("");
 	    open_dialog.setLocation(curr_origin);
 	    open_dialog.setVisible(true);
         open_edit.setSelected(false);


### PR DESCRIPTION
the open tree dialog now tries to get tree name and shot number
if they have been passed as command line parameters on first call.  It
does not clear the fields anymore allowing for a fast switching between
edit mode, normal mode or shot numbers
(try..catch structure may be omissible)
