### PR TITLE
Remove manual setting of executable extension, defer to EXEEXT

### DIFF
--- a/Makefile.inc.in
+++ b/Makefile.inc.in
@@ -28,6 +28,8 @@ SED = @SED@
 TARGET_ARCH = @TARGET_ARCH@
 THREAD = @THREAD@
 
+EXE = @EXEEXT@
+
 abs_builddir = @abs_builddir@
 abs_srcdir = @abs_srcdir@
 abs_top_builddir = @abs_top_builddir@

--- a/mdsdcl/Makefile.in
+++ b/mdsdcl/Makefile.in
@@ -1,7 +1,6 @@
 include @top_srcdir@/Makefile.inc
 
 @MINGW_TRUE@ IMPLIB=@MAKELIBDIR@Mdsdcl.dll.a
-@MINGW_TRUE@ EXE=.exe
 @MINGW_TRUE@ DEF=mdsdclshr.def
 @MINGW_TRUE@ XML_LIBS=-Wl,-Bstatic -lxml2 -lz -Wl,-Bdynamic -liconv  @LIBDL@ @SOCKETLIB@ 
 @MINGW_FALSE@ XML_LIBS=@XML_LIBS@ 

--- a/mdstcpip/Makefile.in
+++ b/mdstcpip/Makefile.in
@@ -2,7 +2,6 @@ include @top_srcdir@/Makefile.inc
 
 @MINGW_TRUE@ IMPLIB_MdsIpShr=@MAKELIBDIR@MdsIpShr.dll.a
 @MINGW_TRUE@ IMPLIB_MdsIpSrvShr=@MAKELIBDIR@MdsIpSrvShr.dll.a
-@MINGW_TRUE@ EXE=.exe
 @MINGW_TRUE@ WIN=.win
 @MINGW_TRUE@ DEF=mdsipshr.def
 

--- a/mdstcpip/zlib/Makefile.am
+++ b/mdstcpip/zlib/Makefile.am
@@ -3,7 +3,6 @@
 include ${top_srcdir}/Makefile.inc
 
 if MINGW
-EXE=.exe
 WIN=.win
 DEF=mdsipshr.def
 endif

--- a/mdstcpip/zlib/Makefile.in
+++ b/mdstcpip/zlib/Makefile.in
@@ -452,7 +452,6 @@ top_build_prefix = @top_build_prefix@
 top_builddir = @top_builddir@
 top_srcdir = @top_srcdir@
 uiddir = @uiddir@
-@MINGW_TRUE@EXE = .exe
 @MINGW_TRUE@WIN = .win
 @MINGW_TRUE@DEF = mdsipshr.def
 lib = @LIBPRE@

--- a/tdic/Makefile.in
+++ b/tdic/Makefile.in
@@ -1,7 +1,6 @@
 include @top_srcdir@/Makefile.inc
 
 @MINGW_TRUE@ DEF=tdishrext.def
-@MINGW_TRUE@ EXE=.exe
 
 LIBS=@LIBS@ -L@MAKESHLIBDIR@ -lMdsIpShr -lTdiShr -lMdsShr -lTreeShr
 TDIC_LIBS= $(LIBS) -ldl @LIBREADLINE@

--- a/tditest/Makefile.in
+++ b/tditest/Makefile.in
@@ -1,7 +1,5 @@
 include @top_srcdir@/Makefile.inc
 
-@MINGW_TRUE@ EXE=.exe
-
 SOURCES = tditest.c
 
 all : @MAKEBINDIR@ @MAKEBINDIR@tditest$(EXE)


### PR DESCRIPTION
Autoconf runs tests that determine the executable extension as part of running any compiler macro, such as AC_PROC_CC.  This gets stored in the output variable @EXEEXT@.  We want to use what autoconf provides instead of testing for MINGW platforms and manually setting .exe as the extension.
