### PR TITLE
Remove labview objects routine called mdsplus_event_abort which was u…

### DIFF
--- a/mdsobjects/labview/mdseventobjectswrp.cpp
+++ b/mdsobjects/labview/mdseventobjectswrp.cpp
@@ -36,7 +36,7 @@ EXPORT void mdsplus_event_destructor(void **lvEventPtr)
 	delete eventPtr;
 	*lvEventPtr = NULL;
 }
-
+/*
 EXPORT void mdsplus_event_abort(const void *lvEventPtr, ErrorCluster *error)
 {
 	Event *eventPtr = NULL;
@@ -57,7 +57,7 @@ EXPORT void mdsplus_event_abort(const void *lvEventPtr, ErrorCluster *error)
 	}
 	fillErrorCluster(errorCode, errorSource, errorMessage, error);
 }
-
+*/
 EXPORT void mdsplus_event_waitData(const void *lvEventPtr, void **lvDataPtrOut, int *timeoutOccurred, ErrorCluster *error)
 {
 	MgErr errorCode = noErr;

--- a/mdsobjects/labview/mdsobjectswrp.h
+++ b/mdsobjects/labview/mdsobjectswrp.h
@@ -238,7 +238,7 @@ extern "C" {
 					int *timeoutOccurred, ErrorCluster * error);
   EXPORT void mdsplus_event_wait(const void *lvEventPtr, int *timeoutOccurred,
 				    ErrorCluster * error);
-  EXPORT void mdsplus_event_abort(const void *lvEventPtr, ErrorCluster * error);
+  // EXPORT void mdsplus_event_abort(const void *lvEventPtr, ErrorCluster * error);
   EXPORT void mdsplus_event_getName(const void *lvEventPtr, LStrHandle lvStrHdlOut,
 				       ErrorCluster * error);
   EXPORT void mdsplus_event_waitRaw(const void *lvEventPtr, LByteArrHdl lvByteArrHdlOut,


### PR DESCRIPTION
…sing an unimplemented abort method of the Event class. This entry point does not appear in any of the LabView objects and is not referenced by anything.
