### PR TITLE
add possible user defined TEST_DIRS to select tests subdirectories

### DIFF
--- a/testing/Makefile.am
+++ b/testing/Makefile.am
@@ -28,22 +28,36 @@ MdsTestShr = @MAKESHLIBDIR@@LIBPRE@MdsTestShr@SHARETYPE@
 $(MdsTestShr): backends/check/libCheck.a libMdsTestBackend.a
 	$(CXX) $(TARGET_ARCH) $(CXXFLAGS) $(OUTPUT_OPTION) @LINKSHARED@ -Wl,-whole-archive $^ -Wl,-no-whole-archive $(LDFLAGS) $(LIBS) $(MAKE_IMPLIB_MdsTestShr)
 
+all-local: $(MdsTestShr)
 
-TEST_SUBDIRS = \
+clean-local:
+	-$(RM) $(MdsTestShr)
+
+
+
+
+
+
+# //////////////////////////////////////////////////////////////////////////// #
+# //  COLLECT TESTS IN SUBDIRECTORIES  /////////////////////////////////////// #
+# //////////////////////////////////////////////////////////////////////////// #
+
+
+TEST_DIRS ?= \
                mdsobjects/python/tests \
                mdslib/testing \
                mdsobjects/cpp/testing
 #              testing/selftest
 
-TEST_OUTDIR    ?= ${top_builddir}/testing
+TEST_OUTDIR  ?= ${top_builddir}/testing
 
 
 
 .PHONY: $(tests_DIRS) $(clean_DIRS) $(tests_valgrind_DIRS) $(tests_valgrind_suppressions_DIRS)
-tests_DIRS = $(addprefix tests__$(top_builddir)/, $(TEST_SUBDIRS))
-clean_DIRS = $(addprefix clean__$(top_builddir)/, $(TEST_SUBDIRS))
-tests_valgrind_DIRS = $(addprefix tests_valgrind__$(top_builddir)/, $(TEST_SUBDIRS))
-tests_valgrind_suppressions_DIRS = $(addprefix tests_valgrind_suppressions__$(top_builddir)/, $(TEST_SUBDIRS))
+tests_DIRS  = $(addprefix tests__$(top_builddir)/, $(TEST_DIRS))
+clean_DIRS  = $(addprefix clean__$(top_builddir)/, $(TEST_DIRS))
+tests_valgrind_DIRS = $(addprefix tests_valgrind__$(top_builddir)/, $(TEST_DIRS))
+tests_valgrind_suppressions_DIRS = $(addprefix tests_valgrind_suppressions__$(top_builddir)/, $(TEST_DIRS))
 $(tests_DIRS):
 	-$(MAKE) $(AM_MAKEFLAGS) -C $(@:tests__%=%) tests
 
@@ -61,24 +75,19 @@ $(tests_valgrind_suppressions_DIRS):
 tests: $(tests_DIRS)
 	@ \
 	echo " -------- CUT HERE for Jenkins  --------------- "; \
-	echo $(addsuffix *.tap,$(TEST_SUBDIRS)); \
+	echo $(addsuffix *.tap,$(TEST_DIRS)); \
 	echo " ---------------------------------------------- "
 
 tests-valgrind: $(tests_valgrind_DIRS)
 	@ \
 	echo " -------- CUT HERE for Jenkins  --------------- "; \
-	echo $(addsuffix *-valgrind-*.xml,$(TEST_SUBDIRS)); \
+	echo $(addsuffix *-valgrind-*.xml,$(TEST_DIRS)); \
 	echo " ---------------------------------------------- "
 
 tests-valgrind-suppressions: $(tests_valgrind_suppressions_DIRS)
 
 tests-clean: $(clean_DIRS)
 
-
-all-local: $(MdsTestShr)
-
-clean-local:
-	-$(RM) $(MdsTestShr)
 
 
 

--- a/testing/Makefile.in
+++ b/testing/Makefile.in
@@ -535,15 +535,10 @@ libMdsTest_a_SOURCES = base_backend.c
 libMdsTestBackend_a_CFLAGS = -D_TESTING -I${srcdir}/backends/check $(AM_CFLAGS)
 libMdsTestBackend_a_SOURCES = check_backend.c
 MdsTestShr = @MAKESHLIBDIR@@LIBPRE@MdsTestShr@SHARETYPE@
-TEST_SUBDIRS = \
-               mdsobjects/python/tests \
-               mdslib/testing \
-               mdsobjects/cpp/testing
-
-tests_DIRS = $(addprefix tests__$(top_builddir)/, $(TEST_SUBDIRS))
-clean_DIRS = $(addprefix clean__$(top_builddir)/, $(TEST_SUBDIRS))
-tests_valgrind_DIRS = $(addprefix tests_valgrind__$(top_builddir)/, $(TEST_SUBDIRS))
-tests_valgrind_suppressions_DIRS = $(addprefix tests_valgrind_suppressions__$(top_builddir)/, $(TEST_SUBDIRS))
+tests_DIRS = $(addprefix tests__$(top_builddir)/, $(TEST_DIRS))
+clean_DIRS = $(addprefix clean__$(top_builddir)/, $(TEST_DIRS))
+tests_valgrind_DIRS = $(addprefix tests_valgrind__$(top_builddir)/, $(TEST_DIRS))
+tests_valgrind_suppressions_DIRS = $(addprefix tests_valgrind_suppressions__$(top_builddir)/, $(TEST_DIRS))
 all: all-recursive
 
 .SUFFIXES:
@@ -931,9 +926,23 @@ include @top_builddir@/Makefile.inc
 @MINGW_TRUE@ MAKE_IMPLIB_MdsTestShr=-Wl,--out-implib,@MAKELIBDIR@MdsTestShr.dll.a
 $(MdsTestShr): backends/check/libCheck.a libMdsTestBackend.a
 	$(CXX) $(TARGET_ARCH) $(CXXFLAGS) $(OUTPUT_OPTION) @LINKSHARED@ -Wl,-whole-archive $^ -Wl,-no-whole-archive $(LDFLAGS) $(LIBS) $(MAKE_IMPLIB_MdsTestShr)
+
+all-local: $(MdsTestShr)
+
+clean-local:
+	-$(RM) $(MdsTestShr)
+
+# //////////////////////////////////////////////////////////////////////////// #
+# //  COLLECT TESTS IN SUBDIRECTORIES  /////////////////////////////////////// #
+# //////////////////////////////////////////////////////////////////////////// #
+
+TEST_DIRS ?= \
+               mdsobjects/python/tests \
+               mdslib/testing \
+               mdsobjects/cpp/testing
 #              testing/selftest
 
-TEST_OUTDIR    ?= ${top_builddir}/testing
+TEST_OUTDIR  ?= ${top_builddir}/testing
 
 .PHONY: $(tests_DIRS) $(clean_DIRS) $(tests_valgrind_DIRS) $(tests_valgrind_suppressions_DIRS)
 $(tests_DIRS):
@@ -952,23 +961,18 @@ $(tests_valgrind_suppressions_DIRS):
 tests: $(tests_DIRS)
 	@ \
 	echo " -------- CUT HERE for Jenkins  --------------- "; \
-	echo $(addsuffix *.tap,$(TEST_SUBDIRS)); \
+	echo $(addsuffix *.tap,$(TEST_DIRS)); \
 	echo " ---------------------------------------------- "
 
 tests-valgrind: $(tests_valgrind_DIRS)
 	@ \
 	echo " -------- CUT HERE for Jenkins  --------------- "; \
-	echo $(addsuffix *-valgrind-*.xml,$(TEST_SUBDIRS)); \
+	echo $(addsuffix *-valgrind-*.xml,$(TEST_DIRS)); \
 	echo " ---------------------------------------------- "
 
 tests-valgrind-suppressions: $(tests_valgrind_suppressions_DIRS)
 
 tests-clean: $(clean_DIRS)
-
-all-local: $(MdsTestShr)
-
-clean-local:
-	-$(RM) $(MdsTestShr)
 
 # Tell versions [3.59,3.63) of GNU make to not export all variables.
 # Otherwise a system limit (for SysV at least) may be exceeded.


### PR DESCRIPTION
makes it possible to select tests subdirectories to be performed by tests target with:
make tests TEST_DIRS="mdslib/testing mdsobject/python/tests"

P.S.   TODO: )
we shall add a tests target per component directory so the above command will also accept  TEST_DIRS="mdslib mdsobject/python ... "
