### PR TITLE
Fix all Tree.lock() invokations moving them from inside the try: fina…

### DIFF
--- a/mdsobjects/python/_tdishr.py
+++ b/mdsobjects/python/_tdishr.py
@@ -26,8 +26,8 @@ def TdiCompile(expression,args=None):
     Tree=_mimport('tree',1).Tree
     xd=descriptor_xd()
     done=False
+    Tree.lock()
     try:
-        Tree.lock()
         restoreContext()
         if args is None:
             status=TdiShr.TdiCompile(_C.pointer(descriptor(expression)),_C.pointer(xd),_C.c_void_p(-1))
@@ -62,8 +62,8 @@ def TdiExecute(expression,args=None):
     Tree=_mimport('tree',1).Tree
     xd=descriptor_xd()
     done=False
+    Tree.lock()
     try:
-        Tree.lock()
         restoreContext()
         if args is None:
             status=TdiShr.TdiExecute(_C.pointer(descriptor(expression)),_C.pointer(xd),_C.c_void_p(-1))
@@ -97,8 +97,8 @@ def TdiDecompile(value):
     descriptor=_descriptor.descriptor
     Tree=_mimport('tree',1).Tree
     xd=descriptor_xd()
+    Tree.lock()
     try:
-        Tree.lock()
         restoreContext()
         status=TdiShr.TdiDecompile(_C.pointer(descriptor(value)),_C.pointer(xd),_C.c_void_p(-1))
     finally:
@@ -118,8 +118,8 @@ def TdiEvaluate(value):
     descriptor_xd=_descriptor.descriptor_xd
     Tree=_mimport('tree',1).Tree
     xd=descriptor_xd()
+    Tree.lock()
     try:
-        Tree.lock()
         restoreContext()
         status=TdiShr.TdiEvaluate(_C.pointer(descriptor(value)),_C.pointer(xd),_C.c_void_p(-1))
     finally:
@@ -136,8 +136,8 @@ def TdiData(value):
     descriptor_xd=_descriptor.descriptor_xd
     Tree=_mimport('tree',1).Tree
     xd=descriptor_xd()
+    Tree.lock()
     try:
-        Tree.lock()
         restoreContext()
         status=TdiShr.TdiData(_C.pointer(descriptor(value)),_C.pointer(xd),_C.c_void_p(-1))
     finally:

--- a/mdsobjects/python/_treeshr.py
+++ b/mdsobjects/python/_treeshr.py
@@ -319,8 +319,8 @@ def TreeDoMethod(n,method,arg=None):
 
 def TreeStartConglomerate(tree,num):
     """Start a conglomerate in a tree."""
+    tree.lock()
     try:
-        tree.lock()
         status=__TreeStartConglomerate(tree.ctx,num)
     finally:
         tree.unlock()
@@ -330,8 +330,8 @@ def TreeStartConglomerate(tree,num):
 
 def TreeEndConglomerate(tree):
     """End a conglomerate in a tree."""
+    tree.lock()
     try:
-        tree.lock()
         status=__TreeEndConglomerate(tree.ctx)
     finally:
         tree.unlock()
@@ -341,8 +341,8 @@ def TreeEndConglomerate(tree):
 
 def TreeTurnOn(n):
     """Turn on a tree node."""
+    n.tree.lock()
     try:
-        n.tree.lock()
         status=__TreeTurnOn(n.tree.ctx,n.nid)
     finally:
         n.tree.unlock()
@@ -354,8 +354,8 @@ def TreeTurnOn(n):
 
 def TreeTurnOff(n):
     """Turn off a tree node."""
+    n.tree.lock()
     try:
-        n.tree.lock()
         status=__TreeTurnOff(n.tree.ctx,n.nid)
     finally:
         n.tree.unlock()
@@ -422,8 +422,8 @@ def TreeAddNode(tree,name,usage):
     return nid.value
 
 def TreeSetSubtree(node,flag):
+    node.tree.lock()
     try:
-        node.tree.lock()
         if flag:
             status=__TreeSetSubtree(node.tree.ctx,node.nid)
         else:
@@ -434,8 +434,8 @@ def TreeSetSubtree(node,flag):
         node.tree.unlock()
 
 def TreeRenameNode(node,name):
+    node.tree.lock()
     try:
-        node.tree.lock()
         status = __TreeRenameNode(node.tree.ctx,node.nid,str.encode(str(name)))
         if not (status & 1):
             raise TreeException(_mdsshr.MdsGetMsg(status))
@@ -443,8 +443,8 @@ def TreeRenameNode(node,name):
         node.tree.unlock()
 
 def TreeAddTag(tree,nid,tag):
+    tree.lock()
     try:
-        tree.lock()
         status = __TreeAddTag(tree.ctx,nid,str.encode(str(tag)))
         if not (status & 1):
             raise TreeException(_mdsshr.MdsGetMsg(status))
@@ -452,8 +452,8 @@ def TreeAddTag(tree,nid,tag):
         tree.unlock()
 
 def TreeRemoveTag(tree,tag):
+    tree.lock()
     try:
-        tree.lock()
         status = __TreeRemoveTag(tree.ctx,str.encode(str(tag)))
         if not (status & 1):
             raise TreeException(_mdsshr.MdsGetMsg(status))
@@ -530,8 +530,8 @@ def TreeGetVersionDate():
 
 def TreeGetNumSegments(n):
     """Get number of segments in a node."""
+    n.tree.lock()
     try:
-        n.tree.lock()
         num=_C.c_int32(0)
         status=__TreeGetNumSegments(n.tree.ctx,n.nid,_C.pointer(num))
     finally:
@@ -547,8 +547,8 @@ def TreePutTimestampedSegment(n,timestampArray,value):
     
     timestampArray=_mimport('mdsarray',1).Int64Array(timestampArray)
     value=_mimport('mdsarray',1).makeArray(value)
+    n.tree.lock()
     try:
-        n.tree.lock()
         status=__TreePutTimestampedSegment(n.tree.ctx,n.nid,descriptor_a(timestampArray).pointer,_C.pointer(descriptor_a(value)))
     finally:
         n.tree.unlock()
@@ -560,8 +560,8 @@ def TreePutTimestampedSegment(n,timestampArray,value):
 def TreeMakeTimestampedSegment(n,timestamps,value,idx,rows_filled):
     """Put a segment"""
     timestamps=_mimport('mdsarray',1).Int64Array(timestamps)
+    n.tree.lock()
     try:
-        n.tree.lock()
         status=__TreeMakeTimestampedSegment(n.tree.ctx,n.nid,descriptor_a(timestamps).pointer,_C.pointer(descriptor_a(value)),idx,rows_filled)
     finally:
         n.tree.unlock()
@@ -572,8 +572,8 @@ def TreeMakeTimestampedSegment(n,timestamps,value,idx,rows_filled):
 
 def TreePutSegment(n,value,idx):
     """Put a segment"""
+    n.tree.lock()
     try:
-        n.tree.lock()
         status=__TreePutSegment(n.tree.ctx,n.nid,idx,_C.pointer(descriptor(value)))
     finally:
         n.tree.unlock()
@@ -584,8 +584,8 @@ def TreePutSegment(n,value,idx):
 
 def TreePutRow(n,bufsize,array,timestamp):
     """Begin a segment."""
+    n.tree.lock()
     try:
-        n.tree.lock()
         array=_mimport('mdsarray',1).makeArray(array)
         status=__TreePutRow(n.tree.ctx,n.nid,bufsize,_C.pointer(_C.c_int64(int(timestamp))),
                              _C.pointer(descriptor_a(array)))
@@ -599,8 +599,8 @@ def TreePutRow(n,bufsize,array,timestamp):
 
 def TreeBeginTimestampedSegment(n,value,idx):
     """Begin a segment"""
+    n.tree.lock()
     try:
-        n.tree.lock()
         status=__TreeBeginTimestampedSegment(n.tree.ctx,n.nid,_C.pointer(descriptor_a(value)),idx)
     finally:
         n.tree.unlock()
@@ -610,8 +610,8 @@ def TreeBeginTimestampedSegment(n,value,idx):
         raise TreeException(_mdsshr.MdsGetMsg(status))
 
 def TreeMakeSegment(n,start,end,dimension,initialValue,idx):
+    n.tree.lock()
     try:
-        n.tree.lock()
         if isinstance(initialValue,_mimport('compound',1).Compound):
             __TreeMakeSegment.argtypes=[_C.c_void_p,_C.c_int32,_C.POINTER(descriptor),_C.POINTER(descriptor),_C.POINTER(descriptor),
                             _C.POINTER(descriptor),_C.c_int32,_C.c_int32]
@@ -634,8 +634,8 @@ def TreeMakeSegment(n,start,end,dimension,initialValue,idx):
 
 def TreeBeginSegment(n,start,end,dimension,initialValue,idx):
     """Begin a segment."""
+    n.tree.lock()
     try:
-        n.tree.lock()
         status=__TreeBeginSegment(n.tree.ctx,n.nid,_C.pointer(descriptor(start)),_C.pointer(descriptor(end)),
                                    _C.pointer(descriptor(dimension)),_C.pointer(descriptor_a(initialValue)),
                                    idx)
@@ -649,8 +649,8 @@ def TreeBeginSegment(n,start,end,dimension,initialValue,idx):
 
 def TreeUpdateSegment(n,start,end,dimension,idx):
     """Update a segment."""
+    n.tree.lock()
     try:
-        n.tree.lock()
         status=__TreeUpdateSegment(n.tree.ctx,n.nid,_C.pointer(descriptor(start)),_C.pointer(descriptor(end)),
                                     _C.pointer(descriptor(dimension)),idx)
     finally:
@@ -709,9 +709,9 @@ def TreeGetDbi(tree,itemname):
     else:
         ans=_C.c_int32(0)
         itmlst=DBI_ITM_INT(item[0],ans)
+    tree.lock()
     try:
-        tree.lock()
-        status=__TreeGetDbi(tree.ctx,_C.cast(
+       status=__TreeGetDbi(tree.ctx,_C.cast(
             _C.pointer(itmlst),_C.c_void_p))
     finally:
         tree.unlock()
@@ -737,8 +737,8 @@ def TreeSetDbi(tree,itemname,value):
     else:
         ans=_C.c_int32(0)
         itmlst=DBI_ITM_INT(item[0],_C.c_int32(int(value)))
+    tree.lock()
     try:
-        tree.lock()
         status=__TreeSetDbi(tree.ctx,_C.cast(
             _C.pointer(itmlst),_C.c_void_p))
     finally:

--- a/mdsobjects/python/tree.py
+++ b/mdsobjects/python/tree.py
@@ -163,8 +163,8 @@ class Tree(object):
         @return: Head node of device added
         @rtype: TreeNode
         """
+        Tree.lock()
         try:
-            Tree.lock()
             nid=_mimport('_treeshr',1).TreeAddConglom(self,str(nodename),str(model))
         finally:
             Tree.unlock()
@@ -179,8 +179,8 @@ class Tree(object):
         @return: Node created.
         @rtype: TreeNode
         """
+        Tree.lock()
         try:
-            Tree.lock()
             nid = _mimport('_treeshr',1).TreeAddNode(self,str(nodename),str(usage))
         finally:
             Tree.unlock()
@@ -195,8 +195,8 @@ class Tree(object):
         _treeshr=_mimport('_treeshr',1)
         import ctypes as _C
         from numpy import array
+        Tree.lock()
         try:
-            Tree.lock()
             try:
                 subtrees=self.getNodeWild('***','subtree')
                 included=subtrees.nid_number.compress(subtrees.include_in_pulse)
@@ -220,8 +220,8 @@ class Tree(object):
         @rtype: None
         """
         _treeshr=_mimport('_treeshr',1)
+        Tree.lock()
         try:
-            Tree.lock()
             first=True
             nodes=self.getNodeWild(wild)
             for node in nodes:
@@ -237,8 +237,8 @@ class Tree(object):
         @type shot: int
         @rtype: None
         """
+        Tree.lock()
         try:
-            Tree.lock()
             _mimport('_treeshr',1).TreeDeletePulse(self,shot)
         finally:
             Tree.unlock()
@@ -272,8 +272,8 @@ class Tree(object):
     def edit(self):
         """Open tree for editing.
         @rtype: None"""
+        Tree.lock()
         try:
-            Tree.lock()
             _mimport('_treeshr',1).TreeOpenEdit(self)
         finally:
             Tree.unlock()
@@ -324,8 +324,8 @@ class Tree(object):
         @return: Current shot number for the specified tree
         @rtype: int
         """
+        Tree.lock()
         try:
-            Tree.lock()
             shot=_mimport('_treeshr',1).TreeGetCurrentShotId(str.encode(treename))
         finally:
             Tree.unlock()
@@ -339,8 +339,8 @@ class Tree(object):
         @return: Current default node
         @rtype: TreeNode
         """
+        Tree.lock()
         try:
-            Tree.lock()
             ans = _mimport('treenode',1).TreeNode(_mimport('_treeshr',1).TreeGetDefault(self.ctx),self)
         finally:
             Tree.unlock()
@@ -429,8 +429,8 @@ class Tree(object):
         """Close edit session discarding node structure and tag changes.
         @rtype: None
         """
+        Tree.lock()
         try:
-            Tree.lock()
             _mimport('_treeshr',1).TreeQuitTree(self)
         finally:
             Tree.unlock()
@@ -487,8 +487,8 @@ class Tree(object):
         @type shot: int
         @rtype None
         """
+        Tree.lock()
         try:
-            Tree.lock()
             status=_mimport('_treeshr',1).TreeSetCurrentShotId(str.encode(treename),shot)
         finally:
             Tree.unlock()
@@ -581,10 +581,10 @@ class Tree(object):
         """Write out edited tree.
         @rtype: None
         """
+        Tree.lock()
         try:
             name=self.tree
             shot=self.shot
-            Tree.lock()
             _mimport('_treeshr',1).TreeWriteTree(self,name,shot)
         finally:
             Tree.unlock()

--- a/mdsobjects/python/treenode.py
+++ b/mdsobjects/python/treenode.py
@@ -149,10 +149,10 @@ class TreeNode(_data.Data):
         if name.lower() == 'local_path':
             return self.getLocalPath()
         if name.upper() in nciAttributes:
+            _tree.Tree.lock()
             try:
                 if name.lower() == 'mclass':
                     name='class';
-                _tree.Tree.lock()
                 self.restoreContext()
                 try:
                     ans = _data.Data.execute('getnci($,$)',self,name)
@@ -254,8 +254,8 @@ class TreeNode(_data.Data):
                 switch="/no"
             else:
                 raise TypeError('Argument must be True or False')
+        _tree.Tree.lock()
         try:
-            _tree.Tree.lock()
             self.restoreContext()
             cmd='tcl("set node \\%s%s%s")'% (self.fullpath,switch,qualifier)
             status = _data.Data.compile(cmd).evaluate()
@@ -405,8 +405,8 @@ class TreeNode(_data.Data):
         @type arg: Data
         @rtype: None
         """
+        _tree.Tree.lock()
         try:
-            _tree.Tree.lock()
             self.restoreContext()
             _mimport('_treeshr',1).TreeDoMethod(self,str(method),arg)
         finally:
@@ -761,8 +761,8 @@ class TreeNode(_data.Data):
         @return: Tag names pointing to this node
         @rtype: ndarray
         """
+        _tree.Tree.lock()
         try:
-            _tree.Tree.lock()
             ans=_mimport('_treeshr',1).TreeFindNodeTags(self)
         finally:
             _tree.Tree.unlock()
@@ -908,10 +908,10 @@ class TreeNode(_data.Data):
         @type data: Data
         @rtype: None
         """
+        _tree.Tree.lock()
         try:
             if isinstance(data,_data.Data) and data.__hasBadTreeReferences__(self.tree):
                 data=data.__fixTreeReferences__(self.tree)
-            _tree.Tree.lock()
             _mimport('_treeshr',1).TreePutRecord(self,data)
         finally:
             _tree.Tree.unlock()
@@ -1062,8 +1062,8 @@ class TreeNode(_data.Data):
         @type flag: bool
         @rtype: None
         """
+        _tree.Tree.lock()
         try:
-            _tree.Tree.lock()
             if flag is True:
                 _mimport('_treeshr',1).TreeTurnOn(self)
             else:
@@ -1292,8 +1292,8 @@ class TreeNodeArray(_data.Data):
     
 
     def __getattr__(self,name):
+        _tree.Tree.lock()
         try:
-            _tree.Tree.lock()
             try:
                 self.restoreContext()
                 ans = _data.Data.execute('getnci($,$)',self.nids,name)


### PR DESCRIPTION
…lly: clauses to just before the try block.

This was fixed in the alpha branch but not patched in the stable branch. If an error occurs in the try block before the lock() was invoked then the attempt to unlock the tree will raise an exception thus hiding the original exception.
