### PR TITLE
Bstandley fix thread handling in tree py

### DIFF
--- a/mdsobjects/python/tree.py
+++ b/mdsobjects/python/tree.py
@@ -18,9 +18,9 @@ _scalar=_mimport('mdsscalar')
 _treenode=_mimport('treenode')
 _ver=_mimport('version')
 
-thread_data=_threading.local()
-thread_data._activeTree=0
-thread_data.private=False
+_thread_data=_threading.local()
+_thread_data._activeTree=0
+_thread_data.private=False
 
 _hard_lock=_threading.Lock()
 
@@ -28,9 +28,10 @@ _openTrees={}
 _activeTree={}
 
 def _getThreadName(thread=None):
+    global _thread_data
     if isinstance(thread,str):
         threadName=thread
-    elif thread_data.private:
+    elif _thread_data.private:
         if thread is None:
             threadName = _threading.current_thread().getName()
         else:
@@ -154,8 +155,8 @@ class Tree(object):
         return ans
 
     def usePrivateCtx(cls,on=True):
-        global thread_data
-        thread_data.private=on
+        global _thread_data
+        _thread_data.private=on
         _treeshr.TreeUsePrivateCtx(on)
     usePrivateCtx=classmethod(usePrivateCtx)
 

--- a/mdsobjects/python/tree.py
+++ b/mdsobjects/python/tree.py
@@ -18,9 +18,11 @@ _scalar=_mimport('mdsscalar')
 _treenode=_mimport('treenode')
 _ver=_mimport('version')
 
-_thread_data=_threading.local()
-_thread_data._activeTree=0
-_thread_data.private=False
+class _ThreadData(_threading.local):
+    def __init__(self):
+        self._activeTree=0
+        self.private=False
+_thread_data=_ThreadData()
 
 _hard_lock=_threading.Lock()
 
@@ -28,7 +30,6 @@ _openTrees={}
 _activeTree={}
 
 def _getThreadName(thread=None):
-    global _thread_data
     if isinstance(thread,str):
         threadName=thread
     elif _thread_data.private:
@@ -155,7 +156,6 @@ class Tree(object):
         return ans
 
     def usePrivateCtx(cls,on=True):
-        global _thread_data
         _thread_data.private=on
         _treeshr.TreeUsePrivateCtx(on)
     usePrivateCtx=classmethod(usePrivateCtx)


### PR DESCRIPTION
I spent some time looking at this and believe I have a good solution.  To start off, I wrote some code (available at http://iceberg.brianstandley.com/derper.py) which demonstrates the problem.  I then found some documentation (https://pymotw.com/2/threading/#thread-specific-data) which indicates that adding attributes to an instance of thread.local _must_ be done by subclassing.   Evidently each additional thread gets a "fresh" copy of _thread_local which does not include any attributes added later in the main thread.  The official module docs completely fail to mention this subtlety . . .

I also removed the global statements, which are not necessary when interacting with only attributes of the global-level object.

Timo's pull request also makes the test code run, but involves more significant modification to the original code, and I am not familiar enough the problem space to say whether it is functionally equivalent, so I suggest merging mine instead.  Sorry Timo ;-)
