### PR TITLE
Twf fix none in list

### DIFF
--- a/mdsobjects/python/mdsdata.py
+++ b/mdsobjects/python/mdsdata.py
@@ -262,7 +262,10 @@ class Data(object):
     def __eq__(self,y):
         """Equals: x.__eq__(y) <==> x==y
         @rtype: Bool"""
-        return Data.execute('$ == $',self,y).bool()
+        try:
+            return Data.execute('$ == $',self,y).bool()
+        except:
+            return False
 
     def __hasBadTreeReferences__(self,tree):
         return False


### PR DESCRIPTION
This supports the use of List data type containing None items. For example:

In Python:

> > > from MDSplus import Tree
> > > t=Tree('test',-1)
> > > t.MYNODE.record=[1,'test',None,2]
> > > MYLIST=t.MYNODE.record
> > > print(MYLIST)
> > > [1, "test", *, 2]
> > > 1 in MYLIST
> > > True
> > > None in MYLIST
> > > True
> > > 'test' in MYLIST
> > > True
> > > 3 in MYLIST
> > > False
