### PR TITLE
Indentation error in TreeFindNodeTags caused tags to only return one …

### DIFF
--- a/mdsobjects/python/_treeshr.py
+++ b/mdsobjects/python/_treeshr.py
@@ -198,7 +198,7 @@ def TreeFindNodeTags(n):
             TreeFree(tag_ptr)
         except:
             done=True
-        tags = _mimport('mdsarray',1).makeArray(tags).astype(_ver.npstr)
+    tags = _mimport('mdsarray',1).makeArray(tags).astype(_ver.npstr)
     return tags
 
 


### PR DESCRIPTION
…tags when node actually has multiple tags
