### PR TITLE
fix for issue #59 in ident.py

### DIFF
--- a/mdsobjects/python/_descriptor.py
+++ b/mdsobjects/python/_descriptor.py
@@ -285,7 +285,7 @@ class descriptor(_C.Structure):
         if isinstance(value,(str,_ver.varstr)):
             if isinstance(value,(_ver.unicode,)):
                 value = value.encode()
-            elif isinstance(value,(_ver.bytes,)):
+            elif not isinstance(value,(str,)):#is bytes (py2: str==bytes)
                 value = value.decode()
             #value is now of type str
             str_d=descriptor_string(value)

--- a/mdsobjects/python/ident.py
+++ b/mdsobjects/python/ident.py
@@ -6,10 +6,12 @@ else:
     return __import__(name,globals(),{},[],level)
 
 _data=_mimport('mdsdata',1)
-
+_ver=_mimport('version',1)
 class Ident(_data.Data):
     """Reference to MDSplus Ken Variable"""
     def __init__(self,name):
+        if _ver.has_bytes and isinstance(name,_ver.bytes):
+            name = name.decode()
         self.name=str(name)
     def __str__(self):
         return self.name


### PR DESCRIPTION
the bytes type when displayed shows as   b'abc'
this is given by the **str** method which is also called on str(b'abc')
It will therefore return "b'abc'" and corrupt the tdi interface
-> name must be decoded properly if it is of bytes type

> import MDSplus;MDSplus.TdiCompile('tdifun(_tdivar)')

returned (on python 3x)

> tdifun(b'_tdivar')

instead of

> tdifun(_tdivar)

resulting in tdi errors on execution or wrong record data when writing
to nodes
