### PR TITLE
Use SIGTERM to terminate server mdsip process in tunnel protocol inst…

### DIFF
--- a/mdsobjects/python/tests/connectionUnitTest.py
+++ b/mdsobjects/python/tests/connectionUnitTest.py
@@ -1,28 +1,26 @@
 from unittest import TestCase,TestSuite
 from connection import Connection
-from event import Event
+from threading import Thread
 
 class connectionTests(TestCase):
 
     def connectionWithThreads(self):
         c=Connection('local://gub')
 
-        class myEvent(Event):
+        class ConnectionThread(Thread):
 
             def run(self):
                 for i in range(1000):
-                    self.test.assertEqual(int(self.c.get('42')),42)
-                self.cancel()
-        e1=myEvent('connectionTestsEvent',100)
-        e1.test=self
-        e1.c=c
-        e2=myEvent('connectionTestsEvent',100)
-        e2.test=self
-        e2.c=c
-        Event.setevent('connectionTestsEvent')
-        e1.join()
-        e2.join()
-        del c
+                    self.test.assertEqual(int(c.get('%d' % i)),i)
+        
+        t1=ConnectionThread()
+        t1.test=self
+        t2=ConnectionThread()
+        t2.test=self
+        t1.start()
+        t2.start()
+        t1.join()
+        t2.join()
 
 
 def suite():

--- a/mdstcpip/IoRoutinesTunnel.c
+++ b/mdstcpip/IoRoutinesTunnel.c
@@ -67,7 +67,7 @@ static int tunnel_disconnect(int id)
 {
   struct TUNNEL_PIPES *p = getTunnelPipes(id);
   if (p) {
-    kill(p->pid, SIGABRT);
+    kill(p->pid, SIGTERM);
     waitpid(p->pid, NULL, WNOHANG);
     close(p->stdin_pipe);
     close(p->stdout_pipe);


### PR DESCRIPTION
…ead of SIGABRT which can cause a core dump. Also use just Thread class for connection tests instead of Event class.
