### PR TITLE
calling PyLongAsLong on some 32 bit platforms returns 0xffffffff

### DIFF
--- a/tdishr/TdiExtPython.c
+++ b/tdishr/TdiExtPython.c
@@ -292,7 +292,7 @@ static void getAnswer(PyObject * value, struct descriptor_xd *outptr)
     if (descr) {
       PyObject *descrPtr = (*PyObject_GetAttrString)(descr, "addressof");
       if (descrPtr) {
-	MdsCopyDxXd((struct descriptor *)(*PyLong_AsLong)(descrPtr), outptr);
+	MdsCopyDxXd((struct descriptor *)(*PyLong_AsVoidPtr)(descrPtr), outptr);
 	(*Py_DecRef)(descrPtr);
       } else {
 	printf("Error getting address of descriptor\n");


### PR DESCRIPTION
On some 32 bit systems calling PyLongAsLong to  convert a python Long to a LONG that is then
cast as a pointer to descriptor return 0xFFFFFFFF.

PyLong_AsVoidPtr however does the right thing on both 32 and 64 bit platforms.
