### PR TITLE
change exceptions from class references to instances.

### DIFF
--- a/tdi/MitDevices/acq132.py
+++ b/tdi/MitDevices/acq132.py
@@ -50,23 +50,21 @@ class ACQ132(acq.ACQ):
 
         active_chan = self.getInteger(self.active_chan, DevBAD_ACTIVE_CHAN)
         if active_chan not in (8,16,32) :
-            raise DevBAD_ACTIVE_CHAN
+            raise DevBAD_ACTIVE_CHAN()
         if self.debugging():
             print "have active chan\n";
 
         try:
             trig_src=self.trig_src.record.getOriginalPartName().getString()[1:]
         except Exception, e:
-            print "trigger source error: %s" %(e,)
-            raise DevBAD_TRIG_SRC
+            raise DevBAD_TRIG_SRC(str(e))
         if self.debugging():
             print "have trig_src\n";
 
         try:
             clock_src=self.clock_src.record.getOriginalPartName().getString()[1:]
-        except:
-            print "clock source error: %s" %(e,)
-            raise DevBAD_CLOCK_SRC
+        except Exception, e:
+            raise DevBAD_CLOCK_SRC(str(e))
         if self.debugging():
             print "have clock src\n";
 

--- a/tdi/MitDevices/acq196.py
+++ b/tdi/MitDevices/acq196.py
@@ -51,23 +51,21 @@ class ACQ196(acq.ACQ):
 
         active_chan = self.getInteger(self.active_chan, DevBAD_ACTIVE_CHAN)
         if active_chan not in (32,64,96) :
-            raise DevBAD_ACTIVE_CHAN
+            raise DevBAD_ACTIVE_CHAN()
         if self.debugging():
             print "have active chan\n";
 
         try:
             trig_src=self.trig_src.record.getOriginalPartName().getString()[1:]
         except Exception, e:
-            print "trigger source error: %s" %(e,)
-            raise DevBAD_TRIG_SRC
+            raise DevBAD_TRIG_SRC(str(e))
         if self.debugging():
             print "have trig_src\n";
 
         try:
             clock_src=self.clock_src.record.getOriginalPartName().getString()[1:]
-        except:
-            print "clock source error: %s" %(e,)
-            raise DevBAD_CLOCK_SRC
+        except Exception, e:
+            raise DevBAD_CLOCK_SRC(str(e))
         if self.debugging():
             print "have clock src\n";
 

--- a/tdi/MitDevices/acq216.py
+++ b/tdi/MitDevices/acq216.py
@@ -50,23 +50,21 @@ class ACQ216(acq.ACQ):
 
         active_chan = self.getInteger(self.active_chan, DevBAD_ACTIVE_CHAN)
         if active_chan not in (4,8,16) :
-            raise DevBAD_ACTIVE_CHAN
+            raise DevBAD_ACTIVE_CHAN()
         if self.debugging():
             print "have active chan\n";
 
         try:
             trig_src=self.trig_src.record.getOriginalPartName().getString()[1:]
         except Exception, e:
-            print "trigger source error: %s" %(e,)
-            raise DevBAD_TRIG_SRC
+            raise DevBAD_TRIG_SRC(str(e))
         if self.debugging():
             print "have trig_src\n";
 
         try:
             clock_src=self.clock_src.record.getOriginalPartName().getString()[1:]
-        except:
-            print "clock source error: %s" %(e,)
-            raise DevBAD_CLOCK_SRC
+        except Exception, e:
+            raise DevBAD_CLOCK_SRC(str(e))
         if self.debugging():
             print "have clock src\n";
 


### PR DESCRIPTION
Change exceptions that are raised from classes to instances.

This allows added arguments to be specified, which in turn means that we can remove some of the prints for error conditions in the code.
