### PR TITLE
fixed argument to encounter a java compiler warning

### DIFF
--- a/javatraverser/Tree.java
+++ b/javatraverser/Tree.java
@@ -681,7 +681,7 @@ public class Tree extends JScrollPane implements TreeSelectionListener,
 			            if(idx < node_methods.length)
 			            {
 				            try {
-				                node_methods[idx].getMethod().invoke(curr_node, null);
+				                node_methods[idx].getMethod().invoke(curr_node);
 				            }catch(Exception exc) {System.out.println("Error executing " + exc); }
 				            curr_tree.expandPath(new TreePath(curr_tree_node.getPath()));
 				            curr_tree.treeDidChange();


### PR DESCRIPTION
prevents warning during compilation:
Tree.java:693: warning: non-varargs call of varargs method with inexact argument type for last parameter;
cast to Object for a varargs call
cast to Object[] for a non-varargs call and to suppress this warning
