### PR TITLE
_decriptor move unicode to bottom

### DIFF
--- a/mdsobjects/python/_descriptor.py
+++ b/mdsobjects/python/_descriptor.py
@@ -115,17 +115,7 @@ class descriptor(_C.Structure):
                 self.pointer=_C.cast(_C.pointer(_C.c_long(value)),type(self.pointer))
                 self.addToCache(value)
                 return
-        try:
-          if isinstance(value,unicode):
-            str_d=descriptor_string(value)
-            d=_C.cast(_C.pointer(str_d),_C.POINTER(descriptor)).contents
-            self.length=d.length
-            self.dtype=d.dtype
-            self.pointer=d.pointer
-            self.addToCache(value)
-            return
-        except:
-          pass
+
         if isinstance(value,str):
             str_d=descriptor_string(value)
             d=_C.cast(_C.pointer(str_d),_C.POINTER(descriptor)).contents
@@ -327,6 +317,16 @@ class descriptor(_C.Structure):
             self.addToCache(apd_a)
             self.addToCache(apd)
             return
+            
+        if isinstance(value,unicode):
+            str_d=descriptor_string(value)
+            d=_C.cast(_C.pointer(str_d),_C.POINTER(descriptor)).contents
+            self.length=d.length
+            self.dtype=d.dtype
+            self.pointer=d.pointer
+            self.addToCache(value)
+            return
+            
         raise TypeError('Cannot make descriptor of '+str(type(value)))
         return
 


### PR DESCRIPTION
this way an error thrown by unicode part is not swallowed by try-structure without affecting the rest
