### PR TITLE
treeshr: Fix use of uninit var

### DIFF
--- a/treeshr/TreeAddNode.c
+++ b/treeshr/TreeAddNode.c
@@ -623,10 +623,11 @@ int64_t _TreeGetDatafileSize(void *dbid)
   int status;
   PINO_DATABASE *dblist = (PINO_DATABASE *) dbid;
   TREE_INFO *info = dblist->tree_info;
-  if ((!info->data_file) || info->data_file->get == 0)
+  if ((!info->data_file) || info->data_file->get == 0) {
     status = TreeOpenDatafileR(info);
-  if (!(status & 1))
-    return -1;
+    if (!(status & 1))
+      return -1;
+  }
   return MDS_IO_LSEEK(info->data_file->get, 0, SEEK_END);
 }
 


### PR DESCRIPTION
_TreeGetDatafileSize(): status was used without being initialized properly in the case where we didn't get inside the first conditional to call TreeOpenDatafileR.  Fix by moving the conditional on status inside the conditional right above it.
