### PR TITLE
little cleanup and fixed type

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,16 @@
-commit 4363f2ec68b6a6d11927a639f66e4c9b71fa6f33 (HEAD -> refs/heads/alpha, refs/remotes/origin/alpha)
+commit 8c20d6bde292d38869ba4259e30b117942b424d2 (HEAD -> refs/heads/alpha, refs/remotes/origin/alpha)
+Author: Tom Fredian <twf@psfc.mit.edu>
+Date:   Tue Oct 27 15:37:20 2015 -0400
+
+    Quick fix for rhel5 which does not have PTHREAD_MUTEX_RECURSIVE defined.
+
+commit 88391d01e5deb6f34f521be60e24aaaab1c3e5d1 (tag: refs/tags/alpha_release-7-0-168)
+Author: MDSplusBuilder <MDSplusBuilder@mdsplus.org>
+Date:   Mon Oct 26 23:35:35 2015 -0400
+
+    New release ---- alpha_release-7-0-168
+
+commit 4363f2ec68b6a6d11927a639f66e4c9b71fa6f33
 Merge: a2a9654 865c76a
 Author: Josh Stillerman <jas@psfc.mit.edu>
 Date:   Mon Oct 26 16:50:33 2015 -0400
@@ -777,7 +789,7 @@ Date:   Wed Sep 30 10:44:04 2015 -0400
     
     Question about TreeUSAGE_SUBTREE_TOP when querying USAGE_STR NCI
 
-commit 984428e05c7c8d633fad7f246be92c22181a1338 (refs/remotes/origin/dev-bstandley)
+commit 984428e05c7c8d633fad7f246be92c22181a1338
 Author: Brian Standley <brian@brianstandley.com>
 Date:   Wed Sep 30 15:57:29 2015 +0200
 

--- a/mdsdcl/cmdExecute.c
+++ b/mdsdcl/cmdExecute.c
@@ -13,6 +13,9 @@
 #include <dcl.h>
 #include <mdsdcl_messages.h>
 #include <pthread.h>
+#ifndef PTHREAD_MUTEX_RECURSIVE
+#define PTHREAD_MUTEX_RECURSIVE PTHREAD_MUTEX_RECURSIVE_NP
+#endif
 #include "dcl_p.h"
 
 static dclDocListPtr dclDocs = 0;


### PR DESCRIPTION
- removed line 5 (unused)
- removed line 72 (wrong re-init of line 71)
- removed line 118 (unused)
- removed trailing spaces
- added () to print for python3 support
- remove tmpfile should appear in output so it will not be forgotten
- tempIdx is a constant and only used once
- no use for terminating ;
- use ctype.value + int
