### PR TITLE
Twf fix windows vs build

### DIFF
--- a/deploy/build_windows_mdsplus
+++ b/deploy/build_windows_mdsplus
@@ -65,7 +65,7 @@ then
     # Strange command needed because of winexe behavior when running without a terminal
     #
     # cat < /dev/null | winexe --debug-stderr -U ${WINBLD_USER} -d 0 //${WINBLD_HOST} "cmd /c ${topsrcdir}/deploy/winbld.bat"
-    curl http://${WINBLD_HOST}:8080/${topsrcdir}/deploy/winbld
+    curl http://${WINBLD_HOST}:8080/${topsrcdir}/deploy/winbld.bat
     # see if files are there
     ls /winbld/${tmpdir}/bin_x86*/*.lib /winbld/${tmpdir}/bin_x86*/MdsObjectsCppShr-VS.* > /dev/null
     rsync -av --include="*/" --include="*.lib" --include="MdsObectsCppShr-VS.dll" --exclude="*" /winbld/${tmpdir}/bin_x86* /buildroot/

--- a/deploy/build_windows_mdsplus
+++ b/deploy/build_windows_mdsplus
@@ -64,7 +64,8 @@ then
     #
     # Strange command needed because of winexe behavior when running without a terminal
     #
-    cat < /dev/null | winexe --debug-stderr -U ${WINBLD_USER} -d 0 //${WINBLD_HOST} "cmd /c ${topsrcdir}/deploy/winbld"
+    # cat < /dev/null | winexe --debug-stderr -U ${WINBLD_USER} -d 0 //${WINBLD_HOST} "cmd /c ${topsrcdir}/deploy/winbld.bat"
+    curl http://${WINBLD_HOST}:8080/${topsrcdir}/deploy/winbld
     # see if files are there
     ls /winbld/${tmpdir}/bin_x86*/*.lib /winbld/${tmpdir}/bin_x86*/MdsObjectsCppShr-VS.* > /dev/null
     rsync -av --include="*/" --include="*.lib" --include="MdsObectsCppShr-VS.dll" --exclude="*" /winbld/${tmpdir}/bin_x86* /buildroot/

--- a/deploy/build_windows_mdsplus
+++ b/deploy/build_windows_mdsplus
@@ -69,8 +69,8 @@ then
     curl http://${WINBLD_HOST}:8080${topsrcdir}/deploy/winbld.bat
     # see if files are there
     ls /winbld/${tmpdir}/bin_x86*/*.lib /winbld/${tmpdir}/bin_x86*/MdsObjectsCppShr-VS.* > /dev/null
-    rsync -av --include="*/" --include="*.lib" --include="MdsObectsCppShr-VS.dll" --exclude="*" /winbld/${tmpdir}/bin_x86* /buildroot/
-    VS_SwITCH=-DVisualStudio
+    rsync -av --include="*/" --include="*.lib" --include="MdsObjectsCppShr-VS.dll" --exclude="*" /winbld/${tmpdir}/bin_x86* /buildroot/
+    VS_SWITCH=-DVisualStudio
 fi
 if [ -d /installer ]
 then

--- a/deploy/build_windows_mdsplus
+++ b/deploy/build_windows_mdsplus
@@ -65,7 +65,8 @@ then
     # Strange command needed because of winexe behavior when running without a terminal
     #
     # cat < /dev/null | winexe --debug-stderr -U ${WINBLD_USER} -d 0 //${WINBLD_HOST} "cmd /c ${topsrcdir}/deploy/winbld.bat"
-    curl http://${WINBLD_HOST}:8080/${topsrcdir}/deploy/winbld.bat
+    echo curl http://${WINBLD_HOST}:8080${topsrcdir}/deploy/winbld.bat
+    curl http://${WINBLD_HOST}:8080${topsrcdir}/deploy/winbld.bat
     # see if files are there
     ls /winbld/${tmpdir}/bin_x86*/*.lib /winbld/${tmpdir}/bin_x86*/MdsObjectsCppShr-VS.* > /dev/null
     rsync -av --include="*/" --include="*.lib" --include="MdsObectsCppShr-VS.dll" --exclude="*" /winbld/${tmpdir}/bin_x86* /buildroot/


### PR DESCRIPTION
The build_windows_mdsplus script used to build the MS Windows installer for MDSplus uses the MingW-64 compilers to build the windows executables and libraries. Since the exception handling in the MingW-64 dll's are incompatible with the that with Windows applications built with Visual Studio we use Visual Studio running on a Windows virtual machine to build just the MdsObjectsCppShr-VS.dll library so users can run VS built applications which use the C++ object inteface to MDSplus.

The build_windows_mdsplus script used to use winexe to execute shell commands on the Windows vm. The winexe application no longer installs on the updated docker image used for building the windows installer so the mechanism for running commands on the Windows vm has been changed to use a "waitress" wsgi application and the build commands are sent using an http transaction. The build_windows_mdsplus script was changed to use this.

Also I discovered that there have been typos in the script for a long time which prevented the special  VS built dll from even being included in the installer! So after all the trouble put in to building the dll using VS it wasn't even being distributed!!! Obviously noone was using it ;-)
