### PR TITLE
config: Remove checks for size of long long

### DIFF
--- a/configure
+++ b/configure
@@ -8290,39 +8290,6 @@ cat >>confdefs.h <<_ACEOF
 _ACEOF
 
 
-# The cast to long int works around a bug in the HP C Compiler
-# version HP92453-01 B.11.11.23709.GP, which incorrectly rejects
-# declarations like `int a3[[(sizeof (unsigned char)) >= 0]];'.
-# This bug is HP SR number 8606223364.
-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking size of long long" >&5
-$as_echo_n "checking size of long long... " >&6; }
-if ${ac_cv_sizeof_long_long+:} false; then :
-  $as_echo_n "(cached) " >&6
-else
-  if ac_fn_c_compute_int "$LINENO" "(long int) (sizeof (long long))" "ac_cv_sizeof_long_long"        "$ac_includes_default"; then :
-
-else
-  if test "$ac_cv_type_long_long" = yes; then
-     { { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
-$as_echo "$as_me: error: in \`$ac_pwd':" >&2;}
-as_fn_error 77 "cannot compute sizeof (long long)
-See \`config.log' for more details" "$LINENO" 5; }
-   else
-     ac_cv_sizeof_long_long=0
-   fi
-fi
-
-fi
-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_sizeof_long_long" >&5
-$as_echo "$ac_cv_sizeof_long_long" >&6; }
-
-
-
-cat >>confdefs.h <<_ACEOF
-#define SIZEOF_LONG_LONG $ac_cv_sizeof_long_long
-_ACEOF
-
-
 
 # Stuff that only non-automake dirs need
 MAKEETCDIR="\$(top_builddir)/etc/"

--- a/configure.ac
+++ b/configure.ac
@@ -550,7 +550,6 @@ else
 fi
 
 AC_CHECK_SIZEOF(long)
-AC_CHECK_SIZEOF(long long)
 
 # Stuff that only non-automake dirs need
 AC_SUBST([MAKEETCDIR], ["\$(top_builddir)/etc/"])

--- a/include/config.h.in
+++ b/include/config.h.in
@@ -219,9 +219,6 @@
 /* The size of `long', as computed by sizeof. */
 #undef SIZEOF_LONG
 
-/* The size of `long long', as computed by sizeof. */
-#undef SIZEOF_LONG_LONG
-
 /* "Define if you are using SRB" */
 #undef SRB
 


### PR DESCRIPTION
I found no uses for SIZEOF_LONG_LONG except in
3rdparty-apis/windows-python27/pyconfig.h, and it is defined locally
there.  So, remove the test, remove the macro from config.h, and
regenerate configure.
