### PR TITLE
Fix call to MDSWfeventTimed in wfevent.fun. The buffer lenth is an in…

### DIFF
--- a/tdi/wfevent.fun
+++ b/tdi/wfevent.fun
@@ -5,7 +5,7 @@ public fun wfevent(in _event, optional _bufsiz, optional _timeout)
   _dlen = 0;
   _data=zero(_blen,0bu);
   _timeout = present(_timeout) ? _timeout : 0;
-  _status = MdsShr->MDSWfeventTimed(_event,_blen,ref(_data),ref(_dlen),val(_timeout));
+  _status = MdsShr->MDSWfeventTimed(_event,val(_blen),ref(_data),ref(_dlen),val(_timeout));
   if (_status & 1) {
     if (_dlen > _blen) _dlen = _blen;
       _data=_data[0 : (_dlen-1)];


### PR DESCRIPTION
…teger passed by value not address
