### PR TITLE
Set the segmented nci flag when segments are stored in a node

### DIFF
--- a/treeshr/TreeSegments.c
+++ b/treeshr/TreeSegments.c
@@ -633,6 +633,7 @@ old array is same size.
       local_nci.length += add_length;
     else
       local_nci.length = (2 ^ 31);
+    local_nci.flags=local_nci.flags | NciM_SEGMENTED;
     TreePutNci(info_ptr, nidx, &local_nci, 0);
     TreeUnLockNci(info_ptr, 0, nidx);
   }
@@ -2510,6 +2511,7 @@ old array is same size.
       local_nci.flags2 |= NciM_EXTENDED_NCI;
     }
     local_nci.length += add_length;
+    local_nci.flags=local_nci.flags | NciM_SEGMENTED;
     TreePutNci(info_ptr, nidx, &local_nci, 0);
   }
   return status;


### PR DESCRIPTION
The SEGMENTED nci bit was not being set when storing segments in a node so getnci(node,'segments') always returned 0. This pull request is to solve issue https://github.com/MDSplus/mdsplus/issues/462
