### PR TITLE
fix docs removal during javascope build

### DIFF
--- a/javascope/Makefile.am
+++ b/javascope/Makefile.am
@@ -21,7 +21,7 @@ endif
 
 # Documentation
 dist_docs_DATA = $(DOCS)
-docsdir = $(exec_prefix)/java/classes/docs
+docsdir = $(exec_prefix)/java/classes/jdocs
 
 dist_java_DATA = jScope.properties MindTerm.jar
 
@@ -31,10 +31,10 @@ $(java_DATA): classjava.stamp
 
 EXTRA_DIST += colors1.tbl
 jScope.jar: colors1.tbl
-	$(MKDIR_P) docs
-	cp $(SUBDOCS) ./docs
-	$(JAR) c0f $@ $(TOPDOCS) $(JSCOPE_CLASS) docs $<
-	rm -Rf docs
+	$(MKDIR_P) jdocs
+	cp $(SUBDOCS) ./jdocs
+	$(JAR) c0f $@ $(TOPDOCS) $(JSCOPE_CLASS) jdocs $<
+	rm -Rf jdocs
 
 WaveDisplay.jar:
 	$(JAR) c0f $@ $(WAVEDISPLAY_CLASS)

--- a/javascope/Makefile.in
+++ b/javascope/Makefile.in
@@ -422,7 +422,7 @@ CLASSPATH_ENV = CLASSPATH=$(MINDTERM)
 
 # Documentation
 dist_docs_DATA = $(DOCS)
-docsdir = $(exec_prefix)/java/classes/docs
+docsdir = $(exec_prefix)/java/classes/jdocs
 dist_java_DATA = jScope.properties MindTerm.jar
 java_DATA = jScope.jar WaveDisplay.jar
 javadir = $(exec_prefix)/java/classes
@@ -844,10 +844,10 @@ uninstall-am: uninstall-binSCRIPTS uninstall-dist_docsDATA \
 @MINGW_FALSE@	$(INSTALL) $< $@
 $(java_DATA): classjava.stamp
 jScope.jar: colors1.tbl
-	$(MKDIR_P) docs
-	cp $(SUBDOCS) ./docs
-	$(JAR) c0f $@ $(TOPDOCS) $(JSCOPE_CLASS) docs $<
-	rm -Rf docs
+	$(MKDIR_P) jdocs
+	cp $(SUBDOCS) ./jdocs
+	$(JAR) c0f $@ $(TOPDOCS) $(JSCOPE_CLASS) jdocs $<
+	rm -Rf jdocs
 
 WaveDisplay.jar:
 	$(JAR) c0f $@ $(WAVEDISPLAY_CLASS)


### PR DESCRIPTION
javascope was using a directory named docs and so the doxygen directory was deleted each time the build process tried to build javascope. So during the 32bit version the configure script was not able to find docs/Makefile.in anymore .. because the first time the javascope/Makefile erased it.

I've renamed the javascope docs temporary to jdocs...
