### PR TITLE
Zack vii zck constant qe

### DIFF
--- a/tdishr/TdiConstant.c
+++ b/tdishr/TdiConstant.c
@@ -130,7 +130,7 @@ DATUM(FLOAT, 2Pi, (float)6.2831853072)	/* circumference/radius    */
     UERR(FLOAT, Na, (float)6.0221367e23, (float)0.0000036e23, "/mol")	/*NA or L Avogadro number  */
     UNITS(FLOAT, P0, (float)1.01325e5, "Pa")	/*atm      atmospheric pressure(exact) */
     DATUM(FLOAT, Pi, (float)3.1415926536)	/* circumference/diameter  */
-    UERR(FLOAT, Qe, (float)1.60217733e-19, (float)0.000000493 - 19, "C")	/*e        charge on electron      */
+    UERR(FLOAT, Qe, (float)1.60217733e-19, (float)0.000000493e-19, "C")	/*e        charge on electron      */
     UERR(FLOAT, Re, (float)2.81794092e-15, (float)0.00000038e-15, "m")	/*re       classical electron radius */
     DATUM(FROP, Roprand, RR)	/* reserved operand        */
     UERR(FLOAT, Rydberg, (float)1.0973731534e7, (float)0.0000000013e7, "/m")	/*Rinf Rydberg constant    */

--- a/tdishr/TdiThreadSafe.c
+++ b/tdishr/TdiThreadSafe.c
@@ -13,9 +13,18 @@ STATIC_THREADSAFE pthread_key_t buffer_key;
 STATIC_THREADSAFE pthread_once_t buffer_key_once = PTHREAD_ONCE_INIT;
 
 STATIC_ROUTINE void buffer_key_alloc();
+#if defined(__has_feature)
+#  if __has_feature(address_sanitizer)
+#    define SKIP_SAN __attribute__((no_sanitize("address")))
+#  endif
+#endif
+#ifndef SKIP_SAN
+#define SKIP_SAN
+#endif
+
 
 /* Return the thread-specific buffer */
-ThreadStatic *TdiThreadStatic()
+SKIP_SAN ThreadStatic *TdiThreadStatic()
 {
   ThreadStatic *p;
   pthread_once(&buffer_key_once, buffer_key_alloc);

--- a/treeshr/TreeThreadSafe.c
+++ b/treeshr/TreeThreadSafe.c
@@ -15,7 +15,17 @@ STATIC_THREADSAFE pthread_once_t buffer_key_once = PTHREAD_ONCE_INIT;
 STATIC_ROUTINE void buffer_key_alloc();
 
 /* Return the thread-specific buffer */
-TreeThreadStatic *TreeGetThreadStatic()
+
+#if defined(__has_feature)
+#  if __has_feature(address_sanitizer)
+#    define SKIP_SAN __attribute__((no_sanitize("address")))
+#  endif
+#endif
+#ifndef SKIP_SAN
+#define SKIP_SAN
+#endif
+
+SKIP_SAN TreeThreadStatic *TreeGetThreadStatic()
 {
   TreeThreadStatic *p;
   pthread_once(&buffer_key_once, buffer_key_alloc);
@@ -52,6 +62,7 @@ EXPORT int TreeUsingPrivateCtx()
 /* Free the thread-specific buffer */
 STATIC_ROUTINE void buffer_destroy(void *buf)
 {
+  printf("buffer_destroy called\n");
   if (buf != NULL) {
     free(buf);
   }


### PR DESCRIPTION
Attempt to suppress memory leak detection in threadsafe code which for some reason started showing up when making a minor change to a numeric constant in pull request https://github.com/MDSplus/mdsplus/pull/546
