### PR TITLE
Add the ability to define the monitor server as a special value of th…

### DIFF
--- a/servershr/Makefile.in
+++ b/servershr/Makefile.in
@@ -24,6 +24,7 @@ SOURCES = \
       ServerCreatePulse.c\
       ServerFindServers.c\
       ServerSendMessage.c\
+      ServerSendMonitor.c\
       ServerQAction.c
 
 OBJECTS = $(SOURCES:.c=.o)

--- a/servershr/ServerBuildDispatchTable.c
+++ b/servershr/ServerBuildDispatchTable.c
@@ -266,21 +266,17 @@ EXPORT int ServerBuildDispatchTable(char *wildcard, char *monitor_name, void **t
 	  tree[i] = cptr[i];
       tree[i] = 0;
       for (i = 0; i < num_actions; /* i++ */ i += num_actions - 1) {
-	struct descrip p1, p2, p3, p4, p5, p6, p7, p8;
 	int mode;
 	int on = actions[i].on;
 	char *server = "";
 	mode = i ? (i == (num_actions - 1) ? MonitorBuildEnd : MonitorBuild) : MonitorBuildBegin;
-	if (!(ServerSendMessage(0, monitor_name, SrvMonitor, 0, 0, 0, 0, 0, 8,
-				MakeDescrip(&p1, DTYPE_CSTRING, 0, 0, tree),
-				MakeDescrip(&p2, DTYPE_LONG, 0, 0, &(*table_ptr)->shot),
-				MakeDescrip(&p3, DTYPE_LONG, 0, 0, &actions[i].phase),
-				MakeDescrip(&p4, DTYPE_LONG, 0, 0, &actions[i].nid),
-				MakeDescrip(&p5, DTYPE_LONG, 0, 0, &on),
-				MakeDescrip(&p6, DTYPE_LONG, 0, 0, &mode),
-				MakeDescrip(&p7, DTYPE_CSTRING, 0, 0, server),
-				MakeDescrip(&p8, DTYPE_LONG, 0, 0, &actions[i].status))
-	      & 1))
+	if (!(ServerSendMonitor(monitor_name, tree, (*table_ptr)->shot,
+				actions[i].phase,
+				actions[i].nid,
+				on,
+				mode,
+				server,
+				actions[i].status)&1))
 	  break;
       }
     }

--- a/servershr/ServerDispatchPhase.c
+++ b/servershr/ServerDispatchPhase.c
@@ -139,7 +139,6 @@ void SendMonitor(int mode, int idx)
 {
   if (MonitorOn) {
     ActionInfo *actions = table->actions;
-    struct descrip p1, p2, p3, p4, p5, p6, p7, p8;
     char tree[13];
     char *cptr;
     int i;
@@ -158,15 +157,8 @@ void SendMonitor(int mode, int idx)
 	server[i] = cptr[i];
     server[i] = 0;
     pthread_mutex_lock(&send_msg_mutex);
-    MonitorOn = ServerSendMessage(0, Monitor, SrvMonitor, 0, 0, 0, 0, 0, 8,
-				  MakeDescrip(&p1, DTYPE_CSTRING, 0, 0, tree),
-				  MakeDescrip(&p2, DTYPE_LONG, 0, 0, &table->shot),
-				  MakeDescrip(&p3, DTYPE_LONG, 0, 0, &actions[idx].phase),
-				  MakeDescrip(&p4, DTYPE_LONG, 0, 0, &actions[idx].nid),
-				  MakeDescrip(&p5, DTYPE_LONG, 0, 0, &on),
-				  MakeDescrip(&p6, DTYPE_LONG, 0, 0, &mode),
-				  MakeDescrip(&p7, DTYPE_CSTRING, 0, 0, server),
-				  MakeDescrip(&p8, DTYPE_LONG, 0, 0, &actions[idx].status));
+    MonitorOn = ServerSendMonitor(Monitor, tree, table->shot, actions[idx].phase,
+				  actions[idx].nid, on, mode, server, actions[idx].status);
     pthread_mutex_unlock(&send_msg_mutex);
   }
 }

--- a/servershr/ServerMonitorCheckin.c
+++ b/servershr/ServerMonitorCheckin.c
@@ -28,23 +28,53 @@ int SERVER$MONITOR_CHECKIN(struct dsc$descriptor *server, void (*ast)(), int ast
 
 ------------------------------------------------------------------------------*/
 
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <mdsshr.h>
 #include <ipdesc.h>
 #include <servershr.h>
 #include "servershrp.h"
 
+static void (*appAst)();
+
+static void eventAst(void *astprm, int msglen, char *msg) {
+  (*appAst)(astprm,msg);
+}
+  
 EXPORT int ServerMonitorCheckin(char *server, void (*ast) (), void *astprm)
 {
+  static int initialize=1;
+  static char *event=0;
   struct descrip p1, p2, p3, p4, p5, p6, p7, p8;
   char *cstring = "";
   int zero = 0;
   int mode = MonitorCheckin;
-  return ServerSendMessage(0, server, SrvMonitor, 0, 0, ast, astprm, 0,
-			   8, MakeDescrip(&p1, DTYPE_CSTRING, 0, 0, cstring),
-			   MakeDescrip(&p2, DTYPE_LONG, 0, 0, &zero),
-			   MakeDescrip(&p3, DTYPE_LONG, 0, 0, &zero),
-			   MakeDescrip(&p4, DTYPE_LONG, 0, 0, &zero),
-			   MakeDescrip(&p5, DTYPE_LONG, 0, 0, &zero),
-			   MakeDescrip(&p6, DTYPE_LONG, 0, 0, &mode),
-			   MakeDescrip(&p7, DTYPE_CSTRING, 0, 0, cstring),
-			   MakeDescrip(&p8, DTYPE_LONG, 0, 0, &zero));
+  appAst=ast;
+  if (initialize) {
+    initialize=0;
+    char *mon_env=getenv(server);
+    if (mon_env == 0) {
+      mon_env=server;
+    }
+    if ((strncasecmp(mon_env,"event:",strlen("event:")) == 0) &&
+	(strlen(mon_env) > strlen("event:"))) {
+      event=strdup(mon_env+strlen("event:"));
+    }
+  }
+  if (event) {
+    int evid;
+    return MDSEventAst(event, eventAst, astprm, &evid);
+  }
+  else {
+    return ServerSendMessage(0, server, SrvMonitor, 0, 0, ast, astprm, 0,
+			     8, MakeDescrip(&p1, DTYPE_CSTRING, 0, 0, cstring),
+			     MakeDescrip(&p2, DTYPE_LONG, 0, 0, &zero),
+			     MakeDescrip(&p3, DTYPE_LONG, 0, 0, &zero),
+			     MakeDescrip(&p4, DTYPE_LONG, 0, 0, &zero),
+			     MakeDescrip(&p5, DTYPE_LONG, 0, 0, &zero),
+			     MakeDescrip(&p6, DTYPE_LONG, 0, 0, &mode),
+			     MakeDescrip(&p7, DTYPE_CSTRING, 0, 0, cstring),
+			     MakeDescrip(&p8, DTYPE_LONG, 0, 0, &zero));
+  }
 }

--- a/servershr/ServerSendMonitor.c
+++ b/servershr/ServerSendMonitor.c
@@ -1,0 +1,56 @@
+#include <mdsshr.h>
+#include <ipdesc.h>
+#include <servershr.h>
+#include "servershrp.h"
+#include <string.h>
+#include <stdlib.h>
+#include <treeshr.h>
+
+int ServerSendMonitor(char *monitor, char *tree, int shot, int phase,
+		      int nid, int on, int mode, char *server, int actstatus) {
+  static int initialize=1;
+  static char *event=0;
+  int status;
+  char now[64];
+  time_t tim;
+  tim = time(0);
+  strcpy(now, ctime(&tim));
+  now[strlen(now) - 1] = 0;
+
+  if (initialize) {
+    initialize=0;
+    char *mon_env=getenv(monitor);
+    if (mon_env == 0) {
+      mon_env=monitor;
+    }
+    if ((strncasecmp(mon_env,"event:",strlen("event:")) == 0) &&
+	(strlen(mon_env) > strlen("event:"))) {
+      event=strdup(mon_env+strlen("event:"));
+    }
+  }
+  if (event) {
+    char *path=TreeGetPath(nid);
+    char *status_text = MdsGetMsg(actstatus);
+    char *eventmsg=alloca(1024);
+    int msglen = snprintf(eventmsg,1023,"%s %d %d %d %d %d %s %d %s %s; %s", tree,
+			  shot, phase, nid, on, mode,
+			  (server && *server) ? server : "unknown",
+			  actstatus, path ? path : "unknown", now, status_text);
+    eventmsg[msglen]=0;
+    status = MDSEvent(event,msglen+1,eventmsg);
+    if (path) free(path);
+  }
+  else {
+    struct descrip p1, p2, p3, p4, p5, p6, p7, p8;    
+    status = ServerSendMessage(0, monitor, SrvMonitor, 0, 0, 0, 0, 0, 8,
+				  MakeDescrip(&p1, DTYPE_CSTRING, 0, 0, tree),
+				  MakeDescrip(&p2, DTYPE_LONG, 0, 0, &shot),
+				  MakeDescrip(&p3, DTYPE_LONG, 0, 0, &phase),
+				  MakeDescrip(&p4, DTYPE_LONG, 0, 0, &nid),
+				  MakeDescrip(&p5, DTYPE_LONG, 0, 0, &on),
+				  MakeDescrip(&p6, DTYPE_LONG, 0, 0, &mode),
+				  MakeDescrip(&p7, DTYPE_CSTRING, 0, 0, server),
+				  MakeDescrip(&p8, DTYPE_LONG, 0, 0, &actstatus));
+  }
+  return status;
+}

--- a/servershr/servershrp.h
+++ b/servershr/servershrp.h
@@ -139,4 +139,7 @@ extern int ServerSendMessage(int *msgid, char *server, int op, int *retstatus, i
 			     int numargs_in, ...);
 #endif
 extern int ServerConnect(char *);
+extern int ServerSendMonitor(char *monitor, char *tree, int shot, int phase, int nid, int on,
+			     int mode, char *server, int actstatus);
+
 #endif


### PR DESCRIPTION
…e keyword event followed by colon followed by name of MDSplus event to use to broadcast action monitor messages to action monitors.

So for example with the C-Mod experiment all the TCL dispatch commands use:

TCL> dispatch/build/monitor=CMOD_MONITOR
TCL> dispatch/phase/monitor=CMOD_MONITOR init
etc.

and the actmon is invoked with:

actmon --monitor=CMOD_MONITOR

Currently CMOD_MONITOR is defined in an environment variable as:

alcdata-new:mdsip_monitor

which causes the dispatch commands to communicate with an mdsip service sending messages about each job dispatched. The actmon depends on the mdsip service handling the monitor message to relay these messages to it and all other running action monitors. If any of these action monitors just stalled this can stall the monitor mdsip service which could in turn stall the dispatch commands. The new feature provided by this pull request allows you do define the "monitor server" environment variable in such a way to use udp events to broadcast these monitor messages. If the environment variable for the monitor server begins with event: the dispatch commands will issue MDSplus events using the event name following the event: prefix. For example on C-Mod we will be able to define the monitor server environment variable as:

export CMOD_MONITOR=event:cmod_monitor

This will tell the dispatch commands to issue events with the name cmod_monitor for dispatching event broadcasts and the action monitor will listen for these event notifications.
