### PR TITLE
jTraverser flag edit dialog

### DIFF
--- a/javamds/JavaTrav.c
+++ b/javamds/JavaTrav.c
@@ -386,22 +386,32 @@ JNIEXPORT void JNICALL Java_Database_putData
     RaiseException(env, MdsGetMsg(status), status);
 }
 
-JNIEXPORT void JNICALL Java_Database_setFlags(JNIEnv * env, jobject obj, jobject jnid, jint flags) {
-  int nid, status;
-  static int nci_flags;
-  static int nci_flags_len = sizeof(int);
-  struct nci_itm nci_list[] = { {4, NciSET_FLAGS, &nci_flags, &nci_flags_len},
-  {NciEND_OF_LIST, 0, 0, 0}
-  };
+JNIEXPORT void JNICALL Java_Database_setFlags(JNIEnv * env, jobject obj, jobject jnid, jint jflags) {
+    int nid, status;
+    int flags = (int)jflags;
+    NCI_ITM itmlst[] =
+    { {0, NciSET_FLAGS, (unsigned char *)&flags, 0}, {0, NciEND_OF_LIST} };
+    jfieldID nid_fid;
+    jclass cls = (*env)->GetObjectClass(env, jnid);
+    nid_fid = (*env)->GetFieldID(env, cls, "datum", "I");
+    nid = (*env)->GetIntField(env, jnid, nid_fid);
+    status = TreeSetNci(nid, itmlst);
+    if (!(status & 1))
+        RaiseException(env, MdsGetMsg(status), status);
+}
 
-  jfieldID nid_fid;
-  jclass cls = (*env)->GetObjectClass(env, jnid);
-  nid_fid = (*env)->GetFieldID(env, cls, "datum", "I");
-  nid = (*env)->GetIntField(env, jnid, nid_fid);
-  nci_flags = flags;
-  status = TreeSetNci(nid, nci_list);
-  if (!(status & 1))
-    RaiseException(env, MdsGetMsg(status), status);
+JNIEXPORT void JNICALL Java_Database_clearFlags(JNIEnv * env, jobject obj, jobject jnid, jint jflags) {
+    int nid, status;
+    int flags = (int)jflags;
+    NCI_ITM itmlst[] =
+    { {0, NciCLEAR_FLAGS, (unsigned char *)&flags, 0}, {0, NciEND_OF_LIST} };
+    jfieldID nid_fid;
+    jclass cls = (*env)->GetObjectClass(env, jnid);
+    nid_fid = (*env)->GetFieldID(env, cls, "datum", "I");
+    nid = (*env)->GetIntField(env, jnid, nid_fid);
+    status = TreeSetNci(nid, itmlst);
+    if (!(status & 1))
+        RaiseException(env, MdsGetMsg(status), status);
 }
 
 JNIEXPORT jint JNICALL Java_Database_getFlags(JNIEnv * env, jobject obj, jobject jnid) {

--- a/javamds/JavaTrav.c
+++ b/javamds/JavaTrav.c
@@ -420,7 +420,7 @@ JNIEXPORT jint JNICALL Java_Database_getFlags(JNIEnv * env, jobject obj, jobject
   status = TreeGetNci(nid, nci_list);
   if (!(status & 1)) {
     RaiseException(env, MdsGetMsg(status), status);
-    return 0xFFFF;
+    return -1;
   }
   return nci_flags;
 }

--- a/javamds/JavaTrav.c
+++ b/javamds/JavaTrav.c
@@ -404,6 +404,27 @@ JNIEXPORT void JNICALL Java_Database_setFlags(JNIEnv * env, jobject obj, jobject
     RaiseException(env, MdsGetMsg(status), status);
 }
 
+JNIEXPORT jint JNICALL Java_Database_getFlags(JNIEnv * env, jobject obj, jobject jnid) {
+  int nid, status;
+  jfieldID nid_fid;
+  jclass cls = (*env)->GetObjectClass(env, jnid);
+  static int nci_flags;
+  static int nci_flags_len = sizeof(int);
+  struct nci_itm nci_list[] = { {4, NciGET_FLAGS, &nci_flags, &nci_flags_len},
+  {NciEND_OF_LIST, 0, 0, 0}
+  };
+
+  nid_fid = (*env)->GetFieldID(env, cls, "datum", "I");
+  nid = (*env)->GetIntField(env, jnid, nid_fid);
+
+  status = TreeGetNci(nid, nci_list);
+  if (!(status & 1)) {
+    RaiseException(env, MdsGetMsg(status), status);
+    return 0xFFFF;
+  }
+  return nci_flags;
+}
+
 JNIEXPORT jobject JNICALL Java_Database_getInfo
     (JNIEnv * env, jobject obj, jobject jnid, jint context) {
   int nid, status;

--- a/javamds/jTraverser_Database.h
+++ b/javamds/jTraverser_Database.h
@@ -70,14 +70,21 @@ extern "C" {
  */
   JNIEXPORT jobjectArray JNICALL Java_jTraverser_Database_getSons(JNIEnv *, jobject, jobject);
 
-/*
- * Class:     jTraverser_Database
- * Method:    getTags
- * Signature: (LjTraverser/NidData;)[Ljava/lang/String;
- */
+  /*
+  * Class:     jTraverser_Database
+  * Method:    getFlags
+  * Signature: (LjTraverser/NidData;)I;
+  */
+  JNIEXPORT jint JNICALL Java_jTraverser_Database_getFlags(JNIEnv *, jobject, jobject);
+
+  /*
+  * Class:     jTraverser_Database
+  * Method:    getTags
+  * Signature: (LjTraverser/NidData;)[Ljava/lang/String;
+  */
   JNIEXPORT jobjectArray JNICALL Java_jTraverser_Database_getTags(JNIEnv *, jobject, jobject);
 
-/*
+  /*
  * Class:     jTraverser_Database
  * Method:    isOn
  * Signature: (LjTraverser/NidData;)Z
@@ -141,6 +148,19 @@ extern "C" {
   JNIEXPORT void JNICALL Java_jTraverser_Database_setTags(JNIEnv *, jobject, jobject, jobjectArray);
 
 /*
+* Class:     jTraverser_Database
+* Method:    setFlags
+* Signature: (LjTraverser/NidData;I;)
+*/
+JNIEXPORT void JNICALL Java_jTraverser_Database_setFlags(JNIEnv *, jobject, jobject, jint);
+/*
+* Class:     jTraverser_Database
+* Method:    clearFlags
+* Signature: (LjTraverser/NidData;I;)
+*/
+JNIEXPORT void JNICALL Java_jTraverser_Database_clearFlags(JNIEnv *, jobject, jobject, jint);
+
+ /*
  * Class:     jTraverser_Database
  * Method:    startDelete
  * Signature: ([LjTraverser/NidData;)[LjTraverser/NidData;

--- a/javatraverser/Database.java
+++ b/javatraverser/Database.java
@@ -99,6 +99,7 @@ public class Database implements RemoteTree{
     public native void setCurrentShot(String experiment, int shot);
     public native String getOriginalPartName(NidData nid) throws DatabaseException;
     public native void setFlags(NidData nid, int flags) throws DatabaseException;
+    public native int getFlags(NidData nid) throws DatabaseException;
     public native void setEvent(String event)throws DatabaseException;
     public native String getMdsMessage(int status);
   }

--- a/javatraverser/Database.java
+++ b/javatraverser/Database.java
@@ -98,6 +98,7 @@ public class Database implements RemoteTree{
     public void setCurrentShot(int shot) {setCurrentShot(name, shot);}
     public native void setCurrentShot(String experiment, int shot);
     public native String getOriginalPartName(NidData nid) throws DatabaseException;
+    public native void clearFlags(NidData nid, int flags) throws DatabaseException;
     public native void setFlags(NidData nid, int flags) throws DatabaseException;
     public native int getFlags(NidData nid) throws DatabaseException;
     public native void setEvent(String event)throws DatabaseException;

--- a/javatraverser/Node.java
+++ b/javatraverser/Node.java
@@ -189,9 +189,21 @@ public class Node
         return info;
     }
 
-    public void setInfo(NodeInfo info) throws DatabaseException,
-        RemoteException
+    public void setInfo(NodeInfo info) throws DatabaseException, RemoteException{}
+    public void setFlags(NodeInfo info) throws DatabaseException, RemoteException
     {
+        int flags = 0;
+        if (!info.on)              flags+= 0x00001;
+        if (info.essential)        flags+= 0x00004;
+        if (info.setup)            flags+= 0x00040;
+        if (info.write_once)       flags+= 0x00080;
+        if (info.compressible)     flags+= 0x00100;
+        if (info.compress_on_put)  flags+= 0x00400;
+        if (info.no_write_model)   flags+= 0x00800;
+        if (info.no_write_shot)    flags+= 0x01000;
+//        if (info.include_in_pulse) flags+= 0x08000;
+//        if (info.compress_segments)flags+= 0x10000;
+        experiment.setFlags(nid, flags);
     }
 
     public boolean isOn()

--- a/javatraverser/Node.java
+++ b/javatraverser/Node.java
@@ -192,7 +192,7 @@ public class Node
 
     public void setInfo(NodeInfo info) throws DatabaseException, RemoteException{}
 
-    public boolean[] getFlags() throws Exception
+    public int getFlags() throws Exception
     {   /*
         0x00001 off
         0x00004 essential
@@ -205,22 +205,17 @@ public class Node
         0x08000 include_in_pulse    
         0x10000 compress_segments    
         */
-	    int flags = experiment.getFlags(nid);
-        if (flags<0)
-            throw new Exception("MdsJava returned -1."); 
-        boolean[] bits = new boolean[32];
-        for (int i = 0; i < 32; i++)
-            bits[i] = (flags & (1 << i)) != 0;
-        return bits;
+        return  experiment.getFlags(nid);
     }
 
-    public void setFlags(boolean[] bits) throws DatabaseException, RemoteException
+    public void setFlag(byte idx) throws DatabaseException, RemoteException
     {
-        int flags = 0;
-        for (int i = 0; i < bits.length; i++)
-            if (bits[i])
-                flags+= (1 >> i);
-        experiment.setFlags(nid, flags);
+        experiment.setFlags(nid, 1<<idx);
+    }
+
+    public void clearFlag(byte idx) throws DatabaseException, RemoteException
+    {
+        experiment.clearFlags(nid, 1<<idx);
     }
 
 

--- a/javatraverser/Node.java
+++ b/javatraverser/Node.java
@@ -6,6 +6,7 @@ import java.rmi.RemoteException.*;
 import javax.swing.tree.*;
 import java.awt.*;
 
+
 public class Node
 {
     RemoteTree experiment;
@@ -190,21 +191,38 @@ public class Node
     }
 
     public void setInfo(NodeInfo info) throws DatabaseException, RemoteException{}
-    public void setFlags(NodeInfo info) throws DatabaseException, RemoteException
+
+    public boolean[] getFlags() throws Exception
+    {   /*
+        0x00001 off
+        0x00004 essential
+        0x00040 setup
+        0x00080 write_once
+        0x00100 compressible        
+        0x00400 compress_on_put     
+        0x00800 no_write_model      
+        0x01000 no_write_shot       
+        0x08000 include_in_pulse    
+        0x10000 compress_segments    
+        */
+	    int flags = experiment.getFlags(nid);
+        if (flags<0)
+            throw new Exception("MdsJava returned -1."); 
+        boolean[] bits = new boolean[32];
+        for (int i = 0; i < 32; i++)
+            bits[i] = (flags & (1 << i)) != 0;
+        return bits;
+    }
+
+    public void setFlags(boolean[] bits) throws DatabaseException, RemoteException
     {
         int flags = 0;
-        if (!info.on)              flags+= 0x00001;
-        if (info.essential)        flags+= 0x00004;
-        if (info.setup)            flags+= 0x00040;
-        if (info.write_once)       flags+= 0x00080;
-        if (info.compressible)     flags+= 0x00100;
-        if (info.compress_on_put)  flags+= 0x00400;
-        if (info.no_write_model)   flags+= 0x00800;
-        if (info.no_write_shot)    flags+= 0x01000;
-//        if (info.include_in_pulse) flags+= 0x08000;
-//        if (info.compress_segments)flags+= 0x10000;
+        for (int i = 0; i < bits.length; i++)
+            if (bits[i])
+                flags+= (1 >> i);
         experiment.setFlags(nid, flags);
     }
+
 
     public boolean isOn()
     {

--- a/javatraverser/NodeEditor.java
+++ b/javatraverser/NodeEditor.java
@@ -7,7 +7,6 @@ public class NodeEditor extends JPanel
     Node node;
     Tree tree;
     TreeDialog frame;
-    
 
     public void setTree(Tree tree)
     {

--- a/javatraverser/RemoteTree.java
+++ b/javatraverser/RemoteTree.java
@@ -24,6 +24,7 @@ public interface RemoteTree extends Remote {
     public void putRow(NidData nid, Data data, long time, int ctx)  throws RemoteException, DatabaseException;
     //public native DatabaseInfo getInfo(); throws DatabaseException;
     public NodeInfo getInfo(NidData nid, int ctx)  throws RemoteException, DatabaseException;
+    public void clearFlags(NidData nid, int flags)  throws RemoteException, DatabaseException;
     public void setFlags(NidData nid, int flags)  throws RemoteException, DatabaseException;
     public int getFlags(NidData nid)  throws RemoteException, DatabaseException;
     public void setTags(NidData nid, String tags[], int ctx) throws RemoteException, DatabaseException;

--- a/javatraverser/RemoteTree.java
+++ b/javatraverser/RemoteTree.java
@@ -24,6 +24,8 @@ public interface RemoteTree extends Remote {
     public void putRow(NidData nid, Data data, long time, int ctx)  throws RemoteException, DatabaseException;
     //public native DatabaseInfo getInfo(); throws DatabaseException;
     public NodeInfo getInfo(NidData nid, int ctx)  throws RemoteException, DatabaseException;
+    public void setFlags(NidData nid, int flags)  throws RemoteException, DatabaseException;
+    public int getFlags(NidData nid)  throws RemoteException, DatabaseException;
     public void setTags(NidData nid, String tags[], int ctx) throws RemoteException, DatabaseException;
     public String[] getTags(NidData nid, int ctx) throws RemoteException, DatabaseException;
     public void renameNode(NidData nid, String name, int ctx) throws RemoteException, DatabaseException;

--- a/javatraverser/Tree.java
+++ b/javatraverser/Tree.java
@@ -17,7 +17,6 @@ public class Tree extends JScrollPane implements TreeSelectionListener,
     static boolean is_remote;
     boolean is_angled_style;
     DefaultMutableTreeNode top;
-    //Node top_node, curr_node;
     JMenuItem menu_items[];
     boolean is_editable;
     JPopupMenu pop = null;
@@ -40,6 +39,16 @@ public class Tree extends JScrollPane implements TreeSelectionListener,
     JTextField add_node_name, add_node_tag, add_subtree_name;
     int add_node_usage;
     JDialog modify_tags_dialog;
+    JDialog modify_flags_dialog;
+    JCheckBox flagBoxes[] = {new JCheckBox("On"),
+                             new JCheckBox("ParentOn"),
+                             new JCheckBox("Essential"),null,null,null,
+                             new JCheckBox("Setup"),
+                             new JCheckBox("WriteOnce"),
+                             new JCheckBox("Compressible"),null,
+                             new JCheckBox("CompressOnPut"),
+                             new JCheckBox("NoWriteModel"),
+                             new JCheckBox("NoWriteShot")};
     JDialog add_device_dialog;
     JList modify_tags_list;
     JTextField curr_tag_selection;
@@ -54,10 +63,11 @@ public class Tree extends JScrollPane implements TreeSelectionListener,
 
     String topExperiment;
         
-// Temporary, to vercome Java's bugs on inner classes
+// Temporary, to overcome Java's bugs on inner classes
     JMenuItem open_b, close_b, quit_b;
     JMenuItem add_action_b, add_dispatch_b, add_numeric_b, add_signal_b, add_task_b, add_text_b,
 	add_window_b, add_axis_b, add_device_b, add_child_b, add_subtree_b, delete_node_b, modify_tags_b,
+    modify_flags_b,
 	rename_node_b;
     JButton ok_cb, add_node_ok;
 
@@ -75,7 +85,7 @@ public class Tree extends JScrollPane implements TreeSelectionListener,
 	    setBackground(Color.white);
 	    curr_tree = null;
 	    curr_experiment = null;
-	    String def_tree = System.getProperty("tree");
+	    String def_tree = System.getenv("tree");
 	    if(def_tree != null)
 	    {
 	        String def_shot = System.getProperty("shot");
@@ -626,6 +636,8 @@ public class Tree extends JScrollPane implements TreeSelectionListener,
 		            delete_node_b.addActionListener(this);
 		            pop.add(modify_tags_b = new JMenuItem("Modify tags"));
 		            modify_tags_b.addActionListener(this);
+		            pop.add(modify_flags_b = new JMenuItem("Modify flags"));
+		            modify_flags_b.addActionListener(this);
 		            pop.add(rename_node_b = new JMenuItem("Rename node"));
 		            rename_node_b.addActionListener(this);
 		            pop.addSeparator();
@@ -722,7 +734,6 @@ public class Tree extends JScrollPane implements TreeSelectionListener,
 	    if(add_node_dialog == null)
 	    {
 	        add_node_dialog = new JDialog(frame);
-	        add_node_dialog.setLocation(curr_origin);
 	        JPanel jp = new JPanel();
 	        jp.setLayout(new BorderLayout());
 	        JPanel jp1 = new JPanel();
@@ -766,7 +777,6 @@ public class Tree extends JScrollPane implements TreeSelectionListener,
 	    if(add_subtree_dialog == null)
 	    {
 	        add_subtree_dialog = new JDialog(frame);
-	        add_subtree_dialog.setLocation(curr_origin);
 	        JPanel jp = new JPanel();
 	        jp.setLayout(new BorderLayout());
 	        JPanel jp1 = new JPanel();
@@ -811,7 +821,6 @@ public class Tree extends JScrollPane implements TreeSelectionListener,
 	    if(add_device_dialog == null)
 	    {
 	        add_device_dialog = new JDialog(frame);
-	        add_device_dialog.setLocation(curr_origin);
 	        JPanel jp = new JPanel();
 	        jp.setLayout(new BorderLayout());
 	        JPanel jp1 = new JPanel();
@@ -1068,30 +1077,9 @@ public class Tree extends JScrollPane implements TreeSelectionListener,
 	    JPanel jp3 = new JPanel();
 	    JButton ok_b = new JButton("Ok");
 	    ok_b.addActionListener(new ActionListener() {
-		    public void actionPerformed(ActionEvent e)
-		    {
-		        String []out_tags = new String[curr_taglist_model.getSize()];
-		        for(int i = 0; i < curr_taglist_model.getSize(); i++)
-		        {
-			        out_tags[i] = (String)curr_taglist_model.getElementAt(i);
-		        }
-		        try {
-			        curr_node.setTags(out_tags);
-		        } catch(Exception exc)
-		        {
-			        JOptionPane.showMessageDialog(frame, exc.getMessage(),
-			            "Error adding tags", JOptionPane.WARNING_MESSAGE);
-		        }
-		        modify_tags_dialog.setVisible(false);
-		}});
+		public void actionPerformed(ActionEvent e){addTag();}
+        });
 	    jp3.add(ok_b);
-	    JButton apply_b = new JButton("Apply");
-	    apply_b.addActionListener(new ActionListener() {
-		public void actionPerformed(ActionEvent e)
-		{
-            addTag();
-		}});
-	    jp3.add(apply_b);
 	    JButton reset_b = new JButton("Reset");
 	    reset_b.addActionListener(new ActionListener() {
 		public void actionPerformed(ActionEvent e) {
@@ -1142,6 +1130,95 @@ public class Tree extends JScrollPane implements TreeSelectionListener,
 		modify_tags_dialog.setVisible(false);
 	}
 
+    public void modifyFlags()
+	{
+	    if(curr_node == null) return;
+	    try {
+	        curr_node.getInfo();
+	    } catch(Exception e)
+	    {
+	        System.out.println("Error getting flags: "+e.getMessage());
+	        return;
+	    }
+        if (modify_flags_dialog == null)
+	    {
+	        modify_flags_dialog = new JDialog(frame);
+	        JPanel jp = new JPanel();
+            jp.setLayout(new BorderLayout());
+	        JPanel jp1 = new JPanel();
+            jp1.setLayout(new GridLayout(4,2));
+            jp1.add(flagBoxes[0]);
+            jp1.add(flagBoxes[2]);
+            jp1.add(flagBoxes[6]);
+            jp1.add(flagBoxes[7]);
+            jp1.add(flagBoxes[8]);
+            jp1.add(flagBoxes[10]);
+            jp1.add(flagBoxes[11]);
+            jp1.add(flagBoxes[12]);
+            jp.add(jp1);
+	        JPanel jp3 = new JPanel();
+	        JButton ok_b = new JButton("Ok");
+	        ok_b.addActionListener(new ActionListener() {
+            public void actionPerformed(ActionEvent e){setFlags();}
+            });
+	        jp3.add(ok_b);
+	        JButton reset_b = new JButton("Reset");
+	        reset_b.addActionListener(new ActionListener() {
+		    public void actionPerformed(ActionEvent e) {
+		    }});
+	        jp3.add(reset_b);
+	        JButton cancel_b = new JButton("Cancel");
+	        cancel_b.addActionListener(new ActionListener() {
+		    public void actionPerformed(ActionEvent e) {
+		        modify_flags_dialog.setVisible(false);
+            }});
+	        jp3.add(cancel_b);
+	        jp.add(jp3, "South");
+	        modify_flags_dialog.getContentPane().add(jp);
+	        modify_flags_dialog.addKeyListener(new KeyAdapter() {
+	            public void keyTyped(KeyEvent e)
+	            {
+	                if(e.getKeyCode() == KeyEvent.VK_ENTER)
+	                    setFlags();
+	            }
+	        });
+    	    modify_flags_dialog.pack();
+        }
+        flagBoxes[0].setSelected(curr_node.info.on);
+        flagBoxes[2].setSelected(curr_node.info.essential);
+        flagBoxes[6].setSelected(curr_node.info.setup);
+        flagBoxes[7].setSelected(curr_node.info.write_once);
+        flagBoxes[8].setSelected(curr_node.info.compressible);
+        flagBoxes[10].setSelected(curr_node.info.compress_on_put);
+        flagBoxes[11].setSelected(curr_node.info.no_write_model);
+        flagBoxes[12].setSelected(curr_node.info.no_write_shot);
+	    modify_flags_dialog.setTitle("Modify flags of " + curr_node.getFullPath());
+	    if (!modify_flags_dialog.isVisible())
+            modify_flags_dialog.setLocation(curr_origin);
+	    modify_flags_dialog.setVisible(true);
+	}
+
+    public void setFlags()
+	{
+        NodeInfo out_info = null;
+        curr_node.info.on =              flagBoxes[0].isSelected();
+        curr_node.info.essential =       flagBoxes[2].isSelected();
+        curr_node.info.setup =           flagBoxes[6].isSelected();
+        curr_node.info.write_once =      flagBoxes[7].isSelected();
+        curr_node.info.compressible =    flagBoxes[8].isSelected();
+        curr_node.info.compress_on_put = flagBoxes[10].isSelected();
+        curr_node.info.no_write_model =  flagBoxes[11].isSelected();
+        curr_node.info.no_write_shot =   flagBoxes[12].isSelected();
+		try {
+			curr_node.setFlags(out_info);
+		} catch(Exception exc)
+		{
+			JOptionPane.showMessageDialog(frame, exc.getMessage(),
+			    "Error setting flags", JOptionPane.WARNING_MESSAGE);
+		}
+		modify_flags_dialog.setVisible(false);
+	}
+
     void renameNode()
     {
 	if(curr_node == null) return;
@@ -1157,9 +1234,8 @@ public class Tree extends JScrollPane implements TreeSelectionListener,
 	    jp1 = new JPanel();
 	    JButton ok_b = new JButton("Ok");
 	    ok_b.addActionListener(new ActionListener() {
-		public void actionPerformed(ActionEvent e) {
-            rename();
-		}});
+		public void actionPerformed(ActionEvent e) {rename();}
+        });
 	    jp1.add(ok_b);
 	    JButton cancel_b = new JButton("Cancel");
 	    cancel_b.addActionListener(new ActionListener() {
@@ -1230,6 +1306,7 @@ public class Tree extends JScrollPane implements TreeSelectionListener,
 	if(jb == (Object)add_device_b) addDevice();
 	if(jb == (Object)delete_node_b) deleteNode();
 	if(jb == (Object)modify_tags_b) modifyTags();
+	if(jb == (Object)modify_flags_b) modifyFlags();
 	if(jb == (Object)rename_node_b) renameNode();
     }
 

--- a/javatraverser/TreeServer.java
+++ b/javatraverser/TreeServer.java
@@ -110,6 +110,10 @@ class TreeServer extends UnicastRemoteObject implements RemoteTree
         NodeInfo info = tree.getInfo(nid, 0);
         return info;
     }    
+    public void clearFlags(NidData nid, int flags) throws DatabaseException
+    {
+        tree.clearFlags(nid, flags);
+    }    
     public void setFlags(NidData nid, int flags) throws DatabaseException
     {
         tree.setFlags(nid, flags);

--- a/javatraverser/TreeServer.java
+++ b/javatraverser/TreeServer.java
@@ -109,6 +109,14 @@ class TreeServer extends UnicastRemoteObject implements RemoteTree
         setContext(ctx);
         NodeInfo info = tree.getInfo(nid, 0);
         return info;
+    }    
+    public void setFlags(NidData nid, int flags) throws DatabaseException
+    {
+        tree.setFlags(nid, flags);
+    }
+    public int getFlags(NidData nid) throws DatabaseException
+    {
+        return tree.getFlags(nid);
     }
     public void setTags(NidData nid, String tags[], int ctx) throws DatabaseException
     {

--- a/javatraverser/jTraverser.java
+++ b/javatraverser/jTraverser.java
@@ -9,7 +9,6 @@ import javax.swing.plaf.*;
 import java.util.*;
 public class jTraverser extends JFrame implements ActionListener
 {
-
     static String exp_name, shot_name;
     static boolean editable;
     Tree tree;
@@ -19,7 +18,6 @@ public class jTraverser extends JFrame implements ActionListener
 	add_window_b, add_axis_b, add_device_b, add_child_b, add_subtree_b, delete_node_b, modify_tags_b,
 	rename_node_b, turn_on_b, turn_off_b, display_data_b, display_nci_b, display_tags_b, modify_data_b,
 	set_default_b, setup_device_b, do_action_b, outline_b, tree_b, copy_b, paste_b;
-
     TreeDialog display_data_d = null, modify_data_d = null, display_nci_d = null, display_tags_d = null;
     DisplayData display_data;
     DisplayNci display_nci;
@@ -139,7 +137,6 @@ public class jTraverser extends JFrame implements ActionListener
 	jm.add(tree_b = new JMenuItem("Tree"));
 	tree_b.addActionListener(this);
 	curr_menu.add(jm);
-
 	tree = new Tree(this);
 	if(exp_name != null)
 	    tree.open(exp_name.toUpperCase(), (shot_name == null)?-1:Integer.parseInt(shot_name), edit, readonly, false);
@@ -159,6 +156,11 @@ public class jTraverser extends JFrame implements ActionListener
 
     public static String getExperimentName(){return exp_name;}
     public static boolean isEditable(){return editable;}
+    public Point dialogLocation()
+    {
+        return new Point(getLocation().x+32,getLocation().y+32);
+    }
+
 public void actionPerformed(ActionEvent e)
 {
     Object source = e.getSource();
@@ -179,7 +181,7 @@ public void actionPerformed(ActionEvent e)
     if(source == (Object)add_subtree_b) tree.addSubtree();
     if(source == (Object)delete_node_b) tree.deleteNode();
     if(source == (Object)modify_tags_b) tree.modifyTags();
-    if(source == (Object)rename_node_b) tree.renameNode();
+    if(source == (Object)rename_node_b) Tree.dialogs.rename.show();
     if(source == (Object)add_device_b) tree.addDevice();
     if(source == (Object)copy_b) TreeNode.copy();
     if(source == (Object)paste_b) TreeNode.paste();
@@ -198,7 +200,6 @@ public void actionPerformed(ActionEvent e)
 	    tree.reportChange();
     }
 
-    Point curr_origin = new Point(getLocation().x+32,getLocation().y+32);
     if(source == (Object)display_data_b)
     {
 	    if(display_data_d == null)
@@ -208,7 +209,7 @@ public void actionPerformed(ActionEvent e)
 	    }
 	    display_data.setNode(curr_node);
 	    display_data_d.pack();
-	    display_data_d.setLocation(curr_origin);
+	    display_data_d.setLocation(dialogLocation());
 	    display_data_d.setVisible(true);
     }
     if(source == (Object)display_nci_b)
@@ -220,7 +221,7 @@ public void actionPerformed(ActionEvent e)
         }
         display_nci.setNode(curr_node);
         display_nci_d.pack();
-        display_nci_d.setLocation(curr_origin);
+        display_nci_d.setLocation(dialogLocation());
         display_nci_d.setVisible(true);
     }
     if(source == (Object)display_tags_b)
@@ -232,7 +233,7 @@ public void actionPerformed(ActionEvent e)
         }
         display_tags.setNode(curr_node);
         display_tags_d.pack();
-        display_tags_d.setLocation(curr_origin);
+        display_tags_d.setLocation(dialogLocation());
         display_tags_d.setVisible(true);
     }
     if(source == (Object)modify_data_b)
@@ -244,7 +245,7 @@ public void actionPerformed(ActionEvent e)
 	    }
 	    modify_data.setNode(curr_node);
 	    modify_data_d.pack();
-	    modify_data_d.setLocation(curr_origin);
+	    modify_data_d.setLocation(dialogLocation());
 	    modify_data_d.setVisible(true);
     }
     if(source == (Object)set_default_b)

--- a/javatraverser/jTraverser.java
+++ b/javatraverser/jTraverser.java
@@ -10,15 +10,15 @@ import java.util.*;
 public class jTraverser extends JFrame implements ActionListener
 {
     static String exp_name, shot_name;
-    static boolean editable;
-    Tree tree;
+    static boolean editable, readonly;
+    static Tree tree;
     JMenu file_m, edit_m, data_m, customize_m;
     JMenuItem open, close, quit;
     JMenuItem add_action_b, add_dispatch_b, add_numeric_b, add_signal_b, add_task_b, add_text_b,
 	add_window_b, add_axis_b, add_device_b, add_child_b, add_subtree_b, delete_node_b, modify_tags_b,
 	rename_node_b, turn_on_b, turn_off_b, display_data_b, display_nci_b, display_tags_b, modify_data_b,
 	set_default_b, setup_device_b, do_action_b, outline_b, tree_b, copy_b, paste_b;
-    TreeDialog display_data_d = null, modify_data_d = null, display_nci_d = null, display_tags_d = null;
+    TreeDialog display_data_d, modify_data_d, display_nci_d, display_tags_d;
     DisplayData display_data;
     DisplayNci display_nci;
     DisplayTags display_tags;
@@ -28,12 +28,13 @@ public class jTraverser extends JFrame implements ActionListener
      */
     public static void main(String args[]) {
 
+    /* the original font is either ugly or defaults to an ugly font if not found 
     if(System.getProperty("os.name").equals("Linux"))
     {
-	    UIManager.put("Label.font", new FontUIResource(new Font("LuciduxSans", Font.BOLD, 11)));
-	    UIManager.put("ComboBox.font", new FontUIResource(new Font("LuciduxSans", Font.BOLD, 11)));
-	    UIManager.put("Button.font", new FontUIResource(new Font("LuciduxSans", Font.BOLD, 11)));
-    }
+	    UIManager.put("Label.font", new FontUIResource(new Font("FreeSerif", Font.BOLD, 11)));
+	    UIManager.put("ComboBox.font", new FontUIResource(new Font("FreeSerif", Font.BOLD, 11)));
+	    UIManager.put("Button.font", new FontUIResource(new Font("FreeSerif", Font.BOLD, 11)));
+    }*/
 
     if(args.length >= 3)
 		FrameRepository.frame = new jTraverser(args[0], args[1], args[2]);
@@ -262,6 +263,7 @@ public void actionPerformed(ActionEvent e)
 void reportChange(String exp, int shot, boolean editable, boolean readonly)
 {
     jTraverser.editable = editable;
+    jTraverser.readonly = readonly;
     jTraverser.exp_name = exp;
     String title;
     if(exp != null)


### PR DESCRIPTION
- added a flag editor
- commented the Linux font to encourage the default one (more readable)
- flag dialog updates on node changes
- flag dialog can display flags change editable ones
- allows to unset setup flag
- used set and clear flags code from tcl_set_node
- fixes rename dialog on changes of current node
- rename now closes if node is changed
- minor code and layout optimisation
