### PR TITLE
Fix the python threads test by disabling the tearDownModule of the tr…

### DIFF
--- a/mdsobjects/python/tests/threadsUnitTest.py
+++ b/mdsobjects/python/tests/threadsUnitTest.py
@@ -5,6 +5,12 @@ import tests.treeUnitTest as treeUnitTest
 import tests.dataUnitTest as dataUnitTest
 import os
 
+treeUnitTest.tearDownModule=None
+
+def tearDownMOdule():
+    import shutil
+    shutil.rmtree(treeUnitTest._tmpdir)
+
 class threadJob(Thread):
     """Thread to execute the treeTests"""
     def run(self):


### PR DESCRIPTION
…ee tests which removes the tmp directory and instead complete that at the end of the threads test. There was a race condition caused and the tmp directory was being deleted before all the threads were done doing the treeUnitTests.
