### PR TITLE
fix empty shape on Arrays

### DIFF
--- a/mdsobjects/python/mdsarray.py
+++ b/mdsobjects/python/mdsarray.py
@@ -79,7 +79,10 @@ class Array(_data.Data):
                 value=_np.ctypeslib.as_array(value)
             except Exception:
                 pass
-        self._value=_np.array(value).__array__(_np.__dict__[self.__class__.__name__[0:len(self.__class__.__name__)-5].lower()])
+        value = _np.array(value)
+        if len(value.shape) == 0:  # happens if value has been a scalar, e.g. int
+            value = value.reshape(1)
+        self._value = value.__array__(_np.__dict__[self.__class__.__name__[0:-5].lower()])
         return
 
     def __getattr__(self,name):

--- a/mdsobjects/python/mdsdata.py
+++ b/mdsobjects/python/mdsdata.py
@@ -52,7 +52,6 @@ def decompile(item):
     @rtype: string"""
 
     return _mimport('_tdishr',1).TdiDecompile(item)
-    return makeData(item).decompile()
 
 def evaluate(item,):
     """Return evaluation of mdsplus object"""


### PR DESCRIPTION
Reshape(1) if shape of input is empty.
Otherwise

``` python
MDSplus.mdsarray.Int32Array(0)[0]
```

throws an error while

``` python
MDSplus.mdsarray.makeArray(0)[0]
```

does not.

-removed unreachable line in mdsdata
