### PR TITLE
prevent infinite loop (stack)

### DIFF
--- a/mdsobjects/python/mdsscalar.py
+++ b/mdsobjects/python/mdsscalar.py
@@ -40,6 +40,7 @@ def makeScalar(value):
     raise TypeError('Cannot make Scalar out of '+str(type(value)))
 
 class Scalar(_data.Data):
+    _value = None
     def __new__(cls,value=0):
         try:
             if (isinstance(value,_array.Array)) or isinstance(value,list) or isinstance(value, _N.ndarray):


### PR DESCRIPTION
If _value is not defined an infinite loop is generated. This may occur
in __new__ executing line:    return super(Scalar,cls).**new**(cls).
Not sure if it should throw and AttributeError or just return None
