### PR TITLE
Twf use weakref for active tree

### DIFF
--- a/mdsobjects/python/tree.py
+++ b/mdsobjects/python/tree.py
@@ -327,13 +327,16 @@ class Tree(object):
         """
         import weakref
         global thread_data
-        if not hasattr(thread_data,"activeTree"):
+        try:
+          if not hasattr(thread_data,"activeTree"):
             thread_data.activeTree=None
             thread_data.private=False
-        if thread_data.private and isinstance(thread_data.activeTree,Tree):
-          return thread_data.activeTree
-        elif isinstance(Tree._activeTree,Tree):
-          return Tree._activeTree
+          if thread_data.private and isinstance(thread_data.activeTree,Tree):
+            return thread_data.activeTree
+          elif isinstance(Tree._activeTree,Tree):
+            return Tree._activeTree
+        except:
+          pass
     getActiveTree=staticmethod(getActiveTree)
 
     def getCurrent(treename):

--- a/mdsobjects/python/tree.py
+++ b/mdsobjects/python/tree.py
@@ -35,14 +35,11 @@ class Tree(object):
         """Delete Tree instance
         @rtype: None
         """
-
         try:
           if self.close:
             status=_treeshr.TreeCloseAll(self.ctx)
             if (status & 1):
               _treeshr.TreeFreeDbid(self.ctx)
-              if Tree.getActiveTree() == self:
-                Tree.setActiveTree(None)
         except:
           pass
         return
@@ -328,13 +325,14 @@ class Tree(object):
         @return: Current active tree
         @rtype: Tree
         """
+        import weakref
         global thread_data
         if not hasattr(thread_data,"activeTree"):
             thread_data.activeTree=None
             thread_data.private=False
-        if thread_data.private:
+        if thread_data.private and isinstance(thread_data.activeTree,Tree):
           return thread_data.activeTree
-        else:
+        elif isinstance(Tree._activeTree,Tree):
           return Tree._activeTree
     getActiveTree=staticmethod(getActiveTree)
 
@@ -467,7 +465,10 @@ class Tree(object):
 
 
     def _setActiveTree(tree):
+        import weakref
         global thread_data
+        if isinstance(tree,Tree):
+          tree=weakref.proxy(tree)
         if not hasattr(thread_data,"activeTree"):
             thread_data.activeTree=None
             thread_data.private=False


### PR DESCRIPTION
Use a weak reference for Tree._activeTree to enable proper cleanup of Tree instances.
