### PR TITLE
1) Only do locking of python GIL when doing setup methods (needed for …

### DIFF
--- a/mdsmisc/mdsmisc.def
+++ b/mdsmisc/mdsmisc.def
@@ -10,3 +10,4 @@ GetNidArray
 GetReferenceCount
 GetReferences
 whoami
+PyCall

--- a/mdsmisc/pycall.c
+++ b/mdsmisc/pycall.c
@@ -21,7 +21,7 @@ static void (*PyGILState_Release) (void *) = 0;
   return 0;\
 }
 
-int PyCall(char *cmd, int lock)
+EXPORT int PyCall(char *cmd, int lock)
 {
 #ifndef _WIN32
   void (*old_handler) (int);
@@ -37,6 +37,10 @@ int PyCall(char *cmd, int lock)
 	      "Please define PyLib to be the name of your python library, i.e. 'python2.4 or /usr/lib/libpython2.4.so.1'\n\n\n");
       return 0;
     }
+#ifdef _WIN32
+    lib = strcpy((char *)malloc(strlen(envsym) + 5), envsym);
+    strcat(lib, ".dll");
+#else
     if (envsym[0] == '/' || strncmp(envsym, "lib", 3) == 0) {
       lib = strcpy((char *)malloc(strlen(envsym) + 1), envsym);
     } else {
@@ -44,7 +48,7 @@ int PyCall(char *cmd, int lock)
       strcat(lib, envsym);
       strcat(lib, ".so");
     }
-    /*** See if python routines are already available ***/
+#endif
 #ifndef _WIN32
     handle = dlopen(0, RTLD_NOLOAD);
 #endif
@@ -83,7 +87,7 @@ int PyCall(char *cmd, int lock)
   return 1;
 }
 
-void PyReleaseThreadLock()
+EXPORT void PyReleaseThreadLock()
 {
   if (PyGILState_GetThisThreadState && PyEval_ReleaseThread) {
     void *STATE = (*PyGILState_GetThisThreadState) ();

--- a/mdsobjects/python/tree.py
+++ b/mdsobjects/python/tree.py
@@ -671,3 +671,16 @@ class Tree(object):
             Tree.unlock()
         if not (status & 1):
             raise _Exceptions.statusToException(status)
+
+class TreeRef(Tree):
+    """The TreeRef class uses the current global dbid ctx to construct a tree reference object.
+    Unlike Tree instances created with no arguments, TreeRef instances do not affect the global
+    dbid ctx when they are deleted."""
+    
+    def __init__(self):
+        pass
+    def __del__(self):
+        pass
+    def _getCtx(self):
+        return _treeshr.TreeGetContext()
+    ctx=property(_getCtx)

--- a/mdsobjects/python/treenode.py
+++ b/mdsobjects/python/treenode.py
@@ -188,7 +188,7 @@ class TreeNode(_data.Data):
             return ans
         raise AttributeError('Attribute %s is not defined' % (name,))
 
-    def __init__(self,n,tree=None):
+    def __init__(self,n,tree=None,treeref=False):
         """Initialze TreeNode
         @param n: Index of the node in the tree.
         @type n: int
@@ -197,7 +197,10 @@ class TreeNode(_data.Data):
         """
         self.__dict__['nid']=int(n);
         if tree is None:
-            self.tree=_tree.Tree()
+            if treeref:
+                self.tree=_tree.TreeRef()
+            else:
+                self.tree=_tree.Tree()
         else:
             self.tree=tree.copy()
 

--- a/tdi/Py.fun
+++ b/tdi/Py.fun
@@ -1,23 +1,5 @@
-public fun Py(in _cmd, optional in _varname, optional in _global_namespace) {
-   fun PyCall(in _routine,_locked, optional in _arg) {
-      if (_locked) {
-        _GIL=build_call(51,getenv("PyLib"),"PyGILState_Ensure"); 
-      }
-      if (present(_arg)) {
-        _ans=build_call(8,getenv("PyLib"),_routine,_arg);
-      } else {
-        _ans=build_call(8,getenv("PyLib"),_routine);
-      }
-      if (_locked) { 
-        build_call(51,getenv("PyLib"),"PyGILState_Release",val(_GIL));
-        if (ALLOCATED(public _PyReleaseThreadLock)) {
-		build_call(8,getenv("PyLib"),"PyEval_ReleaseThread",val(build_call(51,getenv("PyLib"),"PyGILState_GetThisThreadState")));
-		deallocate(public _PyReleaseThreadLock);
-	}
-      }
-      return(_ans);
-   }
-
+public fun Py(in _cmd, optional in _varname, optional in _global_namespace, optional in _lock) {
+   _locked=present(_lock) ? _lock : 0;
    if (NOT ALLOCATED(public _PyInit)) {
      _sym=0qu;
      if (getenv("PyLib") == "") {
@@ -25,37 +7,22 @@ public fun Py(in _cmd, optional in _varname, optional in _global_namespace) {
        write(*,"Please define PyLib to be the name of your python library, i.e. 'python2.4'\n\n\n");
        abort();
      }
-     if (MdsShr->LibFindImageSymbol(descr('MdsMisc'),descr('PyCall'),ref(_sym)) == 1) {
-       MdsMisc->PyCall("from MDSplus import execPy as ___TDI___execPy",val(1));
-       public _PyInit=2;
-     } else {
-       if (MdsShr->LibFindImageSymbol(descr('dl'),descr('dlopen'),ref(_sym)) == 1) {
-	  dl->dlopen('lib'//getenv("PyLib")//'.so',val(258));
-       }
-       PyCall("Py_Initialize",0);
-       PyCall("PyEval_InitThreads",0);
-       public _PyInit=1;
-       PyCall("PyRun_SimpleString",1,"from MDSplus import execPy as ___TDI___execPy");
-     }
+     MdsMisc->PyCall("from MDSplus import execPy as ___TDI___execPy",val(_locked));
    }
    public ___TDI___cmds=_cmd;
    if (present(_varname))
 	_execCall="___TDI___execPy('"//_varname//"')";
     else
         _execCall="___TDI___execPy()";
-   _locked=!present(_nolock);
+   
    deallocate(public ___TDI___exception);
    deallocate(public ___TDI___answer);
 
    public ___TDI___global_ns= present(_global_namespace) ? 1 : 0;
-   if (public _PyInit==1) {
-     PyCall("PyRun_SimpleString",_locked,_execCall);
-   } else {
-     MdsMisc->PyCall(_execCall,val(_locked));
-     if (ALLOCATED(public _PyReleaseThreadLock)) {
-       MdsMisc->PyReleaseThreadLock();
-       deallocate(public _PyReleaseThreadLock);
-     }
+   MdsMisc->PyCall(_execCall,val(_locked));
+   if (ALLOCATED(public _PyReleaseThreadLock)) {
+     MdsMisc->PyReleaseThreadLock();
+     deallocate(public _PyReleaseThreadLock);
    }
    if (allocated(public ___TDI___exception)) {
      public _py_exception=public ___TDI___exception;

--- a/tdi/dev_support/PyDoMethod.fun
+++ b/tdi/dev_support/PyDoMethod.fun
@@ -1,15 +1,12 @@
 public fun PyDoMethod(as_is _nid, in _method,optional in _arg) {
-   _n=getnci(_nid,'fullpath');
    public _result=2; 
    if (present(_arg)) {
 	 public __do_method_arg__=_arg;
    } else {
      public __do_method_arg__=*;
    }
-   _cmds=["from MDSplus import Tree",
-          "t=Tree('"//$expt//"',"//text($shot)//")",
-          "n=t.getNode('"//_n//"')",
-          "t.doMethod(n.nid,'"//_method//"')"];
-   Py(_cmds);
+   _lock=index(upcase(_method),'SETUP') >= 0;
+   Py(["from MDSplus import TreeRef",
+          "TreeRef().doMethod("//text(getnci(_nid,"nid_number"))//",'"//_method//"')"],*,*,_lock);
    return(public _result);
 }

--- a/tdishr/TdiExtPython.c
+++ b/tdishr/TdiExtPython.c
@@ -8,6 +8,7 @@
 #include <signal.h>
 #include <config.h>
 #include <stdlib.h>
+#include <libroutines.h>
 
 #ifdef HAVE_ALLOCA_H
 #include <alloca.h>
@@ -16,72 +17,75 @@
 typedef void* PyObject,PyThreadState;
 typedef ssize_t Py_ssize_t;
 
+static PyThreadState *(*PyGILState_Ensure)() = 0;
+static void (*PyGILState_Release)() = 0;
+static void (*Py_DecRef)() = 0;
+static PyObject *(*PyTuple_New) () = 0;
+static PyObject *(*PyString_FromString) () = 0;
+static PyObject *(*PyUnicode_FromString) () = 0;
+static void (*PyTuple_SetItem) () = 0;
+static PyObject *(*PyTuple_GetItem) () = 0;
+static PyObject *(*PyObject_CallObject) () = 0;
+static PyObject *(*PyObject_GetAttrString) () = 0;
+static void *(*PyLong_AsVoidPtr) () = 0;
+static PyObject *(*PyErr_Occurred) () = 0;
+static void (*PyErr_Print) () = 0;
+static PyObject *(*PyImport_ImportModule) () = 0;
+static PyObject *(*PyModule_GetDict) () = 0;
+static PyObject *(*PyDict_GetItemString) () = 0;
+static PyObject *(*Py_BuildValue) () = 0;
+static PyObject *_Py_NoneStruct;
+static PyObject *(*PyList_Insert) () = 0;
+static PyObject *(*PyObject_CallFunction) () = 0;
+static PyObject *(*PySys_GetObject) () = 0;
+static int64_t (*PyLong_AsLong) () = 0;
+static char *(*PyString_AsString) () = 0;
+static char *(*PyBytes_AsString)() = 0;
+static PyObject *(*PyUnicode_AsEncodedString)() = 0;
+static Py_ssize_t(*PyList_Size) () = 0;
+static int (*PyCallable_Check) () = 0;
+static PyObject *(*PyList_GetItem) () = 0;
+static PyObject *(*PyObject_Str) () = 0;
 
-static void (*DynPy_DecRef)() = 0;
-#define Py_DECREF (*DynPy_DecRef)
-static PyObject *(*DynPyTuple_New) () = 0;
-#define PyTuple_New (*DynPyTuple_New)
-static PyObject *(*DynPyString_FromString) () = 0;
-#define PyString_FromString (*DynPyString_FromString)
-static void (*DynPyTuple_SetItem) () = 0;
-#define PyTuple_SetItem (*DynPyTuple_SetItem)
-static PyObject *(*DynPyTuple_GetItem) () = 0;
-#define PyTuple_GetItem (*DynPyTuple_GetItem)
-static PyObject *(*DynPyObject_CallObject) () = 0;
-#define PyObject_CallObject (*DynPyObject_CallObject)
-static PyObject *(*DynPyObject_GetAttrString) () = 0;
-#define PyObject_GetAttrString (*DynPyObject_GetAttrString)
-static void *(*DynPyLong_AsVoidPtr) () = 0;
-#define PyLong_AsVoidPtr (*DynPyLong_AsVoidPtr)
-static PyObject *(*DynPyErr_Occurred) () = 0;
-#define PyErr_Occurred (*DynPyErr_Occurred)
-static void (*DynPyErr_Print) () = 0;
-#define PyErr_Print (*DynPyErr_Print)
-static PyObject *(*DynPyImport_ImportModule) () = 0;
-#define PyImport_ImportModule (*DynPyImport_ImportModule)
-static PyObject *(*DynPyModule_GetDict) () = 0;
-#define PyModule_GetDict (*DynPyModule_GetDict)
-static PyObject *(*DynPyDict_GetItemString) () = 0;
-#define PyDict_GetItemString (*DynPyDict_GetItemString)
-static PyObject *(*DynPy_BuildValue) () = 0;
-#define Py_BuildValue (*DynPy_BuildValue)
-static PyObject *Dyn_Py_NoneStruct;
-static PyObject *(*DynPy_EndInterpreter) () = 0;
-#define Py_EndInterpreter (*DynPy_EndInterpreter)
-static PyThreadState *(*DynPy_NewInterpreter) () = 0;
-#define Py_NewInterpreter (*DynPy_NewInterpreter)
-static PyObject *(*DynPyList_Append) () = 0;
-#define PyList_Append (*DynPyList_Append)
-static PyObject *(*DynPyObject_CallFunction) () = 0;
-#define PyObject_CallFunction (*DynPyObject_CallFunction)
-static PyObject *(*DynPySys_GetObject) () = 0;
-#define PySys_GetObject (*DynPySys_GetObject)
-static int64_t (*DynPyLong_AsLong) () = 0;
-#define PyLong_AsLong (*DynPyLong_AsLong)
-static char *(*DynPyString_AsString) () = 0;
-#define PyString_AsString (*DynPyString_AsString)
-static Py_ssize_t(*DynPyList_Size) () = 0;
-#define PyList_Size (*DynPyList_Size)
-static int (*DynPyCallable_Check) () = 0;
-#define PyCallable_Check (*DynPyCallable_Check)
-static PyObject *(*DynPyList_GetItem) () = 0;
-#define PyList_GetItem (*DynPyList_GetItem)
-static PyObject *(*DynPyObject_Str) () = 0;
-#define PyObject_Str (*DynPyObject_Str)
-
-#define loadrtn(prefix,name,check) prefix ## name=dlsym(handle,#name);	\
-  if (check && !prefix ## name) { \
+#define loadrtn(name,check) name=dlsym(handle,#name);	\
+  if (check && !name) { \
   fprintf(stderr,"\n\nError finding python routine: %s\n\n",#name); \
   return 0;\
 }
 
+static char *getStringFromPyObj(PyObject *obj) {
+  char *ans;
+  if (PyString_AsString == NULL) {
+    PyObject *uc = (*PyUnicode_AsEncodedString)(obj, "utf-8","");
+    ans = (*PyBytes_AsString)(uc);
+  }
+  else {
+    ans = (*PyString_AsString)(obj);
+  }
+  return ans;
+}
+
+static PyObject *pyObjFromString(char *str) {
+  PyObject *ans;
+  if (PyString_FromString == NULL) {
+    ans = (*PyUnicode_FromString)(str);
+  }
+  else {
+    ans = (*PyString_FromString)(str);
+  }
+  return ans;
+}
+      
+  
 static int Initialize()
 {
-  if (!DynPyTuple_New) {
-    void *(*tmpPy_Initialize) () = 0;
+  if (PyTuple_New == NULL) {
+    void *(*Py_Initialize) () = 0;
     void *handle;
     char *lib;
     char *envsym = getenv("PyLib");
+
+
     if (!envsym) {
       fprintf(stderr,
 	      "\n\nYou cannot use the Py function until you defined the PyLib environment variable!\n\n",
@@ -103,10 +107,10 @@ static int Initialize()
 #ifdef RTLD_NOLOAD
     /*** See if python routines are already available ***/
     handle = dlopen(0, RTLD_NOLOAD);
-    loadrtn(tmp, Py_Initialize, 0);
+    loadrtn(Py_Initialize, 0);
     /*** If not, load the python library ***/
 #endif
-    if (!tmpPy_Initialize) {
+    if (!Py_Initialize) {
       handle = dlopen(lib, RTLD_NOW | RTLD_GLOBAL);
       if (!handle) {
 	fprintf(stderr, "\n\nUnable to load python library: %s\nError: %s\n\n", lib, dlerror());
@@ -114,35 +118,42 @@ static int Initialize()
 	return 0;
       }
       free(lib);
-      loadrtn(tmp, Py_Initialize, 1);
-      (*tmpPy_Initialize) ();
+      loadrtn(Py_Initialize, 1);
+      (*Py_Initialize) ();
     }
-    loadrtn(Dyn, Py_DecRef, 1);
-    loadrtn(Dyn, PyTuple_New, 1);
-    loadrtn(Dyn, PyString_FromString, 1);
-    loadrtn(Dyn, PyTuple_SetItem, 1);
-    loadrtn(Dyn, PyTuple_GetItem, 1);
-    loadrtn(Dyn, PyObject_CallObject, 1);
-    loadrtn(Dyn, PyObject_GetAttrString, 1);
-    loadrtn(Dyn, PyLong_AsVoidPtr, 1);
-    loadrtn(Dyn, PyErr_Occurred, 1);
-    loadrtn(Dyn, PyErr_Print, 1);
-    loadrtn(Dyn, PyImport_ImportModule, 1);
-    loadrtn(Dyn, PyModule_GetDict, 1);
-    loadrtn(Dyn, PyDict_GetItemString, 1);
-    loadrtn(Dyn, Py_BuildValue, 1);
-    loadrtn(Dyn, _Py_NoneStruct, 1);
-    loadrtn(Dyn, Py_EndInterpreter, 1);
-    loadrtn(Dyn, Py_NewInterpreter, 1);
-    loadrtn(Dyn, PyList_Append, 1);
-    loadrtn(Dyn, PyObject_CallFunction, 1);
-    loadrtn(Dyn, PySys_GetObject, 1);
-    loadrtn(Dyn, PyLong_AsLong, 1);
-    loadrtn(Dyn, PyString_AsString, 1);
-    loadrtn(Dyn, PyList_Size, 1);
-    loadrtn(Dyn, PyCallable_Check, 1);
-    loadrtn(Dyn, PyList_GetItem, 1);
-    loadrtn(Dyn, PyObject_Str,1);
+    loadrtn(PyGILState_Ensure,1);
+    loadrtn(PyGILState_Release,1);
+    loadrtn(Py_DecRef, 1);
+    loadrtn(PyTuple_New, 1);
+    loadrtn(PyString_FromString, 0);
+    if (PyString_FromString == NULL) {
+      loadrtn(PyUnicode_FromString, 1);
+    }
+    loadrtn(PyTuple_SetItem, 1);
+    loadrtn(PyTuple_GetItem, 1);
+    loadrtn(PyObject_CallObject, 1);
+    loadrtn(PyObject_GetAttrString, 1);
+    loadrtn(PyLong_AsVoidPtr, 1);
+    loadrtn(PyErr_Occurred, 1);
+    loadrtn(PyErr_Print, 1);
+    loadrtn(PyImport_ImportModule, 1);
+    loadrtn(PyModule_GetDict, 1);
+    loadrtn(PyDict_GetItemString, 1);
+    loadrtn(Py_BuildValue, 1);
+    loadrtn(_Py_NoneStruct, 1);
+    loadrtn(PyList_Insert, 1);
+    loadrtn(PyObject_CallFunction, 1);
+    loadrtn(PySys_GetObject, 1);
+    loadrtn(PyLong_AsLong, 1);
+    loadrtn(PyString_AsString, 0);
+    if (PyString_AsString == NULL) {
+      loadrtn(PyUnicode_AsEncodedString, 1);
+      loadrtn(PyBytes_AsString, 1);
+    }
+    loadrtn(PyList_Size, 1);
+    loadrtn(PyCallable_Check, 1);
+    loadrtn(PyList_GetItem, 1);
+    loadrtn(PyObject_Str,1);
   }
   return 1;
 }
@@ -158,24 +169,24 @@ static PyObject *getFunction(char *modulename, char *functionname)
   PyObject *method;
   PyObject *ans = 0;
   PyObject *args;
-  module = PyImport_ImportModule(modulename);
+  module = (*PyImport_ImportModule)(modulename);
   if (module == 0) {
     printf("Error importing module %s\n", modulename);
-    if (PyErr_Occurred()) {
+    if ((*PyErr_Occurred)()) {
       PyErr_Print();
     }
   } else {
-    ans = PyObject_GetAttrString(module, functionname);
+    ans = (*PyObject_GetAttrString)(module, functionname);
     if (ans == 0) {
       printf("Error finding function called '%s' in module %s\n", functionname, modulename);
-      if (PyErr_Occurred()) {
-	PyErr_Print();
+      if ((*PyErr_Occurred)()) {
+	(*PyErr_Print)();
       }
-      Py_DECREF(module);
+      (*Py_DecRef)(module);
     } else {
-      if (!PyCallable_Check(ans)) {
+      if (!(*PyCallable_Check)(ans)) {
 	printf("Error, item called '%s' in module %s is not callable\n", functionname, modulename);
-	Py_DECREF(ans);
+	(*Py_DecRef)(ans);
 	ans = 0;
       }
     }
@@ -190,18 +201,19 @@ static void addToPath(char *dirspec)
   Py_ssize_t idx, listlen;
   PyObject *sys_path;
   PyObject *path;
-  sys_path = PySys_GetObject("path");
-  listlen = PyList_Size(sys_path);
-  for (idx = 0; idx < listlen; idx++) {
+  int found = 0;
+  sys_path = (*PySys_GetObject)("path");
+  listlen = (*PyList_Size)(sys_path);
+  for (idx = 0; idx < listlen && (found == 0); idx++) {
     PyObject *pathPart;
-    pathPart = PyList_GetItem(sys_path, idx);
-    if (strcmp(PyString_AsString(PyObject_Str(pathPart)), dirspec) == 0) {
-      break;
+    pathPart = (*PyList_GetItem)(sys_path, idx);
+    if (strcmp(getStringFromPyObj((*PyObject_Str)(pathPart)), dirspec) == 0) {
+      found = 1;
     }
   }
-  if (idx == listlen) {
-    path = PyString_FromString(dirspec);
-    PyList_Append(sys_path, path);
+  if (found != 1) {
+    path = pyObjFromString(dirspec);
+    (*PyList_Insert)(sys_path, (Py_ssize_t) 0, path);
   }
 }
 
@@ -239,26 +251,26 @@ static PyObject *argsToTuple(int nargs, struct descriptor **args)
   /* Convert descriptor argument list to a tuple of python objects. */
   int idx = 0;
   PyObject *pointerToObject = 0;
-  PyObject *ans = PyTuple_New(nargs);
+  PyObject *ans = (*PyTuple_New)(nargs);
   if (!pointerToObject)
     pointerToObject = getFunction("MDSplus", "pointerToObject");
   if (pointerToObject) {
     for (idx = 0; idx < nargs; idx++) {
       PyObject *arg =
-	  PyObject_CallFunction(pointerToObject, (sizeof(void *) == 8) ? "L" : "l", args[idx]);
+	(*PyObject_CallFunction)(pointerToObject, (sizeof(void *) == 8) ? "L" : "l", args[idx]);
       if (arg) {
-	PyTuple_SetItem(ans, idx, arg);
+	(*PyTuple_SetItem)(ans, idx, arg);
       } else {
-	if (PyErr_Occurred()) {
-	  PyErr_Print();
+	if ((*PyErr_Occurred)()) {
+	  (*PyErr_Print)();
 	}
 	break;
       }
     }
   }
   if (idx != nargs) {
-    Py_DECREF(ans);
-    ans = PyTuple_New(0);
+    (*Py_DecRef)(ans);
+    ans = (*PyTuple_New)(0);
   }
   return ans;
 }
@@ -268,32 +280,32 @@ static void getAnswer(PyObject * value, struct descriptor_xd *outptr)
   PyObject *makeDataFunction;
   PyObject *dataObj;
   makeDataFunction = getFunction("MDSplus", "makeData");
-  dataObj = PyObject_CallFunction(makeDataFunction, "O", value);
+  dataObj = (*PyObject_CallFunction)(makeDataFunction, "O", value);
   if (dataObj) {
-    PyObject *descr = PyObject_GetAttrString(dataObj, "descriptor");
+    PyObject *descr = (*PyObject_GetAttrString)(dataObj, "descriptor");
     if (descr) {
-      PyObject *descrPtr = PyObject_GetAttrString(descr, "addressof");
+      PyObject *descrPtr = (*PyObject_GetAttrString)(descr, "addressof");
       if (descrPtr) {
-	MdsCopyDxXd((struct descriptor *)PyLong_AsLong(descrPtr), outptr);
-	Py_DECREF(descrPtr);
+	MdsCopyDxXd((struct descriptor *)(*PyLong_AsLong)(descrPtr), outptr);
+	(*Py_DecRef)(descrPtr);
       } else {
 	printf("Error getting address of descriptor\n");
-	if (PyErr_Occurred()) {
-	  PyErr_Print();
+	if ((*PyErr_Occurred)()) {
+	  (*PyErr_Print)();
 	}
       }
-      Py_DECREF(descr);
+      (*Py_DecRef)(descr);
     } else {
       printf("Error getting descriptor\n");
-      if (PyErr_Occurred()) {
-	PyErr_Print();
+      if ((*PyErr_Occurred)()) {
+	(*PyErr_Print)();
       }
     }
-    Py_DECREF(dataObj);
+    (*Py_DecRef)(dataObj);
   } else {
     printf("Error converting answer to MDSplus datatype\n");
-    if (PyErr_Occurred()) {
-      PyErr_Print();
+    if ((*PyErr_Occurred)()) {
+      (*PyErr_Print)();
     }
   }
 }
@@ -316,7 +328,7 @@ int TdiExtPython(struct descriptor *modname_d,
     if (Initialize()) {
       PyObject *ans;
       PyObject *pyargs;
-      PyThreadState *tstate = Py_NewInterpreter();
+      PyThreadState *gil = (*PyGILState_Ensure)();
       PyObject *pyFunction;
       PyObject *pyArgs;
       addToPath(dirspec);
@@ -325,20 +337,20 @@ int TdiExtPython(struct descriptor *modname_d,
       if (pyFunction) {
 	free(filename);
 	pyArgs = argsToTuple(nargs, args);
-	ans = PyObject_CallObject(pyFunction, pyArgs);
+	ans = (*PyObject_CallObject)(pyFunction, pyArgs);
 	if (ans == 0) {
 	  printf("Error calling fun in %s\n", filename);
-	  if (PyErr_Occurred()) {
-	    PyErr_Print();
+	  if ((*PyErr_Occurred)()) {
+	    (*PyErr_Print)();
 	  }
 	} else {
 	  getAnswer(ans, out_ptr);
-	  Py_DECREF(ans);
-	  Py_DECREF(pyArgs);
+	  (*Py_DecRef)(ans);
+	  (*Py_DecRef)(pyArgs);
 	  status = 1;
 	}
       }
-      Py_EndInterpreter(tstate);
+      (*PyGILState_Release)(gil);
     }
   }
 #ifndef _WIN32


### PR DESCRIPTION
…glade based setups)
2) Use MdsMisc->PyCall on windows too.
3)  Prevent closing dbid tree context when doing python doMethod.
4)  Fix py function on windows
5)  Fix tdi py functions for python3.
