### PR TITLE
remove complaint about vinNidOffset - there is no widget for this

### DIFF
--- a/tdi/MitDevices/ACQ216.glade
+++ b/tdi/MitDevices/ACQ216.glade
@@ -980,7 +980,6 @@ fpga pxi</property>
                 <property name="incNidOffset">3</property>
                 <property name="dataNidOffset">0</property>
                 <property name="endIdxNidOffset">2</property>
-		<property name="vinNidOffset">4</property>
               </widget>
               <packing>
                 <property name="position">1</property>


### PR DESCRIPTION
This parameter was added to the digChansWidget creation with an eye towards having a pull down
menu for the gains.  Never implemented. Been complaining since day 1.
