### PR TITLE
Twf combine remcam into camshr

### DIFF
--- a/camshr/Makefile.in
+++ b/camshr/Makefile.in
@@ -89,7 +89,7 @@ install: $(libdir) $(bindir)
 
 @MINGW_TRUE@ MAKE_IMPLIB=-Wl,--out-implib,$(IMPLIB)
 $(SHLIB_BUILD) $(IMPLIB): $(OBJECTS)
-	$(LINK.c) @LINKSHARED@ -nostartfiles -Wl,-soname=$(SHLIB) -o $@.$(MAJOR).$(MINOR) $^ -L@MAKESHLIBDIR@ -lMdsShr $(MAKE_IMPLIB)
+	$(LINK.c) @LINKSHARED@ -nostartfiles -Wl,-soname=$(SHLIB) -o $@.$(MAJOR).$(MINOR) $^ -L@MAKESHLIBDIR@ -lMdsShr -lMdsIpShr $(MAKE_IMPLIB)
 	ln -sf $(SHLIB).$(MAJOR).$(MINOR) $@.$(MAJOR)
 	ln -sf $(SHLIB).$(MAJOR) $@
 

--- a/camshr/Makefile.in
+++ b/camshr/Makefile.in
@@ -45,7 +45,10 @@ SOURCES	= \
 		ScsiSystemStatus.c		 \
 		turn_crate_on_off_line.c \
 		unlock_file.c            \
-		xlate_logicalname.c
+		xlate_logicalname.c \
+		RemCamMulti.c \
+		RemCamSingle.c \
+		RemCamIosb.c
 
 OBJECTS =	$(SOURCES:.c=.o)
 

--- a/camshr/RemCamIosb.c
+++ b/camshr/RemCamIosb.c
@@ -1,0 +1,47 @@
+#include <stdlib.h>
+#include <string.h>
+#include <config.h>
+
+extern unsigned short RemCamLastIosb[4];
+
+int RemCamVerbose(int flag)
+{
+  return 1;
+}
+
+int RemCamBytcnt(unsigned short *iosb)
+{
+  return (int)(iosb ? iosb[1] : RemCamLastIosb[1]);
+}
+
+int RemCamError(int *xexp, int *qexp, unsigned short *iosb_in)
+{
+  unsigned short *iosb = iosb_in ? iosb_in : RemCamLastIosb;
+  return ((!(iosb[0] & 1)) ||
+	  (xexp && ((*xexp & 1) != (iosb[2] & 1))) ||
+	  (qexp && ((*qexp & 1) != ((iosb[2] >> 1) & 1))));
+}
+
+int RemCamX(unsigned short *iosb_in)
+{
+  unsigned short *iosb = iosb_in ? iosb_in : RemCamLastIosb;
+  return ((iosb[0] & 1) && (iosb[2] & 1));
+}
+
+int RemCamQ(unsigned short *iosb_in)
+{
+  unsigned short *iosb = iosb_in ? iosb_in : RemCamLastIosb;
+  return ((iosb[0] & 1) && (iosb[2] & 2));
+}
+
+int RemCamGetStat(unsigned short *iosb_in)
+{
+  memcpy(iosb_in, RemCamLastIosb, sizeof(RemCamLastIosb));
+  return 1;
+}
+
+int RemCamXandQ(unsigned short *iosb_in)
+{
+  unsigned short *iosb = iosb_in ? iosb_in : RemCamLastIosb;
+  return ((iosb[0] & 1) && ((iosb[2] & 3) == 3));
+}

--- a/camshr/RemCamIosb.c
+++ b/camshr/RemCamIosb.c
@@ -34,6 +34,12 @@ int RemCamQ(unsigned short *iosb_in)
   return ((iosb[0] & 1) && (iosb[2] & 2));
 }
 
+int RemCamStatus(unsigned char *iosb_in)
+{
+  unsigned short *iosb = iosb_in ? iosb_in : RemCamLastIosb;
+  return (int)iosb[7];
+}
+
 int RemCamGetStat(unsigned short *iosb_in)
 {
   memcpy(iosb_in, RemCamLastIosb, sizeof(RemCamLastIosb));

--- a/camshr/RemCamMulti.c
+++ b/camshr/RemCamMulti.c
@@ -1,0 +1,148 @@
+#include <ipdesc.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <config.h>
+
+#ifndef min
+#define min(a,b) ((a) < (b)) ? (a) : (b)
+#endif
+
+struct descriptor {
+  unsigned short length;
+  char dtype;
+  char class;
+  void *pointer;
+};
+
+extern short RemCamLastIosb[4];
+extern int RemoteServerId();
+
+static int CamMulti(char *routine, char *name, int a, int f, int count, void *data, int mem,
+		    unsigned short *iosb);
+
+#define MakeMulti(locnam,remnam) \
+int locnam(char *name, int a, int f, int count, void *data, int mem, unsigned short *iosb) \
+{ \
+  return CamMulti(#remnam,name,a,f,count,data,mem,iosb); \
+}
+
+MakeMulti(RemCamFQrepw, FQrepw)
+    MakeMulti(RemCamFQstopw, FQstopw)
+    MakeMulti(RemCamFStopw, FStopw)
+    MakeMulti(RemCamQrepw, Qrepw)
+    MakeMulti(RemCamQscanw, Qscanw)
+    MakeMulti(RemCamQstopw, Qstopw)
+    MakeMulti(RemCamStopw, Stopw)
+
+static int DoCamMulti(char *routine, char *name, int a, int f, int count, void *data, int mem,
+		      short *iosb);
+
+static int CamMulti(char *routine, char *name, int a, int f, int count, void *data, int mem,
+		    unsigned short *iosb)
+{
+  int status = 1;
+
+  iosb = (iosb) ? iosb : (unsigned short *)&RemCamLastIosb;
+
+  status = DoCamMulti(routine, name, a, f, count, data, mem, (short *)&RemCamLastIosb);
+  if (iosb)
+    memcpy(iosb, &RemCamLastIosb, sizeof(RemCamLastIosb));
+  return status;
+}
+
+static void getiosb(int serverid, short *iosb)
+{
+  int status;
+  struct descrip ans_d = { 0, 0, {0, 0, 0, 0, 0, 0, 0}, 0 };
+  status = MdsValue(serverid, "_iosb", &ans_d, 0);
+  if (status & 1 && ans_d.dtype == DTYPE_USHORT && ans_d.ndims == 1 && ans_d.dims[0] == 4) {
+    memcpy(RemCamLastIosb, ans_d.ptr, 8);
+    if (iosb)
+      memcpy(iosb, ans_d.ptr, 8);
+  }
+  if (ans_d.ptr)
+    free(ans_d.ptr);
+}
+
+static void getdata(int serverid, void *data)
+{
+  int status;
+  struct descrip ans_d = { 0, 0, {0, 0, 0, 0, 0, 0, 0}, 0 };
+  status = MdsValue(serverid, "_data", &ans_d, 0);
+  if (status & 1 && (ans_d.dtype == DTYPE_USHORT || ans_d.dtype == DTYPE_LONG) && ans_d.ptr)
+    memcpy(data, ans_d.ptr, ((ans_d.dtype == DTYPE_USHORT) ? 2 : 4) * ans_d.dims[0]);
+  if (ans_d.ptr)
+    free(ans_d.ptr);
+}
+
+static int DoCamMulti(char *routine, char *name, int a, int f, int count, void *data, int mem,
+		      short *iosb)
+{
+  int serverid = RemoteServerId();
+  int status = 0;
+  int writeData;
+  if (serverid) {
+    struct descrip data_d = { 8, 1, {0, 0, 0, 0, 0, 0, 0}, 0 };
+    struct descrip ans_d = { 0, 0, {0, 0, 0, 0, 0, 0, 0}, 0 };
+    char cmd[512];
+    writeData = (!(f & 0x08)) && (f > 8);
+    sprintf(cmd, "CamMulti('%s','%s',%d,%d,%d,%s,%d,_iosb)", routine, name, a, f, count,
+	    writeData ? "_data=$" : "_data", mem);
+    if (writeData) {
+      data_d.dtype = mem < 24 ? DTYPE_SHORT : DTYPE_LONG;
+      data_d.dims[0] = count;
+      data_d.ptr = data;
+      status = MdsValue(serverid, cmd, &data_d, &ans_d, 0);
+    } else {
+      status = MdsValue(serverid, cmd, &ans_d, 0);
+    }
+    if (status & 1 && ans_d.dtype == DTYPE_LONG && ans_d.ptr) {
+      memcpy(&status, ans_d.ptr, 4);
+      free(ans_d.ptr);
+      ans_d.ptr = 0;
+      if (data && f < 8)
+	getdata(serverid, data);
+      getiosb(serverid, iosb);
+    }
+  }
+  return status;
+}
+
+int RemCamSetMAXBUF(char *name, int new)
+{
+  int serverid = RemoteServerId();
+  int status = -1;
+  if (serverid) {
+    struct descrip ans_d = { 0, 0, {0, 0, 0, 0, 0, 0, 0}, 0 };
+    char cmd[512];
+    sprintf(cmd, "CamSetMAXBUF('%s',%d)", name, new);
+    status = MdsValue(serverid, cmd, &ans_d, 0);
+    if (status & 1 && ans_d.dtype == DTYPE_LONG && ans_d.ptr) {
+      memcpy(&status, ans_d.ptr, 4);
+      free(ans_d.ptr);
+      ans_d.ptr = 0;
+    } else
+      status = -1;
+  }
+  return status;
+}
+
+int RemCamGetMAXBUF(char *name)
+{
+  int serverid = RemoteServerId();
+  int status = -1;
+  if (serverid) {
+    struct descrip ans_d = { 0, 0, {0, 0, 0, 0, 0, 0, 0}, 0 };
+    char cmd[512];
+    sprintf(cmd, "CamGetMAXBUF('%s')", name);
+    status = MdsValue(serverid, cmd, &ans_d, 0);
+    if (status & 1 && ans_d.dtype == DTYPE_LONG && ans_d.ptr) {
+      memcpy(&status, ans_d.ptr, 4);
+      free(ans_d.ptr);
+      ans_d.ptr = 0;
+    } else
+      status = -1;
+  }
+  return status;
+}

--- a/camshr/RemCamSingle.c
+++ b/camshr/RemCamSingle.c
@@ -1,0 +1,98 @@
+#include <ipdesc.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <config.h>
+
+struct descriptor {
+  unsigned short length;
+  char dtype;
+  char class;
+  void *pointer;
+};
+
+short RemCamLastIosb[4];
+
+int RemoteServerId()
+{
+  static int socket = 0;
+  if (socket == 0) {
+    char *server = getenv("camac_server");
+    if (server == 0) {
+      printf("Set the camac_server environment variable to your camac server address\n");
+    } else {
+      socket = ConnectToMds(server);
+      if (socket < 0)
+	socket = 0;
+    }
+  }
+  return socket;
+}
+
+static int CamSingle(char *routine, char *name, int a, int f, void *data, int mem, short *iosb);
+
+#define MakeSingle(locnam,remnam) \
+int locnam(char *name, int a, int f, void *data, int mem, short *iosb) \
+{ \
+  return CamSingle(#remnam,name,a,f,data,mem,iosb); \
+}
+
+MakeSingle(RemCamPiow, Piow)
+    MakeSingle(RemCamPioQrepw, PioQrepw)
+
+static void getiosb(int serverid, short *iosb)
+{
+  int status;
+  struct descrip ans_d = { 0, 0, {0, 0, 0, 0, 0, 0, 0}, 0 };
+  status = MdsValue(serverid, "_iosb", &ans_d, 0);
+  if (status & 1 && ans_d.dtype == DTYPE_USHORT && ans_d.ndims == 1 && ans_d.dims[0] == 4) {
+    memcpy(RemCamLastIosb, ans_d.ptr, 8);
+    if (iosb)
+      memcpy(iosb, ans_d.ptr, 8);
+  }
+  if (ans_d.ptr)
+    free(ans_d.ptr);
+}
+
+static void getdata(int serverid, void *data)
+{
+  int status;
+  struct descrip ans_d = { 0, 0, {0, 0, 0, 0, 0, 0, 0}, 0 };
+  status = MdsValue(serverid, "_data", &ans_d, 0);
+  if (status & 1 && (ans_d.dtype == DTYPE_USHORT || ans_d.dtype == DTYPE_LONG) && ans_d.ptr)
+    memcpy(data, ans_d.ptr, (ans_d.dtype == DTYPE_USHORT) ? 2 : 4);
+  if (ans_d.ptr)
+    free(ans_d.ptr);
+}
+
+static int CamSingle(char *routine, char *name, int a, int f, void *data, int mem, short *iosb)
+{
+  int serverid = RemoteServerId();
+  int status = 0;
+  int writeData;
+  if (serverid) {
+    struct descrip data_d = { 8, 0, {0, 0, 0, 0, 0, 0, 0}, 0 };
+    struct descrip ans_d = { 0, 0, {0, 0, 0, 0, 0, 0, 0}, 0 };
+    char cmd[512];
+
+    writeData = (!(f & 0x08)) && (f > 8);
+    sprintf(cmd, "CamSingle('%s','%s',%d,%d,%s,%d,_iosb)", routine, name, a, f,
+	    (writeData) ? "_data=$" : "_data", mem);
+    if (writeData) {
+      data_d.dtype = mem < 24 ? DTYPE_SHORT : DTYPE_LONG;
+      data_d.ptr = data;
+      status = MdsValue(serverid, cmd, &data_d, &ans_d, 0);
+    } else {
+      status = MdsValue(serverid, cmd, &ans_d, 0);
+    }
+    if (status & 1 && ans_d.dtype == DTYPE_LONG && ans_d.ptr) {
+      memcpy(&status, ans_d.ptr, 4);
+      free(ans_d.ptr);
+      ans_d.ptr = 0;
+      if (data && f < 8)
+	getdata(serverid, data);
+      getiosb(serverid, iosb);
+    }
+  }
+  return status;
+}


### PR DESCRIPTION
Currently you need to mount -bind libRemCam.so on top of libCamShr.so or copy it on top of it to get remote camac to work. This is really ugly. This pull request combines local and remote camac into the same library (obsoleting libRemCam). If the environment variable camac_server is defined then the remote camac functions will be performed otherwise local camac operations will be used.
