### PR TITLE
Add an environment variable to change the log directory of the mdsip …

### DIFF
--- a/mdstcpip/GetSetSettings.c
+++ b/mdstcpip/GetSetSettings.c
@@ -81,11 +81,23 @@ char *SetHostfile(char *newhostfile)
   return old;
 }
 
-
 ////////////////////////////////////////////////////////////////////////////////
 //  CONTEXT  ///////////////////////////////////////////////////////////////////
 ////////////////////////////////////////////////////////////////////////////////
 
+char *GetLogDir() {
+  char *logdir=getenv("MDSIP_SERVICE_LOGDIR");
+  if (logdir && (strlen(logdir) > 0)) {
+    logdir=strdup(logdir);
+    size_t len = strlen(logdir);
+    if ((logdir[len-1]=='\\') || (logdir[len-1]=='/')) {
+      logdir[len-1]='\000';
+    }
+  } else {
+    logdir=strdup("C:\\");
+  }
+  return logdir;
+}
 
 unsigned char GetMulti()
 {

--- a/mdstcpip/IoRoutinesTcp.c
+++ b/mdstcpip/IoRoutinesTcp.c
@@ -582,19 +582,23 @@ VOID CALLBACK ShutdownEvent(PVOID arg, BOOLEAN fired)
 
 static int getSocketHandle(char *name)
 {
-  char logfile[1024];
+  char *logdir = GetLogDir();
+  char *portnam = GetPortname();
+  char *logfile = malloc(strlen(logdir)+strlen(portnam)+50);
   HANDLE h;
   int ppid;
   int psock;
   char shutdownEventName[120];
   HANDLE shutdownEvent, waitHandle;
   if (name == 0 || sscanf(name, "%d:%d", &ppid, &psock) != 2) {
-      fprintf(stderr, "Mdsip single connection server can only be started from windows service\n");
-      exit(1);
-    }
-  sprintf(logfile, "C:\\MDSIP_%s_%d.log", GetPortname(), _getpid());
+    fprintf(stderr, "Mdsip single connection server can only be started from windows service\n");
+    exit(1);
+  }
+  sprintf(logfile, "%s\\MDSIP_%s_%d.log", logdir, portnam, _getpid());
   freopen(logfile, "a", stdout);
   freopen(logfile, "a", stderr);
+  free(logdir);
+  free(logfile);
   if (!DuplicateHandle(OpenProcess(PROCESS_ALL_ACCESS, TRUE, ppid),
                        (HANDLE) psock, GetCurrentProcess(), (HANDLE *) & h,
                        PROCESS_ALL_ACCESS, TRUE, DUPLICATE_CLOSE_SOURCE | DUPLICATE_SAME_ACCESS)) {

--- a/mdstcpip/IoRoutinesTcpv6.c
+++ b/mdstcpip/IoRoutinesTcpv6.c
@@ -500,7 +500,9 @@ VOID CALLBACK ShutdownEvent(PVOID arg, BOOLEAN fired)
 
 static int getSocketHandle(char *name)
 {
-  char logfile[1024];
+  char *logdir = GetLogDir();
+  char *portnam = GetPortname();
+  char *logfile = malloc(strlen(logdir)+strlen(portnam)+50);
   HANDLE h;
   int ppid;
   int psock;
@@ -510,9 +512,11 @@ static int getSocketHandle(char *name)
     fprintf(stderr, "Mdsip single connection server can only be started from windows service\n");
     exit(1);
   }
-  sprintf(logfile, "C:\\MDSIP_%s_%d.log", GetPortname(), _getpid());
+  sprintf(logfile, "%s\\MDSIP_%s_%d.log", logdir, portnam, _getpid());
   freopen(logfile, "a", stdout);
   freopen(logfile, "a", stderr);
+  free(logdir);
+  free(logfile);
   if (!DuplicateHandle(OpenProcess(PROCESS_ALL_ACCESS, TRUE, ppid),
 		       (HANDLE) psock, GetCurrentProcess(), (HANDLE *) & h,
 		       PROCESS_ALL_ACCESS, TRUE, DUPLICATE_CLOSE_SOURCE | DUPLICATE_SAME_ACCESS)) {

--- a/mdstcpip/IoRoutinesUdt.c
+++ b/mdstcpip/IoRoutinesUdt.c
@@ -443,19 +443,23 @@ VOID CALLBACK ShutdownEvent(PVOID arg, BOOLEAN fired)
 
 static int getSocketHandle(char *name)
 {
-  char logfile[1024];
+  char *logdir = GetLogDir();
+  char *portnam = GetPortname();
+  char *logfile = malloc(strlen(logdir)+strlen(portnam)+50);
   HANDLE h;
   int ppid;
   int psock;
   char shutdownEventName[120];
   HANDLE shutdownEvent, waitHandle;
   if (name == 0 || sscanf(name, "%d:%d", &ppid, &psock) != 2) {
-      fprintf(stderr, "Mdsip single connection server can only be started from windows service\n");
-      exit(1);
-    }
-  sprintf(logfile, "C:\\MDSIP_%s_%d.log", GetPortname(), _getpid());
+   fprintf(stderr, "Mdsip single connection server can only be started from windows service\n");
+    exit(1);
+  }
+  sprintf(logfile, "%s\\MDSIP_%s_%d.log", logdir, portnam, _getpid());
   freopen(logfile, "a", stdout);
   freopen(logfile, "a", stderr);
+  free(logdir);
+  free(logfile);
   if (!DuplicateHandle(OpenProcess(PROCESS_ALL_ACCESS, TRUE, ppid),
                        (HANDLE) psock, GetCurrentProcess(), (HANDLE *) & h,
                        PROCESS_ALL_ACCESS, TRUE, DUPLICATE_CLOSE_SOURCE | DUPLICATE_SAME_ACCESS)) {

--- a/mdstcpip/IoRoutinesUdtV6.c
+++ b/mdstcpip/IoRoutinesUdtV6.c
@@ -411,7 +411,9 @@ VOID CALLBACK ShutdownEvent(PVOID arg, BOOLEAN fired)
 
 static int getSocketHandle(char *name)
 {
-  char logfile[1024];
+  char *logdir = GetLogDir();
+  char *portnam = GetPortname();
+  char *logfile = malloc(strlen(logdir)+strlen(portnam)+50);
   HANDLE h;
   int ppid;
   int psock;
@@ -421,9 +423,11 @@ static int getSocketHandle(char *name)
     fprintf(stderr, "Mdsip single connection server can only be started from windows service\n");
     exit(1);
   }
-  sprintf(logfile, "C:\\MDSIP_%s_%d.log", GetPortname(), _getpid());
+  sprintf(logfile, "%s\\MDSIP_%s_%d.log", logdir, portnam, _getpid());
   freopen(logfile, "a", stdout);
   freopen(logfile, "a", stderr);
+  free(logdir);
+  free(logfile);
   if (!DuplicateHandle(OpenProcess(PROCESS_ALL_ACCESS, TRUE, ppid),
 		       (HANDLE) psock, GetCurrentProcess(), (HANDLE *) & h,
 		       PROCESS_ALL_ACCESS, TRUE, DUPLICATE_CLOSE_SOURCE | DUPLICATE_SAME_ACCESS)) {

--- a/mdstcpip/mdsip_connections.h
+++ b/mdstcpip/mdsip_connections.h
@@ -392,7 +392,7 @@ EXPORT int GetContextSwitching();
 EXPORT int GetFlags();
 
 EXPORT char *GetHostfile();
-
+EXPORT char *GetLogDir();
 EXPORT int GetMaxCompressionLevel();
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/mdstcpip/mdsip_service.c
+++ b/mdstcpip/mdsip_service.c
@@ -208,10 +208,14 @@ static short GetPort()
 
 static void RedirectOutput()
 {
-  char file[120];
-  sprintf(file, "C:\\MDSIP_%s.log", GetPortname());
+  char *logdir = GetLogDir();
+  char *portname = GetPortname();
+  char *file = malloc(strlen(logdir)+strlen(portname)+20);
+  sprintf(file, "%s\\MDSIP_%s.log", logdir,GetPortname());
   freopen(file, "w", stdout);
   freopen(file, "a", stderr);
+  free(logdir);
+  free(file);
 }
 
 static int ServiceMain(int argc, char **argv)


### PR DESCRIPTION
…services on Windows. New environment variable: MDSIP_SERVICE_LOGDIR can be used to override the default location of C:\
