### PR TITLE
MacOSX 10.11 support

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -539,7 +539,7 @@ mips*) CFLAGS="$CFLAGS -signed -D_BSD_SIGNALS -KPIC";
        MOTIF_LD_LDARC="-multiply_defined suppress -L/usr/OpenMotif/lib"
        dnl LINKSHARED="$LDFLAGS -dynamiclib -install_name $libdir/\$(@F) -headerpad_max_install_names -prebind \
 	   dnl -seg_addr_table_filename \$(@F) -seg_addr_table ../macosx/bindtable -Wl,-single_module";
-	   LINKSHARED="$LDFLAGS -shared -arch i386 -arch x86_64";
+	   LINKSHARED="$LDFLAGS -shared -arch i386 -arch x86_64 -install_name @loader_path/../lib/\$(@F) -headerpad_max_install_names";
            FOR_LINKSHARED="$LDFLAGS -shared";
 	   LINKMODULE="$LDFLAGS -bundle -undefined dynamic_lookup";
        IDL_LD="";

--- a/mdsobjects/python/_mdsshr.py
+++ b/mdsobjects/python/_mdsshr.py
@@ -2,6 +2,7 @@ import ctypes as _C
 from ctypes.util import find_library as _find_library
 import numpy as _N
 import os as _os
+import platform as _platform
 
 if '__package__' not in globals() or __package__ is None or len(__package__)==0:
   def _mimport(name,level):
@@ -14,6 +15,14 @@ _desc=_mimport('_descriptor',1)
 
 class MdsshrException(Exception):
     pass
+
+if _platform.system() == 'Darwin':
+    if not _os.getenv('DYLD_LIBRARY_PATH'):
+        if _os.getenv('MDSPLUS_DIR'):
+            _os.environ['DYLD_LIBRARY_PATH'] = _os.path.join(
+                _os.getenv('MDSPLUS_DIR'),'lib')
+        else:
+            _os.environ['DYLD_LIBRARY_PATH'] = '/usr/local/mdsplus/lib'
 
 def _load_library(name):
     libnam = None


### PR DESCRIPTION
Combined two small changes that remove the dependence on LD_LIBRARY_PATH and / or DYLD_LIBRARY_PATH which are reset in protected processes going forward in MacOS X.  The python changes allow for the MDSplus libraries to be found under $MDSPLUS_DIR/lib  or /usr/local/mdsplus/lib.   

The second change, using @loader_path/../lib/ as the install name allows binaries and libraries in MDSplus to find libraries they've been linked to.  (This is just one way to solve the problem, but I like it since it remains portable... if you move MDSPLUS_DIR, it will still work.)
