### PR TITLE
Have to use units() not units_of() to find units. units_of just retur…

### DIFF
--- a/mdsobjects/python/mdsdata.py
+++ b/mdsobjects/python/mdsdata.py
@@ -137,7 +137,7 @@ class Data(object):
         """Return the TDI evaluation of UNITS_OF(this).
         EmptyData is returned if no units defined.
         @rtype: Data"""
-        return Data.execute('units_of($)',self)
+        return Data.execute('units($)',self)
     def setUnits(self,units):
         """Set the units of the Data instance.
         @type: String


### PR DESCRIPTION
…ns the units of an MDSplus data item while units() tries to find units by looking at properties of the data which might reference other nodes whose data contains the units.
