### PR TITLE
Fix time dependent X-Y plot

### DIFF
--- a/javascope/jScope/WaveInterface.java
+++ b/javascope/jScope/WaveInterface.java
@@ -1379,6 +1379,15 @@ public class WaveInterface
             curr_error = dp.ErrorString();
             return null;
         }
+        //Check for bidimensional X axis
+        if(in_x[curr_wave] != null)
+        {
+            xwd = dp.GetWaveData(in_x[curr_wave]);
+            if(xwd.getNumDimension() == 1)
+                xwd = null; //xwd is different from null ONLY for bidimensional X axis 
+        }
+        
+        
         //wd.setContinuousUpdate(isContinuousUpdate);
         boolean hasErrors = up_err != null || low_err != null;
         if( xDimension == 1)


### PR DESCRIPTION
This fix is to allow jScope display time dependent X-Y mapping that was broken in previous updates
