### PR TITLE
fix for tests to make stdout available in log format

### DIFF
--- a/deploy/jenkins_build
+++ b/deploy/jenkins_build
@@ -148,7 +148,7 @@ test_64 () {
 	    then
 		$MAKE -k tests-valgrind TEST_FORMAT=tap 2>&1;
 	    else
-		$MAKE -k tests-valgrind VALGRIND_TOOLS="${VG_TESTS}" TEST_FORMAT=ta 2>&1;
+		$MAKE -k tests-valgrind VALGRIND_TOOLS="${VG_TESTS}" 2>&1;
 	    fi
 	    tests_valgrind64=$?;
 	fi
@@ -182,7 +182,7 @@ test_64 () {
 		fi
 		$MAKE
 		$MAKE install
-		$MAKE -k tests TEST_FORMAT=tap 2>&1;
+		$MAKE -k tests TEST_FORMAT=log 2>&1;
 		test_64_san_${test}=$?
 		popd
 	    done
@@ -223,7 +223,7 @@ test_32() {
 	    then
 		$MAKE -k tests-valgrind TEST_FORMAT=tap 2>&1;
 	    else
-		$MAKE -k tests-valgrind VALGRIND_TOOLS="${VG_TESTS}" TEST_FORMAT=tap 2>&1;
+		$MAKE -k tests-valgrind VALGRIND_TOOLS="${VG_TESTS}" 2>&1;
 	    fi
 	    tests_valgrind32=$?;
 	fi
@@ -261,7 +261,7 @@ test_32() {
 		fi
 		$MAKE
 		$MAKE install
-		$MAKE -k tests
+		$MAKE -k tests TEST_FORMAT=log
 		test_32_san_${test}=$?
 		popd
 	    done

--- a/testing/check_backend.c
+++ b/testing/check_backend.c
@@ -573,20 +573,25 @@ void __test_init(const char *test_name, const char *file, const int line) {
         // init logger NORMAL by default //
         srunner_init_logging(runner, print_mode);        
         
+        // format of the tests output //
         char *format = getenv("TEST_FORMAT");
-        if(format) { 
-            
-            // stdout redirected to file //
-            FILE *newout = switchStdout(NULL);
-            
+        
+        // to preserve the output format the stdout must be redirected. If no
+        // env is defined the result will be null and stdout will be
+        // suppressed. The log format preserves the normal stdout as no special
+        // formatting is needed.        
+        char *stdout_file = getenv("TEST_STDOUT_FILE");
+        
+        if(format) {
             if( !strcmp(format,"log") || !strcmp(format,"LOG"))            
-                srunner_register_lfun(runner, newout, 0, lfile_lfun, print_mode);
+                srunner_register_lfun(runner, stdout, 0, lfile_lfun, print_mode);
             else if( !strcmp(format,"tap") || !strcmp(format,"TAP"))            
-                srunner_register_lfun(runner, newout, 0, tap_lfun, print_mode);
+                srunner_register_lfun(runner, switchStdout(stdout_file), 0, tap_lfun, print_mode);
             else if( !strcmp(format,"xml") || !strcmp(format,"XML"))            
-                srunner_register_lfun(runner, newout, 0, xml_lfun, print_mode);
+                srunner_register_lfun(runner, switchStdout(stdout_file), 0, xml_lfun, print_mode);
         }
         else {
+            // default to log format //
             srunner_register_lfun(runner, stdout, 0, stdout_lfun, print_mode);            
         }
         
@@ -596,10 +601,7 @@ void __test_init(const char *test_name, const char *file, const int line) {
         // send runner start event //
         log_srunner_start(runner);    
         log_suite_start(runner,suite);    
-        
-        // set fork //
-        //        set_fork_status(srunner_fork_status(runner));
-        
+                
         // set up message pipe in check_msg //
         setup_messaging(); 
         


### PR DESCRIPTION
Tom, I fixed the library to enable tests stdout in log format and modified the sanitize tests in jenkins-build to use TEST_FORMAT=log ..
