### PR TITLE
setevetn: cast to byte before reaching down to MDSSHR->MDS$EVENT

### DIFF
--- a/tdi/setevent.fun
+++ b/tdi/setevent.fun
@@ -2,7 +2,7 @@ public fun SetEvent(in _eventname,optional in _eventdata)
 {
   if (vms())
   {
-    _edata = present(_eventdata) ? ((size(_eventdata) < 12) ? [_eventdata,zero(12,0b)] : _eventdata) : zero(12,0b);
+    _edata = present(_eventdata) ? ((size(_eventdata) < 12) ? [BYTE(_eventdata),zero(12,0b)] : BYTE(_eventdata)) : zero(12,0b);
     _status = MDSSHR->MDS$EVENT(_eventname,_edata);
   }
   else


### PR DESCRIPTION
If the array is not type-cast to Byte, the event system messes up:
Length of original vector but byte sequence of flattened vector.
 e.g.: 
an event is triggered using

> setevent('e',Int32[1,2,3,4,5])
> 
> wfevent('e')

returns

> [1,0,0,0 , 2]

but should return

> [1,2,3,4,5]
