### PR TITLE
camshr: Fix RemCamStatus function signature warning

### DIFF
--- a/camshr/RemCamIosb.c
+++ b/camshr/RemCamIosb.c
@@ -34,7 +34,7 @@ int RemCamQ(unsigned short *iosb_in)
   return ((iosb[0] & 1) && (iosb[2] & 2));
 }
 
-int RemCamStatus(unsigned char *iosb_in)
+int RemCamStatus(unsigned short *iosb_in)
 {
   unsigned short *iosb = iosb_in ? iosb_in : RemCamLastIosb;
   return (int)iosb[7];


### PR DESCRIPTION
All of the RemCam\* functions take in iosb_in as an unsigned short *.  RemCamStatus takes it in as an unsigned char *, but treats it like an unsigned short *.  Adjust the function definition to take in unsigned short \* like the others, removing a warning.
