### PR TITLE
Update mdsmisc build dep

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -165,7 +165,7 @@ math: mdsshr
 mdsdcl: mdsshr
 mdslib: mdstcpip
 mdslibidl: tdishr
-mdsmisc: tdishr
+mdsmisc: tdishr xtreeshr
 mdsobjects/cpp: mdstcpip 
 mdsobjects/java: javascope
 mdstcpip: tdishr


### PR DESCRIPTION
mdsmisc depends on xtreeshr as well as the chain descending from tdishr, so add that to the dependency list helper
