### PR TITLE
Fix windows runaway threads after wfevent receives an event

### DIFF
--- a/mdsshr/UdpEvents.c
+++ b/mdsshr/UdpEvents.c
@@ -82,6 +82,7 @@ static void *handleMessage(void *arg)
 			     (struct sockaddr *)&clientAddr, &addrSize)) < 0) {
       int error = WSAGetLastError();
       if (error == WSAESHUTDOWN || error == WSAEINTR || error == WSAENOTSOCK) {
+	break;
       } else {
 	fprintf(stderr,"Error getting data - %d\n", error);
 


### PR DESCRIPTION
At some point the break was erroneous left out of the code which caused the event handler thread to just spin in a loop after the udp socket was closed after wfevent completed.
