### PR TITLE
show warning if third party package pexpect is not found

### DIFF
--- a/tdi/MitDevices/dt100.py
+++ b/tdi/MitDevices/dt100.py
@@ -1,6 +1,9 @@
 #!/usr/bin/python
 
-import pexpect
+try:
+	import pexpect
+except:
+	print("Package pexpect not found but required for controlling dt100")
 import re
 import transport
 import array


### PR DESCRIPTION
this at least allows to add the device even without that package
