### PR TITLE
set the location of the open dialog relative to it parent

### DIFF
--- a/javatraverser/Tree.java
+++ b/javatraverser/Tree.java
@@ -246,10 +246,8 @@ public class Tree extends JScrollPane implements TreeSelectionListener,
     	if(open_dialog == null)
 	{
 	    if(curr_origin == null)
-		curr_origin = new Point(100, 100);
 	    open_dialog = new JDialog(frame);
 	    open_dialog.setTitle("Open new tree");
-	    //open_dialog.setLocation(curr_origin);
 	    JPanel mjp = new JPanel();
 	    mjp.setLayout(new BorderLayout());
 	    JPanel jp1 = new JPanel();
@@ -283,8 +281,7 @@ public class Tree extends JScrollPane implements TreeSelectionListener,
 	    open_shot.addKeyListener(this);
 	    open_exp.addKeyListener(this);
 	    open_dialog.pack();
-	    curr_origin.x = frame.getLocation().x+32;
-	    curr_origin.y = frame.getLocation().y+32;
+	    curr_origin = new Point(frame.getLocation().x+32,frame.getLocation().y+32);
 	    open_dialog.setLocation(curr_origin);
 	    open_dialog.setVisible(true);
 	}
@@ -292,8 +289,7 @@ public class Tree extends JScrollPane implements TreeSelectionListener,
 	{
 	    open_exp.setText("");
 	    open_shot.setText("");
-	    curr_origin.x = frame.getLocation().x+32;
-	    curr_origin.y = frame.getLocation().y+32;
+	    curr_origin = new Point(frame.getLocation().x+32,frame.getLocation().y+32);
 	    open_dialog.setLocation(curr_origin);
 	    open_dialog.setVisible(true);
         open_edit.setSelected(false);

--- a/javatraverser/Tree.java
+++ b/javatraverser/Tree.java
@@ -283,6 +283,8 @@ public class Tree extends JScrollPane implements TreeSelectionListener,
 	    open_shot.addKeyListener(this);
 	    open_exp.addKeyListener(this);
 	    open_dialog.pack();
+	    curr_origin.x = frame.getLocation().x+32;
+	    curr_origin.y = frame.getLocation().y+32;
 	    open_dialog.setLocation(curr_origin);
 	    open_dialog.setVisible(true);
 	}
@@ -290,6 +292,8 @@ public class Tree extends JScrollPane implements TreeSelectionListener,
 	{
 	    open_exp.setText("");
 	    open_shot.setText("");
+	    curr_origin.x = frame.getLocation().x+32;
+	    curr_origin.y = frame.getLocation().y+32;
 	    open_dialog.setLocation(curr_origin);
 	    open_dialog.setVisible(true);
         open_edit.setSelected(false);


### PR DESCRIPTION
Prevents, that the tree-open dialog is at a fixed position (100,100 from
the upper left corner). It now opens at a fixed relative position to the
main window's upper left corner. This way, it is much more convenient,
especially if you use large or multiple screens.
