### PR TITLE
rewrote _loadglobals

### DIFF
--- a/mdsobjects/python/_loadglobals.py
+++ b/mdsobjects/python/_loadglobals.py
@@ -1,17 +1,20 @@
-def _mimport(name, level=1):
-    try:
-        return __import__(name, globals(), level=level)
-    except:
-        return __import__(name, globals())
-
 def load(gbls):
-  def loadmod(name,gbls):
-    mod=_mimport(name)
-    for key in mod.__dict__:
-      if not key.startswith('_'):
-        gbls[key]=mod.__dict__[key]
+    def loadmod(name, gbls=globals()):
+        try:
+            return __import__(name, gbls, level=1)
+        except:
+            return __import__(name, gbls)
 
-  for mod in ('apd','mdsarray','compound','mdsdata','ident','treenode','mdsscalar',
-              'tree','mdsdevice','event','_tdishr','scope','_mdsshr','_tdishr',
-              '_treeshr','tdipy','_descriptor','connection','mdsExceptions','mdsdcl'):
-    loadmod(mod,gbls)
+    def loadmod_full(name,gbls):
+        mod=loadmod(name)
+        for key in mod.__dict__:
+            if not key.startswith('_'):
+                gbls[key]=mod.__dict__[key]
+
+    for mod in ('apd','mdsarray','compound','mdsdata','ident','treenode','mdsscalar',
+                  'tree','mdsdevice','event','_tdishr','scope','_mdsshr','_tdishr',
+                  '_treeshr','tdipy','_descriptor','connection','mdsdcl'):
+        loadmod_full(mod,gbls)
+    for mod in ('mdsExceptions', 'tdibuiltins'):
+        loadmod(mod, gbls)
+


### PR DESCRIPTION
devides modules into two groups:
- normal modules (require MDSplus.module.method)
- recursive modules (allow MDSplus.method)

reduces the number of toplevel methods
