### PR TITLE
change the rename dialog ...

### DIFF
--- a/javatraverser/Database.java
+++ b/javatraverser/Database.java
@@ -68,7 +68,6 @@ public class Database implements RemoteTree{
     public native Data evaluateSimpleData(Data data, int ctx) throws DatabaseException;
     public native void putData(NidData nid, Data data, int ctx) throws DatabaseException;
     public native void putRow(NidData nid, Data data, long time, int ctx) throws DatabaseException;
-    //public native DatabaseInfo getInfo(); throws DatabaseException;
     public native NodeInfo getInfo(NidData nid, int ctx) throws DatabaseException;
     public native void setTags(NidData nid, String tags[], int ctx) throws DatabaseException;
     public native String[] getTags(NidData nid, int ctx);

--- a/javatraverser/Node.java
+++ b/javatraverser/Node.java
@@ -17,12 +17,13 @@ public class Node
     Node[] sons;
     Node[] members;
     boolean is_member;
-    JLabel tree_label = null;
-    NodeBeanInfo bean_info = null;
+    JLabel tree_label;
+    NodeBeanInfo bean_info;
     Tree hierarchy;
-    static Node copiedNode = null;
+    static Node copiedNode;
     boolean needsOnCheck = true;
     boolean is_on = false;
+    private DefaultMutableTreeNode treenode;
 
     public Node(RemoteTree experiment, Tree hierarchy) throws DatabaseException,
         RemoteException
@@ -40,13 +41,13 @@ public class Node
         members = new Node[0];
     }
 
-    public Node(RemoteTree experiment, Tree hierarchy, Node parent,
-                boolean is_member, NidData nid)
+    public Node(RemoteTree experiment, Tree hierarchy, Node parent, boolean is_member, NidData nid)
     {
         this.experiment = experiment;
         this.hierarchy = hierarchy;
-        this.nid = nid;
         this.parent = parent;
+        this.is_member = is_member;
+        this.nid = nid;
         try
         {
             info = experiment.getInfo(nid, Tree.context);
@@ -59,6 +60,9 @@ public class Node
         members = new Node[0];
 
     }
+
+    public void setTreeNode(DefaultMutableTreeNode treenode){this.treenode = treenode;}
+    public DefaultMutableTreeNode getTreeNode(){return treenode;}
 
     void setOnUnchecked()
     {
@@ -89,6 +93,12 @@ public class Node
             System.out.println("Error getting info " + e);
         }
     }
+
+    public void updateCell()
+    {
+        ;
+    }
+
 
     public void updateData() throws DatabaseException, RemoteException
     {
@@ -192,18 +202,7 @@ public class Node
     public void setInfo(NodeInfo info) throws DatabaseException, RemoteException{}
 
     public int getFlags() throws Exception
-    {   /*
-        0x00001 off
-        0x00004 essential
-        0x00040 setup
-        0x00080 write_once
-        0x00100 compressible        
-        0x00400 compress_on_put     
-        0x00800 no_write_model      
-        0x01000 no_write_shot       
-        0x08000 include_in_pulse    
-        0x10000 compress_segments    
-        */
+    {
         return  experiment.getFlags(nid);
     }
 
@@ -275,8 +274,7 @@ public class Node
                     return;
                 }
                 catch (Exception e)
-                {
-                    
+                {                   
              		try {
                 		experiment.doDeviceMethod(nid, "dw_setup", Tree.context) ;
             		}catch(Exception exc) {
@@ -289,7 +287,6 @@ public class Node
                     	return;
                 	}
 				}
-
             }
         }
         JOptionPane.showMessageDialog(null, "Missing model in descriptor",
@@ -356,6 +353,7 @@ public class Node
         return info.getFullPath();
     }
 
+    public String toString(){return getName();}
     public String getName()
     {
         if (info == null)
@@ -469,9 +467,7 @@ public class Node
 
     public int startDelete()
     {
-        NidData[] nids =
-            {
-            nid};
+        NidData[] nids ={nid};
         try
         {
             return experiment.startDelete(nids, Tree.context).length;
@@ -485,59 +481,56 @@ public class Node
 
     public void executeDelete()
     {
-        NidData[] nids =
-            {
-            nid};
+        NidData[] nids = {nid};
         try
         {
             experiment.executeDelete(Tree.context);
         }
         catch (Exception e)
         {
-            System.out.println("Error executing delete: " + e.getMessage());
+            System.err.println("Error executing delete: " + e.getMessage());
         }
     }
 
-    boolean changePath(String newFullPath)
-    {
-	    try
-        {
-            experiment.renameNode(nid, newFullPath, Tree.context);
-            info = experiment.getInfo(nid, Tree.context);
-            return true;
-        }
-        catch(Exception exc)
-		{
-            JOptionPane.showMessageDialog(FrameRepository.frame, "Error changing node path: "+ exc,
-		    "Error changing node path", JOptionPane.WARNING_MESSAGE);
-		}
-        return false;
-    }
 
-    boolean rename(String newName)
+    boolean move(Node newParent){return changePath(newParent, getName());}
+    boolean rename(String newName){return changePath(parent, newName);}
+    private boolean changePath(Node newParent, String newName)
     {
+        if ((newParent==parent) && (newName==getName())) return false; // nothing to do
         if(newName.length() > 12 || newName.length() == 0)
 	    {
 	        JOptionPane.showMessageDialog(FrameRepository.frame, "Node name lengh must be between 1 and 12 characters",
 		    "Error renaming node", JOptionPane.WARNING_MESSAGE);
             return false;
 	    }
-        String prevPath = getFullPath();
-        int curr;
-        for (curr = prevPath.length() - 1;
-                curr > 0 && prevPath.charAt(curr) != ':' &&
-                prevPath.charAt(curr) != '.'; curr--);
-        String newFullPath = prevPath.substring(0, curr + 1) + newName;
-        return changePath(newFullPath);
+	    try
+        {
+            String sep = is_member ? ":" : "."; 
+            experiment.renameNode(nid, newParent.getFullPath()+sep+newName, Tree.context);
+            info = experiment.getInfo(nid, Tree.context);
+        }
+        catch(Exception exc)
+		{
+            JOptionPane.showMessageDialog(FrameRepository.frame, "Error changing node path: "+ exc,
+		    "Error changing node path", JOptionPane.WARNING_MESSAGE);
+            return false;
+		}
+        if (newParent!=parent)
+        {    
+            parent = newParent;
+            Tree.addNodeToParent(getTreeNode(),parent.getTreeNode());
+        }
+        return true;
     }
 
     private ImageIcon loadIcon(String gifname)
     {
         String base = System.getProperty("icon_base");
-//      return (base == null) ? new ImageIcon(ClassLoader.getSystemResource(gifname)) : new ImageIcon(base + "/" + gifname);
-        return (base == null) ?
-            new ImageIcon(getClass().getClassLoader().getResource(gifname)) :
-            new ImageIcon(base + "/" + gifname);
+        if (base == null)
+            return new ImageIcon(getClass().getClassLoader().getResource(gifname));
+        else
+            return new ImageIcon(base + "/" + gifname);
     }
 
     public JLabel getIcon()
@@ -586,21 +579,11 @@ public class Node
                 icon = loadIcon("compound.gif");
                 break;
         }
-
-        if (is_member)
-            tree_label = new TreeNode(this, ": " + info.name, icon);
-        else
-            tree_label = new TreeNode(this, info.name, icon);
+        tree_label = new TreeNode(this, info.name, icon);
         return tree_label;
     }
 
-    public String toString()
-    {
-        return getName();
-    }
-
-    static public void pasteSubtree(Node fromNode, Node toNode,
-                                    boolean isMember)
+    static public void pasteSubtree(Node fromNode, Node toNode, boolean isMember)
     {
         DefaultMutableTreeNode savedTreeNode = Tree.getCurrTreeNode();
         try

--- a/javatraverser/Tree.java
+++ b/javatraverser/Tree.java
@@ -15,13 +15,12 @@ public class Tree extends JScrollPane implements TreeSelectionListener,
     MouseListener, ActionListener, KeyListener, DataChangeListener
 {
     static boolean is_remote;
-	static Hashtable nodeHash = new Hashtable();
     static jTraverser frame;
     static int curr_dialog_idx;
     static Node curr_node;
-    static DefaultMutableTreeNode curr_tree_node;
     static JTree curr_tree;
     static RemoteTree curr_experiment;
+    static int context;
     boolean is_angled_style;
     private DefaultMutableTreeNode top;
     private JMenuItem menu_items[];
@@ -30,7 +29,6 @@ public class Tree extends JScrollPane implements TreeSelectionListener,
     private PropertyDescriptor curr_property_descr;
     private DialogSet dialog_sets[];
     private java.util.Stack trees, experiments;
-    public static int context;
     private JDialog open_dialog, add_node_dialog, add_subtree_dialog;
     private JTextField open_exp, open_shot;
     private JRadioButton open_readonly, open_edit, open_normal;
@@ -45,10 +43,10 @@ public class Tree extends JScrollPane implements TreeSelectionListener,
     private String[] tags;
 	private JTextField add_device_type, add_device_name;
 	private String lastName;
+    private String topExperiment;
 	public static boolean isRemote(){return is_remote;}
-    public static Node getCurrentNode() {return curr_node;}
+    public static Node getCurrentNode(){return curr_node;}
 
-    String topExperiment;
         
 // Temporary, to overcome Java's bugs on inner classes
     JMenuItem open_b, close_b, quit_b;
@@ -83,7 +81,6 @@ public class Tree extends JScrollPane implements TreeSelectionListener,
 		    shot = -1;
 	        open(def_tree, shot, false, false, false);
 	    }
-
     }
 
 
@@ -163,77 +160,74 @@ public class Tree extends JScrollPane implements TreeSelectionListener,
 
     void close()
     {
-	if(curr_tree == null)
-	    return;
-	try {
-	    curr_experiment.close(Tree.context);
-	} catch(Exception e) {
-	    boolean editable = false;
-	    String name = null;
+	    if(curr_tree == null)
+	        return;
 	    try {
-	        editable = curr_experiment.isEditable();
-	        name = curr_experiment.getName().trim();
-	    }catch(Exception exc){}
-		if(editable)
-	    {
-		    int n = JOptionPane.showConfirmDialog(frame, "Tree " + name +
-		        " open in edit mode has been changed: write it before closing?",
-			    "Closing Tree ", JOptionPane.YES_NO_OPTION);
-		    if(n == JOptionPane.YES_OPTION)
-		    {
-		        try{
-			    curr_experiment.write(Tree.context);
-			    curr_experiment.close(Tree.context);
-		        }catch(Exception exc)
+	        curr_experiment.close(Tree.context);
+	    } catch(Exception e) {
+	        boolean editable = false;
+	        String name = null;
+	        try {
+	            editable = curr_experiment.isEditable();
+	            name = curr_experiment.getName().trim();
+	        }catch(Exception exc){}
+		    if(editable)
+	        {
+		        int n = JOptionPane.showConfirmDialog(frame, "Tree " + name +
+		            " open in edit mode has been changed: write it before closing?",
+			        "Closing Tree ", JOptionPane.YES_NO_OPTION);
+		        if(n == JOptionPane.YES_OPTION)
 		        {
-			    JOptionPane.showMessageDialog(frame, "Error closing tree", exc.getMessage(),JOptionPane.WARNING_MESSAGE);
-			    return;
+		            try {
+			        curr_experiment.write(Tree.context);
+			        curr_experiment.close(Tree.context);
+		            }catch(Exception exc) {
+			            JOptionPane.showMessageDialog(frame, "Error closing tree", exc.getMessage(),JOptionPane.WARNING_MESSAGE);
+			            return;
+		            }
 		        }
-		    }
-		    else
-		    {
-		        try {
-			    curr_experiment.quit(Tree.context);
-		        } catch(Exception exce) {
-			    JOptionPane.showMessageDialog(frame, "Error quitting tree", exce.getMessage(),JOptionPane.WARNING_MESSAGE);
-			    //return;
+		        else
+		        {
+		            try {
+			            curr_experiment.quit(Tree.context);
+		            } catch(Exception exce) {
+    			        JOptionPane.showMessageDialog(frame, "Error quitting tree", exce.getMessage(),JOptionPane.WARNING_MESSAGE);
+		            }
 		        }
-		    }
+	        }
+	        else
+	        {
+		        JOptionPane.showMessageDialog(frame, "Error closing tree", e.getMessage(),JOptionPane.WARNING_MESSAGE);
+		        return;
+	        }
+	    }
+	    trees.pop();
+	    experiments.pop();
+	    if(!trees.empty())
+	    {
+	        curr_tree = (JTree)trees.peek();
+	        curr_experiment = (RemoteTree)experiments.peek();
+	        setViewportView(curr_tree);
+	        try {
+	            frame.reportChange(curr_experiment.getName(), curr_experiment.getShot(), curr_experiment.isEditable(), curr_experiment.isReadonly());
+	            if(jTraverser.editable != curr_experiment.isEditable())
+		            pop = null;
+	            jTraverser.editable = curr_experiment.isEditable();
+	        }catch(Exception exc) {System.err.println("Error in RMI communication: "+exc);}
 	    }
 	    else
 	    {
-		JOptionPane.showMessageDialog(frame, "Error closing tree", e.getMessage(),JOptionPane.WARNING_MESSAGE);
-		return;
+	        curr_tree = null;
+	        curr_experiment = null;
+	        JPanel jp = new JPanel();
+	        setViewportView(new JPanel());
+	        frame.reportChange(null, 0, false, false);
 	    }
-	}
-	trees.pop();
-	experiments.pop();
-	if(!trees.empty())
-	{
-	    curr_tree = (JTree)trees.peek();
-	    curr_experiment = (RemoteTree)experiments.peek();
-	    setViewportView(curr_tree);
-	    try {
-	        frame.reportChange(curr_experiment.getName(), curr_experiment.getShot(), curr_experiment.isEditable(), curr_experiment.isReadonly());
-	        if(jTraverser.editable != curr_experiment.isEditable())
-		        pop = null;
-	        jTraverser.editable = curr_experiment.isEditable();
-	    }catch(Exception exc) {System.err.println("Error in RMI communication: "+exc);}
-	}
-	else
-	{
-	    curr_tree = null;
-	    curr_experiment = null;
-	    JPanel jp = new JPanel();
-	    setViewportView(new JPanel());
-	    frame.reportChange(null, 0, false, false);
-
-	}
-    DeviceSetup.closeOpenDevices();
-    curr_node = null;
-    dialogs.update();
-	frame.pack();
-	repaint();
+        DeviceSetup.closeOpenDevices();
+        curr_node = null;
+        dialogs.update();
+	    frame.pack();
+	    repaint();
     }
 
 
@@ -311,7 +305,7 @@ public class Tree extends JScrollPane implements TreeSelectionListener,
 	    }
 	    try{
 	    shot = Integer.parseInt(shot_t);
-	    } catch(Exception e)	{
+	    } catch(Exception e) {
 	        JOptionPane.showMessageDialog(curr_tree, "Wrong shot number", "Error opening tree",
 		    JOptionPane.WARNING_MESSAGE);
 	        return;
@@ -403,25 +397,24 @@ public class Tree extends JScrollPane implements TreeSelectionListener,
 	        JOptionPane.showMessageDialog(frame, exc.getMessage(), "Error opening "+exp, JOptionPane.ERROR_MESSAGE);
 	        return;
 	    }
-	    top = new DefaultMutableTreeNode(top_node);
-	    nodeHash.put(top, top_node);
+	    top_node.setTreeNode(top = new DefaultMutableTreeNode(top_node));
 	    try {
 	        top_node.expand();
 	    } catch(Exception exc) {
-            System.out.println("Error expanding tree "+ exc);}
+            System.err.println("Error expanding tree "+ exc);}
 	    Node members[] = top_node.getMembers();
 	    for(i = 0; i < members.length; i++)
 	    {
 	        DefaultMutableTreeNode currNode;
 	        top.add(currNode = new DefaultMutableTreeNode(members[i]));
-	        nodeHash.put(currNode, members[i]);
+	        members[i].setTreeNode(currNode);
 	    }
 	    Node sons[] = top_node.getSons();
 	    for(i = 0; i < sons.length; i++)
 	    {
 	        DefaultMutableTreeNode currNode;
 	        top.add(currNode = new DefaultMutableTreeNode(sons[i]));
-	        nodeHash.put(currNode, sons[i]);
+	        sons[i].setTreeNode(currNode);
 	    }
 	    curr_tree = new JTree(top);
 //GAB 2014 Add DragAndDrop capability
@@ -431,34 +424,25 @@ public class Tree extends JScrollPane implements TreeSelectionListener,
         ToolTipManager.sharedInstance().registerComponent(curr_tree);
         curr_tree.addKeyListener(new KeyAdapter() {
             public void keyTyped(KeyEvent e) {
-            if ( (e.getModifiers() & Event.CTRL_MASK) != 0) {
-                int cc = e.getKeyChar();
-                //if(e.getKeyChar() == 'c')
-                if (e.getKeyChar() == 3) {
-                TreeNode.copyToClipboard();
-                }
-            }
-            if (!jTraverser.isEditable())
-                return;
-            if ( (e.getModifiers() & Event.CTRL_MASK) != 0) {
-                if (e.getKeyChar() == 'c')
-                TreeNode.copy();
-                if (e.getKeyChar() == 'v')
-                TreeNode.paste();
-            }
-            else if (e.getKeyChar() == KeyEvent.VK_DELETE ||
-                        e.getKeyChar() == KeyEvent.VK_BACK_SPACE)
-                TreeNode.delete();
-            }
-        });
+                if (e.getKeyChar() ==  KeyEvent.VK_CANCEL) // i.e. Ctrl+C
+                    TreeNode.copyToClipboard();
+                if (!jTraverser.isEditable()) return;
+                if (e.getKeyChar() ==  KeyEvent.VK_CANCEL) // i.e. Ctrl+C
+                    TreeNode.copy();
+                if (e.getKeyChar() ==  24) // i.e. Ctrl+X
+                    TreeNode.cut();
+                if (e.getKeyChar() == 22) // i.e. Ctrl+V
+                    TreeNode.paste();
+                else if (e.getKeyChar() == KeyEvent.VK_DELETE || e.getKeyChar() == KeyEvent.VK_BACK_SPACE)
+                    TreeNode.delete();
+            }});
 	    if(is_angled_style)
 	        curr_tree.putClientProperty("JTree.lineStyle", "Angled");
-
-	    // GAB curr_tree.setEditable(false);
 	    try {
 	        curr_tree.setEditable(curr_experiment.isEditable());
 	    } catch(Exception exc) {
-            curr_tree.setEditable(false);}
+            curr_tree.setEditable(false);
+        }
 	    curr_tree.setCellRenderer(new TreeCellRenderer() {
 	        public Component getTreeCellRendererComponent(JTree tree, Object value, boolean isSelected,
 		        boolean expanded, boolean boh, int row, boolean leaf)
@@ -466,30 +450,20 @@ public class Tree extends JScrollPane implements TreeSelectionListener,
 	            Object usrObj = ((DefaultMutableTreeNode)value).getUserObject();
 	            Node node;
 	            if(usrObj instanceof String)
-	            {
-	                node = (Node)nodeHash.get(value);
-	                String newName = (((String)usrObj).trim()).toUpperCase();
-	                if(lastName == null || !lastName.equals(newName))
+                {
+                    node = Tree.curr_node;
+                    if (node.getTreeNode() == value)
 	                {
-	                    lastName = newName;
-	                    if(newName.length() > 12 || newName.length() == 0)
+	                    String newName = (((String)usrObj).trim()).toUpperCase();
+                        node.getTreeNode().setUserObject(node);
+	                    if(lastName == null || !lastName.equals(newName))
 	                    {
-	                        JOptionPane.showMessageDialog(frame, "Node name lengh must be between 1 and 12 characters",
-		                    "Error renaming node", JOptionPane.WARNING_MESSAGE);
+                            System.out.println("rename: "+ newName);
+	                        lastName = newName;
+		                    node.rename(newName);
 		                }
-		                else
-		                {
-		                    try {
-		                        node.rename(newName);
-		                    }catch(Exception exc)
-		                    {
-                                JOptionPane.showMessageDialog(frame, "Error renaming node: "+ exc,
-		                        "Error renaming node", JOptionPane.WARNING_MESSAGE);
-		                    }
-		                }
-		            }
-	                ((DefaultMutableTreeNode)value).setUserObject(node);
-	            }
+	                }
+                }
 	            else
 		            node = (Node)usrObj;
 		        return node.getIcon();
@@ -515,7 +489,7 @@ public class Tree extends JScrollPane implements TreeSelectionListener,
 	    DefaultMutableTreeNode tree_node = (DefaultMutableTreeNode)e.getPath().getLastPathComponent();
 	    if(tree_node.isLeaf())
 	    {
-	        curr_node = (Node)tree_node.getUserObject();
+	        curr_node = Tree.getNode(tree_node);
 	        Node sons[], members[];
 	        DefaultMutableTreeNode last_node = null;
 	        try {
@@ -526,12 +500,12 @@ public class Tree extends JScrollPane implements TreeSelectionListener,
 	        for(int i = 0; i < members.length; i++)
 	        {
 		        tree_node.add(last_node = new DefaultMutableTreeNode(members[i]));
-		        nodeHash.put(last_node, members[i]);
+		        members[i].setTreeNode(last_node);
 		    }
 	        for(int i = 0; i < sons.length; i++)
 	        {
 		        tree_node.add(last_node = new DefaultMutableTreeNode(sons[i]));
-		        nodeHash.put(last_node, sons[i]);
+		        sons[i].setTreeNode(last_node);
 		    }
 	        if(last_node != null)
 		    curr_tree.expandPath(new TreePath(last_node.getPath()));
@@ -548,11 +522,8 @@ public class Tree extends JScrollPane implements TreeSelectionListener,
 	    if(curr_tree == null) return;
 	    int item_idx;
 
-	    curr_tree_node =
-		    (DefaultMutableTreeNode)curr_tree.getClosestPathForLocation(e.getX(), e.getY()).getLastPathComponent();
+	    DefaultMutableTreeNode curr_tree_node = (DefaultMutableTreeNode)curr_tree.getClosestPathForLocation(e.getX(), e.getY()).getLastPathComponent();
 	    curr_node = (Node)curr_tree_node.getUserObject();
-	    TreeNode.setSelectedNode(curr_node);
-	    //if(e.isPopupTrigger())
 	    if((e.getModifiers() & InputEvent.BUTTON3_MASK) != 0)
 	    {
 	        NodeBeanInfo nbi = curr_node.getBeanInfo();
@@ -561,7 +532,6 @@ public class Tree extends JScrollPane implements TreeSelectionListener,
 
 	        if(pop == null)
 	        {
-		        //dialogs = new JDialog[node_properties.length];
 		        dialog_sets = new DialogSet[node_properties.length];
 		        for(int i = 0; i < node_properties.length; i++)
 		            dialog_sets[i] = new DialogSet();
@@ -617,7 +587,6 @@ public class Tree extends JScrollPane implements TreeSelectionListener,
 			            if(idx < node_properties.length)
 			            {
 			                Tree.curr_dialog_idx = idx;
-
 			                TreeDialog curr_dialog = dialog_sets[idx].getDialog(
 				            node_properties[idx].getPropertyEditorClass(), curr_node);
 			                curr_dialog.pack();
@@ -838,17 +807,11 @@ public class Tree extends JScrollPane implements TreeSelectionListener,
 	    return addNode(usage, name, curr_node);
 	}
 
-
-
     public static Node addNode(int usage, String name, Node toNode)
     {
-        return addNode(usage, name, toNode, curr_tree_node);
-    }
-
-    public static Node addNode(int usage, String name, Node toNode, DefaultMutableTreeNode toTreeNode)
-    {
-        Node new_node = null;
-	    DefaultMutableTreeNode new_tree_node = null;
+        Node new_node;
+	    DefaultMutableTreeNode new_tree_node;
+        DefaultMutableTreeNode toTreeNode = toNode.getTreeNode();
 	    if(name == null || name.length() == 0 || name.length() > 12)
 	    {
 	        JOptionPane.showMessageDialog(frame, "Name length must range between 1 and 12 characters",
@@ -857,43 +820,49 @@ public class Tree extends JScrollPane implements TreeSelectionListener,
 	    }
 	    try {
 	        new_node = toNode.addNode(usage, name);
-	        int num_children = toTreeNode.getChildCount();
-	        int i;
-	        if(num_children > 0)
-	        {
-		        String curr_name;
-		        for(i = 0; i < num_children; i++)
-		        {
-		            curr_name = ((Node)((DefaultMutableTreeNode)toTreeNode.getChildAt(i)).getUserObject()).getName();
-		            if(name.compareTo(curr_name) < 0)
-			        break;
-		        }
-		        curr_tree_node = new_tree_node = new DefaultMutableTreeNode(new_node);
-		        nodeHash.put(new_tree_node, new_node);
-		        DefaultTreeModel tree_model = (DefaultTreeModel)curr_tree.getModel();
-		        tree_model.insertNodeInto(new_tree_node, toTreeNode, i);
-		        //curr_tree.makeVisible(new TreePath(new_tree_node.getPath()));
-		        curr_tree.expandPath(new TreePath(new_tree_node.getPath()));
-		        curr_tree.treeDidChange();
-		        return new_node;
-	        }
-	    }
+            new_tree_node = new DefaultMutableTreeNode(new_node);
+		    new_node.setTreeNode(new_tree_node);
+            Tree.addNodeToParent(new_tree_node, toTreeNode);
+        }
 	    catch(Exception e) {
 	        JOptionPane.showMessageDialog(frame, e.getMessage(),
 		    "Error adding Node", JOptionPane.WARNING_MESSAGE);
 	        return null;
 	    }
-	return new_node;
+	    return new_node;
     }
 
+    static void addNodeToParent(DefaultMutableTreeNode TreeNode, DefaultMutableTreeNode toTreeNode)
+    {
+    	int num_children = toTreeNode.getChildCount();
+	    int i = 0;
+	    if(num_children > 0)
+	    {
+            String name = Tree.getNode(TreeNode).getName();
+		    String curr_name;
+		    for(i = 0; i < num_children; i++)
+		    {
+		        curr_name = ((Node)((DefaultMutableTreeNode)toTreeNode.getChildAt(i)).getUserObject()).getName();
+		        if(name.compareTo(curr_name) < 0)
+			    break;
+		    }
+	    }
+		DefaultTreeModel tree_model = (DefaultTreeModel)Tree.curr_tree.getModel();
+		tree_model.insertNodeInto(TreeNode, toTreeNode, i);
+		Tree.curr_tree.expandPath(new TreePath(TreeNode.getPath()));
+		Tree.curr_tree.treeDidChange();
+    }
 
 	public Node addDevice(String name, String type)
 	{
 	    return addDevice(name, type, curr_node);
 	}
 
-	public static DefaultMutableTreeNode getCurrTreeNode() {return curr_tree_node;}
-	public static void setCurrTreeNode(DefaultMutableTreeNode node){curr_tree_node = node;}
+    public static Node getNode(javax.swing.tree.TreeNode treenode){return Tree.getNode((DefaultMutableTreeNode)treenode);}
+    public static Node getNode(DefaultMutableTreeNode treenode){return (Node)treenode.getUserObject();}
+	public static DefaultMutableTreeNode getCurrTreeNode() {return curr_node.getTreeNode();}
+	public static void setCurrTreeNode(DefaultMutableTreeNode treenode){curr_node = getNode(treenode);}
+
     public static Node addDevice(String name, String type, Node toNode)
     {
 	    DefaultMutableTreeNode new_tree_node = null;
@@ -912,21 +881,20 @@ public class Tree extends JScrollPane implements TreeSelectionListener,
 	    Node new_node = null;
 	    try {
 	        new_node = toNode.addDevice(name, type);
-	        int num_children = curr_tree_node.getChildCount();
+	        int num_children = toNode.getTreeNode().getChildCount();
 	        int i;
 	        if(num_children > 0)
 	        {
 		        String curr_name;
 		        for(i = 0; i < num_children; i++)
 		        {
-		            curr_name = ((Node)((DefaultMutableTreeNode)curr_tree_node.getChildAt(i)).getUserObject()).getName();
+		            curr_name = Tree.getNode(toNode.getTreeNode().getChildAt(i)).getName();
 		            if(name.compareTo(curr_name) < 0)
 			        break;
 		        }
-		        new_tree_node = new DefaultMutableTreeNode(new_node);
-		        nodeHash.put(new_tree_node, new_node);
+		        new_node.setTreeNode(new_tree_node = new DefaultMutableTreeNode(new_node));
 		        DefaultTreeModel tree_model = (DefaultTreeModel)curr_tree.getModel();
-		        tree_model.insertNodeInto(new_tree_node, curr_tree_node, i);
+		        tree_model.insertNodeInto(new_tree_node, curr_node.getTreeNode(), i);
 		        curr_tree.makeVisible(new TreePath(new_tree_node.getPath()));
 		        return new_node;
 	        }
@@ -947,9 +915,6 @@ public class Tree extends JScrollPane implements TreeSelectionListener,
 	    curr_node = null;
 	}
 
-
-
-
     static void deleteNode(Node delNode)
     {
 	    if(delNode == null) return;
@@ -965,10 +930,9 @@ public class Tree extends JScrollPane implements TreeSelectionListener,
 	    {
 	        del_node.executeDelete();
 	        DefaultTreeModel tree_model = (DefaultTreeModel)curr_tree.getModel();
-	        tree_model.removeNodeFromParent(curr_tree_node);
+	        tree_model.removeNodeFromParent(delNode.getTreeNode());
 	    }
     }
-
 
     public void modifyTags()
     {

--- a/javatraverser/Tree.java
+++ b/javatraverser/Tree.java
@@ -480,7 +480,7 @@ public class Tree extends JScrollPane implements TreeSelectionListener,
 		                else
 		                {
 		                    try {
-		                        node.renameLast(newName);
+		                        node.rename(newName);
 		                    }catch(Exception exc)
 		                    {
                                 JOptionPane.showMessageDialog(frame, "Error renaming node: "+ exc,

--- a/javatraverser/TreeNode.java
+++ b/javatraverser/TreeNode.java
@@ -7,63 +7,65 @@ import java.awt.datatransfer.*;
 public class TreeNode extends JLabel
 {
     Node node;
-    static Node selected;
     static Node copied;
+    static boolean cut;
     static Font plain_f, bold_f;
     static {
-	plain_f = new Font("Serif", Font.PLAIN, 12);
-	bold_f = new Font("Serif" ,Font.BOLD, 12);
+	    plain_f = new Font("Serif", Font.PLAIN, 12);
+	    bold_f = new Font("Serif" ,Font.BOLD, 12);
     }
 
-    public static void setSelectedNode(Node sel)
-    {
-	    selected = sel;
-   }
 
 	public static void copyToClipboard()
 	{
 	    try {
-                Clipboard cb = Toolkit.getDefaultToolkit().getSystemClipboard();
-                String []tags = selected.getTags();
-                StringSelection content;
-                String path = selected.getInfo().getPath();
-                content = new StringSelection(path);
-                cb.setContents(content, null);
+            Clipboard cb = Toolkit.getDefaultToolkit().getSystemClipboard();
+            String []tags = Tree.curr_node.getTags();
+            StringSelection content;
+            String path = Tree.curr_node.getFullPath();
+            content = new StringSelection(path);
+            cb.setContents(content, null);
 	    }catch(Exception exc){System.err.println("Cannot copy fullPath to Clipboard");}
 	}
     public static void copy()
     {
-        copied = selected;
+        cut = false;
+        copied = Tree.curr_node;
+        System.out.println("copied: "+copied+" from "+copied.parent);
     }
 
+    public static void cut()
+    {
+        cut = true;
+        copied = Tree.curr_node;
+        System.out.println("cut: "+copied+" from "+copied.parent);
+    }
     public static void paste()
     {
-        if(copied != null && copied != selected)
+        System.out.println((cut ? "moved " : "copied") +copied+ " from " + copied.parent + " to " + Tree.curr_node);
+        if(copied != null && copied != Tree.curr_node)
         {
-            Node.pasteSubtree(copied, selected, true);
+            if (cut)
+            {
+                if (copied.move(Tree.curr_node))
+                    copied = null;
+            }
+            else
+                Node.pasteSubtree(copied, Tree.curr_node, true);
         }
     }
 
     public static void delete()
     {
-        Tree.deleteNode(selected);
+        Tree.deleteNode(Tree.curr_node);
     }
 
     public TreeNode(Node node, String name, Icon icon)
     {
 	    super("MMMMMMMMMMMMMMMM", icon, JLabel.LEFT);
 	    this.node = node;
-        setText(node.getName());
-	    if(node.isOn())
-	        setFont(bold_f);
-	    else
-	        setFont(plain_f);
-	    setForeground(Color.black);
-	    if(node.isDefault())
-	        setBorder(BorderFactory.createLineBorder(Color.black, 1));
-	    else
-	        setBorder(BorderFactory.createLineBorder(Color.white, 1));
-
+	    setFont(bold_f);
+	    setBorder(BorderFactory.createLineBorder(Color.white, 1));
         String tags[] = node.getTags();
         if(tags.length > 0)
         {
@@ -80,21 +82,10 @@ public class TreeNode extends JLabel
 
     public void paint(Graphics g)
     {
-	setText(node.getName());
-	if(node.isDefault())
-	    setForeground(Color.red);
-	else
-	    setForeground(Color.black);
-
-    	if(node.isOn())
-	    setFont(bold_f);
-	else
-	    setFont(plain_f);
-
-	if(selected == node)
-	    setBorder(BorderFactory.createLineBorder(Color.black, 1));
-	else
-	    setBorder(BorderFactory.createLineBorder(Color.white, 1));
-	super.paint(g);
+	    setText(node.getName());
+        setForeground(node.isDefault() ? Color.red : Color.black);
+        setFont(node.isOn() ? bold_f : plain_f);  
+	    setBorder(BorderFactory.createLineBorder((Tree.curr_node == node) ? Color.black : Color.white, 1));
+	    super.paint(g);
     }
 }

--- a/javatraverser/TreeNode.java
+++ b/javatraverser/TreeNode.java
@@ -49,39 +49,33 @@ public class TreeNode extends JLabel
         Tree.deleteNode(selected);
     }
 
-    public TreeNode(Node _node, String name, Icon icon)
+    public TreeNode(Node node, String name, Icon icon)
     {
-	super(name+"                ", icon, JLabel.LEFT);
-	node = _node;
-	if(node.isOn())
-	    setFont(bold_f);
-	else
-	    setFont(plain_f);
-	setForeground(Color.black);
-	if(node.isDefault())
-	    //setText(node.getName().trim() + "                                   ");
-	    //setForeground(Color.red);
-	    setBorder(BorderFactory.createLineBorder(Color.black, 1));
-	else
-	    setBorder(BorderFactory.createLineBorder(Color.white, 1));
-	    //setText(node.getName().trim() + "                                   ");
-	    //setForeground(Color.black);
+	    super("MMMMMMMMMMMMMMMM", icon, JLabel.LEFT);
+	    this.node = node;
+        setText(node.getName());
+	    if(node.isOn())
+	        setFont(bold_f);
+	    else
+	        setFont(plain_f);
+	    setForeground(Color.black);
+	    if(node.isDefault())
+	        setBorder(BorderFactory.createLineBorder(Color.black, 1));
+	    else
+	        setBorder(BorderFactory.createLineBorder(Color.white, 1));
 
-    String tags[] = node.getTags();
-    if(tags.length > 0)
-    {
-        String tagsStr = "";
-        for(int i = 0; i < tags.length; i++)
+        String tags[] = node.getTags();
+        if(tags.length > 0)
         {
-            tagsStr += tags[i];
-            if(i < tags.length - 1)
-                tagsStr += "\n";
+            String tagsStr = "";
+            for(int i = 0; i < tags.length; i++)
+            {
+                tagsStr += tags[i];
+                if(i < tags.length - 1)
+                    tagsStr += "\n";
+            }
+            setToolTipText(tagsStr);
         }
-        setToolTipText(tagsStr);
-    }
-
-
-
     }
 
     public void paint(Graphics g)

--- a/javatraverser/jTraverser.java
+++ b/javatraverser/jTraverser.java
@@ -150,7 +150,6 @@ public class jTraverser extends JFrame implements ActionListener
 	    {
 	        System.exit(0);
 	    }});
-
 	pack();
 	show();
     }
@@ -188,16 +187,15 @@ public void actionPerformed(ActionEvent e)
     if(source == (Object)paste_b) TreeNode.paste();
 
     // Node related
-	Node curr_node = tree.getCurrentNode();
-	if(curr_node == null) return;
+	if(Tree.curr_node == null) return;
     if(source == (Object)turn_on_b)
     {
-	    curr_node.turnOn();
+	    Tree.curr_node.turnOn();
 	    tree.reportChange();
     }
     if(source == (Object)turn_off_b)
     {
-	    curr_node.turnOff();
+	    Tree.curr_node.turnOff();
 	    tree.reportChange();
     }
 
@@ -208,7 +206,7 @@ public void actionPerformed(ActionEvent e)
 	        display_data_d = new TreeDialog(display_data = new DisplayData());
 	        display_data.setFrame(display_data_d);
 	    }
-	    display_data.setNode(curr_node);
+	    display_data.setNode(Tree.curr_node);
 	    display_data_d.pack();
 	    display_data_d.setLocation(dialogLocation());
 	    display_data_d.setVisible(true);
@@ -220,7 +218,7 @@ public void actionPerformed(ActionEvent e)
             display_nci_d = new TreeDialog(display_nci = new DisplayNci());
             display_nci.setFrame(display_nci_d);
         }
-        display_nci.setNode(curr_node);
+        display_nci.setNode(Tree.curr_node);
         display_nci_d.pack();
         display_nci_d.setLocation(dialogLocation());
         display_nci_d.setVisible(true);
@@ -232,7 +230,7 @@ public void actionPerformed(ActionEvent e)
             display_tags_d = new TreeDialog(display_tags = new DisplayTags());
             display_tags.setFrame(display_tags_d);
         }
-        display_tags.setNode(curr_node);
+        display_tags.setNode(Tree.curr_node);
         display_tags_d.pack();
         display_tags_d.setLocation(dialogLocation());
         display_tags_d.setVisible(true);
@@ -244,7 +242,7 @@ public void actionPerformed(ActionEvent e)
 	        modify_data_d = new TreeDialog(modify_data = new ModifyData());
 	        modify_data.setFrame(modify_data_d);
 	    }
-	    modify_data.setNode(curr_node);
+	    modify_data.setNode(Tree.curr_node);
 	    modify_data_d.pack();
 	    modify_data_d.setLocation(dialogLocation());
 	    modify_data_d.setVisible(true);
@@ -252,12 +250,12 @@ public void actionPerformed(ActionEvent e)
     if(source == (Object)set_default_b)
     {
 	    try {
-	        curr_node.setDefault();
+	        Tree.curr_node.setDefault();
 	    }catch(Exception exc) {System.out.println("Error setting default "+exc.getMessage());}
 	    tree.reportChange();
     }
     if(source == (Object)setup_device_b)
-        curr_node.setupDevice();
+        Tree.curr_node.setupDevice();
 }
 
 void reportChange(String exp, int shot, boolean editable, boolean readonly)


### PR DESCRIPTION
... as it is buggy when changing the path
- node.rename is more like move as the full path can be changed
- node.renameLast is the proper rename method in node
- the error dialogs are safer on lower levels
- when requesting the node name the trimmed version is either requested
  or should fit as well
- removed "node" from title as it is too long anyway
