### PR TITLE
use length field for length for all other dtypes

### DIFF
--- a/mdstcpip/ProcessMessage.c
+++ b/mdstcpip/ProcessMessage.c
@@ -786,8 +786,7 @@ Message *ProcessMessage(Connection * connection, Message * message)
 	break;
       }
       d->length =
-	  message->h.dtype ==
-	  DTYPE_CSTRING ? message->h.length : lengths[min(message->h.dtype, 13)];
+	  message->h.dtype < DTYPE_CSTRING ? lengths[message->h.dtype] : message->h.length;
       d->dtype = message->h.dtype;
       if (d->class == CLASS_A) {
 	ARRAY_7 *a = (ARRAY_7 *) d;
@@ -815,7 +814,6 @@ Message *ProcessMessage(Connection * connection, Message * message)
       case IEEE_CLIENT:
       case JAVA_CLIENT:
 	memcpy(d->pointer, message->bytes, dbytes);
-	break;
 	break;
       case CRAY_IEEE_CLIENT:
 	switch (d->dtype) {


### PR DESCRIPTION
allows to send more dtypes correctly e.g. pointers

could not test it since the docker engine does not work
