### PR TITLE
setevetn: cast to byte before reaching down to MDSSHR->MDS$EVENT (rebased)

### DIFF
--- a/tdi/setevent.fun
+++ b/tdi/setevent.fun
@@ -2,7 +2,7 @@ public fun SetEvent(in _eventname,optional in _eventdata)
 {
   if (vms())
   {
-    _edata = present(_eventdata) ? ((size(_eventdata) < 12) ? [_eventdata,zero(12,0b)] : _eventdata) : zero(12,0b);
+    _edata = present(_eventdata) ? ((size(_eventdata) < 12) ? [BYTE(_eventdata),zero(12,0b)] : BYTE(_eventdata)) : zero(12,0b);
     _status = MDSSHR->MDS$EVENT(_eventname,_edata);
   }
   else


### PR DESCRIPTION
if not cast to Byte first setevent does a mix up length of original
vector but byte sequence of flattened vector.
e.g.: Int32[1,2,3,4,5] -> [1,0,0,0 , 2]

> wfevent crashed at that time if handled locally on Windows 64bit, it worked fine while mdsconnect-ed
> 
> now it works but throws error if no byte array is provided on setevent (on python 2.7 and 3.3,...; win and unix)
> 
> Traceback (most recent call last):
> File "<stdin>", line 1, in <module>
> File "python\Lib\site-packages\MDSplus\event.py", line 93, in wfevent
>   return MDSWfeventTimed(event,timeout).deserialize()
> File "python\Lib\site-packages\MDSplus\mdsarray.py", line 195, in deserialize
>   return _data.Data.deserialize(self)
> File "python\Lib\site-packages\MDSplus\mdsdata.py", line 806, in deserialize
>   return _mimport('_mdsshr',1).MdsSerializeDscIn(data)
> File "python\Lib\site-packages\MDSplus_mdsshr.py", line 120, in MdsSerializeDscIn
>   raise MdsException(MdsGetMsg(status))
> MDSplus._mdsshr.MdsException: %LIB-F-INVSTRDES, Invalid string descriptor
> 
> should return [] or None
