### PR TITLE
Do not change WORKSPACE environment variable if already defined

### DIFF
--- a/deploy/build.sh
+++ b/deploy/build.sh
@@ -295,7 +295,7 @@ parsecmd() {
 		BRANCH="${i#*=}"
 		;;
 	    --workspace=*)
-		WORKSPACE="${i#*=}"
+		NEW_WORKSPACE="${i#*=}"
 		;;
 	    --releasedir=*)
 		RELEASEDIR="${i#*=}"
@@ -460,11 +460,14 @@ then
     >&2 echo "Plaform ${PLATFORM} is not supported."
     exit 1
 fi
-if [ -z "$WORKSPACE" ]
+if [ -z "$NEW_WORKSPACE" ]
 then
-    WORKSPACE=$(pwd)/build/${OS}/${BRANCH}
+    if [ -z "$WORKSPACE" ]
+    then
+       WORKSPACE=$(pwd)/build/${OS}/${BRANCH}
+    fi
 else
-    WORKSPACE=$(realpath ${WORKSPACE})/${OS}/${BRANCH}
+    WORKSPACE=$(realpath ${NEW_WORKSPACE})
 fi
 
 if [ "$TEST" = "yes" -a "$TEST_RELEASE" = "yes" ]

--- a/deploy/trigger.sh
+++ b/deploy/trigger.sh
@@ -235,7 +235,7 @@ EOF
     exit 1
 fi
 
-BRANCH=${GIT_BRANCH:7}
+BRANCH=${GIT_BRANCH}
 opts="$opts --branch=$BRANCH"
 
 #


### PR DESCRIPTION
Change handling of WORKSPACE environment variable. If WORKSPACE environment variable is already defined (i.e. in jenkins builds) leave it as is unless overwritten by a --workspace= option on the build.sh invocation. If WORKSPACE is not defined and the --workspace option is not provided then default to $(pwd)/build/${OS}/${BRANCH}.

Also fix handling of the use of the jenkins GIT_BRANCH environment variable which sometimes is set to origin/branch-name and sometime just branch-name. Originally this just trimmed 7 characters from the beginning assuming the origin/ prefix was always there as is the case for the release builds but not the case for pull request tests.
