### PR TITLE
Disable usage of a TdiGetRecord tdi fun originally added for future s…

### DIFF
--- a/tdi/tdishr/TdiGetRecord.fun
+++ b/tdi/tdishr/TdiGetRecord.fun
@@ -1,3 +1,4 @@
+/* Future support for multi-shot trending --- not currently used */
 public fun TdiGetRecord(in _nid, out _out) {
         _out=1;
 	_status=TreeShr->TreeGetRecord(val(_nid),xd(_out));

--- a/tdishr/TdiGetData.c
+++ b/tdishr/TdiGetData.c
@@ -690,7 +690,7 @@ int Tdi1Validation(int opcode, int narg, struct descriptor *list[], struct descr
   return status;
 }
 
-static int use_get_record_fun = 1;
+static int use_get_record_fun = 0;
 EXPORT int TdiGetRecord(int nid, struct descriptor_xd *out)
 {
   int status;
@@ -698,7 +698,7 @@ EXPORT int TdiGetRecord(int nid, struct descriptor_xd *out)
     int stat;
     short opcode = 162;		/* external function */
     DESCRIPTOR_LONG(stat_d, &stat);
-    static DESCRIPTOR(getrec_d, "TdiGetRecord");
+    static DESCRIPTOR(getrec_d, "TdiGetRecord---not-used");
     DESCRIPTOR_LONG(nid_d, (char *)&nid);
     DESCRIPTOR(var_d, "_out");
     DESCRIPTOR_R(getrec, DTYPE_FUNCTION, 4);


### PR DESCRIPTION
…upport of multishot trend data. Causes recursion of Tdi1Compile which is not supported.
