### PR TITLE
Twf add pydevice path devices

### DIFF
--- a/mdsobjects/python/mdsdevice.py
+++ b/mdsobjects/python/mdsdevice.py
@@ -4,10 +4,14 @@ def _mimport(name, level=1):
     except:
         return __import__(name, globals())
 
-from os import getenv
+import os as _os
+from os import getenv as _getenv
 _treeshr=_mimport('_treeshr')
 _treenode=_mimport('treenode')
 _compound=_mimport('compound')
+_ident=_mimport('ident')
+_mdsarray=_mimport('mdsarray')
+_mdsdata=_mimport('mdsdata')
 
 class Device(_treenode.TreeNode):
     """Used for device support classes. Provides ORIGINAL_PART_NAME, PART_NAME and Add methods and allows referencing of subnodes as conglomerate node attributes.
@@ -84,7 +88,7 @@ class Device(_treenode.TreeNode):
         for i in range(16):
             self.__setattr__('signals_channel_%02d' % (i+1,),Signal(...))
     """
-    debug = getenv('DEBUG_DEVICES')
+    debug = _getenv('DEBUG_DEVICES')
     gtkThread = None
 
     def __class_init__(cls):
@@ -185,9 +189,17 @@ class Device(_treenode.TreeNode):
         if isinstance(tree, _treenode.TreeNode): tree = tree.tree
         cls.__class_init__()
         _treeshr.TreeStartConglomerate(tree,len(cls.parts)+1)
+        if isinstance(name,_ident.Ident):
+            name=name.data()
         head=parent.addNode(name,'DEVICE')
         head=cls(head)
-        head.record=_compound.Conglom('__python__',cls.__name__,None,"from %s import %s" % (cls.__module__[0:cls.__module__.index('.')],cls.__name__))
+        try:
+            import_string="from %s import %s" % (cls.__module__[0:cls.__module__.index('.')],cls.__name__)
+        except:
+            import_string=None
+                                                 
+                                                                
+        head.record=_compound.Conglom('__python__',cls.__name__,None,import_string)
         head.write_once=True
         import MDSplus
         glob = MDSplus.__dict__
@@ -265,3 +277,54 @@ class Device(_treenode.TreeNode):
     def waitForSetups(cls):
         Device.gtkThread.join()
     waitForSetups=classmethod(waitForSetups)
+
+
+    def importPyDeviceModule(name):
+        """Find a device support module with a case insensitive lookup of
+        'model'.py in the MDS_PYDEVICE_PATH environment variable search list."""
+
+        import __builtin__
+        import sys
+        check_name=name.lower()+".py"
+        path=_os.environ["MDS_PYDEVICE_PATH"]
+        parts=path.split(';')
+        for part in parts:
+            w=_os.walk(part)
+            for dp,dn,fn in w:
+                for fname in fn:
+                    if fname.lower() == check_name:
+                        sys.path.insert(0,dp)
+                        try:
+                            ans=__builtin__.__import__(fname[:-3])
+                        finally:
+                            sys.path.remove(dp)
+                        return ans
+    importPyDeviceModule=staticmethod(importPyDeviceModule)
+
+    def findPyDevices():
+        """Find all device support modules in the MDS_PYDEVICE_PATH environment variable search list."""
+        ans=list()
+        import __builtin__
+        import sys
+        path=_os.environ["MDS_PYDEVICE_PATH"]
+        parts=path.split(';')
+        for part in parts:
+            w=_os.walk(part)
+            for dp,dn,fn in w:
+                for fname in fn:
+                    if fname.endswith('.py'):
+                        sys.path.insert(0,dp)
+                        try:
+                            devnam=fname[:-3].upper()
+                            device=__builtin__.__import__(fname[:-3]).__dict__[devnam]
+                            ans.append(devnam+'\0')
+                            ans.append('\0')
+                        except:
+                            pass
+                        finally:
+                            sys.path.remove(dp)
+        return _mdsdata.Data.execute(str(ans))
+
+
+    findPyDevices=staticmethod(findPyDevices)
+

--- a/mdsobjects/python/mdsdevice.py
+++ b/mdsobjects/python/mdsdevice.py
@@ -286,19 +286,20 @@ class Device(_treenode.TreeNode):
         import __builtin__
         import sys
         check_name=name.lower()+".py"
-        path=_os.environ["MDS_PYDEVICE_PATH"]
-        parts=path.split(';')
-        for part in parts:
-            w=_os.walk(part)
-            for dp,dn,fn in w:
-                for fname in fn:
-                    if fname.lower() == check_name:
-                        sys.path.insert(0,dp)
-                        try:
-                            ans=__builtin__.__import__(fname[:-3])
-                        finally:
-                            sys.path.remove(dp)
-                        return ans
+        if "MDS_PYDEVICE_PATH" in _os.environ:
+            path=_os.environ["MDS_PYDEVICE_PATH"]
+            parts=path.split(';')
+            for part in parts:
+                w=_os.walk(part)
+                for dp,dn,fn in w:
+                    for fname in fn:
+                        if fname.lower() == check_name:
+                            sys.path.insert(0,dp)
+                            try:
+                                ans=__builtin__.__import__(fname[:-3])
+                            finally:
+                                sys.path.remove(dp)
+                            return ans
     importPyDeviceModule=staticmethod(importPyDeviceModule)
 
     def findPyDevices():
@@ -306,23 +307,24 @@ class Device(_treenode.TreeNode):
         ans=list()
         import __builtin__
         import sys
-        path=_os.environ["MDS_PYDEVICE_PATH"]
-        parts=path.split(';')
-        for part in parts:
-            w=_os.walk(part)
-            for dp,dn,fn in w:
-                for fname in fn:
-                    if fname.endswith('.py'):
-                        sys.path.insert(0,dp)
-                        try:
-                            devnam=fname[:-3].upper()
-                            device=__builtin__.__import__(fname[:-3]).__dict__[devnam]
-                            ans.append(devnam+'\0')
-                            ans.append('\0')
-                        except:
-                            pass
-                        finally:
-                            sys.path.remove(dp)
+        if "MDS_PYDEVICE_PATH" in _os.environ:
+            path=_os.environ["MDS_PYDEVICE_PATH"]
+            parts=path.split(';')
+            for part in parts:
+                w=_os.walk(part)
+                for dp,dn,fn in w:
+                    for fname in fn:
+                        if fname.endswith('.py'):
+                            sys.path.insert(0,dp)
+                            try:
+                                devnam=fname[:-3].upper()
+                                device=__builtin__.__import__(fname[:-3]).__dict__[devnam]
+                                ans.append(devnam+'\0')
+                                ans.append('\0')
+                            except:
+                                pass
+                            finally:
+                                sys.path.remove(dp)
         if len(ans) == 0:
             return None
         else:

--- a/mdsobjects/python/mdsdevice.py
+++ b/mdsobjects/python/mdsdevice.py
@@ -323,7 +323,10 @@ class Device(_treenode.TreeNode):
                             pass
                         finally:
                             sys.path.remove(dp)
-        return _mdsdata.Data.execute(str(ans))
+        if len(ans) == 0:
+            return None
+        else:
+            return _mdsdata.Data.execute(str(ans))
 
 
     findPyDevices=staticmethod(findPyDevices)

--- a/tdi/MdsDevices.fun
+++ b/tdi/MdsDevices.fun
@@ -1,5 +1,5 @@
 fun public MdsDevices() {
-  return ( [MitDevices(),
+  return ( [pydevices(), MitDevices(),
 	'DEMOADC\0',		'TutorialDevices\0',
 	'DIO4\0', 		'RfxDevices\0',
 	'SIS3820\0', 		'RfxDevices\0',

--- a/tdi/dev_support/DevAddDevice.fun
+++ b/tdi/dev_support/DevAddDevice.fun
@@ -7,14 +7,20 @@ public fun DevAddDevice(in _path, in _type, optional out _nidout)
     	_models = MdsDevices();
     	_model = UPCASE(_type)//'\000';
     	for (_idx=0; _idx<size(_models); _idx++, _idx++) {
-	if (UPCASE(_models[_idx])==_model) break;
+	  if (UPCASE(_models[_idx])==_model) break;
 	};
-    	if (_idx == size(_models)) return(0);
+    	if (_idx == size(_models))
+	    return(0);
     	_image = trim(_models[_idx+1]);
     	_image = extract(0, len(_image)-1, _image);
+	_rtn = _type//"__add";
     	_nidout = 0l;
-    	_command = '_stat = '//_image//'->'//_type//'__add(descr("'//_path//'"), descr(" "), _nidout)';
-    	if_error(execute(_command),return(0));
+	_addr = 0Q;
+	_stat=MdsShr->LibFindImageSymbol(descr(_image),descr(_rtn),_addr);
+	if (_stat & 1) { 
+    	  _command = '_stat = '//_image//'->'//_type//'__add(descr("'//_path//'"), descr(" "), _nidout)';
+    	  _stat = if_error(execute(_command),0);
+	};
 	return(_stat);
    }	
    _path_q = (extract(0, 1, _path) == '\\') ? '\\'//_path : _path;

--- a/tdi/dev_support/DevAddDevice.fun
+++ b/tdi/dev_support/DevAddDevice.fun
@@ -2,11 +2,13 @@
 public fun DevAddDevice(in _path, in _type, optional out _nidout)
 {
 
-    fun private DevAddCalledDevice(in _path, in _type) 
-    {
+   fun private DevAddCalledDevice(in _path, in _type) 
+   {
     	_models = MdsDevices();
     	_model = UPCASE(_type)//'\000';
-    	for (_idx=0; _idx<size(_models); _idx++, _idx++) if (UPCASE(_models[_idx])==_model) break;
+    	for (_idx=0; _idx<size(_models); _idx++, _idx++) {
+	if (UPCASE(_models[_idx])==_model) break;
+	};
     	if (_idx == size(_models)) return(0);
     	_image = trim(_models[_idx+1]);
     	_image = extract(0, len(_image)-1, _image);
@@ -14,24 +16,11 @@ public fun DevAddDevice(in _path, in _type, optional out _nidout)
     	_command = '_stat = '//_image//'->'//_type//'__add(descr("'//_path//'"), descr(" "), _nidout)';
     	if_error(execute(_command),return(0));
 	return(_stat);
-     }
-/*     fun private DevAddPythonDevice(in _path, in _type) {
-        if (getenv("PyLib") == "") abort();
-    	_models = MdsDevices();
-    	_model = UPCASE(_type)//'\000';
-    	for (_idx=0; _idx<size(_models); _idx++, _idx++) if (UPCASE(_models[_idx])==_model) break;
-    	if (_idx == size(_models)) return(0);
-    	_module = trim(_models[_idx+1]);
-    	_module = extract(0, len(_module)-1, _module);
-	_model = extract(0,len(_model)-1, _model);
-    	_nidout = 0l;
-        _stat = Py(["from MDSplus import Tree","from "//_module//" import "//_model,_model//".Add(Tree(),'"//_path//"')"]);
-        if (_stat == 0) abort();
-	return(_stat);
-     }
-*/
+   }	
    _path_q = (extract(0, 1, _path) == '\\') ? '\\'//_path : _path;
-  _cmd = "_stat = "//_type//'__add("'//_path_q//'", "'//_type//'")';
-  if_error(execute(_cmd), _stat=DevAddPythonDevice(_path, _type), _stat=DevAddCalledDevice(_path_q,_type) ,return(0));
-  return(_stat);
+   _cmd = "_stat = "//_type//'__add("'//_path_q//'", "'//_type//'")';
+   _stat = if_error(execute(_cmd), DevAddCalledDevice(_path_q, _type));
+   if (~(_stat & 1))
+     _stat=DevAddPythonDevice(_path_q,_type);
+   return(_stat);
 }

--- a/tdi/dev_support/DevAddPythonDevice.py
+++ b/tdi/dev_support/DevAddPythonDevice.py
@@ -1,4 +1,4 @@
-from MDSplus import Data, Tree
+from MDSplus import Data, Tree, Device
 import sys
 def DevAddPythonDevice(path, model):
     """Add a python device to the tree by:
@@ -11,8 +11,18 @@ def DevAddPythonDevice(path, model):
     containing blank filled values containing an \0 character embedded.
     These Strings have to be manipulated to produce simple str() values.
     """
-    
-    model = model.data().upper()
+
+    model = model.data().upper().rstrip()
+    mod = Device.importPyDeviceModule(model)
+    if mod is not None and model in mod.__dict__:
+        try:
+            mod.__dict__[model].Add(Tree(), path)
+            return 1
+        except:
+            raise
+            print ("Error adding device instance of %s: %s" % (model, sys.exc_info()[1]))
+            return 0
+        
     path = path.data()
     models = Data.execute('MdsDevices()')
 

--- a/tdi/dev_support/DevAddPythonDevice.py
+++ b/tdi/dev_support/DevAddPythonDevice.py
@@ -1,4 +1,5 @@
 from MDSplus import Data, Tree, Device
+from MDSplus.mdsExceptions import DevPYDEVICE_NOT_FOUND
 import sys
 def DevAddPythonDevice(path, model):
     """Add a python device to the tree by:
@@ -19,7 +20,6 @@ def DevAddPythonDevice(path, model):
             mod.__dict__[model].Add(Tree(), path)
             return 1
         except:
-            raise
             print ("Error adding device instance of %s: %s" % (model, sys.exc_info()[1]))
             return 0
         
@@ -33,13 +33,9 @@ def DevAddPythonDevice(path, model):
             package = models[idx+1].data()
             package = package[0:package.find('\0')]
             if model == modname:
-                try:
-                    __import__(package).__dict__[model].Add(Tree(), path)
-                    return 1
-                except:
-                    print ("Error adding device instance of %s from %s: %s" % (modname, package, sys.exc_info()[1]))
-                    return 0
+                __import__(package).__dict__[model].Add(Tree(), path)
+                return 1
         except:
             pass
-    return 0
+    return DevPYDEVICE_NOT_FOUND.status
     

--- a/tdi/pydevices.py
+++ b/tdi/pydevices.py
@@ -1,0 +1,4 @@
+from MDSplus import Device
+
+def pydevices():
+    return Device.findPyDevices()


### PR DESCRIPTION
This pull request adds support for defining MDSplus devices in a MDS_PYDEVICE_PATH search path similar to finding tdi functions in the MDS_PATH search path. After this new feature it will not be necessary to package python devices into an installable python package or install devices in your python site configuration. Simply put a 'devname'.py python file in the MDS_PYDEVICE_PATH directory search path with an uppercase 'devname' class subclassed from the Device class.

The devices configured this way will also be found by applications like the traverser and included in the list of possible devices when adding a device node to a tree.

Before merging this request please do some testing with existing device support to ensure that this new feature does not adversely affect the handling of existing devices.
