### PR TITLE
Missing TreeUnLockNci call in _TreeBeginTimestampedSegment

### DIFF
--- a/treeshr/TreeSegments.c
+++ b/treeshr/TreeSegments.c
@@ -2514,6 +2514,7 @@ old array is same size.
     local_nci.flags=local_nci.flags | NciM_SEGMENTED;
     TreePutNci(info_ptr, nidx, &local_nci, 0);
   }
+  TreeUnLockNci(info_ptr, 0, nidx);
   return status;
 }
 


### PR DESCRIPTION
Prevent thread lock problem with timestamped segments. NCI was not getting properly unlockaed in _TreeBeginTimestampedSegment.
