### PR TITLE
0. extended version for future use

### DIFF
--- a/mdsobjects/python/version.py
+++ b/mdsobjects/python/version.py
@@ -3,10 +3,12 @@ This is a helper module.
 Its purpose is to supply tools that are used to generate version specific code.
 Goal is to generate code that work on both python2x and python3x.
 """
+from numpy import generic as npscalar
+from numpy import ndarray as nparray
 from sys import version_info as pyver
 ispy3 = pyver>(3,)
 ispy2 = pyver<(3,)
-#__builtins__ is dict
+# __builtins__ is dict
 has_long      = 'long'       in __builtins__
 has_unicode   = 'unicode'    in __builtins__
 has_basestring= 'basestring' in __builtins__
@@ -16,63 +18,90 @@ has_buffer    = 'buffer'     in __builtins__
 # substitute missing builtins
 if has_long:
     long = long
-else: 
+else:
     long = int
 if has_basestring:
     basestring = basestring
-elif has_bytes: 
-    basestring = (str,bytes)
+elif has_bytes:
+    basestring = (str, bytes)
 else:
     basestring = str
 if has_unicode:
     unicode = unicode
-else:#py3 str is unicode
+else:  # py3 str is unicode
     unicode = str
 if has_bytes:
     bytes = bytes
-else:#py2 str is bytes
+else:  # py2 str is bytes
     bytes = str
 if has_buffer:
     buffer = buffer
 else:
     buffer = memoryview
 
-#helper variant string
+# helper variant string
 if has_unicode:
     varstr = unicode
 else:
     varstr = bytes
 
+# numpy char types
+npunicode = 'U'
+npbytes = 'S'
+if ispy2:
+    npstr = npbytes
+else:
+    npstr = npunicode
+
+
+def _decode(string):
+    try:
+        return string.decode('utf-8', 'backslashreplace')
+    except:
+        return string.decode('CP1252', 'backslashreplace')
+
+
+def _encode(string):
+    return string.encode('utf-8', 'backslashreplace')
+
+
+def _tostring(string, targ, nptarg, conv, lstres):
+    if isinstance(string, targ):  # short cut
+        return targ(string)
+    if isinstance(string, npscalar):
+        return targ(conv(string.astype(nptarg)))
+    if isinstance(string, basestring):
+        return targ(conv(string))
+    if isinstance(string, nparray):
+        string = string.astype(nptarg).tolist()
+    if isinstance(string, (list, tuple)):
+        return type(string)(_tostring(s, targ, nptarg, conv, lstres) for s in string)
+    return lstres(string)
+
+
 def tostr(string):
-    if isinstance(string,basestring):
-        if isinstance(string,str):
-            return string
-        elif isinstance(string, unicode):
-            return string.encode('utf-8','backslashreplace')
-        else:
-            try:
-                return string.decode('utf-8','backslashreplace')
-            except:
-                return string.decode('CP1252','backslashreplace')
+    if ispy2:
+        return _tostring(string, str, npbytes, _encode, bytes)
     else:
-        return str(string)
+        return _tostring(string, str, npunicode, _decode, unicode)
+
 
 def tobytes(string):
-    if isinstance(string,basestring):
-        if isinstance(string,bytes):
-            return string
-        else:
-            return string.encode('utf-8','backslashreplace')
+    if ispy2:
+        return _tostring(string, bytes, npbytes, _encode, bytes)
     else:
-        return bytes(string)
+        def _bytes(string):
+            return _encode(str(string))
+        return _tostring(string, bytes, npbytes, _encode, _bytes)
+
+
 def tounicode(string):
-    if isinstance(string,basestring):
-        if isinstance(string,unicode):
-            return string
-        else:
-            return string.decode('utf-8','backslashreplace')
+    if ispy3:
+        return _tostring(string, unicode, npbytes, _encode, unicode)
     else:
-        return unicode(string)
+        def _unicode(string):
+            return _decode(str(string))
+        return _tostring(string, unicode, npunicode, _decode, _unicode)
 
 # Extract the code attribute of a function. Different implementations
 # are for Python 2/3 compatibility.


### PR DESCRIPTION
-using helper _tostring to manage typecast
-direct typecast of numpy types using numpy build-in astype
-type casting list and tuple iteratively
=> will be used for subsequent pull requests
aim it to safely typecast to the required sting representation independent of the python version.
e.g.: tobytes for strings that go into library calls
tostr for strings that are returned to the python user
