### PR TITLE
all-uppercase attributes will be redirected to getNode

### DIFF
--- a/mdsobjects/python/tree.py
+++ b/mdsobjects/python/tree.py
@@ -132,6 +132,11 @@ class Tree(object):
         @return: Value of attribute
         @rtype: various
         """
+        if name.upper() == name:
+            try:
+                return self.getNode(name)
+            except:
+                pass
         if name.lower() == 'default':
             ans=self.getDefault()
         else:

--- a/mdsobjects/python/treenode.py
+++ b/mdsobjects/python/treenode.py
@@ -132,6 +132,11 @@ class TreeNode(_data.Data):
          @rtype: various
          """
 
+        if name.upper() == name:
+            try:
+                return self.getNode(name)
+            except:
+                pass
         if name.lower() == 'nid':
             try:
                 return self.__dict__['nid']


### PR DESCRIPTION
all-uppercase attributes will be redirected to getNode
- allows a shortcut of node.getNode('DESC') by using node.DESC
- much faster way of getting the desired node
