### PR TITLE
Add __contains__ method to mdsscalar.String

### DIFF
--- a/mdsobjects/python/mdsscalar.py
+++ b/mdsobjects/python/mdsscalar.py
@@ -208,6 +208,10 @@ class String(Scalar):
         """Add: x.__add__(y) <==> x+y
         @rtype: Data"""
         return self.execute('$//$',self,y)
+    def __contains__(self,y):
+        """Contains: x.__contains__(y) <==> y in x
+        @rtype: Bool"""
+        return str(self._value).find(str(y)) != -1
     def __str__(self):
         """String: x.__str__() <==> str(x)
         @rtype: String"""


### PR DESCRIPTION
Python's `in` operator does not behave as expected when dealing directly with MDSplus Strings because the class falls back on the `__getitem__` method.  This works when the test string is either completely absent or exactly matching, but not when it is a substring.  See [docs](https://docs.python.org/2/reference/datamodel.html#object.__contains__).

I would not say that all methods of the built-in type should be implemented for MDSplus Strings, since one can always convert with `str()`.  In this case I think it is necessary, however, because the users's code works for some data but behaves surprisingly for other data.

Tested with Python 2.7 and 3.5.
