### PR TITLE
Fix find command for java directory on make install

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -104,7 +104,7 @@ $(install_DIRS):
 
 .PHONY: install
 install: $(install_DIRS)
-	find $(prefix)/java -name '*.class' -delete #### No need to include class files
+	- find $(prefix)/java -name '*.class' -delete #### No need to include class files
 	$(MKDIR_P) $(prefix)/local/tdi
 	$(MKDIR_P) $(prefix)/java
 	tar cf - $(MISC_PARTS) | (cd $(exec_prefix); tar xf -)

--- a/configure
+++ b/configure
@@ -7348,8 +7348,6 @@ fi
 { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ax_cv_c_compiler_version" >&5
 $as_echo "$ax_cv_c_compiler_version" >&6; }
 
-
-echo "enable_san=$enable_san  GCC=$GCC ax_cv_c_compiler_version = $ax_cv_c_compiler_version"
 if test "$enable_san" = "yes" -a "$GCC" = yes; then
 
 
@@ -7387,7 +7385,6 @@ x$ax_compare_version_B" | sed 's/^ *//' | sort -r | sed "s/x${ax_compare_version
     else enable_san="no"
   fi
 
-   echo "enable_san after version=$enable_san"
    if test "$enable_san" = "yes"; then
        CFLAGS="$CFLAGS -fsanitize=address -fsanitize=undefined -fno-omit-frame-pointer"
    fi


### PR DESCRIPTION
The find command in make install was erroring out if the destination root
directory java did not exist.  Added punctuation to this line so make will ignore it.
