### PR TITLE
jScope eventupdate block

### DIFF
--- a/javascope/jScope/MdsConnection.java
+++ b/javascope/jScope/MdsConnection.java
@@ -74,6 +74,7 @@ public class MdsConnection
             public void run()
             {
                 setName("Process Mds Event Thread");
+                if (jScopeFacade.busy()) return;
                 if( eventName != null )
                         dispatchUpdateEvent(eventName);
                 else

--- a/javascope/jScope/jScopeFacade.java
+++ b/javascope/jScope/jScopeFacade.java
@@ -111,10 +111,13 @@ public class jScopeFacade
     static int num_scope = 0;
     private String config_file;
     static DataServerItem[] server_ip_list;
-    ServerDialog server_diag = null;
+    ServerDialog server_diag;
     static boolean not_sup_local = false;
     private boolean executing_update = false;
     private JFrame main_scope;
+
+    private static jScopeFacade win;
+    public static boolean busy(){return win.executing_update;}
 
     DocPrintJob prnJob = null;
   //  PageFormat pageFormat;
@@ -2907,8 +2910,6 @@ remove 28/06/2005
         String file = null;
         String propertiesFile = null;
  
-        jScopeFacade win = null;
-
         Properties props = System.getProperties();
         String debug = props.getProperty("debug");
         if (debug != null && debug.equals("true"))


### PR DESCRIPTION
Prevents events from dispatching when busy.
It caused jScope to freeze if an event occurred during loading of configuration.
