### PR TITLE
unified the initialisation of python:

### DIFF
--- a/mdsmisc/pycall.c
+++ b/mdsmisc/pycall.c
@@ -6,36 +6,30 @@
 #ifndef _WIN32
 #include <signal.h>
 #endif
-static void *(*PyGILState_Ensure) () = 0;
-static void *(*PyGILState_GetThisThreadState) () = 0;
-static void (*Py_Initialize) () = 0;
-static void (*PyEval_InitThreads) () = 0;
-static void (*PyEval_ReleaseThread) (void *) = 0;
-static void (*PyRun_SimpleString) (char *) = 0;
-static void (*PyGILState_Release) (void *) = 0;
-static void (*PyEval_SaveThread)() = 0;
-static int  (*PyEval_ThreadsInitialized)() = 0;
+
 #define loadrtn(name,check) name=dlsym(handle,#name);	\
   if (check && !name) { \
   fprintf(stderr,"\n\nError finding python routine: %s\n\n",#name); \
-  PyGILState_Ensure=0;\
   return 0;\
 }
+typedef void* PyThreadState;
+static PyThreadState *(*PyGILState_Ensure)() = 0;
+static void (*PyGILState_Release)(PyThreadState *) = 0;
 
-EXPORT int PyCall(char *cmd)
+static void (*PyRun_SimpleString)(char *) = 0;
+
+static int Initialize()
 {
-#ifndef _WIN32
-  void (*old_handler) (int);
-#endif
-  void *GIL;
   if (!PyGILState_Ensure) {
+    void (*Py_Initialize) () = 0;
+    void (*PyEval_InitThreads)() = 0;
+    int  (*PyEval_ThreadsInitialized)() = 0;
+    void *(*PyEval_SaveThread)() = 0;
     void *handle;
     char *lib;
     char *envsym = getenv("PyLib");
     if (!envsym) {
-      fprintf(stderr,
-	      "\n\nYou cannot use the Py function until you defined the PyLib environment variable!\n\n"
-	      "Please define PyLib to be the name of your python library, i.e. 'python2.4 or /usr/lib/libpython2.4.so.1'\n\n\n");
+      fprintf(stderr,"\n\nYou cannot use the Py function until you defined the PyLib environment variable!\n\nPlease define PyLib to be the name of your python library, i.e. 'python2.4 or /usr/lib/libpython2.4.so.1'\n\n\n");
       return 0;
     }
 #ifdef _WIN32
@@ -50,12 +44,13 @@ EXPORT int PyCall(char *cmd)
       strcat(lib, ".so");
     }
 #endif
-#ifndef _WIN32
+#ifdef RTLD_NOLOAD
+    /*** See if python routines are already available ***/
     handle = dlopen(0, RTLD_NOLOAD);
-#endif
-    loadrtn(PyGILState_Ensure, 0);
+    loadrtn(Py_Initialize, 0);
     /*** If not, load the python library ***/
-    if (!PyGILState_Ensure) {
+#endif
+    if (!Py_Initialize) {
       handle = dlopen(lib, RTLD_NOW | RTLD_GLOBAL);
       if (!handle) {
 	fprintf(stderr, "\n\nUnable to load python library: %s\nError: %s\n\n", lib, dlerror());
@@ -63,30 +58,40 @@ EXPORT int PyCall(char *cmd)
 	return 0;
       }
       free(lib);
-      loadrtn(PyGILState_Ensure, 1);
+      loadrtn(Py_Initialize, 1);
+      (*Py_Initialize) ();
+      loadrtn(PyEval_ThreadsInitialized, 1);
+      if ((*PyEval_ThreadsInitialized)() == 0) {
+        loadrtn(PyEval_InitThreads, 1);
+        loadrtn(PyEval_SaveThread, 1);
+        (*PyEval_InitThreads) ();
+        (*PyEval_SaveThread) ();
+      }
     }
-    loadrtn(PyGILState_GetThisThreadState, 1);
-    loadrtn(Py_Initialize, 1);
-    loadrtn(PyEval_InitThreads, 1);
-    loadrtn(PyEval_SaveThread, 1);
-    loadrtn(PyEval_ReleaseThread, 1);
-    loadrtn(PyRun_SimpleString, 1);
+    loadrtn(PyGILState_Ensure, 1);
     loadrtn(PyGILState_Release, 1);
-    (*Py_Initialize) ();
-    loadrtn(PyEval_ThreadsInitialized,1);
-    if ((*PyEval_ThreadsInitialized)() == 0) {
-      (*PyEval_InitThreads) ();
-      (*PyEval_SaveThread) ();
-    }
+    /*** load python functions ***/
+    loadrtn(PyRun_SimpleString, 1);
   }
-  GIL = (*PyGILState_Ensure) ();
-#ifndef _WIN32
-  old_handler = signal(SIGCHLD, SIG_DFL);
-#endif
-  (*PyRun_SimpleString) (cmd);
-#ifndef _WIN32
-  signal(SIGCHLD, old_handler);
-#endif
-  (*PyGILState_Release) (GIL);
   return 1;
+}
+
+EXPORT int PyCall(char *cmd)
+{
+  int status = 0;
+#ifndef _WIN32
+  struct sigaction offact = {SIG_DFL, 0, 0, 0, 0};
+  struct sigaction oldact;
+  sigaction(SIGCHLD, &offact, &oldact);
+#endif
+  if (Initialize()) {
+    PyThreadState *GIL = (*PyGILState_Ensure)();
+    (*PyRun_SimpleString) (cmd);
+    (*PyGILState_Release) (GIL);
+    status = 1;
+  }
+#ifndef _WIN32
+  sigaction(SIGCHLD, &oldact, NULL);
+#endif
+  return status;
 }


### PR DESCRIPTION
- removed extra (*PyEval_SaveThread)(); in line126
- prefer sigaction() over signal()
- define PyThreadState
- removed unused PyGILState_GetThisThreadState
- removed unused PyEval_ReleaseThread
- copied and adapted Initialize() to pycall()
- do not nullify PyGILState_Ensure on loaderror in loadrtn (would happen
  on PyString_FromString->PyUnicode_FromString etc.)
