### PR TITLE
Andrea xinetd

### DIFF
--- a/LabView/Makefile.in
+++ b/LabView/Makefile.in
@@ -99,6 +99,7 @@ am__aclocal_m4_deps = $(top_srcdir)/m4/ax_compare_version.m4 \
 	$(top_srcdir)/m4/m4_ax_check_enable_debug.m4 \
 	$(top_srcdir)/m4/m4_ax_configure_args.m4 \
 	$(top_srcdir)/m4/m4_ax_is_release.m4 \
+	$(top_srcdir)/m4/m4_ax_mdsplus_directories.m4 \
 	$(top_srcdir)/m4/m4_ax_mdsplus_dockerbuild.m4 \
 	$(top_srcdir)/m4/m4_ax_mdsplus_testing.m4 \
 	$(top_srcdir)/m4/m4_ax_perl_module_version.m4 \

--- a/actions/Makefile.in
+++ b/actions/Makefile.in
@@ -103,6 +103,7 @@ am__aclocal_m4_deps = $(top_srcdir)/m4/ax_compare_version.m4 \
 	$(top_srcdir)/m4/m4_ax_check_enable_debug.m4 \
 	$(top_srcdir)/m4/m4_ax_configure_args.m4 \
 	$(top_srcdir)/m4/m4_ax_is_release.m4 \
+	$(top_srcdir)/m4/m4_ax_mdsplus_directories.m4 \
 	$(top_srcdir)/m4/m4_ax_mdsplus_dockerbuild.m4 \
 	$(top_srcdir)/m4/m4_ax_mdsplus_testing.m4 \
 	$(top_srcdir)/m4/m4_ax_perl_module_version.m4 \

--- a/configure
+++ b/configure
@@ -16728,6 +16728,68 @@ esac
 
 
 
+prefix=$(cd ${prefix}; pwd)
+
+
+
+if test "x$exec_prefix" = x"NONE"; then :
+  exec_prefix="${prefix}"
+fi
+
+if test "x$bindir" = x"\${exec_prefix}/bin"; then :
+  bindir="${exec_prefix}/bin"
+fi
+
+if test "x$sbindir" = x"\${exec_prefix}/sbin"; then :
+  sbindir="${exec_prefix}/sbin"
+fi
+
+if test "x$libexecdir" = x"\${exec_prefix}/libexec"; then :
+  libexecdir="${exec_prefix}/libexec"
+fi
+
+if test "x$datarootdir" = x"\${prefix}/share"; then :
+  datarootdir="${prefix}/share"
+fi
+
+if test "x$datadir" = x"\${datarootdir}"; then :
+  datadir="${datarootdir}"
+fi
+
+if test "x$sysconfdir" = x"\${prefix}/etc"; then :
+  sysconfdir="${prefix}/etc"
+fi
+
+if test "x$sharedstatedir" = x"\${prefix}/com"; then :
+  sharedstatedir="${exec_prefix}/com"
+fi
+
+if test "x$localstatedir" = x"\${prefix}/var"; then :
+  localstatedir="${prefix}/var"
+fi
+
+if test "x$includedir" = x"\${prefix}/include"; then :
+  includedir="${prefix}/include"
+fi
+
+
+
+if test "x$libdir" = x"\${exec_prefix}/lib"; then :
+  libdir="${exec_prefix}/lib"
+fi
+
+if test "x$localedir" = x"\${datarootdir}/locale"; then :
+  localedir="${datarootdir}/locale"
+fi
+
+if test "x$mandir" = x"\${datarootdir}/man"; then :
+  mandir="${datarootdir}/man"
+fi
+
+
+
+
+
 
 
 
@@ -16821,7 +16883,7 @@ ac_config_headers="$ac_config_headers include/config.h"
 
 
 
-ac_config_files="$ac_config_files Makefile.inc Makefile docs/Makefile envsyms actions/Makefile camshr/Makefile ccl/Makefile d3dshr/Makefile dwscope/Makefile hdf5/Makefile idlmdsevent/Makefile idlmdswidgets/Makefile javaclient/Makefile javadispatcher/Makefile javamds/Makefile javascope/Makefile javatraverser/Makefile javadevices/Makefile LabView/Makefile manpages/Makefile macosx/Makefile math/Makefile mdsdcl/Makefile mdslib/Makefile mdslib/docs/Makefile mdslib/testing/Makefile mdslibidl/Makefile mdsobjects/cpp/Makefile mdsobjects/cpp/docs/Makefile mdsobjects/cpp/testing/Makefile mdsobjects/cpp/testing/testutils/Makefile mdsobjects/python/docs/Makefile mdsobjects/python/tests/Makefile mdsobjects/java/Makefile mdsobjects/java/docs/Makefile mdsobjects/labview/Makefile mdsmisc/Makefile mdsshr/Makefile mdsshr/docs/Makefile mdssql/Makefile mdstcpip/Makefile mdstcpip/zlib/Makefile mdstcpip/docs/Makefile mdstcpip/docs/img/Makefile mdsvme/Makefile mitdevices/Makefile remcam/Makefile roam/Makefile rpm/Makefile rpm/envsyms rpm/post_install_script scripts/Makefile servershr/Makefile setevent/Makefile tcl/Makefile tdishr/Makefile tdishr/testing/Makefile tdic/Makefile tditest/Makefile testing/Makefile testing/backends/check/Makefile testing/selftest/Makefile traverser/Makefile treeshr/Makefile wfevent/Makefile xmdsshr/Makefile xtreeshr/Makefile icons/Makefile"
+ac_config_files="$ac_config_files Makefile.inc Makefile docs/Makefile envsyms actions/Makefile camshr/Makefile ccl/Makefile d3dshr/Makefile dwscope/Makefile hdf5/Makefile idlmdsevent/Makefile idlmdswidgets/Makefile javaclient/Makefile javadispatcher/Makefile javamds/Makefile javascope/Makefile javatraverser/Makefile javadevices/Makefile LabView/Makefile manpages/Makefile macosx/Makefile math/Makefile mdsdcl/Makefile mdslib/Makefile mdslib/docs/Makefile mdslib/testing/Makefile mdslibidl/Makefile mdsobjects/cpp/Makefile mdsobjects/cpp/docs/Makefile mdsobjects/cpp/testing/Makefile mdsobjects/cpp/testing/testutils/Makefile mdsobjects/python/docs/Makefile mdsobjects/python/tests/Makefile mdsobjects/java/Makefile mdsobjects/java/docs/Makefile mdsobjects/labview/Makefile mdsmisc/Makefile mdsshr/Makefile mdsshr/docs/Makefile mdssql/Makefile mdstcpip/Makefile mdstcpip/zlib/Makefile mdstcpip/docs/Makefile mdstcpip/docs/img/Makefile mdsvme/Makefile mitdevices/Makefile remcam/Makefile roam/Makefile rpm/Makefile rpm/envsyms rpm/post_install_script rpm/mdsipd.xinetd rpm/mdsipsd.xinetd scripts/Makefile servershr/Makefile setevent/Makefile tcl/Makefile tdishr/Makefile tdishr/testing/Makefile tdic/Makefile tditest/Makefile testing/Makefile testing/backends/check/Makefile testing/selftest/Makefile traverser/Makefile treeshr/Makefile wfevent/Makefile xmdsshr/Makefile xtreeshr/Makefile icons/Makefile"
 
 cat >confcache <<\_ACEOF
 # This file is a shell script that caches the results of configure
@@ -17710,6 +17772,8 @@ do
     "rpm/Makefile") CONFIG_FILES="$CONFIG_FILES rpm/Makefile" ;;
     "rpm/envsyms") CONFIG_FILES="$CONFIG_FILES rpm/envsyms" ;;
     "rpm/post_install_script") CONFIG_FILES="$CONFIG_FILES rpm/post_install_script" ;;
+    "rpm/mdsipd.xinetd") CONFIG_FILES="$CONFIG_FILES rpm/mdsipd.xinetd" ;;
+    "rpm/mdsipsd.xinetd") CONFIG_FILES="$CONFIG_FILES rpm/mdsipsd.xinetd" ;;
     "scripts/Makefile") CONFIG_FILES="$CONFIG_FILES scripts/Makefile" ;;
     "servershr/Makefile") CONFIG_FILES="$CONFIG_FILES servershr/Makefile" ;;
     "setevent/Makefile") CONFIG_FILES="$CONFIG_FILES setevent/Makefile" ;;
@@ -18452,6 +18516,9 @@ if test -n "$ac_unrecognized_opts" && test "$enable_option_checking" != no; then
   { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: unrecognized options: $ac_unrecognized_opts" >&5
 $as_echo "$as_me: WARNING: unrecognized options: $ac_unrecognized_opts" >&2;}
 fi
+
+
+
 
 
 ac_config_commands="$ac_config_commands default-1"

--- a/configure
+++ b/configure
@@ -16728,8 +16728,6 @@ esac
 
 
 
-prefix=$(cd ${prefix}; pwd)
-
 
 
 if test "x$exec_prefix" = x"NONE"; then :

--- a/configure.ac
+++ b/configure.ac
@@ -1188,6 +1188,9 @@ dnl add here what goes on bottom of config.h
 AH_BOTTOM()
 
 
+dnl define custom direcotries substitution
+AX_MDSPLUS_DIRECTORIES
+
 AC_SUBST(CAMSHR)
 AC_SUBST(CLOCK_GETTIME_LIB)
 AC_SUBST(D3D_PACKAGE)
@@ -1332,6 +1335,8 @@ AC_OUTPUT(Makefile.inc
           rpm/Makefile
           rpm/envsyms
           rpm/post_install_script
+          rpm/mdsipd.xinetd
+          rpm/mdsipsd.xinetd
           scripts/Makefile
           servershr/Makefile 
           setevent/Makefile
@@ -1350,6 +1355,9 @@ AC_OUTPUT(Makefile.inc
           xtreeshr/Makefile
           icons/Makefile
 )
+
+
+
 
 AC_OUTPUT_COMMANDS(make depend)
 if test "$JAVA_APS" = ""

--- a/docs/Makefile.in
+++ b/docs/Makefile.in
@@ -128,6 +128,7 @@ am__aclocal_m4_deps = $(top_srcdir)/m4/ax_compare_version.m4 \
 	$(top_srcdir)/m4/m4_ax_check_enable_debug.m4 \
 	$(top_srcdir)/m4/m4_ax_configure_args.m4 \
 	$(top_srcdir)/m4/m4_ax_is_release.m4 \
+	$(top_srcdir)/m4/m4_ax_mdsplus_directories.m4 \
 	$(top_srcdir)/m4/m4_ax_mdsplus_dockerbuild.m4 \
 	$(top_srcdir)/m4/m4_ax_mdsplus_testing.m4 \
 	$(top_srcdir)/m4/m4_ax_perl_module_version.m4 \

--- a/dwscope/Makefile.in
+++ b/dwscope/Makefile.in
@@ -103,6 +103,7 @@ am__aclocal_m4_deps = $(top_srcdir)/m4/ax_compare_version.m4 \
 	$(top_srcdir)/m4/m4_ax_check_enable_debug.m4 \
 	$(top_srcdir)/m4/m4_ax_configure_args.m4 \
 	$(top_srcdir)/m4/m4_ax_is_release.m4 \
+	$(top_srcdir)/m4/m4_ax_mdsplus_directories.m4 \
 	$(top_srcdir)/m4/m4_ax_mdsplus_dockerbuild.m4 \
 	$(top_srcdir)/m4/m4_ax_mdsplus_testing.m4 \
 	$(top_srcdir)/m4/m4_ax_perl_module_version.m4 \

--- a/icons/Makefile.in
+++ b/icons/Makefile.in
@@ -100,6 +100,7 @@ am__aclocal_m4_deps = $(top_srcdir)/m4/ax_compare_version.m4 \
 	$(top_srcdir)/m4/m4_ax_check_enable_debug.m4 \
 	$(top_srcdir)/m4/m4_ax_configure_args.m4 \
 	$(top_srcdir)/m4/m4_ax_is_release.m4 \
+	$(top_srcdir)/m4/m4_ax_mdsplus_directories.m4 \
 	$(top_srcdir)/m4/m4_ax_mdsplus_dockerbuild.m4 \
 	$(top_srcdir)/m4/m4_ax_mdsplus_testing.m4 \
 	$(top_srcdir)/m4/m4_ax_perl_module_version.m4 \

--- a/javaclient/Makefile.in
+++ b/javaclient/Makefile.in
@@ -99,6 +99,7 @@ am__aclocal_m4_deps = $(top_srcdir)/m4/ax_compare_version.m4 \
 	$(top_srcdir)/m4/m4_ax_check_enable_debug.m4 \
 	$(top_srcdir)/m4/m4_ax_configure_args.m4 \
 	$(top_srcdir)/m4/m4_ax_is_release.m4 \
+	$(top_srcdir)/m4/m4_ax_mdsplus_directories.m4 \
 	$(top_srcdir)/m4/m4_ax_mdsplus_dockerbuild.m4 \
 	$(top_srcdir)/m4/m4_ax_mdsplus_testing.m4 \
 	$(top_srcdir)/m4/m4_ax_perl_module_version.m4 \

--- a/javadevices/Makefile.in
+++ b/javadevices/Makefile.in
@@ -99,6 +99,7 @@ am__aclocal_m4_deps = $(top_srcdir)/m4/ax_compare_version.m4 \
 	$(top_srcdir)/m4/m4_ax_check_enable_debug.m4 \
 	$(top_srcdir)/m4/m4_ax_configure_args.m4 \
 	$(top_srcdir)/m4/m4_ax_is_release.m4 \
+	$(top_srcdir)/m4/m4_ax_mdsplus_directories.m4 \
 	$(top_srcdir)/m4/m4_ax_mdsplus_dockerbuild.m4 \
 	$(top_srcdir)/m4/m4_ax_mdsplus_testing.m4 \
 	$(top_srcdir)/m4/m4_ax_perl_module_version.m4 \

--- a/javadispatcher/Makefile.in
+++ b/javadispatcher/Makefile.in
@@ -100,6 +100,7 @@ am__aclocal_m4_deps = $(top_srcdir)/m4/ax_compare_version.m4 \
 	$(top_srcdir)/m4/m4_ax_check_enable_debug.m4 \
 	$(top_srcdir)/m4/m4_ax_configure_args.m4 \
 	$(top_srcdir)/m4/m4_ax_is_release.m4 \
+	$(top_srcdir)/m4/m4_ax_mdsplus_directories.m4 \
 	$(top_srcdir)/m4/m4_ax_mdsplus_dockerbuild.m4 \
 	$(top_srcdir)/m4/m4_ax_mdsplus_testing.m4 \
 	$(top_srcdir)/m4/m4_ax_perl_module_version.m4 \

--- a/javascope/Makefile.in
+++ b/javascope/Makefile.in
@@ -102,6 +102,7 @@ am__aclocal_m4_deps = $(top_srcdir)/m4/ax_compare_version.m4 \
 	$(top_srcdir)/m4/m4_ax_check_enable_debug.m4 \
 	$(top_srcdir)/m4/m4_ax_configure_args.m4 \
 	$(top_srcdir)/m4/m4_ax_is_release.m4 \
+	$(top_srcdir)/m4/m4_ax_mdsplus_directories.m4 \
 	$(top_srcdir)/m4/m4_ax_mdsplus_dockerbuild.m4 \
 	$(top_srcdir)/m4/m4_ax_mdsplus_testing.m4 \
 	$(top_srcdir)/m4/m4_ax_perl_module_version.m4 \

--- a/javatraverser/Makefile.in
+++ b/javatraverser/Makefile.in
@@ -102,6 +102,7 @@ am__aclocal_m4_deps = $(top_srcdir)/m4/ax_compare_version.m4 \
 	$(top_srcdir)/m4/m4_ax_check_enable_debug.m4 \
 	$(top_srcdir)/m4/m4_ax_configure_args.m4 \
 	$(top_srcdir)/m4/m4_ax_is_release.m4 \
+	$(top_srcdir)/m4/m4_ax_mdsplus_directories.m4 \
 	$(top_srcdir)/m4/m4_ax_mdsplus_dockerbuild.m4 \
 	$(top_srcdir)/m4/m4_ax_mdsplus_testing.m4 \
 	$(top_srcdir)/m4/m4_ax_perl_module_version.m4 \

--- a/m4/m4_ax_mdsplus_directories.m4
+++ b/m4/m4_ax_mdsplus_directories.m4
@@ -1,0 +1,81 @@
+
+
+dnl FROM /usr/share/autoconf/autoconf/general.m4
+dnl 
+dnl AC_SUBST([bindir],         ['${exec_prefix}/bin'])dnl
+dnl AC_SUBST([sbindir],        ['${exec_prefix}/sbin'])dnl
+dnl AC_SUBST([libexecdir],     ['${exec_prefix}/libexec'])dnl
+dnl AC_SUBST([datarootdir],    ['${prefix}/share'])dnl
+dnl AC_SUBST([datadir],        ['${datarootdir}'])dnl
+dnl AC_SUBST([sysconfdir],     ['${prefix}/etc'])dnl
+dnl AC_SUBST([sharedstatedir], ['${prefix}/com'])dnl
+dnl AC_SUBST([localstatedir],  ['${prefix}/var'])dnl
+dnl AC_SUBST([includedir],     ['${prefix}/include'])dnl
+dnl AC_SUBST([oldincludedir],  ['/usr/include'])dnl
+dnl AC_SUBST([docdir],         [m4_ifset([AC_PACKAGE_TARNAME],
+dnl				     ['${datarootdir}/doc/${PACKAGE_TARNAME}'],
+dnl				     ['${datarootdir}/doc/${PACKAGE}'])])dnl
+dnl AC_SUBST([infodir],        ['${datarootdir}/info'])dnl
+dnl AC_SUBST([htmldir],        ['${docdir}'])dnl
+dnl AC_SUBST([dvidir],         ['${docdir}'])dnl
+dnl AC_SUBST([pdfdir],         ['${docdir}'])dnl
+dnl AC_SUBST([psdir],          ['${docdir}'])dnl
+dnl AC_SUBST([libdir],         ['${exec_prefix}/lib'])dnl
+dnl AC_SUBST([localedir],      ['${datarootdir}/locale'])dnl
+dnl AC_SUBST([mandir],         ['${datarootdir}/man'])dnl
+
+
+
+AC_DEFUN([AX_MDSPLUS_DIRECTORIES],[
+
+dnl Fix prefix with abs path
+AS_VAR_SET([prefix],[$(cd ${prefix}; pwd)])
+
+
+
+AS_VAR_IF([exec_prefix],["NONE"], 
+  AS_VAR_SET([exec_prefix],["${prefix}"]))
+
+AS_VAR_IF([bindir],["\${exec_prefix}/bin"], 
+  AS_VAR_SET([bindir],["${exec_prefix}/bin"]))
+
+AS_VAR_IF([sbindir],["\${exec_prefix}/sbin"], 
+  AS_VAR_SET([sbindir],["${exec_prefix}/sbin"]))
+
+AS_VAR_IF([libexecdir],["\${exec_prefix}/libexec"], 
+  AS_VAR_SET([libexecdir],["${exec_prefix}/libexec"]))
+
+AS_VAR_IF([datarootdir],["\${prefix}/share"], 
+  AS_VAR_SET([datarootdir],["${prefix}/share"]))
+
+AS_VAR_IF([datadir],["\${datarootdir}"], 
+  AS_VAR_SET([datadir],["${datarootdir}"]))
+
+AS_VAR_IF([sysconfdir],["\${prefix}/etc"], 
+  AS_VAR_SET([sysconfdir],["${prefix}/etc"]))
+
+AS_VAR_IF([sharedstatedir],["\${prefix}/com"], 
+  AS_VAR_SET([sharedstatedir],["${exec_prefix}/com"]))
+
+AS_VAR_IF([localstatedir],["\${prefix}/var"], 
+  AS_VAR_SET([localstatedir],["${prefix}/var"]))
+
+AS_VAR_IF([includedir],["\${prefix}/include"], 
+  AS_VAR_SET([includedir],["${prefix}/include"]))
+
+
+
+AS_VAR_IF([libdir],["\${exec_prefix}/lib"], 
+  AS_VAR_SET([libdir],["${exec_prefix}/lib"]))
+
+AS_VAR_IF([localedir],["\${datarootdir}/locale"], 
+  AS_VAR_SET([localedir],["${datarootdir}/locale"]))
+
+AS_VAR_IF([mandir],["\${datarootdir}/man"], 
+  AS_VAR_SET([mandir],["${datarootdir}/man"]))
+
+
+])
+
+
+

--- a/m4/m4_ax_mdsplus_directories.m4
+++ b/m4/m4_ax_mdsplus_directories.m4
@@ -28,10 +28,6 @@ dnl AC_SUBST([mandir],         ['${datarootdir}/man'])dnl
 
 AC_DEFUN([AX_MDSPLUS_DIRECTORIES],[
 
-dnl Fix prefix with abs path
-AS_VAR_SET([prefix],[$(cd ${prefix}; pwd)])
-
-
 
 AS_VAR_IF([exec_prefix],["NONE"], 
   AS_VAR_SET([exec_prefix],["${prefix}"]))

--- a/macosx/Makefile.in
+++ b/macosx/Makefile.in
@@ -100,6 +100,7 @@ am__aclocal_m4_deps = $(top_srcdir)/m4/ax_compare_version.m4 \
 	$(top_srcdir)/m4/m4_ax_check_enable_debug.m4 \
 	$(top_srcdir)/m4/m4_ax_configure_args.m4 \
 	$(top_srcdir)/m4/m4_ax_is_release.m4 \
+	$(top_srcdir)/m4/m4_ax_mdsplus_directories.m4 \
 	$(top_srcdir)/m4/m4_ax_mdsplus_dockerbuild.m4 \
 	$(top_srcdir)/m4/m4_ax_mdsplus_testing.m4 \
 	$(top_srcdir)/m4/m4_ax_perl_module_version.m4 \

--- a/manpages/Makefile.in
+++ b/manpages/Makefile.in
@@ -98,6 +98,7 @@ am__aclocal_m4_deps = $(top_srcdir)/m4/ax_compare_version.m4 \
 	$(top_srcdir)/m4/m4_ax_check_enable_debug.m4 \
 	$(top_srcdir)/m4/m4_ax_configure_args.m4 \
 	$(top_srcdir)/m4/m4_ax_is_release.m4 \
+	$(top_srcdir)/m4/m4_ax_mdsplus_directories.m4 \
 	$(top_srcdir)/m4/m4_ax_mdsplus_dockerbuild.m4 \
 	$(top_srcdir)/m4/m4_ax_mdsplus_testing.m4 \
 	$(top_srcdir)/m4/m4_ax_perl_module_version.m4 \

--- a/mdslib/docs/Makefile.in
+++ b/mdslib/docs/Makefile.in
@@ -128,6 +128,7 @@ am__aclocal_m4_deps = $(top_srcdir)/m4/ax_compare_version.m4 \
 	$(top_srcdir)/m4/m4_ax_check_enable_debug.m4 \
 	$(top_srcdir)/m4/m4_ax_configure_args.m4 \
 	$(top_srcdir)/m4/m4_ax_is_release.m4 \
+	$(top_srcdir)/m4/m4_ax_mdsplus_directories.m4 \
 	$(top_srcdir)/m4/m4_ax_mdsplus_dockerbuild.m4 \
 	$(top_srcdir)/m4/m4_ax_mdsplus_testing.m4 \
 	$(top_srcdir)/m4/m4_ax_perl_module_version.m4 \

--- a/mdslib/testing/Makefile.in
+++ b/mdslib/testing/Makefile.in
@@ -105,6 +105,7 @@ am__aclocal_m4_deps = $(top_srcdir)/m4/ax_compare_version.m4 \
 	$(top_srcdir)/m4/m4_ax_check_enable_debug.m4 \
 	$(top_srcdir)/m4/m4_ax_configure_args.m4 \
 	$(top_srcdir)/m4/m4_ax_is_release.m4 \
+	$(top_srcdir)/m4/m4_ax_mdsplus_directories.m4 \
 	$(top_srcdir)/m4/m4_ax_mdsplus_dockerbuild.m4 \
 	$(top_srcdir)/m4/m4_ax_mdsplus_testing.m4 \
 	$(top_srcdir)/m4/m4_ax_perl_module_version.m4 \

--- a/mdsobjects/cpp/docs/Makefile.in
+++ b/mdsobjects/cpp/docs/Makefile.in
@@ -128,6 +128,7 @@ am__aclocal_m4_deps = $(top_srcdir)/m4/ax_compare_version.m4 \
 	$(top_srcdir)/m4/m4_ax_check_enable_debug.m4 \
 	$(top_srcdir)/m4/m4_ax_configure_args.m4 \
 	$(top_srcdir)/m4/m4_ax_is_release.m4 \
+	$(top_srcdir)/m4/m4_ax_mdsplus_directories.m4 \
 	$(top_srcdir)/m4/m4_ax_mdsplus_dockerbuild.m4 \
 	$(top_srcdir)/m4/m4_ax_mdsplus_testing.m4 \
 	$(top_srcdir)/m4/m4_ax_perl_module_version.m4 \

--- a/mdsobjects/cpp/testing/Makefile.in
+++ b/mdsobjects/cpp/testing/Makefile.in
@@ -117,6 +117,7 @@ am__aclocal_m4_deps = $(top_srcdir)/m4/ax_compare_version.m4 \
 	$(top_srcdir)/m4/m4_ax_check_enable_debug.m4 \
 	$(top_srcdir)/m4/m4_ax_configure_args.m4 \
 	$(top_srcdir)/m4/m4_ax_is_release.m4 \
+	$(top_srcdir)/m4/m4_ax_mdsplus_directories.m4 \
 	$(top_srcdir)/m4/m4_ax_mdsplus_dockerbuild.m4 \
 	$(top_srcdir)/m4/m4_ax_mdsplus_testing.m4 \
 	$(top_srcdir)/m4/m4_ax_perl_module_version.m4 \

--- a/mdsobjects/cpp/testing/testutils/Makefile.in
+++ b/mdsobjects/cpp/testing/testutils/Makefile.in
@@ -100,6 +100,7 @@ am__aclocal_m4_deps = $(top_srcdir)/m4/ax_compare_version.m4 \
 	$(top_srcdir)/m4/m4_ax_check_enable_debug.m4 \
 	$(top_srcdir)/m4/m4_ax_configure_args.m4 \
 	$(top_srcdir)/m4/m4_ax_is_release.m4 \
+	$(top_srcdir)/m4/m4_ax_mdsplus_directories.m4 \
 	$(top_srcdir)/m4/m4_ax_mdsplus_dockerbuild.m4 \
 	$(top_srcdir)/m4/m4_ax_mdsplus_testing.m4 \
 	$(top_srcdir)/m4/m4_ax_perl_module_version.m4 \

--- a/mdsobjects/java/Makefile.in
+++ b/mdsobjects/java/Makefile.in
@@ -99,6 +99,7 @@ am__aclocal_m4_deps = $(top_srcdir)/m4/ax_compare_version.m4 \
 	$(top_srcdir)/m4/m4_ax_check_enable_debug.m4 \
 	$(top_srcdir)/m4/m4_ax_configure_args.m4 \
 	$(top_srcdir)/m4/m4_ax_is_release.m4 \
+	$(top_srcdir)/m4/m4_ax_mdsplus_directories.m4 \
 	$(top_srcdir)/m4/m4_ax_mdsplus_dockerbuild.m4 \
 	$(top_srcdir)/m4/m4_ax_mdsplus_testing.m4 \
 	$(top_srcdir)/m4/m4_ax_perl_module_version.m4 \

--- a/mdsobjects/java/docs/Makefile.in
+++ b/mdsobjects/java/docs/Makefile.in
@@ -128,6 +128,7 @@ am__aclocal_m4_deps = $(top_srcdir)/m4/ax_compare_version.m4 \
 	$(top_srcdir)/m4/m4_ax_check_enable_debug.m4 \
 	$(top_srcdir)/m4/m4_ax_configure_args.m4 \
 	$(top_srcdir)/m4/m4_ax_is_release.m4 \
+	$(top_srcdir)/m4/m4_ax_mdsplus_directories.m4 \
 	$(top_srcdir)/m4/m4_ax_mdsplus_dockerbuild.m4 \
 	$(top_srcdir)/m4/m4_ax_mdsplus_testing.m4 \
 	$(top_srcdir)/m4/m4_ax_perl_module_version.m4 \

--- a/mdsobjects/python/docs/Makefile.in
+++ b/mdsobjects/python/docs/Makefile.in
@@ -128,6 +128,7 @@ am__aclocal_m4_deps = $(top_srcdir)/m4/ax_compare_version.m4 \
 	$(top_srcdir)/m4/m4_ax_check_enable_debug.m4 \
 	$(top_srcdir)/m4/m4_ax_configure_args.m4 \
 	$(top_srcdir)/m4/m4_ax_is_release.m4 \
+	$(top_srcdir)/m4/m4_ax_mdsplus_directories.m4 \
 	$(top_srcdir)/m4/m4_ax_mdsplus_dockerbuild.m4 \
 	$(top_srcdir)/m4/m4_ax_mdsplus_testing.m4 \
 	$(top_srcdir)/m4/m4_ax_perl_module_version.m4 \

--- a/mdsobjects/python/tests/Makefile.in
+++ b/mdsobjects/python/tests/Makefile.in
@@ -104,6 +104,7 @@ am__aclocal_m4_deps = $(top_srcdir)/m4/ax_compare_version.m4 \
 	$(top_srcdir)/m4/m4_ax_check_enable_debug.m4 \
 	$(top_srcdir)/m4/m4_ax_configure_args.m4 \
 	$(top_srcdir)/m4/m4_ax_is_release.m4 \
+	$(top_srcdir)/m4/m4_ax_mdsplus_directories.m4 \
 	$(top_srcdir)/m4/m4_ax_mdsplus_dockerbuild.m4 \
 	$(top_srcdir)/m4/m4_ax_mdsplus_testing.m4 \
 	$(top_srcdir)/m4/m4_ax_perl_module_version.m4 \

--- a/mdsshr/docs/Makefile.in
+++ b/mdsshr/docs/Makefile.in
@@ -128,6 +128,7 @@ am__aclocal_m4_deps = $(top_srcdir)/m4/ax_compare_version.m4 \
 	$(top_srcdir)/m4/m4_ax_check_enable_debug.m4 \
 	$(top_srcdir)/m4/m4_ax_configure_args.m4 \
 	$(top_srcdir)/m4/m4_ax_is_release.m4 \
+	$(top_srcdir)/m4/m4_ax_mdsplus_directories.m4 \
 	$(top_srcdir)/m4/m4_ax_mdsplus_dockerbuild.m4 \
 	$(top_srcdir)/m4/m4_ax_mdsplus_testing.m4 \
 	$(top_srcdir)/m4/m4_ax_perl_module_version.m4 \

--- a/mdstcpip/docs/Makefile.in
+++ b/mdstcpip/docs/Makefile.in
@@ -128,6 +128,7 @@ am__aclocal_m4_deps = $(top_srcdir)/m4/ax_compare_version.m4 \
 	$(top_srcdir)/m4/m4_ax_check_enable_debug.m4 \
 	$(top_srcdir)/m4/m4_ax_configure_args.m4 \
 	$(top_srcdir)/m4/m4_ax_is_release.m4 \
+	$(top_srcdir)/m4/m4_ax_mdsplus_directories.m4 \
 	$(top_srcdir)/m4/m4_ax_mdsplus_dockerbuild.m4 \
 	$(top_srcdir)/m4/m4_ax_mdsplus_testing.m4 \
 	$(top_srcdir)/m4/m4_ax_perl_module_version.m4 \

--- a/mdstcpip/docs/img/Makefile.in
+++ b/mdstcpip/docs/img/Makefile.in
@@ -98,6 +98,7 @@ am__aclocal_m4_deps = $(top_srcdir)/m4/ax_compare_version.m4 \
 	$(top_srcdir)/m4/m4_ax_check_enable_debug.m4 \
 	$(top_srcdir)/m4/m4_ax_configure_args.m4 \
 	$(top_srcdir)/m4/m4_ax_is_release.m4 \
+	$(top_srcdir)/m4/m4_ax_mdsplus_directories.m4 \
 	$(top_srcdir)/m4/m4_ax_mdsplus_dockerbuild.m4 \
 	$(top_srcdir)/m4/m4_ax_mdsplus_testing.m4 \
 	$(top_srcdir)/m4/m4_ax_perl_module_version.m4 \

--- a/mdstcpip/zlib/Makefile.in
+++ b/mdstcpip/zlib/Makefile.in
@@ -100,6 +100,7 @@ am__aclocal_m4_deps = $(top_srcdir)/m4/ax_compare_version.m4 \
 	$(top_srcdir)/m4/m4_ax_check_enable_debug.m4 \
 	$(top_srcdir)/m4/m4_ax_configure_args.m4 \
 	$(top_srcdir)/m4/m4_ax_is_release.m4 \
+	$(top_srcdir)/m4/m4_ax_mdsplus_directories.m4 \
 	$(top_srcdir)/m4/m4_ax_mdsplus_dockerbuild.m4 \
 	$(top_srcdir)/m4/m4_ax_mdsplus_testing.m4 \
 	$(top_srcdir)/m4/m4_ax_perl_module_version.m4 \

--- a/rpm/Makefile.in
+++ b/rpm/Makefile.in
@@ -100,6 +100,7 @@ am__aclocal_m4_deps = $(top_srcdir)/m4/ax_compare_version.m4 \
 	$(top_srcdir)/m4/m4_ax_check_enable_debug.m4 \
 	$(top_srcdir)/m4/m4_ax_configure_args.m4 \
 	$(top_srcdir)/m4/m4_ax_is_release.m4 \
+	$(top_srcdir)/m4/m4_ax_mdsplus_directories.m4 \
 	$(top_srcdir)/m4/m4_ax_mdsplus_dockerbuild.m4 \
 	$(top_srcdir)/m4/m4_ax_mdsplus_testing.m4 \
 	$(top_srcdir)/m4/m4_ax_perl_module_version.m4 \
@@ -115,7 +116,8 @@ DIST_COMMON = $(srcdir)/Makefile.am $(dist_rpm_SCRIPTS) \
 	$(dist_etc_DATA) $(am__dist_rpm_DATA_DIST) $(am__DIST_COMMON)
 mkinstalldirs = $(install_sh) -d
 CONFIG_HEADER = $(top_builddir)/include/config.h
-CONFIG_CLEAN_FILES = envsyms post_install_script
+CONFIG_CLEAN_FILES = envsyms post_install_script mdsipd.xinetd \
+	mdsipsd.xinetd
 CONFIG_CLEAN_VPATH_FILES =
 am__vpath_adj_setup = srcdirstrip=`echo "$(srcdir)" | sed 's|.|.|g'`;
 am__vpath_adj = case $$p in \
@@ -173,6 +175,7 @@ am__dist_rpm_DATA_DIST = mdsipd.xinetd mdsipsd.xinetd \
 DATA = $(dist_etc_DATA) $(dist_rpm_DATA) $(etc_DATA)
 am__tagged_files = $(HEADERS) $(SOURCES) $(TAGS_FILES) $(LISP)
 am__DIST_COMMON = $(srcdir)/Makefile.in $(srcdir)/envsyms.in \
+	$(srcdir)/mdsipd.xinetd.in $(srcdir)/mdsipsd.xinetd.in \
 	$(srcdir)/post_install_script.in
 DISTFILES = $(DIST_COMMON) $(DIST_SOURCES) $(TEXINFOS) $(EXTRA_DIST)
 ACLOCAL = @ACLOCAL@
@@ -502,6 +505,10 @@ $(am__aclocal_m4_deps):
 envsyms: $(top_builddir)/config.status $(srcdir)/envsyms.in
 	cd $(top_builddir) && $(SHELL) ./config.status $(subdir)/$@
 post_install_script: $(top_builddir)/config.status $(srcdir)/post_install_script.in
+	cd $(top_builddir) && $(SHELL) ./config.status $(subdir)/$@
+mdsipd.xinetd: $(top_builddir)/config.status $(srcdir)/mdsipd.xinetd.in
+	cd $(top_builddir) && $(SHELL) ./config.status $(subdir)/$@
+mdsipsd.xinetd: $(top_builddir)/config.status $(srcdir)/mdsipsd.xinetd.in
 	cd $(top_builddir) && $(SHELL) ./config.status $(subdir)/$@
 install-dist_rpmSCRIPTS: $(dist_rpm_SCRIPTS)
 	@$(NORMAL_INSTALL)

--- a/rpm/mdsipd.xinetd.in
+++ b/rpm/mdsipd.xinetd.in
@@ -14,9 +14,8 @@ service mdsip
 ###       /usr/local/mdsplus make sure you change the following
 ###       line to use the directory where you installed MDSplus.
 
-        server          = /usr/local/mdsplus/bin/mdsipd
-
-        server_args     = mdsip /var/log/mdsplus/mdsipd
+        server          = @bindir@/mdsipd
+        server_args     = mdsip @localstatedir@/log/mdsplus/mdsipd
         log_on_failure  += HOST
         log_on_success  += HOST
         flags           = KEEPALIVE NODELAY NOLIBWRAP

--- a/rpm/mdsipsd.xinetd.in
+++ b/rpm/mdsipsd.xinetd.in
@@ -10,8 +10,8 @@ service mdsips
         instances       = UNLIMITED
         per_source      = UNLIMITED
         user            = root
-        server          = /usr/local/mdsplus/bin/mdsipsd
-        server_args     = mdsips /var/log/mdsplus/mdsipsd
+        server          = @bindir@/mdsipsd
+        server_args     = mdsips @localstatedir@/log/mdsplus/mdsipsd
         log_on_failure  += HOST
         log_on_success  += HOST
 }

--- a/scripts/Makefile.in
+++ b/scripts/Makefile.in
@@ -99,6 +99,7 @@ am__aclocal_m4_deps = $(top_srcdir)/m4/ax_compare_version.m4 \
 	$(top_srcdir)/m4/m4_ax_check_enable_debug.m4 \
 	$(top_srcdir)/m4/m4_ax_configure_args.m4 \
 	$(top_srcdir)/m4/m4_ax_is_release.m4 \
+	$(top_srcdir)/m4/m4_ax_mdsplus_directories.m4 \
 	$(top_srcdir)/m4/m4_ax_mdsplus_dockerbuild.m4 \
 	$(top_srcdir)/m4/m4_ax_mdsplus_testing.m4 \
 	$(top_srcdir)/m4/m4_ax_perl_module_version.m4 \

--- a/setevent/Makefile.in
+++ b/setevent/Makefile.in
@@ -100,6 +100,7 @@ am__aclocal_m4_deps = $(top_srcdir)/m4/ax_compare_version.m4 \
 	$(top_srcdir)/m4/m4_ax_check_enable_debug.m4 \
 	$(top_srcdir)/m4/m4_ax_configure_args.m4 \
 	$(top_srcdir)/m4/m4_ax_is_release.m4 \
+	$(top_srcdir)/m4/m4_ax_mdsplus_directories.m4 \
 	$(top_srcdir)/m4/m4_ax_mdsplus_dockerbuild.m4 \
 	$(top_srcdir)/m4/m4_ax_mdsplus_testing.m4 \
 	$(top_srcdir)/m4/m4_ax_perl_module_version.m4 \

--- a/tdishr/testing/Makefile.in
+++ b/tdishr/testing/Makefile.in
@@ -105,6 +105,7 @@ am__aclocal_m4_deps = $(top_srcdir)/m4/ax_compare_version.m4 \
 	$(top_srcdir)/m4/m4_ax_check_enable_debug.m4 \
 	$(top_srcdir)/m4/m4_ax_configure_args.m4 \
 	$(top_srcdir)/m4/m4_ax_is_release.m4 \
+	$(top_srcdir)/m4/m4_ax_mdsplus_directories.m4 \
 	$(top_srcdir)/m4/m4_ax_mdsplus_dockerbuild.m4 \
 	$(top_srcdir)/m4/m4_ax_mdsplus_testing.m4 \
 	$(top_srcdir)/m4/m4_ax_perl_module_version.m4 \

--- a/testing/Makefile.in
+++ b/testing/Makefile.in
@@ -99,6 +99,7 @@ am__aclocal_m4_deps = $(top_srcdir)/m4/ax_compare_version.m4 \
 	$(top_srcdir)/m4/m4_ax_check_enable_debug.m4 \
 	$(top_srcdir)/m4/m4_ax_configure_args.m4 \
 	$(top_srcdir)/m4/m4_ax_is_release.m4 \
+	$(top_srcdir)/m4/m4_ax_mdsplus_directories.m4 \
 	$(top_srcdir)/m4/m4_ax_mdsplus_dockerbuild.m4 \
 	$(top_srcdir)/m4/m4_ax_mdsplus_testing.m4 \
 	$(top_srcdir)/m4/m4_ax_perl_module_version.m4 \

--- a/testing/backends/check/Makefile.in
+++ b/testing/backends/check/Makefile.in
@@ -101,6 +101,7 @@ am__aclocal_m4_deps = $(top_srcdir)/m4/ax_compare_version.m4 \
 	$(top_srcdir)/m4/m4_ax_check_enable_debug.m4 \
 	$(top_srcdir)/m4/m4_ax_configure_args.m4 \
 	$(top_srcdir)/m4/m4_ax_is_release.m4 \
+	$(top_srcdir)/m4/m4_ax_mdsplus_directories.m4 \
 	$(top_srcdir)/m4/m4_ax_mdsplus_dockerbuild.m4 \
 	$(top_srcdir)/m4/m4_ax_mdsplus_testing.m4 \
 	$(top_srcdir)/m4/m4_ax_perl_module_version.m4 \

--- a/testing/selftest/Makefile.in
+++ b/testing/selftest/Makefile.in
@@ -107,6 +107,7 @@ am__aclocal_m4_deps = $(top_srcdir)/m4/ax_compare_version.m4 \
 	$(top_srcdir)/m4/m4_ax_check_enable_debug.m4 \
 	$(top_srcdir)/m4/m4_ax_configure_args.m4 \
 	$(top_srcdir)/m4/m4_ax_is_release.m4 \
+	$(top_srcdir)/m4/m4_ax_mdsplus_directories.m4 \
 	$(top_srcdir)/m4/m4_ax_mdsplus_dockerbuild.m4 \
 	$(top_srcdir)/m4/m4_ax_mdsplus_testing.m4 \
 	$(top_srcdir)/m4/m4_ax_perl_module_version.m4 \

--- a/wfevent/Makefile.in
+++ b/wfevent/Makefile.in
@@ -100,6 +100,7 @@ am__aclocal_m4_deps = $(top_srcdir)/m4/ax_compare_version.m4 \
 	$(top_srcdir)/m4/m4_ax_check_enable_debug.m4 \
 	$(top_srcdir)/m4/m4_ax_configure_args.m4 \
 	$(top_srcdir)/m4/m4_ax_is_release.m4 \
+	$(top_srcdir)/m4/m4_ax_mdsplus_directories.m4 \
 	$(top_srcdir)/m4/m4_ax_mdsplus_dockerbuild.m4 \
 	$(top_srcdir)/m4/m4_ax_mdsplus_testing.m4 \
 	$(top_srcdir)/m4/m4_ax_perl_module_version.m4 \


### PR DESCRIPTION
Adds the m4/m4_ax_mdsplus_directories.m4 file.. it aims at fixing the Autoconf general paths from being recursively dependent to other variables. For example you can use in mdsipd.xinetd the @bindir@ substitution to directly link the install path. Without the fix the @bindir@ is substituted with ${exec_prefix}/bin and this is not usable in a script where ${exec_prefix} can not be previously set.

A similar approach seems to have already been used by other tools.. such as CUPS for example, see:
(http://www.opensource.apple.com/source/cups/cups-327/cups/config-scripts/cups-directories.m4)
