### PR TITLE
Handle absolute paths when adding python devices and report more mean…

### DIFF
--- a/tdi/dev_support/DevAddPythonDevice.py
+++ b/tdi/dev_support/DevAddPythonDevice.py
@@ -1,5 +1,5 @@
 from MDSplus import Data, Tree, Device
-from MDSplus.mdsExceptions import DevPYDEVICE_NOT_FOUND
+from MDSplus.mdsExceptions import DevPYDEVICE_NOT_FOUND,MDSplusException
 import sys
 def DevAddPythonDevice(path, model):
     """Add a python device to the tree by:
@@ -12,19 +12,23 @@ def DevAddPythonDevice(path, model):
     containing blank filled values containing an \0 character embedded.
     These Strings have to be manipulated to produce simple str() values.
     """
-
     model = model.data().upper().rstrip()
     mod = Device.importPyDeviceModule(model)
+    path = str(path.data()).replace('\\\\','\\')
     if mod is not None and model in mod.__dict__:
         try:
             mod.__dict__[model].Add(Tree(), path)
             return 1
         except:
-            print ("Error adding device instance of %s: %s" % (model, sys.exc_info()[1]))
-            return 0
+            e=sys.exc_info()[1]
+            if isinstance(e,MDSplusException):
+                return e.status
+            else:
+                print ("Error adding device instance of %s: %s" % (model, sys.exc_info()[1]))
+                return 0
         
-    path = path.data()
     models = Data.execute('MdsDevices()')
+    cls = None
 
     for idx in range(0, len(models), 2):
         try:
@@ -33,9 +37,20 @@ def DevAddPythonDevice(path, model):
             package = models[idx+1].data()
             package = package[0:package.find('\0')]
             if model == modname:
-                __import__(package).__dict__[model].Add(Tree(), path)
-                return 1
-        except:
+                cls = __import__(package).__dict__[model]
+                break
+        except Exception,e:
             pass
+    if cls is not None:
+        try:
+            cls.Add(Tree(), path)
+            return 1
+        except:
+            e=sys.exc_info()[1]
+            if isinstance(e,MDSplusException):
+                return e.status
+            else:
+                print ("Error adding device instance of %s: %s" % (model, sys.exc_info()[1]))
+                return 0
     return DevPYDEVICE_NOT_FOUND.status
     


### PR DESCRIPTION
and report more meeningful errors instead of always reporting DevPYDEVICE_NOT_FOUND.
