### PR TITLE
Disable usage of a TdiGetRecord tdi fun originally added for future s…

### DIFF
--- a/tdi/tdishr/TdiGetRecord.fun
+++ b/tdi/tdishr/TdiGetRecord.fun
@@ -1,3 +1,4 @@
+/* Future support for multi-shot trending --- not currently used */
 public fun TdiGetRecord(in _nid, out _out) {
         _out=1;
 	_status=TreeShr->TreeGetRecord(val(_nid),xd(_out));

--- a/tdishr/TdiGetData.c
+++ b/tdishr/TdiGetData.c
@@ -497,7 +497,10 @@ extern EXPORT int TdiGetNid(struct descriptor *in_ptr, int *nid_ptr)
         WARNING: $THIS is only defined within the subexpressions.
         WARNING: Use of $THIS or $VALUE can be infinitely recursive.
 */
-int Tdi1This(int opcode, int narg, struct descriptor *list[], struct descriptor_xd *out_ptr)
+int Tdi1This(int opcode __attribute__ ((unused)),
+	     int narg __attribute__ ((unused)),
+	     struct descriptor *list[] __attribute__ ((unused)),
+	     struct descriptor_xd *out_ptr)
 {
   int status = 1;
   if (TdiThreadStatic()->TdiSELF_PTR)
@@ -513,7 +516,9 @@ int Tdi1This(int opcode, int narg, struct descriptor *list[], struct descriptor_
         This allows the data field of signals to reference the raw field of a signal
         and the validation field of params to reference the value field of a param.
 */
-int Tdi1Value(int opcode, int narg, struct descriptor *list[], struct descriptor_xd *out_ptr)
+int Tdi1Value(int opcode __attribute__ ((unused)),
+	      int narg __attribute ((unused)),
+	      struct descriptor *list[] __attribute__ ((unused)), struct descriptor_xd *out_ptr)
 {
   int status = 1;
 
@@ -541,7 +546,9 @@ int Tdi1Value(int opcode, int narg, struct descriptor *list[], struct descriptor
         A major entry point for evaluation of the data of expressions.
                 status = TdiData(&in, &out MDS_END_ARG)
 */
-int Tdi1Data(int opcode, int narg, struct descriptor *list[], struct descriptor_xd *out_ptr)
+int Tdi1Data(int opcode __attribute__ ((unused)),
+	     int narg __attribute__ ((unused)),
+	     struct descriptor *list[], struct descriptor_xd *out_ptr)
 {
   int status = 1;
 
@@ -559,7 +566,10 @@ int Tdi1Data(int opcode, int narg, struct descriptor *list[], struct descriptor_
                 UNITS(other)            UNITS(DATA(other) not stripping above)
                 UNITS(other)            " "     (single blank to keep IDL happy)
 */
-int Tdi1Units(int opcode, int narg, struct descriptor *list[], struct descriptor_xd *out_ptr)
+int Tdi1Units(int opcode __attribute__ ((unused)),
+	      int narg,
+	      struct descriptor *list[],
+	      struct descriptor_xd *out_ptr)
 {
   int status = 1;
   struct descriptor_r *rptr;
@@ -623,7 +633,9 @@ int Tdi1Units(int opcode, int narg, struct descriptor *list[], struct descriptor
                 status = TdiDataWithUnits(&in, &out MDS_END_ARG)
 */
 STATIC_CONSTANT DESCRIPTOR_WITH_UNITS(null, 0, 0);
-int Tdi1DataWithUnits(int opcode, int narg, struct descriptor *list[],
+int Tdi1DataWithUnits(int opcode __attribute__ ((unused)),
+		      int narg __attribute__ ((unused)),
+		      struct descriptor *list[],
 		      struct descriptor_xd *out_ptr)
 {
   int status = 1;
@@ -662,7 +674,10 @@ int Tdi1DataWithUnits(int opcode, int narg, struct descriptor *list[],
         Note that $VALUE would not be defined in that form.
         Need we check that result is logical scalar?
 */
-int Tdi1Validation(int opcode, int narg, struct descriptor *list[], struct descriptor_xd *out_ptr)
+int Tdi1Validation(int opcode __attribute__ ((unused)),
+		   int narg __attribute__ ((unused)),
+		   struct descriptor *list[],
+		   struct descriptor_xd *out_ptr)
 {
   int status = 1;
   struct descriptor_r *rptr;
@@ -690,7 +705,7 @@ int Tdi1Validation(int opcode, int narg, struct descriptor *list[], struct descr
   return status;
 }
 
-static int use_get_record_fun = 1;
+static int use_get_record_fun = 0;
 EXPORT int TdiGetRecord(int nid, struct descriptor_xd *out)
 {
   int status;
@@ -698,7 +713,7 @@ EXPORT int TdiGetRecord(int nid, struct descriptor_xd *out)
     int stat;
     short opcode = 162;		/* external function */
     DESCRIPTOR_LONG(stat_d, &stat);
-    static DESCRIPTOR(getrec_d, "TdiGetRecord");
+    static DESCRIPTOR(getrec_d, "TdiGetRecord----not-used");
     DESCRIPTOR_LONG(nid_d, (char *)&nid);
     DESCRIPTOR(var_d, "_out");
     DESCRIPTOR_R(getrec, DTYPE_FUNCTION, 4);


### PR DESCRIPTION
…upport of multishot trend data. Causes recursion of Tdi1Compile which is not supported.
