### PR TITLE
Fix infinite loop on mac because start of search of connectionList ha…

### DIFF
--- a/mdstcpip/Connections.c
+++ b/mdstcpip/Connections.c
@@ -55,7 +55,7 @@ int NextConnection(void **ctx, char **info_name, void **info, size_t * info_len)
   Connection *c, *next;
   int ans;
   lock_connection_list();
-  next = (*ctx != 0) ? (Connection *) * ctx : ConnectionList;
+  next = (*ctx != (void *)-1) ? (Connection *) * ctx : ConnectionList;
   for (c = ConnectionList; c && c != next; c = c->next) ;
   if (c) {
     *ctx = c->next;
@@ -91,7 +91,7 @@ static void exitHandler(void)
 static void exitHandler(void)
 {
   int id;
-  void *ctx = 0;
+  void *ctx = (void *)-1;
   while ((id = NextConnection(&ctx, 0, 0, 0)) != -1) {
     DisconnectConnection(id);
     ctx = 0;

--- a/mdstcpip/IoRoutinesTunnel.c
+++ b/mdstcpip/IoRoutinesTunnel.c
@@ -118,7 +118,7 @@ static void ChildSignalHandler(int num)
   sigprocmask(SIG_BLOCK, &set, &oldset);
   /* wait for child */
   while ((pid = waitpid((pid_t) - 1, &status, WNOHANG)) > 0) {
-    void *ctx = 0;
+    void *ctx = (void *)-1;
     int id;
     char *info_name;
     void *info;


### PR DESCRIPTION
…s same flag (0) as end of connectionList

On the mac (why not on linux ?)

IoRoutinesTunnel.c asks to look through the connections for for the tunnel process.
In the following example this is an infinite loop, since the ctx starts with 0 and
after the 1st process that is found (it does not satisfy the rest of the boolean) ctx is
0 again.  This causes it to start over.

Worse, since this signal handler starts with disabling signals, you can not even ^C out of it:

'''
fake listner thread for debugging
'''
import multiprocessing as mp
import threading, Queue, traceback
import time
from weakref import WeakKeyDictionary
import **future**

import MDSplus
from  MDSplus import Connection
use_event_listener = True

class EventListenerProc(mp.Process):
   def **init**(self, task_queue, result_queue, _args, *_kargs):
       super(EventListenerProc, self).**init**(_args, *_kargs)
       self.task_queue = task_queue
       self.result_queue = result_queue

   def run(self, _args, *_kargs):
       while True:
           try:
              jobcode, jobparam = self.task_queue.get(True)#True, 0.1)
           except:
              continue
              pass
           ### jobset
           ###   (jobcode, jobparam)
           ###    jobcode : 'wait' : launch thread if it is not waiting
           ###    jobcode : 'exit' : exit loop
           ###    jobcode : 'send' :  when event is recieved
           if jobcode == 'wait':
                pass
           elif jobcode == 'exit':
               break
           elif jobcode == 'disconnect':
               pass
           else:
               pass

class EventListener(threading.Thread):
   def **init**(self, _args, *_kargs):
       super(EventListener, self).**init**(_args, *_kargs)
       self.queue = mp.Queue()   ## queue to receive message
       self.task_queue = mp.JoinableQueue()
       self.listener_proc = EventListenerProc(self.task_queue,
                                              self.queue)
       self.listener_proc.start()
   def run(self, _args, *_kargs):
       while True:
           event_name = self.queue.get(True)
           if event_name == 'stop':
               #globals()['listener_thread'] = None
               return
           mds_event_listener_lock.acquire()
           check = False
           ## do nothing
           mds_event_listener_lock.release()

if **name** == '**main**':
   server = 'ssh://cmodws86.psfc.mit.edu'  # this makes a dead-lokc
   c = Connection(server)

   listener_thread = EventListener()
   listener_thread.task_queue.put(('exit', ''), False)
   listener_thread.queue.put('stop')

   print 'good bye'
