### PR TITLE
adds check for JAVA_HOME eventually set JDK_DIR to JAVA_HOME

### DIFF
--- a/LabView/Makefile.in
+++ b/LabView/Makefile.in
@@ -91,7 +91,8 @@ host_triplet = @host@
 target_triplet = @target@
 subdir = LabView
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
-am__aclocal_m4_deps = $(top_srcdir)/m4/ax_compare_version.m4 \
+am__aclocal_m4_deps = $(top_srcdir)/m4/ax_check_java_home.m4 \
+	$(top_srcdir)/m4/ax_compare_version.m4 \
 	$(top_srcdir)/m4/ax_compiler_vendor.m4 \
 	$(top_srcdir)/m4/ax_compiler_version.m4 \
 	$(top_srcdir)/m4/m4_ac_search_readline.m4 \
@@ -261,6 +262,7 @@ INSTALL_STRIP_PROGRAM = @INSTALL_STRIP_PROGRAM@
 JAR = @JAR@
 JAVAC = @JAVAC@
 JAVACFLAGS = @JAVACFLAGS@
+JAVAC_PATH_NAME = @JAVAC_PATH_NAME@
 JAVA_APS = @JAVA_APS@
 JDK_CFLAGS = @JDK_CFLAGS@
 JDK_DIR = @JDK_DIR@

--- a/actions/Makefile.in
+++ b/actions/Makefile.in
@@ -95,7 +95,8 @@ target_triplet = @target@
 bin_PROGRAMS = actions$(EXEEXT) actmon$(EXEEXT)
 subdir = actions
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
-am__aclocal_m4_deps = $(top_srcdir)/m4/ax_compare_version.m4 \
+am__aclocal_m4_deps = $(top_srcdir)/m4/ax_check_java_home.m4 \
+	$(top_srcdir)/m4/ax_compare_version.m4 \
 	$(top_srcdir)/m4/ax_compiler_vendor.m4 \
 	$(top_srcdir)/m4/ax_compiler_version.m4 \
 	$(top_srcdir)/m4/m4_ac_search_readline.m4 \
@@ -310,6 +311,7 @@ INSTALL_STRIP_PROGRAM = @INSTALL_STRIP_PROGRAM@
 JAR = @JAR@
 JAVAC = @JAVAC@
 JAVACFLAGS = @JAVACFLAGS@
+JAVAC_PATH_NAME = @JAVAC_PATH_NAME@
 JAVA_APS = @JAVA_APS@
 JDK_CFLAGS = @JDK_CFLAGS@
 JDK_DIR = @JDK_DIR@

--- a/configure
+++ b/configure
@@ -844,6 +844,7 @@ GLOBUSLICENSE_TRUE
 RMIC
 JAR
 JAVAC
+JAVAC_PATH_NAME
 RPATHLINK
 RPATHLINK_FALSE
 RPATHLINK_TRUE
@@ -8449,6 +8450,94 @@ fi
 
 
 
+# //////////////////////////////////////////////////////////////////////////// #
+# ///  JDK   ///////////////////////////////////////////////////////////////// #
+# //////////////////////////////////////////////////////////////////////////// #
+
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for JAVA_HOME" >&5
+$as_echo_n "checking for JAVA_HOME... " >&6; }
+# We used a fake loop so that we can use "break" when the result is found.
+while true
+do
+  # If the user defined JAVA_HOME, don't touch it.
+  if ${JAVA_HOME+:} false; then :
+  break
+fi
+
+  # On Mac OS X 10.5 and following, run /usr/libexec/java_home to get
+  # the value of JAVA_HOME to use.
+  # (http://developer.apple.com/library/mac/#qa/qa2001/qa1170.html).
+  JAVA_HOME=`/usr/libexec/java_home 2>/dev/null`
+  if ${JAVA_HOME+:} false; then :
+  break
+fi
+
+  # Extract the first word of "javac", so it can be a program name with args.
+set dummy javac; ac_word=$2
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
+$as_echo_n "checking for $ac_word... " >&6; }
+if ${ac_cv_path_JAVAC_PATH_NAME+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  case $JAVAC_PATH_NAME in
+  [\\/]* | ?:[\\/]*)
+  ac_cv_path_JAVAC_PATH_NAME="$JAVAC_PATH_NAME" # Let the user override the test with a path.
+  ;;
+  *)
+  as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
+for as_dir in $PATH
+do
+  IFS=$as_save_IFS
+  test -z "$as_dir" && as_dir=.
+    for ac_exec_ext in '' $ac_executable_extensions; do
+  if as_fn_executable_p "$as_dir/$ac_word$ac_exec_ext"; then
+    ac_cv_path_JAVAC_PATH_NAME="$as_dir/$ac_word$ac_exec_ext"
+    $as_echo "$as_me:${as_lineno-$LINENO}: found $as_dir/$ac_word$ac_exec_ext" >&5
+    break 2
+  fi
+done
+  done
+IFS=$as_save_IFS
+
+  ;;
+esac
+fi
+JAVAC_PATH_NAME=$ac_cv_path_JAVAC_PATH_NAME
+if test -n "$JAVAC_PATH_NAME"; then
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $JAVAC_PATH_NAME" >&5
+$as_echo "$JAVAC_PATH_NAME" >&6; }
+else
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+fi
+
+
+  if ${JAVAC_PATH_NAME+:} false; then :
+  JAVA_HOME=`echo ${JAVAC_PATH_NAME} \
+                 | sed "s/\(.*\)[/]bin[/]java.*/\1/"`
+fi
+  if ${JAVA_HOME+:} false; then :
+  break
+fi
+
+
+  { $as_echo "$as_me:${as_lineno-$LINENO}: Could not compute JAVA_HOME" >&5
+$as_echo "$as_me: Could not compute JAVA_HOME" >&6;}
+  break
+done
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $JAVA_HOME" >&5
+$as_echo "$JAVA_HOME" >&6; }
+
+if ${JDK_DIR+:} false; then :
+
+else
+  if ${JAVA_HOME+:} false; then :
+  JDK_DIR=${JAVA_HOME}
+fi
+
+fi
+
+
 # Check whether --with-jdk was given.
 if test "${with_jdk+set}" = set; then :
   withval=$with_jdk;
@@ -8617,6 +8706,9 @@ fi
   *) :
      ;;
 esac
+
+
+
 
  if test -r $exec_prefix/GLOBUS_LICENSE; then
   GLOBUSLICENSE_TRUE=

--- a/configure.ac
+++ b/configure.ac
@@ -169,6 +169,18 @@ dnl                                                       [LDFLAGS="-Wl,-syslibr
 dnl                                                       [F77=fort77])])
 dnl AC_MSG_RESULT([$enable_java])
 
+
+# //////////////////////////////////////////////////////////////////////////// #
+# ///  JDK   ///////////////////////////////////////////////////////////////// #
+# //////////////////////////////////////////////////////////////////////////// #
+
+dnl This is a workaround to maintain both JAVA_HOME and JDK_DIR env
+AC_CHECK_JAVA_HOME
+AS_VAR_SET_IF([JDK_DIR],,
+              [AS_VAR_SET_IF([JAVA_HOME],
+                             [AS_VAR_SET([JDK_DIR],[${JAVA_HOME}])])
+              ])
+
 AC_ARG_WITH([jdk],
             [AS_HELP_STRING([--with-jdk=JDKDIR],
                             [specify location of java jdk])],
@@ -200,6 +212,9 @@ AS_CASE([$enable_java],
                 AC_PATH_PROG([JAVAC], [javac], [], [$with_jdk/bin$PATH_SEPARATOR$PATH])
                 AC_PATH_PROG([JAR], [jar], [], [$with_jdk/bin$PATH_SEPARATOR$PATH])
                 AC_PATH_PROG([RMIC], [rmic], [], [$with_jdk/bin$PATH_SEPARATOR$PATH])])
+
+
+
 
 AM_CONDITIONAL([GLOBUSLICENSE], [test -r $exec_prefix/GLOBUS_LICENSE])
 

--- a/docs/Makefile.in
+++ b/docs/Makefile.in
@@ -120,7 +120,8 @@ host_triplet = @host@
 target_triplet = @target@
 subdir = docs
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
-am__aclocal_m4_deps = $(top_srcdir)/m4/ax_compare_version.m4 \
+am__aclocal_m4_deps = $(top_srcdir)/m4/ax_check_java_home.m4 \
+	$(top_srcdir)/m4/ax_compare_version.m4 \
 	$(top_srcdir)/m4/ax_compiler_vendor.m4 \
 	$(top_srcdir)/m4/ax_compiler_version.m4 \
 	$(top_srcdir)/m4/m4_ac_search_readline.m4 \
@@ -263,6 +264,7 @@ INSTALL_STRIP_PROGRAM = @INSTALL_STRIP_PROGRAM@
 JAR = @JAR@
 JAVAC = @JAVAC@
 JAVACFLAGS = @JAVACFLAGS@
+JAVAC_PATH_NAME = @JAVAC_PATH_NAME@
 JAVA_APS = @JAVA_APS@
 JDK_CFLAGS = @JDK_CFLAGS@
 JDK_DIR = @JDK_DIR@

--- a/dwscope/Makefile.in
+++ b/dwscope/Makefile.in
@@ -94,7 +94,8 @@ target_triplet = @target@
 bin_PROGRAMS = dwscope$(EXEEXT) dwscope_remote$(EXEEXT) dwpad$(EXEEXT)
 subdir = dwscope
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
-am__aclocal_m4_deps = $(top_srcdir)/m4/ax_compare_version.m4 \
+am__aclocal_m4_deps = $(top_srcdir)/m4/ax_check_java_home.m4 \
+	$(top_srcdir)/m4/ax_compare_version.m4 \
 	$(top_srcdir)/m4/ax_compiler_vendor.m4 \
 	$(top_srcdir)/m4/ax_compiler_version.m4 \
 	$(top_srcdir)/m4/m4_ac_search_readline.m4 \
@@ -322,6 +323,7 @@ INSTALL_STRIP_PROGRAM = @INSTALL_STRIP_PROGRAM@
 JAR = @JAR@
 JAVAC = @JAVAC@
 JAVACFLAGS = @JAVACFLAGS@
+JAVAC_PATH_NAME = @JAVAC_PATH_NAME@
 JAVA_APS = @JAVA_APS@
 JDK_CFLAGS = @JDK_CFLAGS@
 JDK_DIR = @JDK_DIR@

--- a/icons/Makefile.in
+++ b/icons/Makefile.in
@@ -92,7 +92,8 @@ target_triplet = @target@
 bin_PROGRAMS = icons$(EXEEXT)
 subdir = icons
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
-am__aclocal_m4_deps = $(top_srcdir)/m4/ax_compare_version.m4 \
+am__aclocal_m4_deps = $(top_srcdir)/m4/ax_check_java_home.m4 \
+	$(top_srcdir)/m4/ax_compare_version.m4 \
 	$(top_srcdir)/m4/ax_compiler_vendor.m4 \
 	$(top_srcdir)/m4/ax_compiler_version.m4 \
 	$(top_srcdir)/m4/m4_ac_search_readline.m4 \
@@ -271,6 +272,7 @@ INSTALL_STRIP_PROGRAM = @INSTALL_STRIP_PROGRAM@
 JAR = @JAR@
 JAVAC = @JAVAC@
 JAVACFLAGS = @JAVACFLAGS@
+JAVAC_PATH_NAME = @JAVAC_PATH_NAME@
 JAVA_APS = @JAVA_APS@
 JDK_CFLAGS = @JDK_CFLAGS@
 JDK_DIR = @JDK_DIR@

--- a/javaclient/Makefile.in
+++ b/javaclient/Makefile.in
@@ -91,7 +91,8 @@ host_triplet = @host@
 target_triplet = @target@
 subdir = javaclient
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
-am__aclocal_m4_deps = $(top_srcdir)/m4/ax_compare_version.m4 \
+am__aclocal_m4_deps = $(top_srcdir)/m4/ax_check_java_home.m4 \
+	$(top_srcdir)/m4/ax_compare_version.m4 \
 	$(top_srcdir)/m4/ax_compiler_vendor.m4 \
 	$(top_srcdir)/m4/ax_compiler_version.m4 \
 	$(top_srcdir)/m4/m4_ac_search_readline.m4 \
@@ -262,6 +263,7 @@ INSTALL_STRIP_PROGRAM = @INSTALL_STRIP_PROGRAM@
 JAR = @JAR@
 JAVAC = @JAVAC@
 JAVACFLAGS = @JAVACFLAGS@
+JAVAC_PATH_NAME = @JAVAC_PATH_NAME@
 JAVA_APS = @JAVA_APS@
 JDK_CFLAGS = @JDK_CFLAGS@
 JDK_DIR = @JDK_DIR@

--- a/javadevices/Makefile.in
+++ b/javadevices/Makefile.in
@@ -91,7 +91,8 @@ host_triplet = @host@
 target_triplet = @target@
 subdir = javadevices
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
-am__aclocal_m4_deps = $(top_srcdir)/m4/ax_compare_version.m4 \
+am__aclocal_m4_deps = $(top_srcdir)/m4/ax_check_java_home.m4 \
+	$(top_srcdir)/m4/ax_compare_version.m4 \
 	$(top_srcdir)/m4/ax_compiler_vendor.m4 \
 	$(top_srcdir)/m4/ax_compiler_version.m4 \
 	$(top_srcdir)/m4/m4_ac_search_readline.m4 \
@@ -278,6 +279,7 @@ INSTALL_STRIP_PROGRAM = @INSTALL_STRIP_PROGRAM@
 JAR = @JAR@
 JAVAC = @JAVAC@
 JAVACFLAGS = @JAVACFLAGS@
+JAVAC_PATH_NAME = @JAVAC_PATH_NAME@
 JAVA_APS = @JAVA_APS@
 JDK_CFLAGS = @JDK_CFLAGS@
 JDK_DIR = @JDK_DIR@

--- a/javadispatcher/Makefile.in
+++ b/javadispatcher/Makefile.in
@@ -92,7 +92,8 @@ host_triplet = @host@
 target_triplet = @target@
 subdir = javadispatcher
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
-am__aclocal_m4_deps = $(top_srcdir)/m4/ax_compare_version.m4 \
+am__aclocal_m4_deps = $(top_srcdir)/m4/ax_check_java_home.m4 \
+	$(top_srcdir)/m4/ax_compare_version.m4 \
 	$(top_srcdir)/m4/ax_compiler_vendor.m4 \
 	$(top_srcdir)/m4/ax_compiler_version.m4 \
 	$(top_srcdir)/m4/m4_ac_search_readline.m4 \
@@ -265,6 +266,7 @@ INSTALL_STRIP_PROGRAM = @INSTALL_STRIP_PROGRAM@
 JAR = @JAR@
 JAVAC = @JAVAC@
 JAVACFLAGS = @JAVACFLAGS@
+JAVAC_PATH_NAME = @JAVAC_PATH_NAME@
 JAVA_APS = @JAVA_APS@
 JDK_CFLAGS = @JDK_CFLAGS@
 JDK_DIR = @JDK_DIR@

--- a/javascope/Makefile.in
+++ b/javascope/Makefile.in
@@ -94,7 +94,8 @@ target_triplet = @target@
 @MINGW_FALSE@am__append_2 = $(bin_SCRIPTS)
 subdir = javascope
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
-am__aclocal_m4_deps = $(top_srcdir)/m4/ax_compare_version.m4 \
+am__aclocal_m4_deps = $(top_srcdir)/m4/ax_check_java_home.m4 \
+	$(top_srcdir)/m4/ax_compare_version.m4 \
 	$(top_srcdir)/m4/ax_compiler_vendor.m4 \
 	$(top_srcdir)/m4/ax_compiler_version.m4 \
 	$(top_srcdir)/m4/m4_ac_search_readline.m4 \
@@ -268,6 +269,7 @@ INSTALL_STRIP_PROGRAM = @INSTALL_STRIP_PROGRAM@
 JAR = @JAR@
 JAVAC = @JAVAC@
 JAVACFLAGS = @JAVACFLAGS@
+JAVAC_PATH_NAME = @JAVAC_PATH_NAME@
 JAVA_APS = @JAVA_APS@
 JDK_CFLAGS = @JDK_CFLAGS@
 JDK_DIR = @JDK_DIR@

--- a/javatraverser/Makefile.in
+++ b/javatraverser/Makefile.in
@@ -94,7 +94,8 @@ target_triplet = @target@
 @MINGW_FALSE@am__append_2 = jTraverser.template
 subdir = javatraverser
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
-am__aclocal_m4_deps = $(top_srcdir)/m4/ax_compare_version.m4 \
+am__aclocal_m4_deps = $(top_srcdir)/m4/ax_check_java_home.m4 \
+	$(top_srcdir)/m4/ax_compare_version.m4 \
 	$(top_srcdir)/m4/ax_compiler_vendor.m4 \
 	$(top_srcdir)/m4/ax_compiler_version.m4 \
 	$(top_srcdir)/m4/m4_ac_search_readline.m4 \
@@ -283,6 +284,7 @@ INSTALL_STRIP_PROGRAM = @INSTALL_STRIP_PROGRAM@
 JAR = @JAR@
 JAVAC = @JAVAC@
 JAVACFLAGS = @JAVACFLAGS@
+JAVAC_PATH_NAME = @JAVAC_PATH_NAME@
 JAVA_APS = @JAVA_APS@
 JDK_CFLAGS = @JDK_CFLAGS@
 JDK_DIR = @JDK_DIR@

--- a/m4/ax_check_java_home.m4
+++ b/m4/ax_check_java_home.m4
@@ -1,0 +1,80 @@
+# ===========================================================================
+#    http://www.gnu.org/software/autoconf-archive/ax_check_java_home.html
+# ===========================================================================
+#
+# SYNOPSIS
+#
+#   AX_CHECK_JAVA_HOME
+#
+# DESCRIPTION
+#
+#   Check for Sun Java (JDK / JRE) installation, where the 'java' VM is in.
+#   If found, set environment variable JAVA_HOME = Java installation home,
+#   else left JAVA_HOME untouch, which in most case means JAVA_HOME is
+#   empty.
+#
+#   - JAVA_HOME: must point to installation directory of JDK.
+#   - JRE_HOME: must point to installation directory of JRE.
+#   - CLASSPATH: contains libraries path which JVM will look for.
+#   - PATH: normal environment variable on Windows.
+#
+# LICENSE
+#
+#   Copyright (c) 2008 Gleen Salmon <gleensalmon@yahoo.com>
+#
+#   This program is free software; you can redistribute it and/or modify it
+#   under the terms of the GNU General Public License as published by the
+#   Free Software Foundation; either version 2 of the License, or (at your
+#   option) any later version.
+#
+#   This program is distributed in the hope that it will be useful, but
+#   WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+#   Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License along
+#   with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+#   As a special exception, the respective Autoconf Macro's copyright owner
+#   gives unlimited permission to copy, distribute and modify the configure
+#   scripts that are the output of Autoconf when processing the Macro. You
+#   need not follow the terms of the GNU General Public License when using
+#   or distributing such scripts, even though portions of the text of the
+#   Macro appear in them. The GNU General Public License (GPL) does govern
+#   all other use of the material that constitutes the Autoconf Macro.
+#
+#   This special exception to the GPL applies to versions of the Autoconf
+#   Macro released by the Autoconf Archive. When you make and distribute a
+#   modified version of the Autoconf Macro, you may extend this special
+#   exception to the GPL to apply to your modified version as well.
+
+#serial 7
+
+AU_ALIAS([AC_CHECK_JAVA_HOME], [AX_CHECK_JAVA_HOME])
+
+AC_DEFUN([AX_CHECK_JAVA_HOME],
+[AC_MSG_CHECKING([for JAVA_HOME])
+# We used a fake loop so that we can use "break" when the result is found.
+while true
+do
+  # If the user defined JAVA_HOME, don't touch it.
+  AS_VAR_SET_IF([JAVA_HOME],[break])
+
+  # On Mac OS X 10.5 and following, run /usr/libexec/java_home to get
+  # the value of JAVA_HOME to use.
+  # (http://developer.apple.com/library/mac/#qa/qa2001/qa1170.html).
+  JAVA_HOME=`/usr/libexec/java_home 2>/dev/null`
+  AS_VAR_SET_IF([JAVA_HOME],[break])  
+
+  AC_PATH_PROG([JAVAC_PATH_NAME], [javac])
+  AS_VAR_SET_IF([JAVAC_PATH_NAME],[JAVA_HOME=`echo ${JAVAC_PATH_NAME} \
+                 | sed "s/\(.*\)[[/]]bin[[/]]java.*/\1/"`])
+  AS_VAR_SET_IF([JAVA_HOME],[break])  
+  
+
+  AC_MSG_NOTICE([Could not compute JAVA_HOME])
+  break
+done
+AC_MSG_RESULT([$JAVA_HOME])
+])
+

--- a/macosx/Makefile.in
+++ b/macosx/Makefile.in
@@ -92,7 +92,8 @@ host_triplet = @host@
 target_triplet = @target@
 subdir = macosx
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
-am__aclocal_m4_deps = $(top_srcdir)/m4/ax_compare_version.m4 \
+am__aclocal_m4_deps = $(top_srcdir)/m4/ax_check_java_home.m4 \
+	$(top_srcdir)/m4/ax_compare_version.m4 \
 	$(top_srcdir)/m4/ax_compiler_vendor.m4 \
 	$(top_srcdir)/m4/ax_compiler_version.m4 \
 	$(top_srcdir)/m4/m4_ac_search_readline.m4 \
@@ -265,6 +266,7 @@ INSTALL_STRIP_PROGRAM = @INSTALL_STRIP_PROGRAM@
 JAR = @JAR@
 JAVAC = @JAVAC@
 JAVACFLAGS = @JAVACFLAGS@
+JAVAC_PATH_NAME = @JAVAC_PATH_NAME@
 JAVA_APS = @JAVA_APS@
 JDK_CFLAGS = @JDK_CFLAGS@
 JDK_DIR = @JDK_DIR@

--- a/manpages/Makefile.in
+++ b/manpages/Makefile.in
@@ -90,7 +90,8 @@ host_triplet = @host@
 target_triplet = @target@
 subdir = manpages
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
-am__aclocal_m4_deps = $(top_srcdir)/m4/ax_compare_version.m4 \
+am__aclocal_m4_deps = $(top_srcdir)/m4/ax_check_java_home.m4 \
+	$(top_srcdir)/m4/ax_compare_version.m4 \
 	$(top_srcdir)/m4/ax_compiler_vendor.m4 \
 	$(top_srcdir)/m4/ax_compiler_version.m4 \
 	$(top_srcdir)/m4/m4_ac_search_readline.m4 \
@@ -263,6 +264,7 @@ INSTALL_STRIP_PROGRAM = @INSTALL_STRIP_PROGRAM@
 JAR = @JAR@
 JAVAC = @JAVAC@
 JAVACFLAGS = @JAVACFLAGS@
+JAVAC_PATH_NAME = @JAVAC_PATH_NAME@
 JAVA_APS = @JAVA_APS@
 JDK_CFLAGS = @JDK_CFLAGS@
 JDK_DIR = @JDK_DIR@

--- a/mdslib/docs/Makefile.in
+++ b/mdslib/docs/Makefile.in
@@ -120,7 +120,8 @@ host_triplet = @host@
 target_triplet = @target@
 subdir = mdslib/docs
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
-am__aclocal_m4_deps = $(top_srcdir)/m4/ax_compare_version.m4 \
+am__aclocal_m4_deps = $(top_srcdir)/m4/ax_check_java_home.m4 \
+	$(top_srcdir)/m4/ax_compare_version.m4 \
 	$(top_srcdir)/m4/ax_compiler_vendor.m4 \
 	$(top_srcdir)/m4/ax_compiler_version.m4 \
 	$(top_srcdir)/m4/m4_ac_search_readline.m4 \
@@ -264,6 +265,7 @@ INSTALL_STRIP_PROGRAM = @INSTALL_STRIP_PROGRAM@
 JAR = @JAR@
 JAVAC = @JAVAC@
 JAVACFLAGS = @JAVACFLAGS@
+JAVAC_PATH_NAME = @JAVAC_PATH_NAME@
 JAVA_APS = @JAVA_APS@
 JDK_CFLAGS = @JDK_CFLAGS@
 JDK_DIR = @JDK_DIR@

--- a/mdslib/testing/Makefile.in
+++ b/mdslib/testing/Makefile.in
@@ -97,7 +97,8 @@ TESTS = dtype_test$(EXEEXT)
 check_PROGRAMS = $(am__EXEEXT_1)
 subdir = mdslib/testing
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
-am__aclocal_m4_deps = $(top_srcdir)/m4/ax_compare_version.m4 \
+am__aclocal_m4_deps = $(top_srcdir)/m4/ax_check_java_home.m4 \
+	$(top_srcdir)/m4/ax_compare_version.m4 \
 	$(top_srcdir)/m4/ax_compiler_vendor.m4 \
 	$(top_srcdir)/m4/ax_compiler_version.m4 \
 	$(top_srcdir)/m4/m4_ac_search_readline.m4 \
@@ -483,6 +484,7 @@ INSTALL_STRIP_PROGRAM = @INSTALL_STRIP_PROGRAM@
 JAR = @JAR@
 JAVAC = @JAVAC@
 JAVACFLAGS = @JAVACFLAGS@
+JAVAC_PATH_NAME = @JAVAC_PATH_NAME@
 JAVA_APS = @JAVA_APS@
 JDK_CFLAGS = @JDK_CFLAGS@
 JDK_DIR = @JDK_DIR@

--- a/mdsobjects/cpp/docs/Makefile.in
+++ b/mdsobjects/cpp/docs/Makefile.in
@@ -120,7 +120,8 @@ host_triplet = @host@
 target_triplet = @target@
 subdir = mdsobjects/cpp/docs
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
-am__aclocal_m4_deps = $(top_srcdir)/m4/ax_compare_version.m4 \
+am__aclocal_m4_deps = $(top_srcdir)/m4/ax_check_java_home.m4 \
+	$(top_srcdir)/m4/ax_compare_version.m4 \
 	$(top_srcdir)/m4/ax_compiler_vendor.m4 \
 	$(top_srcdir)/m4/ax_compiler_version.m4 \
 	$(top_srcdir)/m4/m4_ac_search_readline.m4 \
@@ -266,6 +267,7 @@ INSTALL_STRIP_PROGRAM = @INSTALL_STRIP_PROGRAM@
 JAR = @JAR@
 JAVAC = @JAVAC@
 JAVACFLAGS = @JAVACFLAGS@
+JAVAC_PATH_NAME = @JAVAC_PATH_NAME@
 JAVA_APS = @JAVA_APS@
 JDK_CFLAGS = @JDK_CFLAGS@
 JDK_DIR = @JDK_DIR@

--- a/mdsobjects/cpp/testing/Makefile.in
+++ b/mdsobjects/cpp/testing/Makefile.in
@@ -109,7 +109,8 @@ TESTS = buildtest$(EXEEXT) MdsExceptionTest$(EXEEXT) \
 check_PROGRAMS = $(am__EXEEXT_1)
 subdir = mdsobjects/cpp/testing
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
-am__aclocal_m4_deps = $(top_srcdir)/m4/ax_compare_version.m4 \
+am__aclocal_m4_deps = $(top_srcdir)/m4/ax_check_java_home.m4 \
+	$(top_srcdir)/m4/ax_compare_version.m4 \
 	$(top_srcdir)/m4/ax_compiler_vendor.m4 \
 	$(top_srcdir)/m4/ax_compiler_version.m4 \
 	$(top_srcdir)/m4/m4_ac_search_readline.m4 \
@@ -685,6 +686,7 @@ INSTALL_STRIP_PROGRAM = @INSTALL_STRIP_PROGRAM@
 JAR = @JAR@
 JAVAC = @JAVAC@
 JAVACFLAGS = @JAVACFLAGS@
+JAVAC_PATH_NAME = @JAVAC_PATH_NAME@
 JAVA_APS = @JAVA_APS@
 JDK_CFLAGS = @JDK_CFLAGS@
 JDK_DIR = @JDK_DIR@

--- a/mdsobjects/cpp/testing/testutils/Makefile.in
+++ b/mdsobjects/cpp/testing/testutils/Makefile.in
@@ -92,7 +92,8 @@ host_triplet = @host@
 target_triplet = @target@
 subdir = mdsobjects/cpp/testing/testutils
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
-am__aclocal_m4_deps = $(top_srcdir)/m4/ax_compare_version.m4 \
+am__aclocal_m4_deps = $(top_srcdir)/m4/ax_check_java_home.m4 \
+	$(top_srcdir)/m4/ax_compare_version.m4 \
 	$(top_srcdir)/m4/ax_compiler_vendor.m4 \
 	$(top_srcdir)/m4/ax_compiler_version.m4 \
 	$(top_srcdir)/m4/m4_ac_search_readline.m4 \
@@ -321,6 +322,7 @@ INSTALL_STRIP_PROGRAM = @INSTALL_STRIP_PROGRAM@
 JAR = @JAR@
 JAVAC = @JAVAC@
 JAVACFLAGS = @JAVACFLAGS@
+JAVAC_PATH_NAME = @JAVAC_PATH_NAME@
 JAVA_APS = @JAVA_APS@
 JDK_CFLAGS = @JDK_CFLAGS@
 JDK_DIR = @JDK_DIR@

--- a/mdsobjects/java/Makefile.in
+++ b/mdsobjects/java/Makefile.in
@@ -91,7 +91,8 @@ host_triplet = @host@
 target_triplet = @target@
 subdir = mdsobjects/java
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
-am__aclocal_m4_deps = $(top_srcdir)/m4/ax_compare_version.m4 \
+am__aclocal_m4_deps = $(top_srcdir)/m4/ax_check_java_home.m4 \
+	$(top_srcdir)/m4/ax_compare_version.m4 \
 	$(top_srcdir)/m4/ax_compiler_vendor.m4 \
 	$(top_srcdir)/m4/ax_compiler_version.m4 \
 	$(top_srcdir)/m4/m4_ac_search_readline.m4 \
@@ -278,6 +279,7 @@ INSTALL_STRIP_PROGRAM = @INSTALL_STRIP_PROGRAM@
 JAR = @JAR@
 JAVAC = @JAVAC@
 JAVACFLAGS = @JAVACFLAGS@
+JAVAC_PATH_NAME = @JAVAC_PATH_NAME@
 JAVA_APS = @JAVA_APS@
 JDK_CFLAGS = @JDK_CFLAGS@
 JDK_DIR = @JDK_DIR@

--- a/mdsobjects/java/docs/Makefile.in
+++ b/mdsobjects/java/docs/Makefile.in
@@ -120,7 +120,8 @@ host_triplet = @host@
 target_triplet = @target@
 subdir = mdsobjects/java/docs
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
-am__aclocal_m4_deps = $(top_srcdir)/m4/ax_compare_version.m4 \
+am__aclocal_m4_deps = $(top_srcdir)/m4/ax_check_java_home.m4 \
+	$(top_srcdir)/m4/ax_compare_version.m4 \
 	$(top_srcdir)/m4/ax_compiler_vendor.m4 \
 	$(top_srcdir)/m4/ax_compiler_version.m4 \
 	$(top_srcdir)/m4/m4_ac_search_readline.m4 \
@@ -264,6 +265,7 @@ INSTALL_STRIP_PROGRAM = @INSTALL_STRIP_PROGRAM@
 JAR = @JAR@
 JAVAC = @JAVAC@
 JAVACFLAGS = @JAVACFLAGS@
+JAVAC_PATH_NAME = @JAVAC_PATH_NAME@
 JAVA_APS = @JAVA_APS@
 JDK_CFLAGS = @JDK_CFLAGS@
 JDK_DIR = @JDK_DIR@

--- a/mdsobjects/python/docs/Makefile.in
+++ b/mdsobjects/python/docs/Makefile.in
@@ -120,7 +120,8 @@ host_triplet = @host@
 target_triplet = @target@
 subdir = mdsobjects/python/docs
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
-am__aclocal_m4_deps = $(top_srcdir)/m4/ax_compare_version.m4 \
+am__aclocal_m4_deps = $(top_srcdir)/m4/ax_check_java_home.m4 \
+	$(top_srcdir)/m4/ax_compare_version.m4 \
 	$(top_srcdir)/m4/ax_compiler_vendor.m4 \
 	$(top_srcdir)/m4/ax_compiler_version.m4 \
 	$(top_srcdir)/m4/m4_ac_search_readline.m4 \
@@ -264,6 +265,7 @@ INSTALL_STRIP_PROGRAM = @INSTALL_STRIP_PROGRAM@
 JAR = @JAR@
 JAVAC = @JAVAC@
 JAVACFLAGS = @JAVACFLAGS@
+JAVAC_PATH_NAME = @JAVAC_PATH_NAME@
 JAVA_APS = @JAVA_APS@
 JDK_CFLAGS = @JDK_CFLAGS@
 JDK_DIR = @JDK_DIR@

--- a/mdsobjects/python/tests/Makefile.in
+++ b/mdsobjects/python/tests/Makefile.in
@@ -96,7 +96,8 @@ target_triplet = @target@
 check_PROGRAMS =
 subdir = mdsobjects/python/tests
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
-am__aclocal_m4_deps = $(top_srcdir)/m4/ax_compare_version.m4 \
+am__aclocal_m4_deps = $(top_srcdir)/m4/ax_check_java_home.m4 \
+	$(top_srcdir)/m4/ax_compare_version.m4 \
 	$(top_srcdir)/m4/ax_compiler_vendor.m4 \
 	$(top_srcdir)/m4/ax_compiler_version.m4 \
 	$(top_srcdir)/m4/m4_ac_search_readline.m4 \
@@ -437,6 +438,7 @@ INSTALL_STRIP_PROGRAM = @INSTALL_STRIP_PROGRAM@
 JAR = @JAR@
 JAVAC = @JAVAC@
 JAVACFLAGS = @JAVACFLAGS@
+JAVAC_PATH_NAME = @JAVAC_PATH_NAME@
 JAVA_APS = @JAVA_APS@
 JDK_CFLAGS = @JDK_CFLAGS@
 JDK_DIR = @JDK_DIR@

--- a/mdsshr/docs/Makefile.in
+++ b/mdsshr/docs/Makefile.in
@@ -120,7 +120,8 @@ host_triplet = @host@
 target_triplet = @target@
 subdir = mdsshr/docs
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
-am__aclocal_m4_deps = $(top_srcdir)/m4/ax_compare_version.m4 \
+am__aclocal_m4_deps = $(top_srcdir)/m4/ax_check_java_home.m4 \
+	$(top_srcdir)/m4/ax_compare_version.m4 \
 	$(top_srcdir)/m4/ax_compiler_vendor.m4 \
 	$(top_srcdir)/m4/ax_compiler_version.m4 \
 	$(top_srcdir)/m4/m4_ac_search_readline.m4 \
@@ -264,6 +265,7 @@ INSTALL_STRIP_PROGRAM = @INSTALL_STRIP_PROGRAM@
 JAR = @JAR@
 JAVAC = @JAVAC@
 JAVACFLAGS = @JAVACFLAGS@
+JAVAC_PATH_NAME = @JAVAC_PATH_NAME@
 JAVA_APS = @JAVA_APS@
 JDK_CFLAGS = @JDK_CFLAGS@
 JDK_DIR = @JDK_DIR@

--- a/mdstcpip/docs/Makefile.in
+++ b/mdstcpip/docs/Makefile.in
@@ -120,7 +120,8 @@ host_triplet = @host@
 target_triplet = @target@
 subdir = mdstcpip/docs
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
-am__aclocal_m4_deps = $(top_srcdir)/m4/ax_compare_version.m4 \
+am__aclocal_m4_deps = $(top_srcdir)/m4/ax_check_java_home.m4 \
+	$(top_srcdir)/m4/ax_compare_version.m4 \
 	$(top_srcdir)/m4/ax_compiler_vendor.m4 \
 	$(top_srcdir)/m4/ax_compiler_version.m4 \
 	$(top_srcdir)/m4/m4_ac_search_readline.m4 \
@@ -324,6 +325,7 @@ INSTALL_STRIP_PROGRAM = @INSTALL_STRIP_PROGRAM@
 JAR = @JAR@
 JAVAC = @JAVAC@
 JAVACFLAGS = @JAVACFLAGS@
+JAVAC_PATH_NAME = @JAVAC_PATH_NAME@
 JAVA_APS = @JAVA_APS@
 JDK_CFLAGS = @JDK_CFLAGS@
 JDK_DIR = @JDK_DIR@

--- a/mdstcpip/docs/img/Makefile.in
+++ b/mdstcpip/docs/img/Makefile.in
@@ -90,7 +90,8 @@ host_triplet = @host@
 target_triplet = @target@
 subdir = mdstcpip/docs/img
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
-am__aclocal_m4_deps = $(top_srcdir)/m4/ax_compare_version.m4 \
+am__aclocal_m4_deps = $(top_srcdir)/m4/ax_check_java_home.m4 \
+	$(top_srcdir)/m4/ax_compare_version.m4 \
 	$(top_srcdir)/m4/ax_compiler_vendor.m4 \
 	$(top_srcdir)/m4/ax_compiler_version.m4 \
 	$(top_srcdir)/m4/m4_ac_search_readline.m4 \
@@ -230,6 +231,7 @@ INSTALL_STRIP_PROGRAM = @INSTALL_STRIP_PROGRAM@
 JAR = @JAR@
 JAVAC = @JAVAC@
 JAVACFLAGS = @JAVACFLAGS@
+JAVAC_PATH_NAME = @JAVAC_PATH_NAME@
 JAVA_APS = @JAVA_APS@
 JDK_CFLAGS = @JDK_CFLAGS@
 JDK_DIR = @JDK_DIR@

--- a/mdstcpip/zlib/Makefile.in
+++ b/mdstcpip/zlib/Makefile.in
@@ -92,7 +92,8 @@ host_triplet = @host@
 target_triplet = @target@
 subdir = mdstcpip/zlib
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
-am__aclocal_m4_deps = $(top_srcdir)/m4/ax_compare_version.m4 \
+am__aclocal_m4_deps = $(top_srcdir)/m4/ax_check_java_home.m4 \
+	$(top_srcdir)/m4/ax_compare_version.m4 \
 	$(top_srcdir)/m4/ax_compiler_vendor.m4 \
 	$(top_srcdir)/m4/ax_compiler_version.m4 \
 	$(top_srcdir)/m4/m4_ac_search_readline.m4 \
@@ -311,6 +312,7 @@ INSTALL_STRIP_PROGRAM = @INSTALL_STRIP_PROGRAM@
 JAR = @JAR@
 JAVAC = @JAVAC@
 JAVACFLAGS = @JAVACFLAGS@
+JAVAC_PATH_NAME = @JAVAC_PATH_NAME@
 JAVA_APS = @JAVA_APS@
 JDK_CFLAGS = @JDK_CFLAGS@
 JDK_DIR = @JDK_DIR@

--- a/rpm/Makefile.in
+++ b/rpm/Makefile.in
@@ -92,7 +92,8 @@ host_triplet = @host@
 target_triplet = @target@
 subdir = rpm
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
-am__aclocal_m4_deps = $(top_srcdir)/m4/ax_compare_version.m4 \
+am__aclocal_m4_deps = $(top_srcdir)/m4/ax_check_java_home.m4 \
+	$(top_srcdir)/m4/ax_compare_version.m4 \
 	$(top_srcdir)/m4/ax_compiler_vendor.m4 \
 	$(top_srcdir)/m4/ax_compiler_version.m4 \
 	$(top_srcdir)/m4/m4_ac_search_readline.m4 \
@@ -271,6 +272,7 @@ INSTALL_STRIP_PROGRAM = @INSTALL_STRIP_PROGRAM@
 JAR = @JAR@
 JAVAC = @JAVAC@
 JAVACFLAGS = @JAVACFLAGS@
+JAVAC_PATH_NAME = @JAVAC_PATH_NAME@
 JAVA_APS = @JAVA_APS@
 JDK_CFLAGS = @JDK_CFLAGS@
 JDK_DIR = @JDK_DIR@

--- a/scripts/Makefile.in
+++ b/scripts/Makefile.in
@@ -91,7 +91,8 @@ host_triplet = @host@
 target_triplet = @target@
 subdir = scripts
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
-am__aclocal_m4_deps = $(top_srcdir)/m4/ax_compare_version.m4 \
+am__aclocal_m4_deps = $(top_srcdir)/m4/ax_check_java_home.m4 \
+	$(top_srcdir)/m4/ax_compare_version.m4 \
 	$(top_srcdir)/m4/ax_compiler_vendor.m4 \
 	$(top_srcdir)/m4/ax_compiler_version.m4 \
 	$(top_srcdir)/m4/m4_ac_search_readline.m4 \
@@ -264,6 +265,7 @@ INSTALL_STRIP_PROGRAM = @INSTALL_STRIP_PROGRAM@
 JAR = @JAR@
 JAVAC = @JAVAC@
 JAVACFLAGS = @JAVACFLAGS@
+JAVAC_PATH_NAME = @JAVAC_PATH_NAME@
 JAVA_APS = @JAVA_APS@
 JDK_CFLAGS = @JDK_CFLAGS@
 JDK_DIR = @JDK_DIR@

--- a/setevent/Makefile.in
+++ b/setevent/Makefile.in
@@ -92,7 +92,8 @@ target_triplet = @target@
 bin_PROGRAMS = setevent$(EXEEXT)
 subdir = setevent
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
-am__aclocal_m4_deps = $(top_srcdir)/m4/ax_compare_version.m4 \
+am__aclocal_m4_deps = $(top_srcdir)/m4/ax_check_java_home.m4 \
+	$(top_srcdir)/m4/ax_compare_version.m4 \
 	$(top_srcdir)/m4/ax_compiler_vendor.m4 \
 	$(top_srcdir)/m4/ax_compiler_version.m4 \
 	$(top_srcdir)/m4/m4_ac_search_readline.m4 \
@@ -272,6 +273,7 @@ INSTALL_STRIP_PROGRAM = @INSTALL_STRIP_PROGRAM@
 JAR = @JAR@
 JAVAC = @JAVAC@
 JAVACFLAGS = @JAVACFLAGS@
+JAVAC_PATH_NAME = @JAVAC_PATH_NAME@
 JAVA_APS = @JAVA_APS@
 JDK_CFLAGS = @JDK_CFLAGS@
 JDK_DIR = @JDK_DIR@

--- a/tdishr/testing/Makefile.in
+++ b/tdishr/testing/Makefile.in
@@ -97,7 +97,8 @@ TESTS = build_test$(EXEEXT)
 check_PROGRAMS = $(am__EXEEXT_1)
 subdir = tdishr/testing
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
-am__aclocal_m4_deps = $(top_srcdir)/m4/ax_compare_version.m4 \
+am__aclocal_m4_deps = $(top_srcdir)/m4/ax_check_java_home.m4 \
+	$(top_srcdir)/m4/ax_compare_version.m4 \
 	$(top_srcdir)/m4/ax_compiler_vendor.m4 \
 	$(top_srcdir)/m4/ax_compiler_version.m4 \
 	$(top_srcdir)/m4/m4_ac_search_readline.m4 \
@@ -483,6 +484,7 @@ INSTALL_STRIP_PROGRAM = @INSTALL_STRIP_PROGRAM@
 JAR = @JAR@
 JAVAC = @JAVAC@
 JAVACFLAGS = @JAVACFLAGS@
+JAVAC_PATH_NAME = @JAVAC_PATH_NAME@
 JAVA_APS = @JAVA_APS@
 JDK_CFLAGS = @JDK_CFLAGS@
 JDK_DIR = @JDK_DIR@

--- a/testing/Makefile.in
+++ b/testing/Makefile.in
@@ -91,7 +91,8 @@ host_triplet = @host@
 target_triplet = @target@
 subdir = testing
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
-am__aclocal_m4_deps = $(top_srcdir)/m4/ax_compare_version.m4 \
+am__aclocal_m4_deps = $(top_srcdir)/m4/ax_check_java_home.m4 \
+	$(top_srcdir)/m4/ax_compare_version.m4 \
 	$(top_srcdir)/m4/ax_compiler_vendor.m4 \
 	$(top_srcdir)/m4/ax_compiler_version.m4 \
 	$(top_srcdir)/m4/m4_ac_search_readline.m4 \
@@ -327,6 +328,7 @@ INSTALL_STRIP_PROGRAM = @INSTALL_STRIP_PROGRAM@
 JAR = @JAR@
 JAVAC = @JAVAC@
 JAVACFLAGS = @JAVACFLAGS@
+JAVAC_PATH_NAME = @JAVAC_PATH_NAME@
 JAVA_APS = @JAVA_APS@
 JDK_CFLAGS = @JDK_CFLAGS@
 JDK_DIR = @JDK_DIR@

--- a/testing/backends/check/Makefile.in
+++ b/testing/backends/check/Makefile.in
@@ -93,7 +93,8 @@ target_triplet = @target@
 bin_PROGRAMS = build_test$(EXEEXT)
 subdir = testing/backends/check
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
-am__aclocal_m4_deps = $(top_srcdir)/m4/ax_compare_version.m4 \
+am__aclocal_m4_deps = $(top_srcdir)/m4/ax_check_java_home.m4 \
+	$(top_srcdir)/m4/ax_compare_version.m4 \
 	$(top_srcdir)/m4/ax_compiler_vendor.m4 \
 	$(top_srcdir)/m4/ax_compiler_version.m4 \
 	$(top_srcdir)/m4/m4_ac_search_readline.m4 \
@@ -295,6 +296,7 @@ INSTALL_STRIP_PROGRAM = @INSTALL_STRIP_PROGRAM@
 JAR = @JAR@
 JAVAC = @JAVAC@
 JAVACFLAGS = @JAVACFLAGS@
+JAVAC_PATH_NAME = @JAVAC_PATH_NAME@
 JAVA_APS = @JAVA_APS@
 JDK_CFLAGS = @JDK_CFLAGS@
 JDK_DIR = @JDK_DIR@

--- a/testing/selftest/Makefile.in
+++ b/testing/selftest/Makefile.in
@@ -99,7 +99,8 @@ bin_PROGRAMS = example3$(EXEEXT) example_assert$(EXEEXT)
 check_PROGRAMS = $(am__EXEEXT_1)
 subdir = testing/selftest
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
-am__aclocal_m4_deps = $(top_srcdir)/m4/ax_compare_version.m4 \
+am__aclocal_m4_deps = $(top_srcdir)/m4/ax_check_java_home.m4 \
+	$(top_srcdir)/m4/ax_compare_version.m4 \
 	$(top_srcdir)/m4/ax_compiler_vendor.m4 \
 	$(top_srcdir)/m4/ax_compiler_version.m4 \
 	$(top_srcdir)/m4/m4_ac_search_readline.m4 \
@@ -553,6 +554,7 @@ INSTALL_STRIP_PROGRAM = @INSTALL_STRIP_PROGRAM@
 JAR = @JAR@
 JAVAC = @JAVAC@
 JAVACFLAGS = @JAVACFLAGS@
+JAVAC_PATH_NAME = @JAVAC_PATH_NAME@
 JAVA_APS = @JAVA_APS@
 JDK_CFLAGS = @JDK_CFLAGS@
 JDK_DIR = @JDK_DIR@

--- a/wfevent/Makefile.in
+++ b/wfevent/Makefile.in
@@ -92,7 +92,8 @@ target_triplet = @target@
 bin_PROGRAMS = wfevent$(EXEEXT)
 subdir = wfevent
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
-am__aclocal_m4_deps = $(top_srcdir)/m4/ax_compare_version.m4 \
+am__aclocal_m4_deps = $(top_srcdir)/m4/ax_check_java_home.m4 \
+	$(top_srcdir)/m4/ax_compare_version.m4 \
 	$(top_srcdir)/m4/ax_compiler_vendor.m4 \
 	$(top_srcdir)/m4/ax_compiler_version.m4 \
 	$(top_srcdir)/m4/m4_ac_search_readline.m4 \
@@ -272,6 +273,7 @@ INSTALL_STRIP_PROGRAM = @INSTALL_STRIP_PROGRAM@
 JAR = @JAR@
 JAVAC = @JAVAC@
 JAVACFLAGS = @JAVACFLAGS@
+JAVAC_PATH_NAME = @JAVAC_PATH_NAME@
 JAVA_APS = @JAVA_APS@
 JDK_CFLAGS = @JDK_CFLAGS@
 JDK_DIR = @JDK_DIR@


### PR DESCRIPTION
This adds a m4 macro that looks for JAVA_HOME in envs .. JAVA_HOME is the standard variable pointing to the JDK directory installed .. if it doesn't find JAVA_HOME set it test the path of the javac executable.

the following are the default java variable that are usually defined:
- JAVA_HOME: must point to installation directory of JDK.
- JRE_HOME: must point to installation directory of JRE.
- CLASSPATH: contains libraries path which JVM will look for.
