### PR TITLE
Alpha descriptor a contigous

### DIFF
--- a/mdsobjects/python/_descriptor.py
+++ b/mdsobjects/python/_descriptor.py
@@ -696,20 +696,23 @@ class descriptor_a(_C.Structure):
 
     def __init__(self,*value):
         if len(value) == 1:
+            value = value[0]
+            if not value.flags.f_contiguous:
+                value=value.copy('F')
             self.dclass=_mdsclasses.CLASS_A
             self.scale=0
             self.digits=0
             self.aflags=0
-            self.dtype=_dtypes.mdsdtypes.fromNumpy(value[0])
-            self.length=value[0].itemsize
-            self.pointer=_C.c_void_p(value[0].ctypes.data)
-            self.dimct=_N.shape(_N.shape(value[0]))[0]
-            self.arsize=value[0].nbytes
+            self.dtype=_dtypes.mdsdtypes.fromNumpy(value)
+            self.length=value.itemsize
+            self.pointer=_C.c_void_p(value.ctypes.data)
+            self.dimct=_N.shape(_N.shape(value))[0]
+            self.arsize=value.nbytes
             self.a0=self.pointer
             if self.dimct > 1:
                 self.coeff=1
                 for i in range(self.dimct):
-                    self.coeff_and_bounds[i]=_N.shape(value[0])[i]
+                    self.coeff_and_bounds[i]=_N.shape(value)[i]
         return
 
     def __getattr__(self,name):

--- a/mdsobjects/python/_descriptor.py
+++ b/mdsobjects/python/_descriptor.py
@@ -98,12 +98,10 @@ class descriptor(_C.Structure):
             value=_data.makeData(value)
 
         if isinstance(value,_N.ndarray):
-            if not value.flags.c_contiguous:
-                value=value.copy()
             if str(value.dtype)[1:2]=='S':
                 for i in range(len(value.flat)):
                     value.flat[i]=value.flat[i].ljust(value.itemsize)
-            a=descriptor_a(value.T)
+            a=descriptor_a(value)
             self.length=10000
             self.dtype=_dtypes.DTYPE_DSC
             self.pointer=_C.cast(_C.pointer(a),type(self.pointer))
@@ -696,7 +694,7 @@ class descriptor_a(_C.Structure):
 
     def __init__(self,*value):
         if len(value) == 1:
-            value = value[0]
+            value = value[0].T
             if not value.flags.f_contiguous:
                 value=value.copy('F')
             self.dclass=_mdsclasses.CLASS_A

--- a/mdsobjects/python/_treeshr.py
+++ b/mdsobjects/python/_treeshr.py
@@ -637,8 +637,7 @@ def TreeBeginSegment(n,start,end,dimension,initialValue,idx):
     try:
         n.tree.lock()
         status=__TreeBeginSegment(n.tree.ctx,n.nid,_C.pointer(descriptor(start)),_C.pointer(descriptor(end)),
-                                   _C.pointer(descriptor(dimension)),_C.pointer(descriptor_a(initialValue)),
-                                   idx)
+                                   _C.pointer(descriptor(dimension)),_C.pointer(descriptor_a(initialValue)),idx)
     finally:
         n.tree.unlock()
     if (status & 1):


### PR DESCRIPTION
fixed the descriptor_a handling and thereby the segmented data storing
the contiguous check is missing for direct calls of descriptor_s as done by makeSegmented etc
also Transposing is missing.
python first dim is time!!!

old:
normal data:= (8, 6, 4)->[8,6,4]->(4, 6, 8)
segmented:=  (8, 6, 4)->[2,6,8]->(8, 6, 2)
4 segments:={(2, 6, 4)->[2,6,4]->(2, 6, 4)}
fixed:
normal data:= (8, 6, 4)->[4,6,8]->(8, 6, 4)
segmented:=  (8, 6, 4)->[4,6,8]->(8, 6, 4)
4 segments:={(2, 6, 4)->[4,6,2]->(2, 6, 4)}
