### PR TITLE
Prevent destruction of data contained in deleted nodes until the edit…

### DIFF
--- a/treeshr/TreeAddNode.c
+++ b/treeshr/TreeAddNode.c
@@ -680,6 +680,7 @@ int _TreeWriteTree(void **dbid, char const *exp_ptr, int shotid)
             int ntreefd;
             TREE_INFO *info_ptr = (*dblist)->tree_info;
             char *nfilenam = strcpy(malloc(strlen(info_ptr->filespec) + 2), info_ptr->filespec);
+	    _TreeDeleteNodesWrite(*dbid);
             trim_excess_nodes(info_ptr);
             header_pages = (sizeof(TREE_HEADER) + 511) / 512;
             node_pages = (info_ptr->header->nodes * sizeof(NODE) + 511) / 512;

--- a/treeshr/TreeDeleteNode.c
+++ b/treeshr/TreeDeleteNode.c
@@ -228,18 +228,43 @@ extern void _TreeDeleteNodeExecute(void *dbid)
       }
     }
     if ((int)nid.node < edit->first_in_mem) {
-      NCI old_nci;
-      int nidx = nid.node;
-      TreeGetNciLw(dblist->tree_info, nidx, &old_nci);
-      TreePutNci(dblist->tree_info, nidx, &empty_nci, 1);
-      TreeUnLockNci(dblist->tree_info, 0, nidx);
-   } else
+      DELETED_NID *dnid = malloc(sizeof(DELETED_NID));
+      dnid->next=edit->deleted_nid_list;
+      dnid->nid=nid;
+      edit->deleted_nid_list=dnid;
+    }
+    else
       memcpy(edit->nci + nid.node - edit->first_in_mem, &empty_nci, sizeof(struct nci));
     memcpy(node->name, "deleted node", sizeof(node->name));
     LoadShort(zero, &node->conglomerate_elt);
     node->member = 0;
     node->brother = 0;
     node->usage = 0;
+  }
+  dblist->modified = 1;
+  _TreeDeleteNodeInitialize(dbid, 0, 0, 1);
+}
+
+void _TreeDeleteNodesWrite(void *dbid) {
+  PINO_DATABASE *dblist = (PINO_DATABASE *) dbid;
+  static NID nid;
+  NODE *node;
+  NODE *prevnode = 0;
+  NODE *parent;
+  static NCI empty_nci;
+  NODE *firstempty = (dblist->tree_info->header->free == -1) ? (NODE *) 0 :
+      (NODE *) ((char *)dblist->tree_info->node + dblist->tree_info->header->free);
+
+  TREE_EDIT *edit = dblist->tree_info->edit;
+  DELETED_NID *dnid,*next;
+  NCI old_nci;
+  int nidx;
+  static int zero = 0;
+  for (dnid=edit->deleted_nid_list,edit->deleted_nid_list=0; dnid; dnid=next) {
+    next=dnid->next;
+    nid=dnid->nid;
+    free(dnid);
+    node = nid_to_node(dblist, &nid);
     if (prevnode) {
       int tmp;
       prevnode->parent = node_offset(node, prevnode);
@@ -251,6 +276,7 @@ extern void _TreeDeleteNodeExecute(void *dbid)
       dblist->tree_info->header->free = swapint((char *)&tmp);
       node->child = 0;
     }
+    prevnode = node;
     if (firstempty) {
       int tmp;
       node->parent = node_offset(firstempty, node);
@@ -258,10 +284,11 @@ extern void _TreeDeleteNodeExecute(void *dbid)
       firstempty->child = swapint((char *)&tmp);
     } else
       node->parent = 0;
-    prevnode = node;
+    nidx = nid.node;
+    TreeGetNciLw(dblist->tree_info, nidx, &old_nci);
+    TreePutNci(dblist->tree_info, nidx, &empty_nci, 1);
+    TreeUnLockNci(dblist->tree_info, 0, nidx);
   }
-  dblist->modified = 1;
-  _TreeDeleteNodeInitialize(dbid, 0, 0, 1);
 }
 
 /*------------------------------------------------------------------------------

--- a/treeshr/treeshrp.h
+++ b/treeshr/treeshrp.h
@@ -383,6 +383,11 @@ editting. It keeps track of dynamic memory
 allocations for tree expansions
 *********************************************/
 
+typedef struct deleted_nid {
+  NID nid;
+  struct deleted_nid *next;
+} DELETED_NID;
+
 typedef struct tree_edit {
   int header_pages;
   int node_vm_size;
@@ -396,9 +401,10 @@ typedef struct tree_edit {
   short conglomerate_size;
   short conglomerate_index;
   unsigned conglomerate_setup:1;
+  DELETED_NID *deleted_nid_list;
 } TREE_EDIT;
 #ifdef EMPTY_EDIT
-static const TREE_EDIT empty_edit;
+static const TREE_EDIT empty_edit = {0};
 #endif
 
 /********************************************
@@ -711,6 +717,7 @@ extern int TreeFindTag(const char *tagnam, const char *treename, int *tagidx);
 int _TreeFindTag(PINO_DATABASE * db, NODE * default_node, short treelen, const char *tree,
 		 short taglen, const char *tagnam, NODE ** nodeptr, int *tagidx);
 extern int TreeCallHook(TreeshrHookType operation, TREE_INFO * info, int nid);
+extern void _TreeDeleteNodesWrite(void *dbid);
 extern int TreeGetDatafile(TREE_INFO * info_ptr, unsigned char *rfa, int *buffer_size, char *record,
 			   int *retsize, int *nodenum, unsigned char flags);
 extern int TreeEstablishRundownEvent(TREE_INFO * info);


### PR DESCRIPTION
… modifications are written.

This addresses https://github.com/MDSplus/mdsplus/issues/561

See example below:

TCL> set tree main
TCL> create pulse 1
TCL> set tree main/shot=1
TCL> put member 42
TCL> decompile member
42
TCL> verify
Node summary:
  Allocated = 7/14
  Free      = 7/14
  Other     = 0/14
TCL> edit main/shot=1
TCL> delete node member
TCL> verify
Node summary:
  Allocated = 6/14
  Free      = 7/14
  Other     = 1/14
TCL> close/confirm
TCL> set tree main/shot=1
TCL> decompile member
42
TCL> verify
Node summary:
  Allocated = 7/14
  Free      = 7/14
  Other     = 0/14
TCL> edit main/shot=1
TCL> delete node member
TCL> verify
Node summary:
  Allocated = 6/14
  Free      = 7/14
  Other     = 1/14
TCL> write
TCL> verify
Node summary:
  Allocated = 6/14
  Free      = 8/14
  Other     = 0/14
