### PR TITLE
ensure consistent behavior on different platforms

### DIFF
--- a/tdishr/TdiDecompile.c
+++ b/tdishr/TdiDecompile.c
@@ -637,7 +637,7 @@ int Tdi0Decompile(struct descriptor *in_ptr, int prec, struct descriptor_d *out_
     case DTYPE_POINTER:{
 	char outstr[256];
 	struct descriptor out = { 0, DTYPE_T, CLASS_S, outstr };
-	out.length = sprintf(outstr, "Pointer(%p)", *(void **)in_ptr->pointer);
+	out.length = sprintf(outstr, "Pointer(%#x)", *(void **)in_ptr->pointer);
 	status = StrAppend(out_ptr, (struct descriptor *)&out);
 	break;
       }


### PR DESCRIPTION
%p results in different outputs on unix and windows systems

``` tdi
Windows64: Pointer(0000000000000000)
Unix:      Pointer(nil)

Windows64: Pointer(0001234567890ABC)
Unix:      Pointer(0x1234567890abc)
```
