### PR TITLE
add autostore method for use by boards connecting back and asking for…

### DIFF
--- a/tdi/MitDevices/acq132.py
+++ b/tdi/MitDevices/acq132.py
@@ -79,7 +79,7 @@ class ACQ132(acq.ACQ):
         if self.debugging():
             print "have pre trig\n";
 
-        post_trig = self.getInt(self.active_chan, DevBAD_POST_TRIG)*1024
+        post_trig = self.getInt(self.post_trig, DevBAD_POST_TRIG)*1024
         if self.debugging():
             print "have post trig\n";
 
@@ -136,15 +136,15 @@ class ACQ132(acq.ACQ):
 
     INITFTP=initftp
 
-    def store(self, arg="checks"):
+    def store(self, arg1='checks', arg2='noauto'):
         import MitDevices
         import time
         if self.debugging():
             print "Begining store\n"
 
-        self.checkTrigger()
+        self.checkTrigger(arg1, arg2)
         self.loadSettings()
-        self.checkTreeAndShot(arg)
+        self.checkTreeAndShot(arg1, arg2)
         self.storeStatusCommands()
 
         preTrig = self.getPreTrig()

--- a/tdi/MitDevices/acq196.py
+++ b/tdi/MitDevices/acq196.py
@@ -80,7 +80,7 @@ class ACQ196(acq.ACQ):
         if self.debugging():
             print "have pre trig\n";
 
-        post_trig = self.getInt(self.active_chan, DevBAD_POST_TRIG)*1024
+        post_trig = self.getInt(self.post_trig, DevBAD_POST_TRIG)*1024
         if self.debugging():
             print "have post trig\n";
 
@@ -160,13 +160,13 @@ class ACQ196(acq.ACQ):
 
     INITFTP=initftp
         
-    def store(self, arg='checks'):
+    def store(self, arg1='checks', arg2='noauto'):
         if self.debugging():
             print "Begining store\n"
 
-        self.checkTrigger()
+        self.checkTrigger(arg1, arg2)
         self.loadSettings()
-        self.checkTreeAndShot(arg)
+        self.checkTreeAndShot(arg1, arg2)
         self.storeStatusCommands()
 
         preTrig = self.getPreTrig()

--- a/tdi/MitDevices/acq216.py
+++ b/tdi/MitDevices/acq216.py
@@ -79,7 +79,7 @@ class ACQ216(acq.ACQ):
         if self.debugging():
             print "have pre trig\n";
 
-        post_trig = self.getInt(self.active_chan, DevBAD_POST_TRIG)*1024
+        post_trig = self.getInt(self.post_trig, DevBAD_POST_TRIG)*1024
         if self.debugging():
             print "have post trig\n";
 
@@ -184,14 +184,13 @@ class ACQ216(acq.ACQ):
 
     INITFTP=initftp
         
-    def store(self, arg='checks'):
-
+    def store(self, arg1='checks', arg2='noauto'):
         if self.debugging():
             print "Begining store\n"
 
-        self.checkTrigger()
+        self.checkTrigger(arg1, arg2)
         self.loadSettings()
-        self.checkTreeAndShot(arg)
+        self.checkTreeAndShot(arg1, arg2)
         self.storeStatusCommands()
 
         preTrig = self.getPreTrig()


### PR DESCRIPTION
… store to be done

When checking for a trigger if the store method is being done by the user:
i.e. do /meth store
the code must wait for the board to complete its post processing step

When the board is doing a store, this is part of the post processing step, but performed
after the board has done its other 'system' post processing.  The store method used in this
case needs to count a 'I'm post processing' response from the board as OK
