### PR TITLE
PyDoMethod should return PyUNHANDLED_EXCEPTION status instead of 0

### DIFF
--- a/tdi/dev_support/PyDoMethod.py
+++ b/tdi/dev_support/PyDoMethod.py
@@ -1,5 +1,5 @@
 from MDSplus import Int32, Device
-from MDSplus.mdsExceptions import TreeNOMETHOD,DevPYDEVICE_NOT_FOUND
+from MDSplus.mdsExceptions import TreeNOMETHOD,DevPYDEVICE_NOT_FOUND,PyUNHANDLED_EXCEPTION
 from sys import stderr,exc_info
 
 def PyDoMethod(n,method,*args):
@@ -42,4 +42,5 @@ def PyDoMethod(n,method,*args):
         if hasattr(exc,'status'):
             return [exc.status,None]
         else:
-            return [Int32(0),None]
+            return [PyUNHANDLED_EXCEPTION.status,None]
+


### PR DESCRIPTION
If a python device support module raises an exception which is not a standard MDSplus status exception then the status returned by PyDoMethod should be PyUNHANDLED_EXCEPTION instead of returning the old standard, uninformative error status of 0.  This is to partially fix https://github.com/MDSplus/mdsplus/issues/659.
