### PR TITLE
remove last colon otherwise devices cannot be instantiated

### DIFF
--- a/tdi/dev_support/MdsDevices.fun
+++ b/tdi/dev_support/MdsDevices.fun
@@ -41,6 +41,6 @@ fun public MdsDevices() {
     'RFXVICONTROL', 'RfxDevices',
     'REDPYTADC', 'RfxDevices',
     'BNC845', 'W7xDevices',
-    'QC9200', 'W7xDevices',
+    'QC9200', 'W7xDevices'
   ]);
 }


### PR DESCRIPTION
Removed last colon otherwise devices cannot be instantiated
