### PR TITLE
Fix length of string returned by LibSysAscTim

### DIFF
--- a/mdsshr/librtl.c
+++ b/mdsshr/librtl.c
@@ -1008,7 +1008,7 @@ EXPORT int LibSysAscTim(unsigned short *len, struct descriptor *str, int *time_i
 {
   char *time_str;
   char time_out[24];
-  unsigned short slen = sizeof(time_out);
+  unsigned short slen = sizeof(time_out)-1;
   time_t bintim = LibCvtTim(time_in, 0);
   int64_t chunks = time_in ? *(int64_t *)time_in % 10000000 : 0;
   time_str = ctime(&bintim);


### PR DESCRIPTION
This fixes a problem with the date_time() tdi function returning a string descriptor with a length 1 character longer than it should causing it to reference uninitialized memory.
