### PR TITLE
For some reason the use of python based funs causes a problem with th…

### DIFF
--- a/mdsobjects/python/_descriptor.py
+++ b/mdsobjects/python/_descriptor.py
@@ -193,7 +193,7 @@ class descriptor(_C.Structure):
                 if value.args[i] is None:
                     c_d.dscptrs[i]=_C.cast(_C.c_void_p(0),type(c_d.dscptrs[i]))
                 else:
-                    c_d.dscptrs[i]=_C.pointer(descriptor(value.args[i]))
+                    c_d.dscptrs[i]=_C.cast(_C.pointer(descriptor(value.args[i])),type(c_d.dscptrs[i]))
             self.length=1000
             self.dtype=_dtypes.DTYPE_DSC
             self.pointer=_C.cast(_C.pointer(c_d),type(self.pointer))


### PR DESCRIPTION
…e ctypes POINTER function used in creating descriptors. This fix uses the ctypes cast function to cast a POINTER(descriptor) to the type of an instance of a pointer to a descriptor.
