### PR TITLE
Question about TreeUSAGE_SUBTREE_TOP when querying USAGE_STR NCI

### DIFF
--- a/mdsshr/mds_dsc_string.c
+++ b/mdsshr/mds_dsc_string.c
@@ -5,6 +5,7 @@
 #include		<mdsshr.h>
 
 #define checkString(S)  if (id==S)  return #S ;
+#define checkAltStr(A, S)  if (id==A)  return #S ;
 
 char *MdsDtypeString(int id)
 {
@@ -125,7 +126,8 @@ char *MdsUsageString(int id)
       checkString(TreeUSAGE_WINDOW)
       checkString(TreeUSAGE_AXIS)
       checkString(TreeUSAGE_SUBTREE)
+      checkAltStr(TreeUSAGE_SUBTREE_TOP, TreeUSAGE_SUBTREE)
       checkString(TreeUSAGE_COMPOUND_DATA)
-      sprintf(usageString, "USAGE_?_0x%02X", id);
+      sprintf(usageString, "TreeUSAGE_?_0x%02X", id);
   return (usageString);
 }


### PR DESCRIPTION
GETNCI(subtree_node, 'USAGE_STR') returns "USAGE_?_0x0F" due to the runtime change from TreeUSAGE_SUBTREE (=11) to TreeUSAGE_SUBTREE_TOP (=15).  This patch does two things:
1. Always returns a string with the same prefix "TreeUSAGE_" which seems to be what the Python module expects.
2. Maps TreeUSAGE_SUBTREE_TOP onto TreeUSAGE_SUBTREE for the purposes of the USAGE_STR NCI.  It seem to me this is the right thing to do since the "user" does not care that the runtime usage is different due to the way in which subtrees are integrated into the parent tree.  This is consistent with the code in TreeGetNci.c.
