### PR TITLE
test for unused wires prevented PXI output of internal clock

### DIFF
--- a/tdi/MitDevices/acq.py
+++ b/tdi/MitDevices/acq.py
@@ -466,7 +466,7 @@ add_cmd get.trig >> $settingsf
                 if self.debugging():
                     print "error retrieving bus %s\n" %(e,)
                 bus = ''
-            if wire != 'fpga' and bus != '' :
+            if bus != '' :
                 fd.write("set.route %s in %s out %s\n" %(line, wire, bus,))
                 if self.debugging():
                     print "set.route %s in %s out %s\n" %(line, wire, bus,)


### PR DESCRIPTION
The test which decided a wire was unused, and no routing commands should be issued
was checking if the source was fpga.  It turns out that in order to get the
internal clock out the back on a PXI line, the source for the clock output must be
fpga.
