### PR TITLE
Add compatibility to the older MdsException exception class

### DIFF
--- a/mdsobjects/python/_mdsshr.py
+++ b/mdsobjects/python/_mdsshr.py
@@ -28,7 +28,7 @@ __MDSEventCan.argtypes=[_C.c_int32,]
 __MDSEvent=_mdsshr.MDSEvent
 __MDSEvent.argtypes=[_C.c_char_p,_C.c_int32,_C.c_void_p]
 
-class MdsshrException(Exception):
+class MdsshrException(_Exceptions.MDSplusException):
     pass
 
 class MdsInvalidEvent(MdsshrException):

--- a/mdsobjects/python/connection.py
+++ b/mdsobjects/python/connection.py
@@ -18,7 +18,7 @@ _data=_mimport('mdsdata')
 _dtypes=_mimport('_mdsdtypes')
 _ver=_mimport('version')
 
-class MdsIpException(Exception):
+class MdsIpException(_Exceptions.MDSplusException):
   pass
 
 __MdsIpShr=_ver.load_library('MdsIpShr')

--- a/mdsobjects/python/mdsExceptions/__init__.py
+++ b/mdsobjects/python/mdsExceptions/__init__.py
@@ -11,8 +11,16 @@ import glob as _g
 class MDSplusException(Exception):
   severities=["W", "S", "E", "I", "F", "?", "?", "?"]
   def __init__(self,status=None):
-    if status is not None:
+    if status is not None and isinstance(status,int):
       self.status=status
+    else:
+      self.status=-1
+      self.msgnam='UNKNOWN'
+      if isinstance(status,str):
+	self.message=status
+      else:
+        self.message='Unknown exception'
+      self.fac='MDSplus'
     self.severity=self.severities[self.status & 7]
 
   def __str__(self):

--- a/mdsobjects/python/mdsdata.py
+++ b/mdsobjects/python/mdsdata.py
@@ -9,6 +9,11 @@ import numpy as _N
 _dtypes=_mimport('_mdsdtypes')
 _ver=_mimport('version')
 
+_mdsExceptions=_mimport('mdsExceptions')
+
+MDSplusException = _mdsExceptions.MDSplusException
+MdsException = MDSplusException
+
 def getUnits(item):
     """Return units of item. Evaluate the units expression if necessary.
     @rtype: string"""

--- a/mdsobjects/python/treenode.py
+++ b/mdsobjects/python/treenode.py
@@ -19,7 +19,7 @@ _ver=_mimport('version')
 
 
 
-class TreeNodeException(Exception):
+class TreeNodeException(_Exceptions.MDSplusException):
   pass
 
 nciAttributes = ('BROTHER','CACHED','CHILD','CHILDREN_NIDS','MCLASS','CLASS_STR',


### PR DESCRIPTION
All exception classes in the MDSplus module should now be a subclass of MDSplusException. MDSplusException is now a global symbol in the MDSplus module as is MdsException which is just an alias for MDSplusException. This enables the following:
from MDSplus import *
try:
  n=Tree('gub',-1),getNode('foo')
except MdsException:
  print "Got an MdsException

You can now also raise MDSplusException if desired:

raise MDSplusException("this is a made up exception")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
mdsExceptions.**init**.MDSplusException: %MDSPLUS-?-UNKNOWN, this is a made up exception
