### PR TITLE
tdishr TdiCompileDependency.c: Remove unused var

### DIFF
--- a/tdishr/TdiCompileDependency.c
+++ b/tdishr/TdiCompileDependency.c
@@ -8,6 +8,5 @@
 int Tdi1CompileDependency(int opcode, int narg, struct descriptor *list[],
 			  struct descriptor_xd *out_ptr)
 {
-  int status = 1;
   return 1;
 }


### PR DESCRIPTION
Remove status, an unused variable inside an empty function
