### PR TITLE
jTraverser fixed NullPointerException

### DIFF
--- a/javatraverser/Node.java
+++ b/javatraverser/Node.java
@@ -598,7 +598,7 @@ public class Node
                                           "Error copying subtree",
                                           JOptionPane.WARNING_MESSAGE);
         }
-        Tree.setCurrTreeNode(savedTreeNode);
+        Tree.setCurrentNode(savedTreeNode);
     }
 
     public static void copySubtreeContent(Node fromNode, Node toNode)


### PR DESCRIPTION
fixed NullPointerException by handling the value of Tree.curr_node 
using getters and setters for a better control and sync selected
TreeNode with curr_node defaulting to TOP if old ref becomes invalid
