### PR TITLE
treeshr/TdiOpen.c: Fix uninit var

### DIFF
--- a/treeshr/TreeOpen.c
+++ b/treeshr/TreeOpen.c
@@ -901,7 +901,7 @@ static int OpenOne(TREE_INFO * info, char *tree, int shot, char *type, int new, 
 static int MapTree(char *tree, int shot, TREE_INFO * info, int edit_flag, int report)
 {
   int status;
-  int nomap;
+  int nomap = 0;
   int fd;
 
   /******************************************


### PR DESCRIPTION
nomap could possibly be used uninitialized, so set to zero here
