### PR TITLE
Fix TreeFindNodeTags for python3

### DIFF
--- a/mdsobjects/python/_treeshr.py
+++ b/mdsobjects/python/_treeshr.py
@@ -198,7 +198,7 @@ def TreeFindNodeTags(n):
             TreeFree(tag_ptr)
         except:
             done=True
-    tags = _mimport('mdsarray',1).makeArray(tags).astype(_ver.npstr)
+    tags = _mimport('mdsarray',1).makeArray(tags)
     return tags
 
 


### PR DESCRIPTION
Removed the astype call which fixed it for python3 and still works with python2.
