### PR TITLE
Fix mac problem with hang trying to exit after connect

### DIFF
--- a/mdstcpip/IoRoutinesTunnel.c
+++ b/mdstcpip/IoRoutinesTunnel.c
@@ -67,8 +67,8 @@ static int tunnel_disconnect(int id)
   struct TUNNEL_PIPES *p = getTunnelPipes(id);
   if (p) {
     int status;
-    kill(p->pid, 6);
-    waitpid(p->pid, &status, 0);
+    kill(p->pid, SIGABRT);
+    waitpid(p->pid, &status, WNOHANG);
     close(p->stdin_pipe);
     close(p->stdout_pipe);
   }


### PR DESCRIPTION
On macintosh when a process (python) makes a connection object using ssh
and then creates a subprocess which completes, when the system tries
to delete the connection object the waitpid call hangs.

Added WNOHANG flag to the waitpid call

Before pulling this we should verify it compiles on windoz.
