### PR TITLE
javamds/JavaTrav.c: Pass pointers to free without cast

### DIFF
--- a/javamds/JavaTrav.c
+++ b/javamds/JavaTrav.c
@@ -809,7 +809,7 @@ JNIEXPORT jobjectArray JNICALL Java_Database_getMembers
     (*env)->SetObjectArrayElement(env, jnids, i, jnid);
   }
   if (num_nids > 0)
-    free((char *)nids);
+    free(nids);
 
 /* //printf("\nEnd getMembers");*/
   return jnids;


### PR DESCRIPTION
The free() function takes in a void\* as its argument, so casting from any pointer type to void\* is wrong, and this code casted from int\* to char*, which is more wrong.  Remove casting entirely.
