### PR TITLE
prevent FlagDialog from getting focus

### DIFF
--- a/javatraverser/Tree.java
+++ b/javatraverser/Tree.java
@@ -1144,6 +1144,7 @@ public class Tree extends JScrollPane implements TreeSelectionListener,
             private static void construct()
 	        {
 	            dialog = new JDialog(frame);
+	            dialog.setFocusableWindowState(false);
 	            JPanel jp = new JPanel();
                 jp.setLayout(new BorderLayout());
 	            JPanel jp1 = new JPanel();


### PR DESCRIPTION
allows a fast way of toggling flags:
You can navigate through a large number of nodes using arrow-keys and quickly toggle flag with the mouse. 
