### PR TITLE
Fix pending lock in TreeSetXNci

### DIFF
--- a/treeshr/TreeSegments.c
+++ b/treeshr/TreeSegments.c
@@ -1579,6 +1579,8 @@ int _TreeSetXNci(void *dbid, int nid, char *xnciname, struct descriptor *value)
       SeekToRfa(attributes_offset, local_nci.DATA_INFO.DATA_LOCATION.rfa);
       local_nci.flags2 |= NciM_EXTENDED_NCI;
       TreePutNci(info_ptr, nidx, &local_nci, 0);
+//Required because TreeGetNciLw is holding the lock
+      TreeUnLockNci(info_ptr, 0, nidx);
     } else {
       TreeUnLockNci(info_ptr, 0, nidx);
     }


### PR DESCRIPTION
This change is required to leave NCI unlocked. It did not show using a single thread because that is a recursive lock. However a separate thread of the same process is blocked after the first call to TreeSetXNci
