### PR TITLE
jTraverser dialogs (rename/nci) + cut and paste nodes

### DIFF
--- a/javamds/JavaData.c
+++ b/javamds/JavaData.c
@@ -558,7 +558,8 @@ struct descriptor *ObjectToDescrip(JNIEnv * env, jobject obj)
   struct descriptor_a *array_d;
   static DESCRIPTOR_R(template_rec, 0, 1);
   struct descriptor_r *record_d;
-  int i, ndescs, opcode, dtype, dclass;
+  int i, ndescs, opcode;
+  unsigned char dtype, dclass;
   jobject jdescs;
   jsize length;
   jbyteArray jbytes;
@@ -585,10 +586,10 @@ struct descriptor *ObjectToDescrip(JNIEnv * env, jobject obj)
     return NULL;
   }
   cls = (*env)->GetObjectClass(env, obj);
-  dtype_fid = (*env)->GetFieldID(env, cls, "dtype", "I"),
-      dclass_fid = (*env)->GetFieldID(env, cls, "dclass", "I");
-  dtype = (*env)->GetIntField(env, obj, dtype_fid),
-      dclass = (*env)->GetIntField(env, obj, dclass_fid);
+  dclass_fid = (*env)->GetFieldID(env, cls, "dclass", "B");
+  dclass = (*env)->GetIntField(env, obj, dclass_fid);
+  dtype_fid = (*env)->GetFieldID(env, cls, "dtype", "B");
+  dtype = (*env)->GetIntField(env, obj, dtype_fid);
   switch (dclass) {
   case CLASS_S:
     desc = (struct descriptor *)malloc(sizeof(struct descriptor));

--- a/javamds/JavaTrav.c
+++ b/javamds/JavaTrav.c
@@ -446,24 +446,25 @@ JNIEXPORT jobject JNICALL Java_Database_getInfo
       conglomerate_nids, owner_id, owner_len, dtype_len, class_len, length, length_len, usage_len,
       name_len, fullpath_len, minpath_len, conglomerate_elt,
       conglomerate_elt_len, path_len;
-  static char dtype, class, time_str[256], usage, name[16], fullpath[512], minpath[512],
-       path[512];
+  static unsigned char dtype, class, usage;
+  static char time_str[256], name[16], fullpath[512], minpath[512], path[512];
   unsigned short asctime_len;
   struct descriptor time_dsc = { 256, DTYPE_T, CLASS_S, time_str };
 
-  struct nci_itm nci_list[] = { {4, NciGET_FLAGS, &nci_flags, &nci_flags_len},
-  {8, NciTIME_INSERTED, time_inserted, &time_len},
-  {4, NciOWNER_ID, &owner_id, &owner_len},
+  struct nci_itm nci_list[] = {
   {1, NciCLASS, &class, &class_len},
   {1, NciDTYPE, &dtype, &dtype_len},
-  {4, NciLENGTH, &length, &length_len},
   {1, NciUSAGE, &usage, &usage_len},
-  {16, NciNODE_NAME, name, &name_len},
+  {4, NciGET_FLAGS, &nci_flags, &nci_flags_len},
+  {4, NciOWNER_ID, &owner_id, &owner_len},
+  {4, NciLENGTH, &length, &length_len},
+  {4, NciNUMBER_OF_ELTS, &conglomerate_nids, &conglomerate_nids_len},
+  {4, NciCONGLOMERATE_ELT, &conglomerate_elt, &conglomerate_elt_len},
+  {8, NciTIME_INSERTED, time_inserted, &time_len},
+  {15, NciNODE_NAME, name, &name_len},
   {511, NciFULLPATH, fullpath, &fullpath_len},
   {511, NciMINPATH, minpath, &minpath_len},
   {511, NciPATH, path, &path_len},
-  {4, NciNUMBER_OF_ELTS, &conglomerate_nids, &conglomerate_nids_len},
-  {4, NciCONGLOMERATE_ELT, &conglomerate_elt, &conglomerate_elt_len},
   {NciEND_OF_LIST, 0, 0, 0}
   };
 
@@ -484,35 +485,25 @@ JNIEXPORT jobject JNICALL Java_Database_getInfo
   cls = (*env)->FindClass(env, "NodeInfo");
   constr =
       (*env)->GetStaticMethodID(env, cls, "getNodeInfo",
-				"(ZZZZZZZZZLjava/lang/String;IIIIILjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;II)LNodeInfo;");
-  args[0].z = (nci_flags & NciM_STATE) == 0;
-  args[1].z = (nci_flags & NciM_PARENT_STATE) == 0;
-  args[2].z = (nci_flags & NciM_SETUP_INFORMATION) != 0;
-  args[3].z = (nci_flags & NciM_WRITE_ONCE) != 0;
-  args[4].z = (nci_flags & NciM_COMPRESSIBLE) != 0;
-  args[5].z = (nci_flags & NciM_COMPRESS_ON_PUT) != 0;
-  args[6].z = (nci_flags & NciM_NO_WRITE_MODEL) != 0;
-  args[7].z = (nci_flags & NciM_NO_WRITE_SHOT) != 0;
-  args[8].z = (nci_flags & NciM_ESSENTIAL) != 0;
-
+				"(BBBIIIIILjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)LNodeInfo;");
   if (time_inserted[0] || time_inserted[1]) {
     LibSysAscTim(&asctime_len, &time_dsc, time_inserted);
     time_str[asctime_len] = 0;
   } else
     strcpy(time_str, "???");
-  args[9].l = (*env)->NewStringUTF(env, time_str);
-  args[10].i = owner_id;
-  args[11].i = dtype;
-  args[12].i = class;
-  args[13].i = length;
-  args[14].i = (int)usage;
-  args[15].l = (*env)->NewStringUTF(env, name);
-  args[16].l = (*env)->NewStringUTF(env, fullpath);
-  args[17].l = (*env)->NewStringUTF(env, minpath);
-  args[18].l = (*env)->NewStringUTF(env, path);
-  args[19].i = conglomerate_nids;
-  args[20].i = conglomerate_elt;
-
+  args[0].b = class;
+  args[1].b = dtype;
+  args[2].b = usage;
+  args[3].i = nci_flags;
+  args[4].i = owner_id;
+  args[5].i = length;
+  args[6].i = conglomerate_nids;
+  args[7].i = conglomerate_elt;
+  args[8].l = (*env)->NewStringUTF(env, time_str);
+  args[9].l = (*env)->NewStringUTF(env, name);
+  args[10].l = (*env)->NewStringUTF(env, fullpath);
+  args[11].l = (*env)->NewStringUTF(env, minpath);
+  args[12].l = (*env)->NewStringUTF(env, path);
   return (*env)->CallStaticObjectMethodA(env, cls, constr, args);
 }
 

--- a/javatraverser/Data.java
+++ b/javatraverser/Data.java
@@ -12,9 +12,8 @@ public abstract class Data implements Serializable
         try {
 	    System.loadLibrary("JavaMds");
 	    }catch(Exception e) {System.out.println("Cannot load library " + e); }
-    }
-*/    int dclass;
-    int dtype;
+    }*/
+    byte dclass, dtype;
     Vector data_listeners = new Vector();
     public Data()
     {
@@ -83,50 +82,59 @@ public abstract class Data implements Serializable
     abstract boolean isAtomic();
 
 
-    public static final int DTYPE_BU = 2;
-    public static final int DTYPE_WU = 3;
-    public static final int DTYPE_LU = 4;
-    public static final int DTYPE_QU = 5;
-    public static final int DTYPE_OU = 25;
-    public static final int DTYPE_B = 6;
-    public static final int DTYPE_W = 7;
-    public static final int DTYPE_L = 8;
-    public static final int DTYPE_Q = 9;
-    public static final int DTYPE_O = 26;
-    public static final int DTYPE_FLOAT = 52;
-    public static final int DTYPE_DOUBLE = 53;
-    public static final int DTYPE_FTC = 55;
-    public static final int DTYPE_T = 14;
-    public static final int DTYPE_IDENT = 191;
-    public static final int DTYPE_NID = 192;
-    public static final int DTYPE_PATH = 193;
-    public static final int DTYPE_PARAM = 194;
-    public static final int DTYPE_SIGNAL = 195;
-    public static final int DTYPE_DIMENSION = 196;
-    public static final int DTYPE_WINDOW = 197;
-    public static final int DTYPE_SLOPE = 198;
-    public static final int DTYPE_FUNCTION = 199;
-    public static final int DTYPE_CONGLOM = 200;
-    public static final int DTYPE_RANGE = 201;
-    public static final int DTYPE_ACTION = 202;
-    public static final int DTYPE_DISPATCH = 203;
-    public static final int DTYPE_PROGRAM = 204;
-    public static final int DTYPE_ROUTINE = 205;
-    public static final int DTYPE_PROCEDURE = 206;
-    public static final int DTYPE_METHOD = 207;
-    public static final int DTYPE_DEPENDENCY = 208;
-    public static final int DTYPE_CONDITION = 209;
-    public static final int DTYPE_EVENT = 210;
-    public static final int DTYPE_WITH_UNITS = 211;
-    public static final int DTYPE_CALL = 212;
-    public static final int DTYPE_WITH_ERROR = 213;
+    public static final byte DTYPE_BU = 2;
+    public static final byte DTYPE_WU = 3;
+    public static final byte DTYPE_LU = 4;
+    public static final byte DTYPE_QU = 5;
+    public static final byte DTYPE_OU = 25;
+    public static final byte DTYPE_B = 6;
+    public static final byte DTYPE_W = 7;
+    public static final byte DTYPE_L = 8;
+    public static final byte DTYPE_Q = 9;
+    public static final byte DTYPE_O = 26;
+    public static final byte DTYPE_FLOAT = 52;
+    public static final byte DTYPE_DOUBLE = 53;
+    public static final byte DTYPE_FSC = 54;
+    public static final byte DTYPE_FTC = 55;
+    public static final byte DTYPE_F = 10;
+    public static final byte DTYPE_D = 11;
+    public static final byte DTYPE_G = 27;
+    public static final byte DTYPE_H = 28;
+    public static final byte DTYPE_T = 14;
+    public static final byte DTYPE_POINTER = 51;
+    public static final byte DTYPE_DSC = 24;
+    public static final byte DTYPE_IDENT = -65; //191
+    public static final byte DTYPE_NID = -64; //192
+    public static final byte DTYPE_PATH = -63; //193
+    public static final byte DTYPE_PARAM = -62; //194
+    public static final byte DTYPE_SIGNAL = -61; //195
+    public static final byte DTYPE_DIMENSION = -60; //196
+    public static final byte DTYPE_WINDOW = -59; //197
+    public static final byte DTYPE_SLOPE = -58; //198
+    public static final byte DTYPE_FUNCTION = -57; //199
+    public static final byte DTYPE_CONGLOM = -56; //200
+    public static final byte DTYPE_RANGE = -55; //201
+    public static final byte DTYPE_ACTION = -54; //202
+    public static final byte DTYPE_DISPATCH = -53; //203
+    public static final byte DTYPE_PROGRAM = -52; //204
+    public static final byte DTYPE_ROUTINE = -51; //205
+    public static final byte DTYPE_PROCEDURE = -50; //206
+    public static final byte DTYPE_METHOD = -49; //207
+    public static final byte DTYPE_DEPENDENCY = -48; //208
+    public static final byte DTYPE_CONDITION = -47; //209
+    public static final byte DTYPE_EVENT = -46; //210
+    public static final byte DTYPE_WITH_UNITS = -45; //211
+    public static final byte DTYPE_CALL = -44; //212
+    public static final byte DTYPE_WITH_ERROR = -43; //213
+    public static final byte DTYPE_LIST = -42;//214
+    public static final byte DTYPE_TUPLE = -41;//215
+    public static final byte DTYPE_DICTIONARY = -40;//216
 
-
-    public static final int CLASS_S = 1;
-    public static final int CLASS_D = 2;
-    public static final int CLASS_A = 4;
-    public static final int CLASS_R = 194;
-    public static final int CLASS_APD = 196;
+    public static final byte CLASS_S = 1;
+    public static final byte CLASS_D = 2;
+    public static final byte CLASS_A = 4;
+    public static final byte CLASS_R = -62; //194
+    public static final byte CLASS_APD = -60; //196
 }
 
 

--- a/javatraverser/Data.java
+++ b/javatraverser/Data.java
@@ -26,10 +26,10 @@ public abstract class Data implements Serializable
 //              System.loadLibrary("TreeShr");
 //              System.loadLibrary("TdiShr");
               System.loadLibrary("JavaMds");
-	        }catch(Throwable e)
+	        }catch(Exception exc)
                 {
-                  System.out.println("Load library "+e);
-                  e.printStackTrace();
+                  jTraverser.stderr("Error loading library", exc);
+                  exc.printStackTrace();
                 }
 	    }
     }

--- a/javatraverser/Database.java
+++ b/javatraverser/Database.java
@@ -15,10 +15,10 @@ public class Database implements RemoteTree{
  //           System.loadLibrary("TdiShr");
             System.loadLibrary("JavaMds");
 	    }
-            catch(Throwable e)
+            catch(Exception exc)
             {
-              System.out.println("Cannot load library " + e);
-              e.printStackTrace();
+              jTraverser.stderr("Cannot load library ", exc);
+              exc.printStackTrace();
             }
     }
     public Database() {super();}

--- a/javatraverser/Database.java
+++ b/javatraverser/Database.java
@@ -68,7 +68,6 @@ public class Database implements RemoteTree{
     public native Data evaluateSimpleData(Data data, int ctx) throws DatabaseException;
     public native void putData(NidData nid, Data data, int ctx) throws DatabaseException;
     public native void putRow(NidData nid, Data data, long time, int ctx) throws DatabaseException;
-    //public native DatabaseInfo getInfo(); throws DatabaseException;
     public native NodeInfo getInfo(NidData nid, int ctx) throws DatabaseException;
     public native void setTags(NidData nid, String tags[], int ctx) throws DatabaseException;
     public native String[] getTags(NidData nid, int ctx);

--- a/javatraverser/DisplayNci.java
+++ b/javatraverser/DisplayNci.java
@@ -5,115 +5,149 @@ import java.awt.event.*;
 
 public class DisplayNci extends NodeEditor implements ActionListener
 {
-    JLabel label1, label2, label3, label4;
+    JLabel label0, label1, label2, label3;
     public DisplayNci()
     {
-	setLayout(new BorderLayout());
-	JPanel jp = new JPanel();
-	jp.setLayout(new GridLayout(4,1));
-	jp.add(label1 = new JLabel("prova1"));
-	jp.add(label2 = new JLabel("prova2"));
-	jp.add(label3 = new JLabel("prova3"));
-	jp.add(label4 = new JLabel("prova4"));
-	add(jp, "North");
-	JPanel jp1 = new JPanel();
-	JButton cancel = new JButton("Cancel");
-	jp1.add(cancel);
-	add(jp1, "South");
-	cancel.addActionListener(this);
+	    setLayout(new BorderLayout());
+	    JPanel jp, jpsub;
+        add(jp = new JPanel(), "North");
+	    jp.setLayout(new GridBagLayout());
+        GridBagConstraints c = new GridBagConstraints();
+        c.fill = GridBagConstraints.EAST;
+        c.gridx=0;
+        c.gridy=0;
+	    jp.add(label0 = new JLabel(""), c);
+        c.gridy=1;
+	    jp.add(label1 = new JLabel(""), c);
+        c.gridy=2;
+	    jp.add(label2 = new JLabel(""), c);
+        c.gridy=3;
+	    jp.add(label3 = new JLabel(""), c);
+	    add(jp = new JPanel(), "South");
+	    JButton close;
+	    jp.add(close = new JButton("Close"));
+	    close.addActionListener(this);
     }
     public void actionPerformed(ActionEvent e) {
 		frame.dispose();
     }
 
-
-    public void setNode(Node _node)
+    public void setNode(Node node)
     {	
-	NodeInfo info;
-	node = _node;
-	frame.setTitle("Display Nci information");
-	try{
-	    info = node.getInfo();
-	}catch(Exception e){System.out.println("Error retieving Nci"); return; }
-	label1.setText(info.name);
-	StringBuffer sb = new StringBuffer("Status: ");
-	if(info.on)
-	    sb.append("on, ");
-	else
-	    sb.append("off, ");
-	if(info.parent_on)
-	    sb.append("parent is on");
-	else
-	    sb.append("parent is off");
-	if(info.setup)
-	    sb.append(", setup");
-	if(info.write_once)
-	    sb.append(", write once");
-	if(info.compressible)
-	    sb.append(", compressible");
-	if(info.compress_on_put)
-	    sb.append(", compress on put");
-	if(info.no_write_model)
-	    sb.append(", no write model");
-	if(info.no_write_shot)
-	    sb.append(", no write shot");
-	label2.setText(sb.toString());
-	label3.setText("Data inserted: "+ info.date_inserted); 
-	
-	String dtype = "", dclass = "";
-	if(info.length == 0)
-	    label4.setText("There is no data stored for this node");
-	else
-	{
-	    switch(info.dtype) {
-		case  Data.DTYPE_BU: dtype = "DTYPE_BU"; break;
-		case Data.DTYPE_WU: dtype = "DTYPE_WU"; break;
-		case Data.DTYPE_LU: dtype = "DTYPE_LU"; break;
-		case Data.DTYPE_QU: dtype = "DTYPE_QU"; break;
-		case Data.DTYPE_OU: dtype = "DTYPE_OU"; break;
-		case Data.DTYPE_B: dtype = "DTYPE_B"; break;
-		case Data.DTYPE_W: dtype = "DTYPE_W"; break;
-		case Data.DTYPE_L: dtype = "DTYPE_L"; break;
-		case Data.DTYPE_Q: dtype = "DTYPE_Q"; break;
-		case Data.DTYPE_O: dtype = "DTYPE_O"; break;
-		case Data.DTYPE_FLOAT: dtype = "DTYPE_FLOAT"; break;
-		case Data.DTYPE_DOUBLE: dtype = "DTYPE_DOUBLE"; break;
-		case Data.DTYPE_T: dtype = "DTYPE_T"; break;
-		case Data.DTYPE_IDENT: dtype = "DTYPE_IDENT"; break;
-		case Data.DTYPE_NID: dtype = "DTYPE_NID"; break;
-		case Data.DTYPE_PATH: dtype = "DTYPE_PATH"; break;
-		case Data.DTYPE_PARAM: dtype = "DTYPE_PARAM"; break;
-		case Data.DTYPE_SIGNAL: dtype = "DTYPE_SIGNAL"; break;
-		case Data.DTYPE_DIMENSION: dtype = "DTYPE_DIMENSION"; break;
-		case Data.DTYPE_WINDOW: dtype = "DTYPE_WINDOW"; break;
-		case Data.DTYPE_FUNCTION: dtype = "DTYPE_FUNCTION"; break;
-		case Data.DTYPE_CONGLOM: dtype = "DTYPE_CONGLOM"; break;
-		case Data.DTYPE_RANGE: dtype = "DTYPE_RANGE"; break;
-		case Data.DTYPE_ACTION: dtype = "DTYPE_ACTION"; break;
-		case Data.DTYPE_DISPATCH: dtype = "DTYPE_DISPATCH"; break;
-		case Data.DTYPE_PROGRAM: dtype = "DTYPE_PROGRAM"; break;
-		case Data.DTYPE_ROUTINE: dtype = "DTYPE_ROUTINE"; break;
-		case Data.DTYPE_PROCEDURE: dtype = "DTYPE_PROCEDURE"; break;
-		case Data.DTYPE_METHOD: dtype = "DTYPE_METHOD"; break;
-		case Data.DTYPE_DEPENDENCY: dtype = "DTYPE_DEPENDENCY"; break;
-		case Data.DTYPE_CONDITION: dtype = "DTYPE_CONDITION"; break;
-		case Data.DTYPE_EVENT: dtype = "DTYPE_EVENT"; break;
-		case Data.DTYPE_WITH_UNITS: dtype = "DTYPE_WITH_UNITS"; break;
-		case Data.DTYPE_CALL: dtype = "DTYPE_CALL"; break;
-		case Data.DTYPE_WITH_ERROR: dtype = "DTYPE_WITH_ERROR"; break;
+	    this.node = node;
+	    frame.setTitle("Display Nci information");
+	    try{
+	        node.getInfo();
+	    }catch(Exception e){System.out.println("Error retieving Nci"); return; }
+	    label0.setText(node.getFullPath());
+	    StringBuffer sb = new StringBuffer("<html><table cols=1 width=300><td><nobr>Status: ");
+        final String sep = "</nobr>, <nobr>";
+	    if(node.isOn())
+	        sb.append("on");
+	    else
+	        sb.append("off");
+        sb.append(sep+"parent is ");
+	    if(node.isParentState())
+	        sb.append("off");
+	    else
+	        sb.append("on");
+	    if(node.isSetup())
+	        sb.append(sep+"setup");
+	    if(node.isEssential())
+	        sb.append(sep+"essential");
+	    if(node.isCached())
+	        sb.append(sep+"cached");
+	    if(node.isVersion())
+	        sb.append(sep+"version");
+	    if(node.isSegmented())
+	        sb.append(sep+"segmented");
+	    if(node.isWriteOnce())
+	        sb.append(sep+"write once");
+	    if(node.isCompressible())
+	        sb.append(sep+"compressible");
+	    if(node.isDoNotCompress())
+	        sb.append(sep+"do not compress");
+	    if(node.isCompressOnPut())
+	        sb.append(sep+"compress on put");
+	    if(node.isNoWriteModel())
+	        sb.append(sep+"no write model");
+	    if(node.isNoWriteShot())
+	        sb.append(sep+"no write shot");
+	    if(node.isPathReference())
+	        sb.append(sep+"path reference");
+	    if(node.isNidReference())
+	        sb.append(sep+"nid reference");
+	    if(node.isCompressSegments())
+	        sb.append(sep+"compress segments");
+	    if(node.isIncludeInPulse())
+	        sb.append(sep+"include in pulse");
+        sb.append("</nobr></td></table></html>");
+	    label1.setText(sb.toString());
+	    label2.setText("Data inserted: "+ node.getDate()); 
+	    String dtype, dclass;
+	    if(node.getLength() == 0)
+	        label3.setText("There is no data stored for this node");
+	    else
+	    {
+	        switch(node.getDType()) {
+		        case Data.DTYPE_BU: dtype = "DTYPE_BU"; break;
+		        case Data.DTYPE_WU: dtype = "DTYPE_WU"; break;
+		        case Data.DTYPE_LU: dtype = "DTYPE_LU"; break;
+		        case Data.DTYPE_QU: dtype = "DTYPE_QU"; break;
+		        case Data.DTYPE_OU: dtype = "DTYPE_OU"; break;
+		        case Data.DTYPE_B: dtype = "DTYPE_B"; break;
+		        case Data.DTYPE_W: dtype = "DTYPE_W"; break;
+		        case Data.DTYPE_L: dtype = "DTYPE_L"; break;
+		        case Data.DTYPE_Q: dtype = "DTYPE_Q"; break;
+		        case Data.DTYPE_O: dtype = "DTYPE_O"; break;
+		        case Data.DTYPE_FLOAT: dtype = "DTYPE_FLOAT"; break;
+		        case Data.DTYPE_DOUBLE: dtype = "DTYPE_DOUBLE"; break;
+		        case Data.DTYPE_FSC: dtype = "DTYPE_FSC"; break;
+		        case Data.DTYPE_FTC: dtype = "DTYPE_FTC"; break;
+		        case Data.DTYPE_F: dtype = "DTYPE_F"; break;
+		        case Data.DTYPE_D: dtype = "DTYPE_D"; break;
+		        case Data.DTYPE_G: dtype = "DTYPE_G"; break;
+		        case Data.DTYPE_H: dtype = "DTYPE_H"; break;
+		        case Data.DTYPE_T: dtype = "DTYPE_T"; break;
+		        case Data.DTYPE_POINTER: dtype = "DTYPE_POINTER"; break;
+		        case Data.DTYPE_DSC: dtype = "DTYPE_DSC"; break;
+		        case Data.DTYPE_IDENT: dtype = "DTYPE_IDENT"; break;
+		        case Data.DTYPE_NID: dtype = "DTYPE_NID"; break;
+		        case Data.DTYPE_PATH: dtype = "DTYPE_PATH"; break;
+		        case Data.DTYPE_PARAM: dtype = "DTYPE_PARAM"; break;
+		        case Data.DTYPE_SIGNAL: dtype = "DTYPE_SIGNAL"; break;
+		        case Data.DTYPE_DIMENSION: dtype = "DTYPE_DIMENSION"; break;
+		        case Data.DTYPE_WINDOW: dtype = "DTYPE_WINDOW"; break;
+		        case Data.DTYPE_SLOPE: dtype = "DTYPE_SLOPE"; break;
+		        case Data.DTYPE_FUNCTION: dtype = "DTYPE_FUNCTION"; break;
+		        case Data.DTYPE_CONGLOM: dtype = "DTYPE_CONGLOM"; break;
+		        case Data.DTYPE_RANGE: dtype = "DTYPE_RANGE"; break;
+		        case Data.DTYPE_ACTION: dtype = "DTYPE_ACTION"; break;
+		        case Data.DTYPE_DISPATCH: dtype = "DTYPE_DISPATCH"; break;
+		        case Data.DTYPE_PROGRAM: dtype = "DTYPE_PROGRAM"; break;
+		        case Data.DTYPE_ROUTINE: dtype = "DTYPE_ROUTINE"; break;
+		        case Data.DTYPE_PROCEDURE: dtype = "DTYPE_PROCEDURE"; break;
+		        case Data.DTYPE_METHOD: dtype = "DTYPE_METHOD"; break;
+		        case Data.DTYPE_DEPENDENCY: dtype = "DTYPE_DEPENDENCY"; break;
+		        case Data.DTYPE_CONDITION: dtype = "DTYPE_CONDITION"; break;
+		        case Data.DTYPE_EVENT: dtype = "DTYPE_EVENT"; break;
+		        case Data.DTYPE_WITH_UNITS: dtype = "DTYPE_WITH_UNITS"; break;
+		        case Data.DTYPE_CALL: dtype = "DTYPE_CALL"; break;
+		        case Data.DTYPE_WITH_ERROR: dtype = "DTYPE_WITH_ERROR"; break;
+		        case Data.DTYPE_LIST: dtype = "DTYPE_LIST"; break;
+		        case Data.DTYPE_TUPLE: dtype = "DTYPE_TUPLE"; break;
+		        case Data.DTYPE_DICTIONARY: dtype = "DTYPE_DICTIONARY"; break;
+                default: dtype = "DTYPE" + ((int)node.getDType() & 0xFF); break;
+	        }
+	        switch(node.getDClass()) {
+		        case Data.CLASS_S: dclass = "CLASS_S"; break;
+		        case Data.CLASS_D: dclass = "CLASS_D"; break;
+		        case Data.CLASS_A: dclass = "CLASS_A"; break;
+		        case Data.CLASS_R: dclass = "CLASS_R"; break;
+		        case Data.CLASS_APD: dclass = "CLASS_APD"; break;
+                default: dclass = "CLASS" + ((int)node.getDClass() & 0xFF); break;
+	        }
+	        label3.setText(dtype+"   "+dclass+"   Length: "+node.getLength()+" bytes");
 	    }
-	    switch(info.dclass) {
-		case Data.CLASS_S: dclass = "CLASS_S"; break;
-		case Data.CLASS_D: dclass = "CLASS_D"; break;
-		case Data.CLASS_A: dclass = "CLASS_A"; break;
-		case Data.CLASS_R: dclass = "CLASS_R"; break;
-		case Data.CLASS_APD: dclass = "CLASS_APD"; break;
-	    }
-	    label4.setText("Dtype: "+dtype+"  Class: " + dclass + "  Length: "+info.length + " bytes");
-	}
-	
-	
-	
-}
-
+    }
 }

--- a/javatraverser/DisplayNci.java
+++ b/javatraverser/DisplayNci.java
@@ -31,9 +31,8 @@ public class DisplayNci extends NodeEditor implements ActionListener
     {	
 	    this.node = node;
 	    frame.setTitle("Display Nci information");
-	    try{
-	        node.getInfo();
-	    }catch(Exception e){System.err.println("Error retieving Nci"); return; }
+	    try{node.getInfo();}
+        catch (Exception exc){jTraverser.stderr("Error retieving Nci", exc);}
 	    StringBuffer sb = new StringBuffer("<html><table width=\"320\"> <tr><td width=\"60\" align=\"left\"/><nobr>full path:</nobr></td><td align=\"left\">");
         sb.append(node.getFullPath());
         sb.append("</td></tr><tr><td align=\"left\" valign=\"top\">Status:</td><td align=\"left\"><nobr>");

--- a/javatraverser/DisplayNci.java
+++ b/javatraverser/DisplayNci.java
@@ -5,27 +5,22 @@ import java.awt.event.*;
 
 public class DisplayNci extends NodeEditor implements ActionListener
 {
-    JLabel label0, label1, label2, label3;
+    JLabel label;
     public DisplayNci()
     {
 	    setLayout(new BorderLayout());
-	    JPanel jp, jpsub;
+	    JPanel jp;
         add(jp = new JPanel(), "North");
 	    jp.setLayout(new GridBagLayout());
         GridBagConstraints c = new GridBagConstraints();
         c.fill = GridBagConstraints.EAST;
         c.gridx=0;
         c.gridy=0;
-	    jp.add(label0 = new JLabel(""), c);
+	    jp.add(label = new JLabel(""), c);
+ 	    add(jp = new JPanel(), "South");
         c.gridy=1;
-	    jp.add(label1 = new JLabel(""), c);
-        c.gridy=2;
-	    jp.add(label2 = new JLabel(""), c);
-        c.gridy=3;
-	    jp.add(label3 = new JLabel(""), c);
-	    add(jp = new JPanel(), "South");
 	    JButton close;
-	    jp.add(close = new JButton("Close"));
+	    jp.add(close = new JButton("Close"), c);
 	    close.addActionListener(this);
     }
     public void actionPerformed(ActionEvent e) {
@@ -38,9 +33,10 @@ public class DisplayNci extends NodeEditor implements ActionListener
 	    frame.setTitle("Display Nci information");
 	    try{
 	        node.getInfo();
-	    }catch(Exception e){System.out.println("Error retieving Nci"); return; }
-	    label0.setText(node.getFullPath());
-	    StringBuffer sb = new StringBuffer("<html><table cols=1 width=300><td><nobr>Status: ");
+	    }catch(Exception e){System.err.println("Error retieving Nci"); return; }
+	    StringBuffer sb = new StringBuffer("<html><table width=\"320\"> <tr><td width=\"60\" align=\"left\"/><nobr>full path:</nobr></td><td align=\"left\">");
+        sb.append(node.getFullPath());
+        sb.append("</td></tr><tr><td align=\"left\" valign=\"top\">Status:</td><td align=\"left\"><nobr>");
         final String sep = "</nobr>, <nobr>";
 	    if(node.isOn())
 	        sb.append("on");
@@ -81,12 +77,10 @@ public class DisplayNci extends NodeEditor implements ActionListener
 	        sb.append(sep+"compress segments");
 	    if(node.isIncludeInPulse())
 	        sb.append(sep+"include in pulse");
-        sb.append("</nobr></td></table></html>");
-	    label1.setText(sb.toString());
-	    label2.setText("Data inserted: "+ node.getDate()); 
+        sb.append("</nobr></td></tr><tr><td align=\"left\">Data:</td><td align=\"left\">");
 	    String dtype, dclass;
 	    if(node.getLength() == 0)
-	        label3.setText("There is no data stored for this node");
+	        sb.append("There is no data stored for this node");
 	    else
 	    {
 	        switch(node.getDType()) {
@@ -147,7 +141,11 @@ public class DisplayNci extends NodeEditor implements ActionListener
 		        case Data.CLASS_APD: dclass = "CLASS_APD"; break;
                 default: dclass = "CLASS" + ((int)node.getDClass() & 0xFF); break;
 	        }
-	        label3.setText(dtype+"   "+dclass+"   Length: "+node.getLength()+" bytes");
+            sb.append("<nobr>"+dtype+"&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"+dclass+"&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"+node.getLength()+" Bytes</nobr>");
+            sb.append("</td></tr><tr><td align=\"left\">Inserted:</td><td align=\"left\">");
+            sb.append(node.getDate());
+            sb.append("</td></tr></table></html>");
 	    }
+	    label.setText(sb.toString());
     }
 }

--- a/javatraverser/Node.java
+++ b/javatraverser/Node.java
@@ -17,12 +17,13 @@ public class Node
     Node[] sons;
     Node[] members;
     boolean is_member;
-    JLabel tree_label = null;
-    NodeBeanInfo bean_info = null;
+    JLabel tree_label;
+    NodeBeanInfo bean_info;
     Tree hierarchy;
-    static Node copiedNode = null;
+    static Node copiedNode;
     boolean needsOnCheck = true;
     boolean is_on = false;
+    private DefaultMutableTreeNode treenode;
 
     public Node(RemoteTree experiment, Tree hierarchy) throws DatabaseException,
         RemoteException
@@ -40,13 +41,13 @@ public class Node
         members = new Node[0];
     }
 
-    public Node(RemoteTree experiment, Tree hierarchy, Node parent,
-                boolean is_member, NidData nid)
+    public Node(RemoteTree experiment, Tree hierarchy, Node parent, boolean is_member, NidData nid)
     {
         this.experiment = experiment;
         this.hierarchy = hierarchy;
-        this.nid = nid;
         this.parent = parent;
+        this.is_member = is_member;
+        this.nid = nid;
         try
         {
             info = experiment.getInfo(nid, Tree.context);
@@ -59,6 +60,9 @@ public class Node
         members = new Node[0];
 
     }
+
+    public void setTreeNode(DefaultMutableTreeNode treenode){this.treenode = treenode;}
+    public DefaultMutableTreeNode getTreeNode(){return treenode;}
 
     void setOnUnchecked()
     {
@@ -89,6 +93,12 @@ public class Node
             System.out.println("Error getting info " + e);
         }
     }
+
+    public void updateCell()
+    {
+        ;
+    }
+
 
     public void updateData() throws DatabaseException, RemoteException
     {
@@ -192,18 +202,7 @@ public class Node
     public void setInfo(NodeInfo info) throws DatabaseException, RemoteException{}
 
     public int getFlags() throws Exception
-    {   /*
-        0x00001 off
-        0x00004 essential
-        0x00040 setup
-        0x00080 write_once
-        0x00100 compressible        
-        0x00400 compress_on_put     
-        0x00800 no_write_model      
-        0x01000 no_write_shot       
-        0x08000 include_in_pulse    
-        0x10000 compress_segments    
-        */
+    {
         return  experiment.getFlags(nid);
     }
 
@@ -275,8 +274,7 @@ public class Node
                     return;
                 }
                 catch (Exception e)
-                {
-                    
+                {                   
              		try {
                 		experiment.doDeviceMethod(nid, "dw_setup", Tree.context) ;
             		}catch(Exception exc) {
@@ -289,7 +287,6 @@ public class Node
                     	return;
                 	}
 				}
-
             }
         }
         JOptionPane.showMessageDialog(null, "Missing model in descriptor",
@@ -356,6 +353,7 @@ public class Node
         return info.getFullPath();
     }
 
+    public String toString(){return getName();}
     public String getName()
     {
         if (info == null)
@@ -469,9 +467,7 @@ public class Node
 
     public int startDelete()
     {
-        NidData[] nids =
-            {
-            nid};
+        NidData[] nids ={nid};
         try
         {
             return experiment.startDelete(nids, Tree.context).length;
@@ -485,59 +481,58 @@ public class Node
 
     public void executeDelete()
     {
-        NidData[] nids =
-            {
-            nid};
+        NidData[] nids = {nid};
         try
         {
             experiment.executeDelete(Tree.context);
         }
         catch (Exception e)
         {
-            System.out.println("Error executing delete: " + e.getMessage());
+            System.err.println("Error executing delete: " + e.getMessage());
         }
     }
 
-    boolean changePath(String newFullPath)
-    {
-	    try
-        {
-            experiment.renameNode(nid, newFullPath, Tree.context);
-            info = experiment.getInfo(nid, Tree.context);
-            return true;
-        }
-        catch(Exception exc)
-		{
-            JOptionPane.showMessageDialog(FrameRepository.frame, "Error changing node path: "+ exc,
-		    "Error changing node path", JOptionPane.WARNING_MESSAGE);
-		}
-        return false;
-    }
 
-    boolean rename(String newName)
+    boolean move(Node newParent){return changePath(newParent, getName());}
+    boolean rename(String newName){return changePath(parent, newName);}
+    private boolean changePath(Node newParent, String newName)
     {
+        if ((newParent==parent) && (newName==getName())) return false; // nothing to do
         if(newName.length() > 12 || newName.length() == 0)
 	    {
 	        JOptionPane.showMessageDialog(FrameRepository.frame, "Node name lengh must be between 1 and 12 characters",
 		    "Error renaming node", JOptionPane.WARNING_MESSAGE);
             return false;
 	    }
-        String prevPath = getFullPath();
-        int curr;
-        for (curr = prevPath.length() - 1;
-                curr > 0 && prevPath.charAt(curr) != ':' &&
-                prevPath.charAt(curr) != '.'; curr--);
-        String newFullPath = prevPath.substring(0, curr + 1) + newName;
-        return changePath(newFullPath);
+	    try
+        {
+            String sep = is_member ? ":" : "."; 
+            experiment.renameNode(nid, newParent.getFullPath()+sep+newName, Tree.context);
+            info = experiment.getInfo(nid, Tree.context);
+        }
+        catch(Exception exc)
+		{
+            JOptionPane.showMessageDialog(FrameRepository.frame, "Error changing node path: "+ exc,
+		    "Error changing node path", JOptionPane.WARNING_MESSAGE);
+            return false;
+		}
+        if (newParent!=parent)
+        {    
+            parent = newParent;
+	        DefaultTreeModel tree_model = (DefaultTreeModel)Tree.curr_tree.getModel();
+	        tree_model.removeNodeFromParent(getTreeNode());
+            Tree.addNodeToParent(getTreeNode(),parent.getTreeNode());
+        }
+        return true;
     }
 
     private ImageIcon loadIcon(String gifname)
     {
         String base = System.getProperty("icon_base");
-//      return (base == null) ? new ImageIcon(ClassLoader.getSystemResource(gifname)) : new ImageIcon(base + "/" + gifname);
-        return (base == null) ?
-            new ImageIcon(getClass().getClassLoader().getResource(gifname)) :
-            new ImageIcon(base + "/" + gifname);
+        if (base == null)
+            return new ImageIcon(getClass().getClassLoader().getResource(gifname));
+        else
+            return new ImageIcon(base + "/" + gifname);
     }
 
     public JLabel getIcon()
@@ -586,21 +581,11 @@ public class Node
                 icon = loadIcon("compound.gif");
                 break;
         }
-
-        if (is_member)
-            tree_label = new TreeNode(this, ": " + info.name, icon);
-        else
-            tree_label = new TreeNode(this, info.name, icon);
+        tree_label = new TreeNode(this, info.name, icon);
         return tree_label;
     }
 
-    public String toString()
-    {
-        return getName();
-    }
-
-    static public void pasteSubtree(Node fromNode, Node toNode,
-                                    boolean isMember)
+    static public void pasteSubtree(Node fromNode, Node toNode, boolean isMember)
     {
         DefaultMutableTreeNode savedTreeNode = Tree.getCurrTreeNode();
         try

--- a/javatraverser/Node.java
+++ b/javatraverser/Node.java
@@ -47,14 +47,8 @@ public class Node
         this.parent = parent;
         this.is_member = is_member;
         this.nid = nid;
-        try
-        {
-            info = experiment.getInfo(nid, Tree.context);
-        }
-        catch (Exception e)
-        {
-            System.out.println("Error getting info " + e);
-        }
+        try{info = experiment.getInfo(nid, Tree.context);}
+        catch (Exception exc){jTraverser.stderr("Error getting info", exc);}
         sons = new Node[0];
         members = new Node[0];
     }
@@ -86,10 +80,7 @@ public class Node
             info = experiment.getInfo(nid, Tree.context);
             tree_label = null;
         }
-        catch (Exception e)
-        {
-            System.out.println("Error getting info " + e);
-        }
+        catch (Exception exc){jTraverser.stderr("Error getting info", exc);}
     }
 
     public void updateCell()
@@ -140,27 +131,15 @@ public class Node
 
     public void turnOn()
     {
-        try
-        {
-            experiment.setOn(nid, true, Tree.context);
-        }
-        catch (Exception e)
-        {
-            System.out.println("Error turning on " + e.getMessage());
-        }
+        try{experiment.setOn(nid, true, Tree.context);}
+        catch (Exception exc){jTraverser.stderr("Error turning on", exc);}
         setOnUnchecked();
     }
 
     public void turnOff()
     {
-        try
-        {
-            experiment.setOn(nid, false, Tree.context);
-        }
-        catch (Exception e)
-        {
-            System.out.println("Error turning on " + e.getMessage());
-        }
+        try{experiment.setOn(nid, false, Tree.context);}
+        catch (Exception exc){jTraverser.stderr("Error turning off", exc);}
         setOnUnchecked();
     }
 
@@ -195,7 +174,7 @@ public class Node
         try{
             info = experiment.getInfo(nid, Tree.context);
         }
-        catch (Exception exc){System.err.println("Error checking info " + exc);}
+        catch (Exception exc){jTraverser.stderr("Error checking info",exc);}
         return info;
     }
 
@@ -247,7 +226,7 @@ public class Node
     }
     public int getFlags()
     {   try{info.setFlags(experiment.getFlags(nid));}
-        catch(Exception exc){System.err.println("Error updating flags " + exc);}
+        catch(Exception exc){jTraverser.stderr("Error updating flags",exc);}
         return info.getFlags();
     }
 
@@ -260,10 +239,7 @@ public class Node
             {
                 is_on = experiment.isOn(nid, Tree.context);
             }
-            catch (Exception exc)
-            {
-                System.err.println("Error checking state " + exc);
-            }
+            catch (Exception exc){jTraverser.stderr("Error checking state",exc);}
         }
         return is_on;
     }
@@ -335,9 +311,8 @@ public class Node
         {
             curr_nid = experiment.getDefault(Tree.context);
         }
-        catch (Exception exc)
-        {
-            System.err.println("Error getting default " + exc);
+        catch (Exception exc){
+            jTraverser.stderr("Error getting default", exc);
             return false;
         }
         return curr_nid.datum == nid.datum;
@@ -461,10 +436,7 @@ public class Node
         {
             return experiment.startDelete(nids, Tree.context).length;
         }
-        catch (Exception e)
-        {
-            System.out.println("Starting delete: " + e.getMessage());
-        }
+        catch (Exception exc){jTraverser.stderr("Error starting delete", exc);}
         return 0;
     }
 
@@ -475,10 +447,7 @@ public class Node
         {
             experiment.executeDelete(Tree.context);
         }
-        catch (Exception e)
-        {
-            System.err.println("Error executing delete: " + e.getMessage());
-        }
+        catch (Exception exc){jTraverser.stderr("Error executing delete", exc);}
     }
 
 
@@ -641,10 +610,7 @@ public class Node
             fromNode.expand();
             toNode.expand();
         }
-        catch (Exception exc)
-        {
-            System.err.println("Error expanding nodes: " + exc);
-        }
+        catch (Exception exc){jTraverser.stderr("Error expanding nodes", exc);}
         try
         {
             Data data = fromNode.getData();
@@ -654,8 +620,7 @@ public class Node
                     toNode.setData(data);
             }
         }
-        catch (Throwable exc)
-        {}
+        catch (Throwable exc){}
         for (int i = 0; i < fromNode.sons.length; i++)
             copySubtreeContent(fromNode.sons[i], toNode.sons[i]);
         for (int i = 0; i < fromNode.members.length; i++)

--- a/javatraverser/NodeInfo.java
+++ b/javatraverser/NodeInfo.java
@@ -5,95 +5,100 @@ import java.io.*;
 
 public class NodeInfo implements Serializable
 {
+    public static final byte USAGE_ANY = 0;
+    public static final byte USAGE_NONE = 1;
+    public static final byte USAGE_STRUCTURE= 1;
+    public static final byte USAGE_ACTION = 2;
+    public static final byte USAGE_DEVICE = 3;
+    public static final byte USAGE_DISPATCH = 4;
+    public static final byte USAGE_NUMERIC = 5;
+    public static final byte USAGE_SIGNAL = 6;
+    public static final byte USAGE_TASK = 7;
+    public static final byte USAGE_TEXT = 8;
+    public static final byte USAGE_WINDOW = 9;
+    public static final byte USAGE_AXIS = 10;
+    public static final byte USAGE_SUBTREE = 11;
+    public static final byte USAGE_COMPOUND_DATA = 12;
+    public static final byte USAGE_MAXIMUM = 12;
 
-    boolean on, parent_on, setup, write_once, compressible, compress_on_put,
-    no_write_model, no_write_shot, essential;
-    String date_inserted, name, fullpath, minpath, path;
-    int owner, dtype, dclass, length, usage, conglomerate_elt, conglomerate_nids;
-    static NodeInfo getNodeInfo(boolean on, boolean parent_on, boolean setup, boolean write_once,
-	    boolean compressible, boolean compress_on_put, boolean no_write_model,
-	    boolean no_write_shot, boolean essential, String date_inserted,
-	    int owner, int dtype, int dclass, int length, int usage,
-	    String name, String fullpath, String minpath, String path, int conglomerate_nids, int conglomerate_elt)
+    public static final int STATE =            1 << 0;
+    public static final int PARENT_STATE =     1 << 1;
+    public static final int ESSENTIAL =        1 << 2;
+    public static final int CACHED =           1 << 3;
+    public static final int VERSION =          1 << 4;
+    public static final int SEGMENTED =        1 << 5;
+    public static final int SETUP =            1 << 6;
+    public static final int WRITE_ONCE =       1 << 7;
+    public static final int COMPRESSIBLE =     1 << 8;
+    public static final int DO_NOT_COMPRESS =  1 << 9;
+    public static final int COMPRESS_ON_PUT =  1 << 10;
+    public static final int NO_WRITE_MODEL =   1 << 11;
+    public static final int NO_WRITE_SHOT =    1 << 12;
+    public static final int PATH_REFERENCE =   1 << 13;
+    public static final int NID_REFERENCE =    1 << 14;
+    public static final int COMPRESS_SEGMENTS =1 << 15;
+    public static final int INCLUDE_IN_PULSE = 1 << 16;
 
+    public static final NodeInfo getNodeInfo(byte dclass, byte dtype, byte usage, int flags, int owner, int length, int conglomerate_nids, int conglomerate_elt,
+	                                   String date_inserted, String name, String fullpath, String minpath, String path)
     {
-	return new NodeInfo(on, parent_on, setup, write_once, compressible, compress_on_put,
-	    no_write_model, no_write_shot, essential, date_inserted, owner, dtype, dclass, length,
-	    usage, name, fullpath, minpath, path, conglomerate_nids, conglomerate_elt);
+	return new NodeInfo(dclass, dtype, usage, flags, owner, length, conglomerate_nids, conglomerate_elt,
+	                    date_inserted, name, fullpath, minpath, path);
     }
 
-    NodeInfo(boolean on, boolean parent_on, boolean setup, boolean write_once,
-	boolean compressible, boolean compress_on_put, boolean no_write_model,
-	boolean no_write_shot, boolean essential, String date_inserted,
-	int owner, int dtype, int dclass, int length, int usage,
-	String name, String fullpath, String minpath, String path, int conglomerate_nids, int conglomerate_elt)
-    {
-	this.on = on;
-	this.parent_on = parent_on;
-	this.setup = setup;
-	this.write_once = write_once;
-	this.compressible = compressible;
-	this.compress_on_put = compress_on_put;
-	this.no_write_model = no_write_model;
-	this.no_write_shot = no_write_shot;
-        this.essential = essential;
-	this.date_inserted = date_inserted;
-	this.owner = owner;
-	this.dtype = dtype;
-	this.dclass = dclass;
-	this.length = length;
-	this.usage = usage;
-	this.name = name;
-	this.fullpath = fullpath;
-	this.minpath = minpath;
-    this.path = path;
-	this.conglomerate_nids = conglomerate_nids;
-	this.conglomerate_elt = conglomerate_elt;
-    }
-    public final boolean isOn() {return on;}
-    public final boolean isParentOn() {return parent_on;}
-    public final boolean isSetup() {return setup;}
-    public final boolean isWriteOnce() { return write_once;}
-    public final boolean isCompressible() { return compressible;}
-    public final boolean isCompressOnPut() { return compress_on_put;}
-    public final boolean isNoWriteModel() { return no_write_model;}
-    public final boolean isNoWriteShot() { return no_write_shot;}
-    public final boolean isEssential() { return essential;}
+    private final String date_inserted, name, fullpath, minpath, path;
+    private final byte dtype, dclass, usage;
+    private final int owner, length, conglomerate_elt, conglomerate_nids;
+    private int flags;
 
-    public final String getDate() {return date_inserted;}
+    public NodeInfo(byte dclass, byte dtype, byte usage, int flags, int owner, int length, int conglomerate_nids, int conglomerate_elt,
+	                String date_inserted, String name, String fullpath, String minpath, String path)
+    {
+	    this.dclass = dclass;
+	    this.dtype = dtype;
+	    this.usage = usage;
+        this.flags = flags;
+	    this.owner = owner;
+	    this.length = length;
+	    this.conglomerate_nids = conglomerate_nids;
+	    this.conglomerate_elt = conglomerate_elt;
+	    this.date_inserted = date_inserted;
+	    this.name = name.trim();
+	    this.fullpath = fullpath;
+	    this.minpath = minpath;
+        this.path = path;
+    }
+    public final void setFlags(int flags){this.flags = flags;}
+    public final byte getDClass() {return dclass;}
+    public final byte getDType() {return dtype;}
+    public final byte getUsage() {return usage;}
+    public final int getFlags(){return flags;}
     public final int getOwner() {return owner;}
-    public final int getDtype() {return dtype;}
-    public final int getDClass() {return dclass;}
     public final int getLength() {return length;}
-    public final String getName() {return name; }
-    public final String getFullPath() {return fullpath; }
-    public final String getMinpath() { return minpath;}
-    public final String getPath() { return path;}
     public final int getConglomerateNids() {return conglomerate_nids; }
     public final int getConglomerateElt() { return conglomerate_elt;}
-    public final int getUsage() {return usage; }
-    public static final int USAGE_ANY = 0;
-    public static final int USAGE_NONE = 1;
-    public static final int USAGE_STRUCTURE= 1;
-    public static final int USAGE_ACTION = 2;
-    public static final int USAGE_DEVICE = 3;
-    public static final int USAGE_DISPATCH = 4;
-    public static final int USAGE_NUMERIC = 5;
-    public static final int USAGE_SIGNAL = 6;
-    public static final int USAGE_TASK = 7;
-    public static final int USAGE_TEXT = 8;
-    public static final int USAGE_WINDOW = 9;
-    public static final int USAGE_AXIS = 10;
-    public static final int USAGE_SUBTREE = 11;
-    public static final int USAGE_COMPOUND_DATA = 12;
-    public static final int USAGE_MAXIMUM = 12;
-
-
-
-    public static final int WRITE_ONCE = 0x00000080;
-    public static final int COMPRESSIBLE   =     0x00000100;
-    public static final int DO_NOT_COMPRESS =    0x00000200;
-    public static final int COMPRESS_ON_PUT  =   0x00000400;
-    public static final int NO_WRITE_MODEL  =    0x00000800;
-    public static final int NO_WRITE_SHOT   =    0x00001000;
+    public final String getDate() {return date_inserted;}
+    public final String getName() {return name;}
+    public final String getFullPath() {return fullpath;}
+    public final String getMinPath() {return minpath;}
+    public final String getPath() {return path;}
+    public final boolean isOn(){return !isState();}
+    public final boolean isParentOn(){return !isParentState();}
+    public final boolean isState(){return (flags & STATE) != 0;}
+    public final boolean isParentState(){return (flags & PARENT_STATE) != 0;}
+    public final boolean isEssential(){return (flags & ESSENTIAL) != 0;}
+    public final boolean isCached(){return (flags & CACHED) != 0;}
+    public final boolean isVersion(){return (flags & VERSION) != 0;}
+    public final boolean isSegmented(){return (flags & SEGMENTED) != 0;}
+    public final boolean isSetup(){return (flags & SETUP) != 0;}
+    public final boolean isWriteOnce(){return (flags & WRITE_ONCE) != 0;}
+    public final boolean isCompressible(){return (flags & COMPRESSIBLE) != 0;}
+    public final boolean isDoNotCompress(){return (flags & DO_NOT_COMPRESS) != 0;}
+    public final boolean isCompressOnPut(){return (flags & COMPRESS_ON_PUT) != 0;}
+    public final boolean isNoWriteModel(){return (flags & NO_WRITE_MODEL) != 0;}
+    public final boolean isNoWriteShot(){return (flags & NO_WRITE_SHOT) != 0;}
+    public final boolean isPathReference(){return (flags & PATH_REFERENCE) != 0;}
+    public final boolean isNidReference(){return (flags & NID_REFERENCE) != 0;}
+    public final boolean isCompressSegments(){return (flags & COMPRESS_SEGMENTS) != 0;}
+    public final boolean isIncludeInPulse(){return (flags & INCLUDE_IN_PULSE) != 0;}
 }

--- a/javatraverser/Tree.java
+++ b/javatraverser/Tree.java
@@ -452,13 +452,12 @@ public class Tree extends JScrollPane implements TreeSelectionListener,
                     if (node.getTreeNode() == value)
 	                {
 	                    String newName = (((String)usrObj).trim()).toUpperCase();
-                        node.getTreeNode().setUserObject(node);
 	                    if(lastName == null || !lastName.equals(newName))
 	                    {
-                            System.out.println("rename: "+ newName);
 	                        lastName = newName;
 		                    node.rename(newName);
 		                }
+                        node.getTreeNode().setUserObject(node);
 	                }
                 }
 	            else
@@ -1131,7 +1130,7 @@ public class Tree extends JScrollPane implements TreeSelectionListener,
 		    curr_dialog = new TreeDialog(curr_editor);
 		    curr_editor.setFrame(curr_dialog);
 		    dialogs.addElement(curr_dialog);
-		}catch(Exception exc) {System.out.println("Error creating node editor "+exc);}
+		}catch(Exception exc) {System.err.println("Error creating node editor "+exc);}
 	    }
 	    curr_dialog.setUsed(true);
 	    curr_dialog.getEditor().setNode(node);
@@ -1142,6 +1141,7 @@ public class Tree extends JScrollPane implements TreeSelectionListener,
     {
         reportChange();
     }
+
     //Inner class FromTranferHandler managed drag operation
     class FromTransferHandler extends TransferHandler
     {
@@ -1153,12 +1153,9 @@ public class Tree extends JScrollPane implements TreeSelectionListener,
         {
             if(curr_tree == null) return null;
             try {
-                NodeInfo info = curr_node.getInfo();
-                return new StringSelection(topExperiment + ":" + info.fullpath);
+                return new StringSelection(topExperiment + ":" + curr_node.getFullPath());
             }catch(Exception exc) {return null;}
-            
         }    
-            
     }
     
     static class dialogs
@@ -1216,8 +1213,8 @@ public class Tree extends JScrollPane implements TreeSelectionListener,
                     {
                         final byte ii = i;
                         flag[i].addActionListener(new ActionListener() {
-                        public void actionPerformed(ActionEvent e){
-                            editFlag(ii);
+                            public void actionPerformed(ActionEvent e){
+                                editFlag(ii);
                         }});
                     }
                 jp.add(jp1);
@@ -1225,8 +1222,8 @@ public class Tree extends JScrollPane implements TreeSelectionListener,
                 jp3.setLayout(new GridLayout(1,2));
 	            jp3.add(close_b = new JButton("Close"));
 	            close_b.addActionListener(new ActionListener() {
-                public void actionPerformed(ActionEvent e){
-                    close();
+                    public void actionPerformed(ActionEvent e){
+                        close();
                 }});
 	            jp3.add(update_b = new JButton("Refresh"));
 	            update_b.addActionListener(new ActionListener() {
@@ -1236,12 +1233,10 @@ public class Tree extends JScrollPane implements TreeSelectionListener,
 	            jp.add(jp3, "South");
 	            dialog.getContentPane().add(jp);
 	            dialog.addKeyListener(new KeyAdapter() {
-	                public void keyTyped(KeyEvent e)
-	                {
+	                public void keyTyped(KeyEvent e) {
 	                    if(e.getKeyCode() == KeyEvent.VK_ESCAPE)
                             dialog.setVisible(false);
-	                }
-	            });
+	            }});
     	        dialog.pack();
             }
             private static void editFlag(byte idx)
@@ -1277,7 +1272,6 @@ public class Tree extends JScrollPane implements TreeSelectionListener,
                     flags[i] = (iflags & (1 << i)) != 0;
                 return flags;
             }
-
             public static void show()
 	        {
                 if (dialog == null)

--- a/javatraverser/Tree.java
+++ b/javatraverser/Tree.java
@@ -15,13 +15,12 @@ public class Tree extends JScrollPane implements TreeSelectionListener,
     MouseListener, ActionListener, KeyListener, DataChangeListener
 {
     static boolean is_remote;
-	static Hashtable nodeHash = new Hashtable();
     static jTraverser frame;
     static int curr_dialog_idx;
     static Node curr_node;
-    static DefaultMutableTreeNode curr_tree_node;
     static JTree curr_tree;
     static RemoteTree curr_experiment;
+    static int context;
     boolean is_angled_style;
     private DefaultMutableTreeNode top;
     private JMenuItem menu_items[];
@@ -30,7 +29,6 @@ public class Tree extends JScrollPane implements TreeSelectionListener,
     private PropertyDescriptor curr_property_descr;
     private DialogSet dialog_sets[];
     private java.util.Stack trees, experiments;
-    public static int context;
     private JDialog open_dialog, add_node_dialog, add_subtree_dialog;
     private JTextField open_exp, open_shot;
     private JRadioButton open_readonly, open_edit, open_normal;
@@ -45,10 +43,10 @@ public class Tree extends JScrollPane implements TreeSelectionListener,
     private String[] tags;
 	private JTextField add_device_type, add_device_name;
 	private String lastName;
+    private String topExperiment;
 	public static boolean isRemote(){return is_remote;}
-    public static Node getCurrentNode() {return curr_node;}
+    public static Node getCurrentNode(){return curr_node;}
 
-    String topExperiment;
         
 // Temporary, to overcome Java's bugs on inner classes
     JMenuItem open_b, close_b, quit_b;
@@ -83,7 +81,6 @@ public class Tree extends JScrollPane implements TreeSelectionListener,
 		    shot = -1;
 	        open(def_tree, shot, false, false, false);
 	    }
-
     }
 
 
@@ -163,77 +160,74 @@ public class Tree extends JScrollPane implements TreeSelectionListener,
 
     void close()
     {
-	if(curr_tree == null)
-	    return;
-	try {
-	    curr_experiment.close(Tree.context);
-	} catch(Exception e) {
-	    boolean editable = false;
-	    String name = null;
+	    if(curr_tree == null)
+	        return;
 	    try {
-	        editable = curr_experiment.isEditable();
-	        name = curr_experiment.getName().trim();
-	    }catch(Exception exc){}
-		if(editable)
-	    {
-		    int n = JOptionPane.showConfirmDialog(frame, "Tree " + name +
-		        " open in edit mode has been changed: write it before closing?",
-			    "Closing Tree ", JOptionPane.YES_NO_OPTION);
-		    if(n == JOptionPane.YES_OPTION)
-		    {
-		        try{
-			    curr_experiment.write(Tree.context);
-			    curr_experiment.close(Tree.context);
-		        }catch(Exception exc)
+	        curr_experiment.close(Tree.context);
+	    } catch(Exception e) {
+	        boolean editable = false;
+	        String name = null;
+	        try {
+	            editable = curr_experiment.isEditable();
+	            name = curr_experiment.getName().trim();
+	        }catch(Exception exc){}
+		    if(editable)
+	        {
+		        int n = JOptionPane.showConfirmDialog(frame, "Tree " + name +
+		            " open in edit mode has been changed: write it before closing?",
+			        "Closing Tree ", JOptionPane.YES_NO_OPTION);
+		        if(n == JOptionPane.YES_OPTION)
 		        {
-			    JOptionPane.showMessageDialog(frame, "Error closing tree", exc.getMessage(),JOptionPane.WARNING_MESSAGE);
-			    return;
+		            try {
+			        curr_experiment.write(Tree.context);
+			        curr_experiment.close(Tree.context);
+		            }catch(Exception exc) {
+			            JOptionPane.showMessageDialog(frame, "Error closing tree", exc.getMessage(),JOptionPane.WARNING_MESSAGE);
+			            return;
+		            }
 		        }
-		    }
-		    else
-		    {
-		        try {
-			    curr_experiment.quit(Tree.context);
-		        } catch(Exception exce) {
-			    JOptionPane.showMessageDialog(frame, "Error quitting tree", exce.getMessage(),JOptionPane.WARNING_MESSAGE);
-			    //return;
+		        else
+		        {
+		            try {
+			            curr_experiment.quit(Tree.context);
+		            } catch(Exception exce) {
+    			        JOptionPane.showMessageDialog(frame, "Error quitting tree", exce.getMessage(),JOptionPane.WARNING_MESSAGE);
+		            }
 		        }
-		    }
+	        }
+	        else
+	        {
+		        JOptionPane.showMessageDialog(frame, "Error closing tree", e.getMessage(),JOptionPane.WARNING_MESSAGE);
+		        return;
+	        }
+	    }
+	    trees.pop();
+	    experiments.pop();
+	    if(!trees.empty())
+	    {
+	        curr_tree = (JTree)trees.peek();
+	        curr_experiment = (RemoteTree)experiments.peek();
+	        setViewportView(curr_tree);
+	        try {
+	            frame.reportChange(curr_experiment.getName(), curr_experiment.getShot(), curr_experiment.isEditable(), curr_experiment.isReadonly());
+	            if(jTraverser.editable != curr_experiment.isEditable())
+		            pop = null;
+	            jTraverser.editable = curr_experiment.isEditable();
+	        }catch(Exception exc) {System.err.println("Error in RMI communication: "+exc);}
 	    }
 	    else
 	    {
-		JOptionPane.showMessageDialog(frame, "Error closing tree", e.getMessage(),JOptionPane.WARNING_MESSAGE);
-		return;
+	        curr_tree = null;
+	        curr_experiment = null;
+	        JPanel jp = new JPanel();
+	        setViewportView(new JPanel());
+	        frame.reportChange(null, 0, false, false);
 	    }
-	}
-	trees.pop();
-	experiments.pop();
-	if(!trees.empty())
-	{
-	    curr_tree = (JTree)trees.peek();
-	    curr_experiment = (RemoteTree)experiments.peek();
-	    setViewportView(curr_tree);
-	    try {
-	        frame.reportChange(curr_experiment.getName(), curr_experiment.getShot(), curr_experiment.isEditable(), curr_experiment.isReadonly());
-	        if(jTraverser.editable != curr_experiment.isEditable())
-		        pop = null;
-	        jTraverser.editable = curr_experiment.isEditable();
-	    }catch(Exception exc) {System.err.println("Error in RMI communication: "+exc);}
-	}
-	else
-	{
-	    curr_tree = null;
-	    curr_experiment = null;
-	    JPanel jp = new JPanel();
-	    setViewportView(new JPanel());
-	    frame.reportChange(null, 0, false, false);
-
-	}
-    DeviceSetup.closeOpenDevices();
-    curr_node = null;
-    dialogs.update();
-	frame.pack();
-	repaint();
+        DeviceSetup.closeOpenDevices();
+        curr_node = null;
+        dialogs.update();
+	    frame.pack();
+	    repaint();
     }
 
 
@@ -311,7 +305,7 @@ public class Tree extends JScrollPane implements TreeSelectionListener,
 	    }
 	    try{
 	    shot = Integer.parseInt(shot_t);
-	    } catch(Exception e)	{
+	    } catch(Exception e) {
 	        JOptionPane.showMessageDialog(curr_tree, "Wrong shot number", "Error opening tree",
 		    JOptionPane.WARNING_MESSAGE);
 	        return;
@@ -403,25 +397,24 @@ public class Tree extends JScrollPane implements TreeSelectionListener,
 	        JOptionPane.showMessageDialog(frame, exc.getMessage(), "Error opening "+exp, JOptionPane.ERROR_MESSAGE);
 	        return;
 	    }
-	    top = new DefaultMutableTreeNode(top_node);
-	    nodeHash.put(top, top_node);
+	    top_node.setTreeNode(top = new DefaultMutableTreeNode(top_node));
 	    try {
 	        top_node.expand();
 	    } catch(Exception exc) {
-            System.out.println("Error expanding tree "+ exc);}
+            System.err.println("Error expanding tree "+ exc);}
 	    Node members[] = top_node.getMembers();
 	    for(i = 0; i < members.length; i++)
 	    {
 	        DefaultMutableTreeNode currNode;
 	        top.add(currNode = new DefaultMutableTreeNode(members[i]));
-	        nodeHash.put(currNode, members[i]);
+	        members[i].setTreeNode(currNode);
 	    }
 	    Node sons[] = top_node.getSons();
 	    for(i = 0; i < sons.length; i++)
 	    {
 	        DefaultMutableTreeNode currNode;
 	        top.add(currNode = new DefaultMutableTreeNode(sons[i]));
-	        nodeHash.put(currNode, sons[i]);
+	        sons[i].setTreeNode(currNode);
 	    }
 	    curr_tree = new JTree(top);
 //GAB 2014 Add DragAndDrop capability
@@ -431,34 +424,25 @@ public class Tree extends JScrollPane implements TreeSelectionListener,
         ToolTipManager.sharedInstance().registerComponent(curr_tree);
         curr_tree.addKeyListener(new KeyAdapter() {
             public void keyTyped(KeyEvent e) {
-            if ( (e.getModifiers() & Event.CTRL_MASK) != 0) {
-                int cc = e.getKeyChar();
-                //if(e.getKeyChar() == 'c')
-                if (e.getKeyChar() == 3) {
-                TreeNode.copyToClipboard();
-                }
-            }
-            if (!jTraverser.isEditable())
-                return;
-            if ( (e.getModifiers() & Event.CTRL_MASK) != 0) {
-                if (e.getKeyChar() == 'c')
-                TreeNode.copy();
-                if (e.getKeyChar() == 'v')
-                TreeNode.paste();
-            }
-            else if (e.getKeyChar() == KeyEvent.VK_DELETE ||
-                        e.getKeyChar() == KeyEvent.VK_BACK_SPACE)
-                TreeNode.delete();
-            }
-        });
+                if (e.getKeyChar() ==  KeyEvent.VK_CANCEL) // i.e. Ctrl+C
+                    TreeNode.copyToClipboard();
+                if (!jTraverser.isEditable()) return;
+                if (e.getKeyChar() ==  KeyEvent.VK_CANCEL) // i.e. Ctrl+C
+                    TreeNode.copy();
+                if (e.getKeyChar() ==  24) // i.e. Ctrl+X
+                    TreeNode.cut();
+                if (e.getKeyChar() == 22) // i.e. Ctrl+V
+                    TreeNode.paste();
+                else if (e.getKeyChar() == KeyEvent.VK_DELETE || e.getKeyChar() == KeyEvent.VK_BACK_SPACE)
+                    TreeNode.delete();
+            }});
 	    if(is_angled_style)
 	        curr_tree.putClientProperty("JTree.lineStyle", "Angled");
-
-	    // GAB curr_tree.setEditable(false);
 	    try {
 	        curr_tree.setEditable(curr_experiment.isEditable());
 	    } catch(Exception exc) {
-            curr_tree.setEditable(false);}
+            curr_tree.setEditable(false);
+        }
 	    curr_tree.setCellRenderer(new TreeCellRenderer() {
 	        public Component getTreeCellRendererComponent(JTree tree, Object value, boolean isSelected,
 		        boolean expanded, boolean boh, int row, boolean leaf)
@@ -466,30 +450,20 @@ public class Tree extends JScrollPane implements TreeSelectionListener,
 	            Object usrObj = ((DefaultMutableTreeNode)value).getUserObject();
 	            Node node;
 	            if(usrObj instanceof String)
-	            {
-	                node = (Node)nodeHash.get(value);
-	                String newName = (((String)usrObj).trim()).toUpperCase();
-	                if(lastName == null || !lastName.equals(newName))
+                {
+                    node = Tree.curr_node;
+                    if (node.getTreeNode() == value)
 	                {
-	                    lastName = newName;
-	                    if(newName.length() > 12 || newName.length() == 0)
+	                    String newName = (((String)usrObj).trim()).toUpperCase();
+                        node.getTreeNode().setUserObject(node);
+	                    if(lastName == null || !lastName.equals(newName))
 	                    {
-	                        JOptionPane.showMessageDialog(frame, "Node name lengh must be between 1 and 12 characters",
-		                    "Error renaming node", JOptionPane.WARNING_MESSAGE);
+                            System.out.println("rename: "+ newName);
+	                        lastName = newName;
+		                    node.rename(newName);
 		                }
-		                else
-		                {
-		                    try {
-		                        node.rename(newName);
-		                    }catch(Exception exc)
-		                    {
-                                JOptionPane.showMessageDialog(frame, "Error renaming node: "+ exc,
-		                        "Error renaming node", JOptionPane.WARNING_MESSAGE);
-		                    }
-		                }
-		            }
-	                ((DefaultMutableTreeNode)value).setUserObject(node);
-	            }
+	                }
+                }
 	            else
 		            node = (Node)usrObj;
 		        return node.getIcon();
@@ -515,7 +489,7 @@ public class Tree extends JScrollPane implements TreeSelectionListener,
 	    DefaultMutableTreeNode tree_node = (DefaultMutableTreeNode)e.getPath().getLastPathComponent();
 	    if(tree_node.isLeaf())
 	    {
-	        curr_node = (Node)tree_node.getUserObject();
+	        curr_node = Tree.getNode(tree_node);
 	        Node sons[], members[];
 	        DefaultMutableTreeNode last_node = null;
 	        try {
@@ -526,12 +500,12 @@ public class Tree extends JScrollPane implements TreeSelectionListener,
 	        for(int i = 0; i < members.length; i++)
 	        {
 		        tree_node.add(last_node = new DefaultMutableTreeNode(members[i]));
-		        nodeHash.put(last_node, members[i]);
+		        members[i].setTreeNode(last_node);
 		    }
 	        for(int i = 0; i < sons.length; i++)
 	        {
 		        tree_node.add(last_node = new DefaultMutableTreeNode(sons[i]));
-		        nodeHash.put(last_node, sons[i]);
+		        sons[i].setTreeNode(last_node);
 		    }
 	        if(last_node != null)
 		    curr_tree.expandPath(new TreePath(last_node.getPath()));
@@ -548,11 +522,8 @@ public class Tree extends JScrollPane implements TreeSelectionListener,
 	    if(curr_tree == null) return;
 	    int item_idx;
 
-	    curr_tree_node =
-		    (DefaultMutableTreeNode)curr_tree.getClosestPathForLocation(e.getX(), e.getY()).getLastPathComponent();
+	    DefaultMutableTreeNode curr_tree_node = (DefaultMutableTreeNode)curr_tree.getClosestPathForLocation(e.getX(), e.getY()).getLastPathComponent();
 	    curr_node = (Node)curr_tree_node.getUserObject();
-	    TreeNode.setSelectedNode(curr_node);
-	    //if(e.isPopupTrigger())
 	    if((e.getModifiers() & InputEvent.BUTTON3_MASK) != 0)
 	    {
 	        NodeBeanInfo nbi = curr_node.getBeanInfo();
@@ -561,7 +532,6 @@ public class Tree extends JScrollPane implements TreeSelectionListener,
 
 	        if(pop == null)
 	        {
-		        //dialogs = new JDialog[node_properties.length];
 		        dialog_sets = new DialogSet[node_properties.length];
 		        for(int i = 0; i < node_properties.length; i++)
 		            dialog_sets[i] = new DialogSet();
@@ -617,7 +587,6 @@ public class Tree extends JScrollPane implements TreeSelectionListener,
 			            if(idx < node_properties.length)
 			            {
 			                Tree.curr_dialog_idx = idx;
-
 			                TreeDialog curr_dialog = dialog_sets[idx].getDialog(
 				            node_properties[idx].getPropertyEditorClass(), curr_node);
 			                curr_dialog.pack();
@@ -838,17 +807,11 @@ public class Tree extends JScrollPane implements TreeSelectionListener,
 	    return addNode(usage, name, curr_node);
 	}
 
-
-
     public static Node addNode(int usage, String name, Node toNode)
     {
-        return addNode(usage, name, toNode, curr_tree_node);
-    }
-
-    public static Node addNode(int usage, String name, Node toNode, DefaultMutableTreeNode toTreeNode)
-    {
-        Node new_node = null;
-	    DefaultMutableTreeNode new_tree_node = null;
+        Node new_node;
+	    DefaultMutableTreeNode new_tree_node;
+        DefaultMutableTreeNode toTreeNode = toNode.getTreeNode();
 	    if(name == null || name.length() == 0 || name.length() > 12)
 	    {
 	        JOptionPane.showMessageDialog(frame, "Name length must range between 1 and 12 characters",
@@ -857,43 +820,49 @@ public class Tree extends JScrollPane implements TreeSelectionListener,
 	    }
 	    try {
 	        new_node = toNode.addNode(usage, name);
-	        int num_children = toTreeNode.getChildCount();
-	        int i;
-	        if(num_children > 0)
-	        {
-		        String curr_name;
-		        for(i = 0; i < num_children; i++)
-		        {
-		            curr_name = ((Node)((DefaultMutableTreeNode)toTreeNode.getChildAt(i)).getUserObject()).getName();
-		            if(name.compareTo(curr_name) < 0)
-			        break;
-		        }
-		        curr_tree_node = new_tree_node = new DefaultMutableTreeNode(new_node);
-		        nodeHash.put(new_tree_node, new_node);
-		        DefaultTreeModel tree_model = (DefaultTreeModel)curr_tree.getModel();
-		        tree_model.insertNodeInto(new_tree_node, toTreeNode, i);
-		        //curr_tree.makeVisible(new TreePath(new_tree_node.getPath()));
-		        curr_tree.expandPath(new TreePath(new_tree_node.getPath()));
-		        curr_tree.treeDidChange();
-		        return new_node;
-	        }
-	    }
+            new_tree_node = new DefaultMutableTreeNode(new_node);
+		    new_node.setTreeNode(new_tree_node);
+            Tree.addNodeToParent(new_tree_node, toTreeNode);
+        }
 	    catch(Exception e) {
 	        JOptionPane.showMessageDialog(frame, e.getMessage(),
 		    "Error adding Node", JOptionPane.WARNING_MESSAGE);
 	        return null;
 	    }
-	return new_node;
+	    return new_node;
     }
 
+    static void addNodeToParent(DefaultMutableTreeNode TreeNode, DefaultMutableTreeNode toTreeNode)
+    {
+    	int num_children = toTreeNode.getChildCount();
+	    int i = 0;
+	    if(num_children > 0)
+	    {
+            String name = Tree.getNode(TreeNode).getName();
+		    String curr_name;
+		    for(i = 0; i < num_children; i++)
+		    {
+		        curr_name = ((Node)((DefaultMutableTreeNode)toTreeNode.getChildAt(i)).getUserObject()).getName();
+		        if(name.compareTo(curr_name) < 0)
+			    break;
+		    }
+	    }
+		DefaultTreeModel tree_model = (DefaultTreeModel)Tree.curr_tree.getModel();
+		tree_model.insertNodeInto(TreeNode, toTreeNode, i);
+		Tree.curr_tree.expandPath(new TreePath(TreeNode.getPath()));
+		Tree.curr_tree.treeDidChange();
+    }
 
 	public Node addDevice(String name, String type)
 	{
 	    return addDevice(name, type, curr_node);
 	}
 
-	public static DefaultMutableTreeNode getCurrTreeNode() {return curr_tree_node;}
-	public static void setCurrTreeNode(DefaultMutableTreeNode node){curr_tree_node = node;}
+    public static Node getNode(javax.swing.tree.TreeNode treenode){return Tree.getNode((DefaultMutableTreeNode)treenode);}
+    public static Node getNode(DefaultMutableTreeNode treenode){return (Node)treenode.getUserObject();}
+	public static DefaultMutableTreeNode getCurrTreeNode() {return curr_node.getTreeNode();}
+	public static void setCurrTreeNode(DefaultMutableTreeNode treenode){curr_node = getNode(treenode);}
+
     public static Node addDevice(String name, String type, Node toNode)
     {
 	    DefaultMutableTreeNode new_tree_node = null;
@@ -912,21 +881,20 @@ public class Tree extends JScrollPane implements TreeSelectionListener,
 	    Node new_node = null;
 	    try {
 	        new_node = toNode.addDevice(name, type);
-	        int num_children = curr_tree_node.getChildCount();
+	        int num_children = toNode.getTreeNode().getChildCount();
 	        int i;
 	        if(num_children > 0)
 	        {
 		        String curr_name;
 		        for(i = 0; i < num_children; i++)
 		        {
-		            curr_name = ((Node)((DefaultMutableTreeNode)curr_tree_node.getChildAt(i)).getUserObject()).getName();
+		            curr_name = Tree.getNode(toNode.getTreeNode().getChildAt(i)).getName();
 		            if(name.compareTo(curr_name) < 0)
 			        break;
 		        }
-		        new_tree_node = new DefaultMutableTreeNode(new_node);
-		        nodeHash.put(new_tree_node, new_node);
+		        new_node.setTreeNode(new_tree_node = new DefaultMutableTreeNode(new_node));
 		        DefaultTreeModel tree_model = (DefaultTreeModel)curr_tree.getModel();
-		        tree_model.insertNodeInto(new_tree_node, curr_tree_node, i);
+		        tree_model.insertNodeInto(new_tree_node, curr_node.getTreeNode(), i);
 		        curr_tree.makeVisible(new TreePath(new_tree_node.getPath()));
 		        return new_node;
 	        }
@@ -947,9 +915,6 @@ public class Tree extends JScrollPane implements TreeSelectionListener,
 	    curr_node = null;
 	}
 
-
-
-
     static void deleteNode(Node delNode)
     {
 	    if(delNode == null) return;
@@ -965,10 +930,9 @@ public class Tree extends JScrollPane implements TreeSelectionListener,
 	    {
 	        del_node.executeDelete();
 	        DefaultTreeModel tree_model = (DefaultTreeModel)curr_tree.getModel();
-	        tree_model.removeNodeFromParent(curr_tree_node);
+	        tree_model.removeNodeFromParent(delNode.getTreeNode());
 	    }
     }
-
 
     public void modifyTags()
     {

--- a/javatraverser/Tree.java
+++ b/javatraverser/Tree.java
@@ -49,11 +49,8 @@ public class Tree extends JScrollPane implements TreeSelectionListener,
 
         
 // Temporary, to overcome Java's bugs on inner classes
-    JMenuItem open_b, close_b, quit_b;
     JMenuItem add_action_b, add_dispatch_b, add_numeric_b, add_signal_b, add_task_b, add_text_b,
-	add_window_b, add_axis_b, add_device_b, add_child_b, add_subtree_b, delete_node_b, modify_tags_b,
-    flags_b,
-	rename_node_b;
+	add_window_b, add_axis_b, add_device_b, add_child_b, add_subtree_b, delete_node_b, modify_tags_b;
     JButton ok_cb, add_node_ok;
 
     public Tree(JFrame _frame)
@@ -521,8 +518,7 @@ public class Tree extends JScrollPane implements TreeSelectionListener,
     {
 	    if(curr_tree == null) return;
 	    int item_idx;
-
-	    DefaultMutableTreeNode curr_tree_node = (DefaultMutableTreeNode)curr_tree.getClosestPathForLocation(e.getX(), e.getY()).getLastPathComponent();
+	    final DefaultMutableTreeNode curr_tree_node = (DefaultMutableTreeNode)curr_tree.getClosestPathForLocation(e.getX(), e.getY()).getLastPathComponent();
 	    curr_node = (Node)curr_tree_node.getUserObject();
 	    if((e.getModifiers() & InputEvent.BUTTON3_MASK) != 0)
 	    {
@@ -532,6 +528,7 @@ public class Tree extends JScrollPane implements TreeSelectionListener,
 
 	        if(pop == null)
 	        {
+                JMenuItem mitem;
 		        dialog_sets = new DialogSet[node_properties.length];
 		        for(int i = 0; i < node_properties.length; i++)
 		            dialog_sets[i] = new DialogSet();
@@ -567,11 +564,11 @@ public class Tree extends JScrollPane implements TreeSelectionListener,
 		            delete_node_b.addActionListener(this);
 		            pop.add(modify_tags_b = new JMenuItem("Modify tags"));
 		            modify_tags_b.addActionListener(this);
-		            pop.add(rename_node_b = new JMenuItem("Rename node"));
-		            rename_node_b.addActionListener(new ActionListener() {
+		            pop.add(mitem = new JMenuItem("Rename node"));
+		            mitem.addActionListener(new ActionListener() {
 		                public void actionPerformed(ActionEvent e) {
-                        dialogs.rename.show();
-                        }});
+                            dialogs.rename.show();
+                    }});
 		            pop.addSeparator();
 	            }
 	            item_idx = 0;
@@ -618,22 +615,27 @@ public class Tree extends JScrollPane implements TreeSelectionListener,
 		            });
 		            item_idx++;
 	            }
-		        pop.add(flags_b = new JMenuItem("Flags"));
-		        flags_b.addActionListener(new ActionListener() {
-		                public void actionPerformed(ActionEvent e) {
+		        pop.add(mitem = new JMenuItem("Flags"));
+		        mitem.addActionListener(new ActionListener(){
+		            public void actionPerformed(ActionEvent e){
                         dialogs.flags.show();
-                        }});
+                }});
 	            pop.addSeparator();
-	            pop.add(open_b = new JMenuItem("Open"));
-	            open_b.addActionListener(this);//) {
-		        //public void actionPerformed(ActionEvent e) { Open(); }});
-
-	            pop.add(close_b = new JMenuItem("Close"));
-	            close_b.addActionListener(this);//new ActionListener() {
-		        //public void actionPerformed(ActionEvent e) {close(); }});
-
-	            pop.add(quit_b = new JMenuItem("Quit"));
-	            quit_b.addActionListener(this);
+	            pop.add(mitem = new JMenuItem("Open"));
+	            mitem.addActionListener(new ActionListener(){
+		            public void actionPerformed(ActionEvent e){
+                        open();
+                }});
+	            pop.add(mitem = new JMenuItem("Close"));
+	            mitem.addActionListener(new ActionListener(){
+		            public void actionPerformed(ActionEvent e){
+                        close();
+                }});
+	            pop.add(mitem = new JMenuItem("Quit"));
+	            mitem.addActionListener(new ActionListener(){
+		            public void actionPerformed(ActionEvent e){
+                        quit();
+                }});
 	        }
 	        item_idx = 0;
 	        for(int i = 0; i < node_properties.length; i++)
@@ -1068,9 +1070,6 @@ public class Tree extends JScrollPane implements TreeSelectionListener,
     public void actionPerformed(ActionEvent e)
     {
 	Object jb = e.getSource();
-	if(jb == (Object)open_b) open();
-	if(jb == (Object)close_b) close();
-	if(jb == (Object)quit_b) quit();
 	if(jb == (Object)ok_cb) open_ok();
 	if(jb == (Object)add_action_b) addNode(NodeInfo.USAGE_ACTION);
 	if(jb == (Object)add_dispatch_b) addNode(NodeInfo.USAGE_DISPATCH);

--- a/javatraverser/Tree.java
+++ b/javatraverser/Tree.java
@@ -480,7 +480,7 @@ public class Tree extends JScrollPane implements TreeSelectionListener,
 		                else
 		                {
 		                    try {
-		                        node.renameLast(newName);
+		                        node.rename(newName);
 		                    }catch(Exception exc)
 		                    {
                                 JOptionPane.showMessageDialog(frame, "Error renaming node: "+ exc,

--- a/javatraverser/TreeNode.java
+++ b/javatraverser/TreeNode.java
@@ -7,63 +7,65 @@ import java.awt.datatransfer.*;
 public class TreeNode extends JLabel
 {
     Node node;
-    static Node selected;
     static Node copied;
+    static boolean cut;
     static Font plain_f, bold_f;
     static {
-	plain_f = new Font("Serif", Font.PLAIN, 12);
-	bold_f = new Font("Serif" ,Font.BOLD, 12);
+	    plain_f = new Font("Serif", Font.PLAIN, 12);
+	    bold_f = new Font("Serif" ,Font.BOLD, 12);
     }
 
-    public static void setSelectedNode(Node sel)
-    {
-	    selected = sel;
-   }
 
 	public static void copyToClipboard()
 	{
 	    try {
-                Clipboard cb = Toolkit.getDefaultToolkit().getSystemClipboard();
-                String []tags = selected.getTags();
-                StringSelection content;
-                String path = selected.getInfo().getPath();
-                content = new StringSelection(path);
-                cb.setContents(content, null);
+            Clipboard cb = Toolkit.getDefaultToolkit().getSystemClipboard();
+            String []tags = Tree.curr_node.getTags();
+            StringSelection content;
+            String path = Tree.curr_node.getFullPath();
+            content = new StringSelection(path);
+            cb.setContents(content, null);
 	    }catch(Exception exc){System.err.println("Cannot copy fullPath to Clipboard");}
 	}
     public static void copy()
     {
-        copied = selected;
+        cut = false;
+        copied = Tree.curr_node;
+        System.out.println("copied: "+copied+" from "+copied.parent);
     }
 
+    public static void cut()
+    {
+        cut = true;
+        copied = Tree.curr_node;
+        System.out.println("cut: "+copied+" from "+copied.parent);
+    }
     public static void paste()
     {
-        if(copied != null && copied != selected)
+        System.out.println((cut ? "moved " : "copied") +copied+ " from " + copied.parent + " to " + Tree.curr_node);
+        if(copied != null && copied != Tree.curr_node)
         {
-            Node.pasteSubtree(copied, selected, true);
+            if (cut)
+            {
+                if (copied.move(Tree.curr_node))
+                    copied = null;
+            }
+            else
+                Node.pasteSubtree(copied, Tree.curr_node, true);
         }
     }
 
     public static void delete()
     {
-        Tree.deleteNode(selected);
+        Tree.deleteNode(Tree.curr_node);
     }
 
     public TreeNode(Node node, String name, Icon icon)
     {
 	    super("MMMMMMMMMMMMMMMM", icon, JLabel.LEFT);
 	    this.node = node;
-        setText(node.getName());
-	    if(node.isOn())
-	        setFont(bold_f);
-	    else
-	        setFont(plain_f);
-	    setForeground(Color.black);
-	    if(node.isDefault())
-	        setBorder(BorderFactory.createLineBorder(Color.black, 1));
-	    else
-	        setBorder(BorderFactory.createLineBorder(Color.white, 1));
-
+	    setFont(bold_f);
+	    setBorder(BorderFactory.createLineBorder(Color.white, 1));
         String tags[] = node.getTags();
         if(tags.length > 0)
         {
@@ -80,21 +82,10 @@ public class TreeNode extends JLabel
 
     public void paint(Graphics g)
     {
-	setText(node.getName());
-	if(node.isDefault())
-	    setForeground(Color.red);
-	else
-	    setForeground(Color.black);
-
-    	if(node.isOn())
-	    setFont(bold_f);
-	else
-	    setFont(plain_f);
-
-	if(selected == node)
-	    setBorder(BorderFactory.createLineBorder(Color.black, 1));
-	else
-	    setBorder(BorderFactory.createLineBorder(Color.white, 1));
-	super.paint(g);
+	    setText(node.getName());
+        setForeground(node.isDefault() ? Color.red : Color.black);
+        setFont(node.isOn() ? bold_f : plain_f);  
+	    setBorder(BorderFactory.createLineBorder((Tree.curr_node == node) ? Color.black : Color.white, 1));
+	    super.paint(g);
     }
 }

--- a/javatraverser/TreeNode.java
+++ b/javatraverser/TreeNode.java
@@ -49,39 +49,33 @@ public class TreeNode extends JLabel
         Tree.deleteNode(selected);
     }
 
-    public TreeNode(Node _node, String name, Icon icon)
+    public TreeNode(Node node, String name, Icon icon)
     {
-	super(name+"                ", icon, JLabel.LEFT);
-	node = _node;
-	if(node.isOn())
-	    setFont(bold_f);
-	else
-	    setFont(plain_f);
-	setForeground(Color.black);
-	if(node.isDefault())
-	    //setText(node.getName().trim() + "                                   ");
-	    //setForeground(Color.red);
-	    setBorder(BorderFactory.createLineBorder(Color.black, 1));
-	else
-	    setBorder(BorderFactory.createLineBorder(Color.white, 1));
-	    //setText(node.getName().trim() + "                                   ");
-	    //setForeground(Color.black);
+	    super("MMMMMMMMMMMMMMMM", icon, JLabel.LEFT);
+	    this.node = node;
+        setText(node.getName());
+	    if(node.isOn())
+	        setFont(bold_f);
+	    else
+	        setFont(plain_f);
+	    setForeground(Color.black);
+	    if(node.isDefault())
+	        setBorder(BorderFactory.createLineBorder(Color.black, 1));
+	    else
+	        setBorder(BorderFactory.createLineBorder(Color.white, 1));
 
-    String tags[] = node.getTags();
-    if(tags.length > 0)
-    {
-        String tagsStr = "";
-        for(int i = 0; i < tags.length; i++)
+        String tags[] = node.getTags();
+        if(tags.length > 0)
         {
-            tagsStr += tags[i];
-            if(i < tags.length - 1)
-                tagsStr += "\n";
+            String tagsStr = "";
+            for(int i = 0; i < tags.length; i++)
+            {
+                tagsStr += tags[i];
+                if(i < tags.length - 1)
+                    tagsStr += "\n";
+            }
+            setToolTipText(tagsStr);
         }
-        setToolTipText(tagsStr);
-    }
-
-
-
     }
 
     public void paint(Graphics g)

--- a/javatraverser/TreeNode.java
+++ b/javatraverser/TreeNode.java
@@ -25,24 +25,24 @@ public class TreeNode extends JLabel
             String path = Tree.curr_node.getFullPath();
             content = new StringSelection(path);
             cb.setContents(content, null);
-	    }catch(Exception exc){System.err.println("Cannot copy fullPath to Clipboard");}
+	    }catch(Exception exc){jTraverser.stderr("Cannot copy fullPath to Clipboard", exc);}
 	}
     public static void copy()
     {
         cut = false;
         copied = Tree.curr_node;
-        System.out.println("copied: "+copied+" from "+copied.parent);
+        jTraverser.stdout("copy: "+copied+" from "+copied.parent);
     }
 
     public static void cut()
     {
         cut = true;
         copied = Tree.curr_node;
-        System.out.println("cut: "+copied+" from "+copied.parent);
+        jTraverser.stdout("cut: "+copied+" from "+copied.parent);
     }
     public static void paste()
     {
-        System.out.println((cut ? "moved " : "copied") +copied+ " from " + copied.parent + " to " + Tree.curr_node);
+        jTraverser.stdout((cut ? "moved: " : "copied: ") +copied+ " from " + copied.parent + " to " + Tree.curr_node);
         if(copied != null && copied != Tree.curr_node)
         {
             if (cut)
@@ -82,7 +82,7 @@ public class TreeNode extends JLabel
 
     public void paint(Graphics g)
     {
-	    setText(node.getName());
+	    setText(node.getName()+"      ");
         setForeground(node.isDefault() ? Color.red : Color.black);
         setFont(node.isOn() ? bold_f : plain_f);  
 	    setBorder(BorderFactory.createLineBorder((Tree.curr_node == node) ? Color.black : Color.white, 1));

--- a/javatraverser/TreeServer.java
+++ b/javatraverser/TreeServer.java
@@ -30,8 +30,7 @@ class TreeServer extends UnicastRemoteObject implements RemoteTree
    /* Low level MDS database management routines, will be  masked by the Node class*/
     public int open() throws DatabaseException
     {
-        System.out.println("Server: start open lastCtx = "+lastCtx);
-
+        jTraverser.stdout("Server: start open lastCtx = "+lastCtx);
         tree.open();
         contexts.insertElementAt(new Long(tree.saveContext()), lastCtx);
         return lastCtx++;
@@ -268,14 +267,12 @@ class TreeServer extends UnicastRemoteObject implements RemoteTree
         RemoteTree server = null;
         try {
             server = new TreeServer();
-       }catch(Exception exc)
-       {
-            System.err.println("Error creating TreeServer: " + exc);
+        }catch(Exception exc){
+            jTraverser.stderr("Error creating TreeServer", exc);
             System.exit(0);
-       }
-       try {
-        Naming.rebind("TreeServer", server);
-       }catch(Exception exc) {System.err.println("Error in Naming.rebind: " + exc);}
+        }
+        try {Naming.rebind("TreeServer", server);}
+        catch(Exception exc) {jTraverser.stderr("Error in Naming.rebind", exc);}
     }
 }
 

--- a/javatraverser/jTraverser.java
+++ b/javatraverser/jTraverser.java
@@ -150,7 +150,6 @@ public class jTraverser extends JFrame implements ActionListener
 	    {
 	        System.exit(0);
 	    }});
-
 	pack();
 	show();
     }
@@ -188,16 +187,15 @@ public void actionPerformed(ActionEvent e)
     if(source == (Object)paste_b) TreeNode.paste();
 
     // Node related
-	Node curr_node = tree.getCurrentNode();
-	if(curr_node == null) return;
+	if(Tree.curr_node == null) return;
     if(source == (Object)turn_on_b)
     {
-	    curr_node.turnOn();
+	    Tree.curr_node.turnOn();
 	    tree.reportChange();
     }
     if(source == (Object)turn_off_b)
     {
-	    curr_node.turnOff();
+	    Tree.curr_node.turnOff();
 	    tree.reportChange();
     }
 
@@ -208,7 +206,7 @@ public void actionPerformed(ActionEvent e)
 	        display_data_d = new TreeDialog(display_data = new DisplayData());
 	        display_data.setFrame(display_data_d);
 	    }
-	    display_data.setNode(curr_node);
+	    display_data.setNode(Tree.curr_node);
 	    display_data_d.pack();
 	    display_data_d.setLocation(dialogLocation());
 	    display_data_d.setVisible(true);
@@ -220,7 +218,7 @@ public void actionPerformed(ActionEvent e)
             display_nci_d = new TreeDialog(display_nci = new DisplayNci());
             display_nci.setFrame(display_nci_d);
         }
-        display_nci.setNode(curr_node);
+        display_nci.setNode(Tree.curr_node);
         display_nci_d.pack();
         display_nci_d.setLocation(dialogLocation());
         display_nci_d.setVisible(true);
@@ -232,7 +230,7 @@ public void actionPerformed(ActionEvent e)
             display_tags_d = new TreeDialog(display_tags = new DisplayTags());
             display_tags.setFrame(display_tags_d);
         }
-        display_tags.setNode(curr_node);
+        display_tags.setNode(Tree.curr_node);
         display_tags_d.pack();
         display_tags_d.setLocation(dialogLocation());
         display_tags_d.setVisible(true);
@@ -244,7 +242,7 @@ public void actionPerformed(ActionEvent e)
 	        modify_data_d = new TreeDialog(modify_data = new ModifyData());
 	        modify_data.setFrame(modify_data_d);
 	    }
-	    modify_data.setNode(curr_node);
+	    modify_data.setNode(Tree.curr_node);
 	    modify_data_d.pack();
 	    modify_data_d.setLocation(dialogLocation());
 	    modify_data_d.setVisible(true);
@@ -252,12 +250,12 @@ public void actionPerformed(ActionEvent e)
     if(source == (Object)set_default_b)
     {
 	    try {
-	        curr_node.setDefault();
+	        Tree.curr_node.setDefault();
 	    }catch(Exception exc) {System.out.println("Error setting default "+exc.getMessage());}
 	    tree.reportChange();
     }
     if(source == (Object)setup_device_b)
-        curr_node.setupDevice();
+        Tree.curr_node.setupDevice();
 }
 
 void reportChange(String exp, int shot, boolean editable, boolean readonly)

--- a/javatraverser/jTraverser.java
+++ b/javatraverser/jTraverser.java
@@ -12,6 +12,7 @@ public class jTraverser extends JFrame implements ActionListener
     static String exp_name, shot_name;
     static boolean editable, readonly;
     static Tree tree;
+    static JLabel status = new JLabel("jTaverser started");
     JMenu file_m, edit_m, data_m, customize_m;
     JMenuItem open, close, quit;
     JMenuItem add_action_b, add_dispatch_b, add_numeric_b, add_signal_b, add_task_b, add_text_b,
@@ -48,10 +49,21 @@ public class jTraverser extends JFrame implements ActionListener
     }
 
 
+    public static void stdout(String line)
+    {
+         status.setText(line);
+    }
+    public static void stderr(String line, Exception exc)
+    {
+         jTraverser.status.setText("ERROR: "+line+" ("+exc.getMessage()+")");
+         System.err.println(line+"\n"+exc);
+    }
+
     public jTraverser(String exp_name, String shot_name, String access)
     {
 	this.exp_name = exp_name;
 	this.shot_name = shot_name;
+	setTitle("jTraverser - no tree open");
 	Boolean edit = false;
 	Boolean readonly = false;
 	if (access != null)
@@ -141,10 +153,8 @@ public class jTraverser extends JFrame implements ActionListener
 	tree = new Tree(this);
 	if(exp_name != null)
 	    tree.open(exp_name.toUpperCase(), (shot_name == null)?-1:Integer.parseInt(shot_name), edit, readonly, false);
-	else
-	    setTitle("jTraverser - no tree open");
-	getContentPane().add(tree);
-
+	getContentPane().add(tree, BorderLayout.NORTH);
+    getContentPane().add(status, BorderLayout.SOUTH);
 	addWindowListener(new WindowAdapter() {
 	    public void windowClosing(WindowEvent e)
 	    {
@@ -251,7 +261,7 @@ public void actionPerformed(ActionEvent e)
     {
 	    try {
 	        Tree.curr_node.setDefault();
-	    }catch(Exception exc) {System.out.println("Error setting default "+exc.getMessage());}
+	    }catch(Exception exc) {jTraverser.stderr("Error setting default",exc);}
 	    tree.reportChange();
     }
     if(source == (Object)setup_device_b)
@@ -266,20 +276,21 @@ void reportChange(String exp, int shot, boolean editable, boolean readonly)
     String title;
     if(exp != null)
     {
-	title = "jTraverser - Tree: " + exp;
-	if(editable)
-	    title = title + " (edit) ";
-	if(readonly)
-	    title = title + " (readonly) ";
-	title = title + " Shot: " + shot;
+	    title = "Tree: " + exp;
+	    if(editable)
+	        title = title + " (edit) ";
+	    if(readonly)
+	        title = title + " (readonly) ";
+	    title = title + " Shot: " + shot;
+        jTraverser.stdout(title);
     }
     else
     {
-	title = "jTraverser - no tree open";
-	edit_m.setEnabled(false);
-	data_m.setEnabled(false);
+	    title = "no tree open";
+	    edit_m.setEnabled(false);
+	    data_m.setEnabled(false);
     }
-    setTitle(title);
+    setTitle("jTraverser - "+title);
     if(exp == null) return;
     data_m.setEnabled(true);
     if(editable)


### PR DESCRIPTION
- change the rename dialog as it is buggy when changing the path
- node.rename is more like move as the full path can be changed
- node.renameLast is the proper rename method in node
- the error dialogs are safer on lower levels
- when requesting the node name the trimmed version is either requested or should fit as well
- removed "node" from title as it is too long anyway
- fixed and implemented copy and move of node structures
- Ctrl+X cuts, Ctrl+C copies, and Ctrl+V pastes
- restructured NodeInfo (included all flags)
- made field private with getters
- modified JavaTrav.c to return flags int
- change dclass, dtype, and usage to byte to solve uint vs int issue
  this fixed the DType and Class display on DisplayNci
- modified JavaTrav.c to use unsignad char for dclass, dtype, and usage
- modified JavaData.c to use unsigned char for dclass, dtype
- improved layout of the DisplayNci to handle longer flag lines in a aligned table
- added status bar
