### PR TITLE
jTraverser Upgrade

### DIFF
--- a/javatraverser/Node.java
+++ b/javatraverser/Node.java
@@ -493,11 +493,9 @@ public class Node
             return new ImageIcon(base + "/" + gifname);
     }
 
-    public JLabel getIcon()
+    public JLabel getIcon(boolean isSelected)
     {
         if (info == null)return null;
-        if (tree_label != null)
-            return tree_label;
         ImageIcon icon = null;
         switch (getUsage())
         {
@@ -539,7 +537,7 @@ public class Node
                 icon = loadIcon("compound.gif");
                 break;
         }
-        tree_label = new TreeNode(this, getName(), icon);
+        tree_label = new TreeNode(this, getName(), icon, isSelected);
         return tree_label;
     }
 

--- a/javatraverser/Node.java
+++ b/javatraverser/Node.java
@@ -459,7 +459,7 @@ public class Node
         if(newName.length() > 12 || newName.length() == 0)
 	    {
 	        JOptionPane.showMessageDialog(FrameRepository.frame, "Node name lengh must be between 1 and 12 characters",
-		    "Error renaming node", JOptionPane.WARNING_MESSAGE);
+		    "Error renaming node: "+newName.length(), JOptionPane.WARNING_MESSAGE);
             return false;
 	    }
 	    try

--- a/javatraverser/NodeInfo.java
+++ b/javatraverser/NodeInfo.java
@@ -36,8 +36,8 @@ public class NodeInfo implements Serializable
     public static final int NO_WRITE_SHOT =    1 << 12;
     public static final int PATH_REFERENCE =   1 << 13;
     public static final int NID_REFERENCE =    1 << 14;
-    public static final int COMPRESS_SEGMENTS =1 << 15;
-    public static final int INCLUDE_IN_PULSE = 1 << 16;
+    public static final int INCLUDE_IN_PULSE = 1 << 15;
+    public static final int COMPRESS_SEGMENTS =1 << 16;
 
     public static final NodeInfo getNodeInfo(byte dclass, byte dtype, byte usage, int flags, int owner, int length, int conglomerate_nids, int conglomerate_elt,
 	                                   String date_inserted, String name, String fullpath, String minpath, String path)

--- a/javatraverser/RemoteTree.java
+++ b/javatraverser/RemoteTree.java
@@ -54,4 +54,3 @@ public interface RemoteTree extends Remote {
     public void setCurrentShot(String experiment, int shot)throws RemoteException;
     public void setEvent(String event)throws RemoteException, DatabaseException;
 }
-

--- a/javatraverser/Tree.java
+++ b/javatraverser/Tree.java
@@ -571,7 +571,7 @@ public class Tree extends JScrollPane implements TreeSelectionListener,
 			            {
 			                Tree.curr_dialog_idx = idx;
 			                TreeDialog curr_dialog = dialog_sets[idx].getDialog(
-				            node_properties[idx].getPropertyEditorClass(), currnode);
+				            node_properties[idx].getPropertyEditorClass(), Tree.getCurrentNode());
 			                curr_dialog.pack();
 			                curr_dialog.setLocation(frame.dialogLocation());
 			                curr_dialog.setVisible(true);
@@ -592,7 +592,7 @@ public class Tree extends JScrollPane implements TreeSelectionListener,
 			            if(idx < node_methods.length)
 			            {
 				            try {
-				                node_methods[idx].getMethod().invoke(currnode);
+				                node_methods[idx].getMethod().invoke(Tree.getCurrentNode());
 				            }catch(Exception exc) {System.out.println("Error executing " + exc); }
 				            curr_tree.expandPath(new TreePath(curr_tree_node.getPath()));
 				            curr_tree.treeDidChange();

--- a/javatraverser/Tree.java
+++ b/javatraverser/Tree.java
@@ -418,7 +418,6 @@ public class Tree extends JScrollPane implements TreeSelectionListener,
             public void keyTyped(KeyEvent e) {
                 if (e.getKeyChar() ==  KeyEvent.VK_CANCEL) // i.e. Ctrl+C
                     TreeNode.copyToClipboard();
-                if (!jTraverser.isEditable()) return;
                 if (e.getKeyChar() ==  KeyEvent.VK_CANCEL) // i.e. Ctrl+C
                     TreeNode.copy();
                 if (e.getKeyChar() ==  24) // i.e. Ctrl+X
@@ -472,7 +471,7 @@ public class Tree extends JScrollPane implements TreeSelectionListener,
 	    } catch(Exception exc) {
             editable = false;}
 	    frame.reportChange(exp,shot,editable,readonly);
-}
+    }
 
 
     public void valueChanged(TreeSelectionEvent e)

--- a/javatraverser/TreeNode.java
+++ b/javatraverser/TreeNode.java
@@ -15,7 +15,6 @@ public class TreeNode extends JLabel
 	    bold_f = new Font("Serif" ,Font.BOLD, 12);
     }
 
-
 	public static void copyToClipboard()
 	{
 	    try {
@@ -27,6 +26,7 @@ public class TreeNode extends JLabel
             cb.setContents(content, null);
 	    }catch(Exception exc){jTraverser.stderr("Cannot copy fullPath to Clipboard", exc);}
 	}
+
     public static void copy()
     {
         cut = false;
@@ -36,28 +36,42 @@ public class TreeNode extends JLabel
 
     public static void cut()
     {
-        cut = true;
-        copied = Tree.curr_node;
-        jTraverser.stdout("cut: "+copied+" from "+copied.parent);
+        if (jTraverser.isEditable())
+        {
+            cut = true;
+            copied = Tree.curr_node;
+            jTraverser.stdout("cut: "+copied+" from "+copied.parent);
+        }
+        else
+            copy();
     }
+
     public static void paste()
     {
-        jTraverser.stdout((cut ? "moved: " : "copied: ") +copied+ " from " + copied.parent + " to " + Tree.curr_node);
-        if(copied != null && copied != Tree.curr_node)
+        if (jTraverser.isEditable())
         {
-            if (cut)
+            jTraverser.stdout((cut ? "moved: " : "copied: ") +copied+ " from " + copied.parent + " to " + Tree.curr_node);
+            if(copied != null && copied != Tree.curr_node)
             {
-                if (copied.move(Tree.curr_node))
-                    copied = null;
+                if (cut)
+                {
+                    if (copied.move(Tree.curr_node))
+                        copied = null;
+                }
+                else
+                    Node.pasteSubtree(copied, Tree.curr_node, true);
             }
-            else
-                Node.pasteSubtree(copied, Tree.curr_node, true);
         }
+        else
+            jTraverser.stdout("Cannot paste "+copied+". Tree not in edit mode.");
     }
 
     public static void delete()
     {
-        Tree.deleteNode(Tree.curr_node);
+        if (jTraverser.isEditable())
+            Tree.deleteNode(Tree.curr_node);
+        else
+            jTraverser.stdout("Cannot delete "+Tree.curr_node+". Tree not in edit mode.");
     }
 
     public TreeNode(Node node, String name, Icon icon)

--- a/javatraverser/jTraverser.java
+++ b/javatraverser/jTraverser.java
@@ -10,7 +10,7 @@ import java.util.*;
 public class jTraverser extends JFrame implements ActionListener
 {
     static String exp_name, shot_name;
-    static boolean editable, readonly;
+    static boolean editable, readonly, model;
     static Tree tree;
     static JLabel status = new JLabel("jTaverser started");
     JMenu file_m, edit_m, data_m, customize_m;
@@ -197,15 +197,16 @@ public void actionPerformed(ActionEvent e)
     if(source == (Object)paste_b) TreeNode.paste();
 
     // Node related
-	if(Tree.curr_node == null) return;
+    Node currnode = Tree.getCurrentNode();
+	if(currnode == null) return;
     if(source == (Object)turn_on_b)
     {
-	    Tree.curr_node.turnOn();
+	    currnode.turnOn();
 	    tree.reportChange();
     }
     if(source == (Object)turn_off_b)
     {
-	    Tree.curr_node.turnOff();
+	    currnode.turnOff();
 	    tree.reportChange();
     }
 
@@ -216,7 +217,7 @@ public void actionPerformed(ActionEvent e)
 	        display_data_d = new TreeDialog(display_data = new DisplayData());
 	        display_data.setFrame(display_data_d);
 	    }
-	    display_data.setNode(Tree.curr_node);
+	    display_data.setNode(currnode);
 	    display_data_d.pack();
 	    display_data_d.setLocation(dialogLocation());
 	    display_data_d.setVisible(true);
@@ -228,7 +229,7 @@ public void actionPerformed(ActionEvent e)
             display_nci_d = new TreeDialog(display_nci = new DisplayNci());
             display_nci.setFrame(display_nci_d);
         }
-        display_nci.setNode(Tree.curr_node);
+        display_nci.setNode(currnode);
         display_nci_d.pack();
         display_nci_d.setLocation(dialogLocation());
         display_nci_d.setVisible(true);
@@ -240,7 +241,7 @@ public void actionPerformed(ActionEvent e)
             display_tags_d = new TreeDialog(display_tags = new DisplayTags());
             display_tags.setFrame(display_tags_d);
         }
-        display_tags.setNode(Tree.curr_node);
+        display_tags.setNode(currnode);
         display_tags_d.pack();
         display_tags_d.setLocation(dialogLocation());
         display_tags_d.setVisible(true);
@@ -252,7 +253,7 @@ public void actionPerformed(ActionEvent e)
 	        modify_data_d = new TreeDialog(modify_data = new ModifyData());
 	        modify_data.setFrame(modify_data_d);
 	    }
-	    modify_data.setNode(Tree.curr_node);
+	    modify_data.setNode(currnode);
 	    modify_data_d.pack();
 	    modify_data_d.setLocation(dialogLocation());
 	    modify_data_d.setVisible(true);
@@ -260,16 +261,17 @@ public void actionPerformed(ActionEvent e)
     if(source == (Object)set_default_b)
     {
 	    try {
-	        Tree.curr_node.setDefault();
+	        currnode.setDefault();
 	    }catch(Exception exc) {jTraverser.stderr("Error setting default",exc);}
 	    tree.reportChange();
     }
     if(source == (Object)setup_device_b)
-        Tree.curr_node.setupDevice();
+        currnode.setupDevice();
 }
 
 void reportChange(String exp, int shot, boolean editable, boolean readonly)
 {
+    jTraverser.model = shot<0;
     jTraverser.editable = editable;
     jTraverser.readonly = readonly;
     jTraverser.exp_name = exp;


### PR DESCRIPTION
- fixed rename/move
- fixed NodeInfo constant mix up
- get current selection instead of curr_node
- colorize labels according to Setup, nowrite*, writeOnce, includeInPulse
- remove short cut in Node.getIcon to get full capabilities of JTree
- hence no need for TreeNode.paint -> constructor
