### PR TITLE
If the array is not type-cast to Byte, the event system messes up:

### DIFF
--- a/tdi/setevent.fun
+++ b/tdi/setevent.fun
@@ -1,16 +1,8 @@
 public fun SetEvent(in _eventname,optional in _eventdata)
 {
-  if (vms())
-  {
-    _edata = present(_eventdata) ? ((size(_eventdata) < 12) ? [_eventdata,zero(12,0b)] : _eventdata) : zero(12,0b);
-    _status = MDSSHR->MDS$EVENT(_eventname,_edata);
-  }
+  if (present(_eventdata)) 
+      _status = MdsShr->MDSEvent(_eventname,val(size(_eventdata)),ref(byte(_eventdata)));
   else
-  {
-    if (present(_eventdata))
-      _status = MdsShr->MDSEvent(_eventname,val(size(_eventdata)),ref(_eventdata));
-    else
-      _status = MdsShr->MDSEvent(_eventname,val(0),val(0));
-  }	
+    _status = MdsShr->MDSEvent(_eventname,val(0),val(0));
   return(_status);
 }


### PR DESCRIPTION
Length of original vector but byte sequence of flattened vector.
e.g.:
an event is triggered using

```
setevent('e',Int32[1,2,3,4,5])

wfevent('e')
```

returns

```
[1,0,0,0 , 2]
```

but should return

```
[1,2,3,4,5]
```
