### PR TITLE
added uniform debug methods to device group initializer

### DIFF
--- a/mdsobjects/python/mdsdevice.py
+++ b/mdsobjects/python/mdsdevice.py
@@ -91,6 +91,56 @@ class Device(_treenode.TreeNode):
     debug = _getenv('DEBUG_DEVICES')
     gtkThread = None
 
+    """ debug safe import """
+    if debug:
+        if int(debug)<0:
+            @staticmethod
+            def _debugDevice(d):
+                from MDSplus import Device
+                import types
+                def dummy(self,*args,**kvargs):
+                    return 1
+                db = {}
+                for k,v in d.__dict__.items():
+                    if isinstance(v,(types.FunctionType,)):
+                        db[k] = dummy
+                    else:
+                        db[k] = v
+                return type(d.__name__,(Device,),db)
+        else:
+            @staticmethod
+            def _debugDevice(device):
+                return device
+        @staticmethod
+        def _debug(s,p=tuple()):
+            from sys import stdout as _stdout
+            _stdout.write(s % p)
+    else:
+        @staticmethod
+        def _debug(s,p=tuple()):
+            pass
+        @staticmethod
+        def _debugDevice(device):
+            return device
+    @staticmethod
+    def _mimport(loc,glob,filename,name=None):
+        if isinstance(name,(tuple,list)):
+            for n in name:
+                Device._mimport(loc,glob,filename,n)
+            return
+        if name is None: name = filename
+        Device._debug('loading %-21s',(name+':'))
+        try:
+            try:
+                device = __import__(filename, glob, fromlist=[name], level=1).__getattribute__(name)
+            except:
+                device = __import__(filename, glob, fromlist=[name]).__getattribute__(name)
+            Device._debug(' successful\n')
+            loc[name] = Device._debugDevice(device)
+        except Exception as exc:
+            Device._debug(' failed: %s\n'%exc)
+    """ /debug safe import """
+
     def __class_init__(cls):
         if not hasattr(cls,'initialized'):
             if hasattr(cls,'parts'):

--- a/tdi/MitDevices/__init__.py
+++ b/tdi/MitDevices/__init__.py
@@ -27,25 +27,33 @@ try:
 except:
     __version__='Unknown'
 
-from Dt200WriteMaster import Dt200WriteMaster
-from acq132     import ACQ132
-from acq196     import ACQ196
-from acq196ao   import ACQ196AO
-from acq216     import ACQ216
-from acq216_ftp import ACQ216_FTP
-from cp7452     import CP7452
-from dtao32     import DTAO32
-from dtdo32     import DTDO32
-from dt132      import DT132
-from dt216b     import DT216B
-from dt196      import DT196
-from dt196a     import DT196A
-from dt196b     import DT196B
-from dt216      import DT216
-from dt216a     import DT216A
-from raspicam	import RASPICAM
-from picam      import PICAM
-from timeSignature import timeSignatureAnalyze, timeSignature
-import acq200
-import transport
-import dt100
+def _mimport(filename,name=None,local=locals()):
+    from MDSplus import Device
+    Device._mimport(globals(),local,filename,name)
+
+_mimport('Dt200WriteMaster')
+_mimport('acq132','ACQ132')
+_mimport('acq196','ACQ196')
+_mimport('acq196ao','ACQ196AO')
+_mimport('acq200','ACQ200')
+_mimport('acq216','ACQ216')
+_mimport('acq216_ftp','ACQ216_FTP')
+
+_mimport('cp7452','CP7452')
+
+_mimport('dtao32','DTAO32')
+_mimport('dtdo32','DTDO32')
+
+_mimport('dt100','DT100')
+_mimport('dt132','DT132')
+_mimport('dt216b','DT216B')
+_mimport('dt196','DT196')
+_mimport('dt196a','DT196A')
+_mimport('dt196b','DT196B')
+_mimport('dt216','DT216')
+_mimport('dt216a','DT216A')
+
+_mimport('raspicam','RASPICAM')
+_mimport('picam','PICAM')
+
+_mimport('timeSignature',['timeSignature','timeSignatureAnalyze'])

--- a/tdi/MitDevices/acq.py
+++ b/tdi/MitDevices/acq.py
@@ -21,9 +21,9 @@ class ACQ(MDSplus.Device):
     methods:
       debugging() - is debugging enabled.  Controlled by environment variable DEBUG_DEVICES
 
-    
+
     """
-    
+
     acq_parts=[
         {'path':':NODE','type':'text','value':'192.168.0.254'},
         {'path':':COMMENT','type':'text'},
@@ -36,7 +36,7 @@ class ACQ(MDSplus.Device):
 
 
     parts2=[
-        {'path':':INT_CLOCK','type':'axis','options':('no_write_model','write_once')},       
+        {'path':':INT_CLOCK','type':'axis','options':('no_write_model','write_once')},
         {'path':':TRIG_SRC','type':'numeric','valueExpr':'head.di3','options':('no_write_shot',)},
         {'path':':TRIG_EDGE','type':'text','value':'rising','options':('no_write_shot',)},
         {'path':':CLOCK_SRC','type':'numeric','valueExpr':'head.int_clock','options':('no_write_shot',)},
@@ -195,7 +195,7 @@ class ACQ(MDSplus.Device):
                 print "json is loaded\n"
             if tree != self.settings['tree'] :
                 print "ACQ Device open tree is %s board armed with tree %s\n" % (tree, self.settings["tree"],)
-                raise DevWRONG_TREE() 
+                raise DevWRONG_TREE()
             if path != self.settings['path'] :
                 print "ACQ device tree path %s, board armed with path %s\n" % (path, self.settings["path"],)
                 raise DevWRONG_PATH()
@@ -251,7 +251,7 @@ class ACQ(MDSplus.Device):
             print "get state after loop returned %s\n" % (state,)
         if state != "ACQ32:0 ST_STOP" :
             print "ACQ196 device not triggered /%s/\n"% (self.getBoardState(),)
-            return 0  
+            return 0
         return 1
 
     def getBoardState(self):
@@ -260,7 +260,7 @@ class ACQ(MDSplus.Device):
         last_error = None
         for t in range(10):
             try:
-                UUT = acq200.Acq200(transport.factory(boardip))
+                UUT = acq200.ACQ200(transport.factory(boardip))
             except Exception, e:
                 print "could not connect to the board %s"% (boardip,)
                 last_error=e
@@ -281,7 +281,7 @@ class ACQ(MDSplus.Device):
 #        import socket,time
 #	for tries in range(5):
 #            s=socket.socket()
-#	    s.settimeout(5.) 
+#	    s.settimeout(5.)
 #            state="Unknown"
 #            try:
 #                s.connect((self.getBoardIp(),54545))
@@ -300,9 +300,9 @@ class ACQ(MDSplus.Device):
 #	        state = "off-line"
 #                s.close()
 #            time.sleep(3)
-#                  
 #
-# Let this function raise an error that will be 
+#
+# Let this function raise an error that will be
 # Thrown all the way out of the device method
 #
     def getMyIp(self):
@@ -373,7 +373,7 @@ add_cmd get.trig >> $settingsf
         if self.debugging():
             print "starting finishJSON"
         fd.write("end_json >> $settingsf\n")
-            
+
         if auto_store != None :
             if self.debugging():
                 fd.write("mdsValue 'setenv(\"\"DEBUG_DEVICES=yes\"\")'\n")
@@ -430,7 +430,7 @@ add_cmd get.trig >> $settingsf
                     dim = MDSplus.Dimension(MDSplus.Window(start/inc, end/inc, self.trig_src ), MDSplus.Range(None, None, clock.evaluate().getDelta()*inc))
                 dat = MDSplus.Data.compile(
                         'build_signal(build_with_units((($1+ ($2-$1)*($value - -32768)/(32767 - -32768 ))), "V") ,build_with_units($3,"Counts"),$4)',
-                        vins[chan*2], vins[chan*2+1], buf,dim) 
+                        vins[chan*2], vins[chan*2+1], buf,dim)
                 exec('c=self.input_'+'%02d'%(chan+1,)+'.record=dat')
 
     def startInitializationFile(self, fd, trig_src, pre_trig, post_trig):
@@ -479,7 +479,7 @@ add_cmd get.trig >> $settingsf
         settingsfd.seek(0,0)
         if self.debugging():
             print "got the settings\n"
-            
+
         try :
             settings = json.load(settingsfd)
         except Exception,e:
@@ -489,7 +489,7 @@ add_cmd get.trig >> $settingsf
         if self.debugging():
             print "The settings are loaded\n"
         return settings
-    
+
 #
 # Do not return status let caller catch (or not)
 # exceptions
@@ -533,7 +533,7 @@ add_cmd get.trig >> $settingsf
             clock_div = 1
         if self.debugging():
            print "clock div is %d\n" % (clock_div,)
-        
+
         if clock_src == 'INT_CLOCK' :
             intClock = float(self.settings['getInternalClock'].split()[1])
             delta=1.0/float(intClock)
@@ -562,9 +562,9 @@ add_cmd get.trig >> $settingsf
     def waitftp(self) :
         import time
         from MDSplus.mdsExceptions import DevOFFLINE
-        from MDSplus.mdsExceptions import DevNOT_TRIGGERED 
+        from MDSplus.mdsExceptions import DevNOT_TRIGGERED
         from MDSplus.mdsExceptions import DevIO_STUCK
-        from MDSplus.mdsExceptions import DevTRIGGERED_NOT_STORED 
+        from MDSplus.mdsExceptions import DevTRIGGERED_NOT_STORED
         from MDSplus.mdsExceptions import DevUNKOWN_STATE
 
         """Wait for board to finish digitizing and storing the data"""
@@ -610,15 +610,15 @@ add_cmd get.trig >> $settingsf
             if self.debugging() :
                 print "executing trigger on board %s, trig_src is %s."% (boardip, trig_src,)
             trig_src = trig_src[2:]
-        
-            UUT = acq200.Acq200(transport.factory(boardip))
+
+            UUT = acq200.ACQ200(transport.factory(boardip))
             route = UUT.uut.acq2sh('get.route D%s'%(trig_src,))
 
             d1 = UUT.uut.acq2sh('set.route d%s in fpga out'%(trig_src,))
             d2 = UUT.uut.acq2sh('set.dtacq dio_bit %s P'%(trig_src,))
             d3 = UUT.uut.acq2sh('set.route %s' %(route,))
             d4 = UUT.uut.acq2sh('set.dtacq dio_bit %s -'%(trig_src,))
-            
+
             if self.debugging():
                 print "got back: %s\n" % (route,)
 	        print "     and: %s\n" % (d1,)
@@ -635,9 +635,9 @@ add_cmd get.trig >> $settingsf
         from MDSplus.mdsExceptions import DevACQCMD_FAILED
 
         boardip = self.getBoardIp()
-        
+
         try:
-            UUT = acq200.Acq200(transport.factory(boardip))
+            UUT = acq200.ACQ200(transport.factory(boardip))
             a = UUT.uut.acqcmd(str(arg))
         except Exception, e:
             print "could not send %s to the board" %(str(arg),)
@@ -649,9 +649,9 @@ add_cmd get.trig >> $settingsf
     def acq2sh(self, arg):
         from MDSplus.mdsExceptions import DevACQ2SH_FAILED
         boardip = self.getBoardIp()
-        
+
         try:
-            UUT = acq200.Acq200(transport.factory(boardip))
+            UUT = acq200.ACQ200(transport.factory(boardip))
             a = UUT.uut.acq2sh(str(arg))
         except Exception, e:
             print "could not connect to the board %s"% (boardip,)
@@ -664,7 +664,7 @@ add_cmd get.trig >> $settingsf
         self.acqcmd('getNumSamples')
         return 1
     GETNUMSAMPLES=getnumsamples
-    
+
     def getstate(self):
         self.acqcmd('getState')
         return 1

--- a/tdi/MitDevices/acq200.py
+++ b/tdi/MitDevices/acq200.py
@@ -1,6 +1,4 @@
 #!/usr/bin/python
-
-import dt100
 import re
 
 #       12345678901234567890123456789012
@@ -16,7 +14,7 @@ GNS_PRE   = 1
 GNS_POST  = 2
 GNS_ELAPSED = 3
 
-class Acq200:
+class ACQ200:
 	'models an ACQ200 class intelligent digitizer'
 	def set_dio32(self, value = IN32):
 		return self.uut.acq2sh("set.dio32 " + value)

--- a/tdi/MitDevices/acq_ftp.py
+++ b/tdi/MitDevices/acq_ftp.py
@@ -20,9 +20,9 @@ class ACQ_FTP(MDSplus.Device):
     methods:
       debugging() - is debugging enabled.  Controlled by environment variable DEBUG_DEVICES
 
-    
+
     """
-    
+
     acq_parts=[
         {'path':':NODE','type':'text','value':'192.168.0.254'},
         {'path':':COMMENT','type':'text'},
@@ -35,7 +35,7 @@ class ACQ_FTP(MDSplus.Device):
 
 
     parts2=[
-        {'path':':INT_CLOCK','type':'axis','options':('no_write_model','write_once')},       
+        {'path':':INT_CLOCK','type':'axis','options':('no_write_model','write_once')},
         {'path':':TRIG_SRC','type':'numeric','valueExpr':'head.di3','options':('no_write_shot',)},
         {'path':':TRIG_EDGE','type':'text','value':'rising','options':('no_write_shot',)},
         {'path':':CLOCK_SRC','type':'numeric','valueExpr':'head.int_clock','options':('no_write_shot',)},
@@ -68,7 +68,7 @@ class ACQ_FTP(MDSplus.Device):
     debug=None
 
     wires = [ 'fpga','mezz','rio','pxi','lemo', 'none', 'fpga pxi', ' ']
-    
+
 
     def debugging(self):
 	if self.debug == None :
@@ -99,7 +99,7 @@ class ACQ_FTP(MDSplus.Device):
 	    binValues.read(f,end-start+1)
             ans = numpy.array(binValues, dtype=numpy.int16)
 	    if inc > 1 :
-		asns = ans[::inc]
+		ans = ans[::inc]
             f.close()
         except Exception,e :
 	   print "readRawData - %s" % e
@@ -108,7 +108,7 @@ class ACQ_FTP(MDSplus.Device):
 
     def timeoutHandler(self,sig,stack):
         raise Exception("Timeout occurred")
-        
+
     def getState(self):
         """Get the current state"""
         import socket,signal
@@ -124,7 +124,7 @@ class ACQ_FTP(MDSplus.Device):
         signal.alarm(0)
         s.close()
         return state
-                  
+
     def doInit(self,tree,shot,path):
         """Tell the board to arm"""
         import socket,signal
@@ -185,7 +185,7 @@ class ACQ_FTP(MDSplus.Device):
         if self.debugging() :
             print "sending command %s."%(cmd,)
         try:
-            UUT = acq200.Acq200(transport.factory(boardip))
+            UUT = acq200.ACQ200(transport.factory(boardip))
         except:
             print "could not connect to the board %s"% (boardip,)
         try:
@@ -201,9 +201,9 @@ class ACQ_FTP(MDSplus.Device):
 
     def acqcmd(self, arg):
         boardip = self.getBoardIp()
-        
+
         try:
-            UUT = acq200.Acq200(transport.factory(boardip))
+            UUT = acq200.ACQ200(transport.factory(boardip))
         except:
             print "could not connect to the board %s"% (boardip,)
         try:
@@ -216,9 +216,9 @@ class ACQ_FTP(MDSplus.Device):
 
     def acq2sh(self, arg):
         boardip = self.getBoardIp()
-        
+
         try:
-            UUT = acq200.Acq200(transport.factory(boardip))
+            UUT = acq200.ACQ200(transport.factory(boardip))
         except:
             print "could not connect to the board %s"% (boardip,)
         try:

--- a/tdi/MitDevices/dt100.py
+++ b/tdi/MitDevices/dt100.py
@@ -1,9 +1,6 @@
 #!/usr/bin/python
 
-try:
-	import pexpect
-except:
-	print("Package pexpect not found but required for controlling dt100")
+import pexpect
 import re
 import transport
 import array
@@ -29,7 +26,7 @@ class Connection:
 		self.p = _p
 
 
-class Dt100(transport.Transport):
+class DT100(transport.Transport):
 	'connects to remote dt100 server, holds open connections and handles transactions'
 
 	def logtx(self, s):

--- a/tdi/MitDevices/dt196.py
+++ b/tdi/MitDevices/dt196.py
@@ -1,8 +1,6 @@
 from MDSplus import Device,Data,Action,Dispatch,Method, makeArray, Range, Signal, Window, Dimension
 
 from tempfile import *
-import acq200
-import transport
 from Dt200WriteMaster import Dt200WriteMaster
 
 from time import sleep, time
@@ -13,9 +11,9 @@ import array
 class DT196(Device):
     """
     D-Tacq ACQ196  96 channel transient recorder
-    
+
     """
-    
+
     parts=[
         {'path':':NODE','type':'text','value':'192.168.0.254','options':('no_write_shot',)},
         {'path':':BOARD','type':'text','value':'192.168.0.0','options':('no_write_shot',)},
@@ -52,7 +50,7 @@ class DT196(Device):
     parts.append({'path':':STORE_ACTION','type':'action',
                   'valueExpr':"Action(Dispatch('CAMAC_SERVER','STORE',50,None),Method(None,'STORE',head))",
                   'options':('no_write_shot',)})
-    
+
     trig_sources=[ 'DI0',
                    'DI1',
                    'DI2',
@@ -63,9 +61,9 @@ class DT196(Device):
     clock_sources = trig_sources
     clock_sources.append('INT')
     clock_sources.append('MASTER')
-    
+
     wires = [ 'fpga','mezz','rio','pxi','lemo', 'none', 'fpga pxi', ' ']
-    
+
     del i
     def getPreTrig(self,str) :
 	parts = str.split('=')
@@ -114,7 +112,7 @@ class DT196(Device):
 
     def timeoutHandler(self,sig,stack):
         raise Exception("Timeout occurred")
-        
+
     def getState(self):
         """Get the current state"""
         import socket,signal
@@ -130,7 +128,7 @@ class DT196(Device):
         signal.alarm(0)
         s.close()
         return state
-                  
+
     def doInit(self,tree,shot,path):
         """Get the current state"""
         import socket,signal
@@ -268,7 +266,7 @@ class DT196(Device):
             return 0
 
     INITFTP=initftp
-        
+
     def storeftp(self, arg):
 
         try:
@@ -312,7 +310,7 @@ class DT196(Device):
             delta=1./float(intClock)
 	else:
 	    delta = 0
-        
+
         #trigExpr = 'self.%s'% str(self.trig_src.record)
         #trig_src = eval(trigExpr.lower())
         trig_src = self.__getattr__(str(self.trig_src.record).lower())
@@ -364,7 +362,7 @@ class DT196(Device):
 			dim = Dimension(Window(start, end, trig_src ), axis)
                     else:
 			dim = Data.compile('Map($,$)', Dimension(Window(start/inc, end/inc, trig_src), axis), Range(start, end, inc))
-                    dat = Data.compile('build_signal(build_with_units( $*(0. + $value), "V") ,build_with_units($,"Counts"),$)', coefficent, buf,dim) 
+                    dat = Data.compile('build_signal(build_with_units( $*(0. + $value), "V") ,build_with_units($,"Counts"),$)', coefficent, buf,dim)
                     exec('c=self.input_'+'%02d'%(chan+1,)+'.record=dat')
 	return 1
 

--- a/tdi/MitDevices/dt196a.py
+++ b/tdi/MitDevices/dt196a.py
@@ -1,8 +1,6 @@
 from MDSplus import Device,Data,Action,Dispatch,Method, makeArray, Range, Signal, Window, Dimension
 
 from tempfile import *
-import acq200
-import transport
 from Dt200WriteMaster import Dt200WriteMaster
 
 from time import sleep, time
@@ -13,9 +11,9 @@ import array
 class DT196A(Device):
     """
     D-Tacq ACQ196  96 channel transient recorder
-    
+
     """
-    
+
     parts=[
         {'path':':NODE','type':'text','value':'192.168.0.254','options':('no_write_shot',)},
         {'path':':BOARD','type':'text','value':'192.168.0.0','options':('no_write_shot',)},
@@ -56,7 +54,7 @@ class DT196A(Device):
     parts.append({'path':':STORE_ACTION','type':'action',
                   'valueExpr':"Action(Dispatch('CAMAC_SERVER','STORE',50,None),Method(None,'WAITFTP',head))",
                   'options':('no_write_shot',)})
-    
+
     trig_sources=[ 'DI0',
                    'DI1',
                    'DI2',
@@ -67,9 +65,9 @@ class DT196A(Device):
     clock_sources = trig_sources
     clock_sources.append('INT')
     clock_sources.append('MASTER')
-    
+
     wires = [ 'fpga','mezz','rio','pxi','lemo', 'none', 'fpga pxi', ' ']
-    
+
     del i
     def getPreTrig(self,str) :
 	parts = str.split('=')
@@ -119,7 +117,7 @@ class DT196A(Device):
 
     def timeoutHandler(self,sig,stack):
         raise Exception("Timeout occurred")
-        
+
     def getState(self):
         """Get the current state"""
         import socket,signal
@@ -135,7 +133,7 @@ class DT196A(Device):
         signal.alarm(0)
         s.close()
         return state
-                  
+
     def doInit(self,tree,shot,path):
         """Get the current state"""
         import socket,signal
@@ -277,7 +275,7 @@ class DT196A(Device):
             return 0
 
     INITFTP=initftp
-        
+
     def storeftp(self, arg):
 
         try:
@@ -333,7 +331,7 @@ class DT196A(Device):
             delta=1./float(intClock)
 	else:
 	    delta = 0
-        
+
         trig_src = self.__getattr__(str(self.trig_src.record).lower())
 #
 # now store each channel
@@ -376,8 +374,8 @@ class DT196A(Device):
 			dim = Dimension(Window(start, end, trig_src ), axis)
                     else:
 			dim = Data.compile('Map($,$)', Dimension(Window(start/inc, end/inc, trig_src), axis), Range(start, end, inc))
-#                    dat = Data.compile('build_signal(build_with_units( $*(0. + $value), "V") ,build_with_units($,"Counts"),$)', coefficent, buf,dim) 
-		    dat = Data.compile('_v0=$, _v1=$, build_signal(build_with_units(( _v0+ (_v1-_v0)*($value - -32768)/(32767 - -32768 )), "V") ,build_with_units($,"Counts"),$)', vins[chan*2], vins[chan*2+1], buf,dim) 
+#                    dat = Data.compile('build_signal(build_with_units( $*(0. + $value), "V") ,build_with_units($,"Counts"),$)', coefficent, buf,dim)
+		    dat = Data.compile('_v0=$, _v1=$, build_signal(build_with_units(( _v0+ (_v1-_v0)*($value - -32768)/(32767 - -32768 )), "V") ,build_with_units($,"Counts"),$)', vins[chan*2], vins[chan*2+1], buf,dim)
                     exec('c=self.input_'+'%02d'%(chan+1,)+'.record=dat')
 	return 1
 

--- a/tdi/MitDevices/dt216.py
+++ b/tdi/MitDevices/dt216.py
@@ -1,8 +1,6 @@
 from MDSplus import Device,Data,Action,Dispatch,Method, makeArray, Range, Signal, Window, Dimension
 
 from tempfile import *
-import acq200
-import transport
 from Dt200WriteMaster import Dt200WriteMaster
 
 from time import sleep, time
@@ -13,9 +11,9 @@ import array
 class DT216(Device):
     """
     D-Tacq ACQ216  16 channel transient recorder
-    
+
     """
-    
+
     parts=[
         {'path':':NODE','type':'text','value':'192.168.0.254','options':('no_write_shot',)},
         {'path':':BOARD','type':'text','value':'192.168.0.0','options':('no_write_shot',)},
@@ -52,7 +50,7 @@ class DT216(Device):
     parts.append({'path':':STORE_ACTION','type':'action',
                   'valueExpr':"Action(Dispatch('CAMAC_SERVER','STORE',50,None),Method(None,'STORE',head))",
                   'options':('no_write_shot',)})
-    
+
     trig_sources=[ 'DI0',
                    'DI1',
                    'DI2',
@@ -63,9 +61,9 @@ class DT216(Device):
     clock_sources = trig_sources
     clock_sources.append('INT')
     clock_sources.append('MASTER')
-    
+
     wires = [ 'fpga','mezz','rio','pxi','lemo', 'none', 'fpga pxi', ' ']
-    
+
     del i
     def getPreTrig(self,str) :
 	parts = str.split('=')
@@ -115,7 +113,7 @@ class DT216(Device):
 
     def timeoutHandler(self,sig,stack):
         raise Exception("Timeout occurred")
-        
+
     def getState(self):
         """Get the current state"""
         import socket,signal
@@ -131,7 +129,7 @@ class DT216(Device):
         signal.alarm(0)
         s.close()
         return state
-                  
+
     def doInit(self,tree,shot,path):
         """Get the current state"""
         import socket,signal
@@ -269,7 +267,7 @@ class DT216(Device):
             return 0
 
     INITFTP=initftp
-        
+
     def storeftp(self, arg):
 
         try:
@@ -313,7 +311,7 @@ class DT216(Device):
             delta=1./float(intClock)
 	else:
 	    delta = 0
-        
+
         #trigExpr = 'self.%s'% str(self.trig_src.record)
         #trig_src = eval(trigExpr.lower())
         trig_src = self.__getattr__(str(self.trig_src.record).lower())
@@ -365,7 +363,7 @@ class DT216(Device):
 			dim = Dimension(Window(start, end, trig_src ), axis)
                     else:
 			dim = Data.compile('Map($,$)', Dimension(Window(start/inc, end/inc, trig_src), axis), Range(start, end, inc))
-                    dat = Data.compile('build_signal(build_with_units( $*(0. + $value), "V") ,build_with_units($,"Counts"),$)', coefficent, buf,dim) 
+                    dat = Data.compile('build_signal(build_with_units( $*(0. + $value), "V") ,build_with_units($,"Counts"),$)', coefficent, buf,dim)
                     exec('c=self.input_'+'%02d'%(chan+1,)+'.record=dat')
 	return 1
 

--- a/tdi/MitDevices/dt216a.py
+++ b/tdi/MitDevices/dt216a.py
@@ -1,8 +1,6 @@
 from MDSplus import Device,Data,Action,Dispatch,Method, makeArray, Range, Signal, Window, Dimension
 
 from tempfile import *
-import acq200
-import transport
 from Dt200WriteMaster import Dt200WriteMaster
 
 from time import sleep, time
@@ -13,11 +11,11 @@ import array
 class DT216A(Device):
     """
     D-Tacq ACQ216  16 channel transient recorder
-    
+
     """
-    
+
     parts=[
-        {'path':':NODE','type':'text','value':'192.168.0.254','options':('no_write_shot',)}, 
+        {'path':':NODE','type':'text','value':'192.168.0.254','options':('no_write_shot',)},
         {'path':':BOARD','type':'text','value':'192.168.0.0','options':('no_write_shot',)},
         {'path':':COMMENT','type':'text'},
         {'path':':RANGES','type':'text','value':'192.168.0.0','options':('write_once',)},
@@ -57,7 +55,7 @@ class DT216A(Device):
     parts.append({'path':':STORE_ACTION','type':'action',
                   'valueExpr':"Action(Dispatch('CAMAC_SERVER','STORE',50,None),Method(None,'WAITFTP',head))",
                   'options':('no_write_shot',)})
-    
+
     trig_sources=[ 'DI0',
                    'DI1',
                    'DI2',
@@ -68,9 +66,9 @@ class DT216A(Device):
     clock_sources = trig_sources
     clock_sources.append('INT')
     clock_sources.append('MASTER')
-    
+
     wires = [ 'fpga','mezz','rio','pxi','lemo', 'none', 'fpga pxi', ' ']
-    
+
     del i
     def getPreTrig(self,str) :
 	parts = str.split('=')
@@ -120,7 +118,7 @@ class DT216A(Device):
 
     def timeoutHandler(self,sig,stack):
         raise Exception("Timeout occurred")
-        
+
     def getState(self):
         """Get the current state"""
         import socket,signal
@@ -136,7 +134,7 @@ class DT216A(Device):
         signal.alarm(0)
         s.close()
         return state
-                  
+
     def doInit(self,tree,shot,path):
         """Get the current state"""
         import socket,signal
@@ -281,7 +279,7 @@ class DT216A(Device):
             return 0
 
     INITFTP=initftp
-        
+
     def storeftp(self, arg):
 
         try:
@@ -337,7 +335,7 @@ class DT216A(Device):
             delta=1./float(intClock)
 	else:
 	    delta = 0
-        
+
         trig_src = self.__getattr__(str(self.trig_src.record).lower())
 #
 # now store each channel
@@ -380,8 +378,8 @@ class DT216A(Device):
 			dim = Dimension(Window(start, end, trig_src ), axis)
                     else:
 			dim = Data.compile('Map($,$)', Dimension(Window(start/inc, end/inc, trig_src), axis), Range(start, end, inc))
-#                    dat = Data.compile('build_signal(build_with_units( $*(0. + $value), "V") ,build_with_units($,"Counts"),$)', coefficent, buf,dim) 
-		    dat = Data.compile('_v0=$, _v1=$, build_signal(build_with_units(( _v0+ (_v1-_v0)*($value - -32768)/(32767 - -32768 )), "V") ,build_with_units($,"Counts"),$)', vins[chan*2], vins[chan*2+1], buf,dim) 
+#                    dat = Data.compile('build_signal(build_with_units( $*(0. + $value), "V") ,build_with_units($,"Counts"),$)', coefficent, buf,dim)
+		    dat = Data.compile('_v0=$, _v1=$, build_signal(build_with_units(( _v0+ (_v1-_v0)*($value - -32768)/(32767 - -32768 )), "V") ,build_with_units($,"Counts"),$)', vins[chan*2], vins[chan*2+1], buf,dim)
                     exec('c=self.input_'+'%02d'%(chan+1,)+'.record=dat')
 	return 1
 

--- a/tdi/MitDevices/dt216b.py
+++ b/tdi/MitDevices/dt216b.py
@@ -1,26 +1,23 @@
 from MDSplus import Device,Data,Action,Dispatch,Method, makeArray, Range, Signal, Window, Dimension
-from Dt200WriteMaster import Dt200WriteMaster
 from tempfile import *
 import acq200
 import transport
 
-from time import sleep
 import os
-import numpy
 
 class DT216B(Device):
     """
     D-Tacq ACQ216  16 channel transient recorder
-    
+
     Methods:
     Add() - add a DT216B device to the tree open for edit
-    Init(arg) - initialize the DT216B device 
+    Init(arg) - initialize the DT216B device
                 write setup parameters and waveforms to the device
     Store(arg) - store the data acquired by the device
     Help(arg) - Print this message
-    
+
     Nodes:
-    
+
     :HOSTIP - mdsip address of the host storing the data.  Usually 192.168.0.254:8106
      BOARDIP'- ip addres sof the card as a string something like 192.168.0.40
      COMMENT - user comment string
@@ -29,18 +26,18 @@ class DT216B(Device):
             :bus  - string specifying the destination of this signal { 'fpga','rio','pxi', 'none }
     :ACTIVE_CHANS - number of active channels {2, 4, 8, 16}
      INT_CLOCK - stored by module (representation of internal clock
-     MASTER    - points to INT_CLOCK node - needed a node to fill into clock_src       
+     MASTER    - points to INT_CLOCK node - needed a node to fill into clock_src
      TRIG_SRC - reference to DIn line used for trigger (DI3)
-     TRIG_EDGE - string {rising, falling} 
+     TRIG_EDGE - string {rising, falling}
      CLOCK_SRC - reference to line (DIn) used for clock or INT_CLOCK, or MASTER
-     CLOCK_DIV - NOT CURRENTLY IMPLIMENTED 
+     CLOCK_DIV - NOT CURRENTLY IMPLIMENTED
      CLOCK_EDGE -  string {rising, falling}
      CLOCK_FREQ - frequency for internal clock
      PRE_TRIG - pre trigger samples MUST BE ZERO FOR NOW
      POST_TRIG - post trigger samples
      SEGMENTS - number of segments to store data in NOT IMPLIMENTED FOR NOW
      CLOCK - Filled in by store place for module to store clock information
-     RANGES - place for module to store calibration information 
+     RANGES - place for module to store calibration information
      STATUS_CMDS - array of shell commands to send to the module to record firmware version  etc
      BOARD_STATUS - place for module to store answers for STATUS_CMDS as signal
      INPUT_[01-16] - place for module to store data in volts (reference to INPUT_NN:RAW)
@@ -51,7 +48,7 @@ class DT216B(Device):
      INIT_ACTION - dispatching information for INIT
      STORE_ACTION - dispatching information for STORE
     """
-    
+
     parts=[
         {'path':':HOSTIP','type':'text','value':'192.168.0.254','options':('no_write_shot',)},
         {'path':':BOARDIP','type':'text','value':'192.168.0.0','options':('no_write_shot',)},
@@ -62,8 +59,8 @@ class DT216B(Device):
         parts.append({'path':':DI%1.1d:BUS'%(i,),'type':'text','options':('no_write_shot',)})
         parts.append({'path':':DI%1.1d:WIRE'%(i,),'type':'text','options':('no_write_shot',)})
     parts2=[
-        {'path':':ACTIVE_CHANS','type':'numeric','value':16,'options':('no_write_shot',)},        
-        {'path':':INT_CLOCK','type':'axis','options':('no_write_model','write_once')},       
+        {'path':':ACTIVE_CHANS','type':'numeric','value':16,'options':('no_write_shot',)},
+        {'path':':INT_CLOCK','type':'axis','options':('no_write_model','write_once')},
         {'path':':MASTER','type':'axis','valueExpr':'head.int_clock', 'options':('no_write_model','write_once')},
         {'path':':TRIG_SRC','type':'numeric','valueExpr':'head.di3','options':('no_write_shot',)},
         {'path':':TRIG_EDGE','type':'text','value':'rising','options':('no_write_shot',)},
@@ -96,7 +93,7 @@ class DT216B(Device):
     parts.append({'path':':WAIT_ACTION','type':'action',
                   'valueExpr':"Action(Dispatch('CAMAC_SERVER','STORE',50,None),Method(None,'WAIT',head))",
                   'options':('no_write_shot',)})
-    
+
     clock_edges=['rising', 'falling']
     trigger_edges = clock_edges
     trig_sources=[ 'DI0',
@@ -109,18 +106,18 @@ class DT216B(Device):
     clock_sources = trig_sources
     clock_sources.append('INT_CLOCK')
     clock_sources.append('MASTER')
-    
+
     wires = [ 'fpga','mezz','rio','pxi','lemo', 'none', 'fpga pxi']
-    
+
     del i
-    
+
     def check(self, expression, message):
         try:
             ans = eval(expression)
             return ans
         except:
             raise Exception, message
-        
+
     def init(self, arg):
         """
         Initialize the device
@@ -131,7 +128,7 @@ class DT216B(Device):
         debug=os.getenv("DEBUG_DEVICES")
         try:
             boardip=self.check( 'str(self.boardip.record)', "Must specify a board ipaddress")
-            UUT = acq200.Acq200(transport.factory(boardip))
+            UUT = acq200.ACQ200(transport.factory(boardip))
             active_chans = self.check("int(self.active_chans)", "Must specify active chans as int in (2, 4, 8, 16)")
             if active_chans not in (2,4,8,16) :
                 print "active chans must be in (2, 4,8, 16 )"
@@ -149,13 +146,13 @@ class DT216B(Device):
             if clock_src == 'INT_CLOCK' or clock_src == 'MASTER':
                 clock_freq = self.check('int(self.clock_freq)', "Must specify a frequency for internal clock")
             else:
-                clock_freq = self.check('int(self.clock_freq)', "Must specify a frequency for external clock")                
+                clock_freq = self.check('int(self.clock_freq)', "Must specify a frequency for external clock")
                 clock_div = self.check('int(self.clock_div)', "Must specify a divisor for external clock")
             pre_trig=self.check('int(self.pre_trig.data()*1024)', "Must specify pre trigger samples")
             post_trig=self.check('int(self.post_trig.data()*1024)', "Must specify post trigger samples")
             UUT.set_abort()
             UUT.clear_routes()
-            
+
             for i in range(6):
                 line = 'd%1.1d' % i
                 try:
@@ -183,7 +180,7 @@ class DT216B(Device):
 		UUT.uut.acqcmd("setExternalClock %s" % clock_src)
             UUT.setPrePostMode(pre_trig, post_trig)
             mask = UUT.uut.acqcmd('getChannelMask').split('=')[-1]
-            UUT.set_arm() 
+            UUT.set_arm()
             return  1
 
         except Exception,e:
@@ -191,18 +188,18 @@ class DT216B(Device):
             return 0
 
     INIT=init
-        
+
     def getVins(self, UUT):
         vins = UUT.uut.acq2sh('get.vin 1:16')
         ans = eval('makeArray([%s])' % vins)
         return ans
 
-        
+
     def getInternalClock(self, UUT):
         clock_str = UUT.uut.acqcmd('getInternalClock').split()[0].split('=')[1]
         print "clock_str is -%s-" % clock_str
         return eval('int(%s)' % clock_str)
-        
+
     def store(self, arg):
         """
         Store the data from the device
@@ -218,7 +215,7 @@ class DT216B(Device):
         debug=os.getenv("DEBUG_DEVICES")
         try:
             boardip=self.check( 'str(self.boardip.record)', "Must specify a board ipaddress")
-            UUT = acq200.Acq200(transport.factory(boardip))
+            UUT = acq200.ACQ200(transport.factory(boardip))
             try:
                 ans = []
                 cmds = self.status_cmds.record
@@ -244,7 +241,7 @@ class DT216B(Device):
             mask = UUT.uut.acqcmd('getChannelMask').split('=')[-1]
             if debug:
                 print "pre = %d, post = %d" % (pre, post, )
-            clock_src=self.check('self.clock_src.record.getOriginalPartName().getString()[1:]', "Clock source must be a string") 
+            clock_src=self.check('self.clock_src.record.getOriginalPartName().getString()[1:]', "Clock source must be a string")
             if clock_src == 'INT_CLOCK' or clock_src == 'MASTER' :
                 self.clock.record = Range(delta=1./self.getInternalClock(UUT))
             else:
@@ -328,7 +325,7 @@ class DT216B(Device):
         except Exception,e :
             print "Error storing DT216B Device\n%s" % ( str(e), )
             return 0
-                
+
         return 1
 
     STORE=store
@@ -341,8 +338,8 @@ class DT216B(Device):
     HELP=help
 
     def wait(self, arg):
-	""" 
-           Wait method for dt216b module  
+	"""
+           Wait method for dt216b module
            wait for the device to complete
            asynchronous data acquisition tasks
         """

--- a/tdi/MitDevices/transport.py
+++ b/tdi/MitDevices/transport.py
@@ -1,5 +1,3 @@
-import dt100
-
 class Transport:
         def connectMaster(self):
                 pass
@@ -13,8 +11,7 @@ class Transport:
         def acq2sh(self,  command):
                 pass
 
-
-
 def factory(uut):
-        # if uut is a single number -> local file transport
-        return dt100.Dt100(uut)
+    import dt100
+    # if uut is a single number -> local file transport
+    return dt100.DT100(uut)

--- a/tdi/RfxDevices/__init__.py
+++ b/tdi/RfxDevices/__init__.py
@@ -27,71 +27,55 @@ try:
 except:
     __version__='Unknown'
 
-from MDSplus import Device as _debug
-if _debug.debug:
-    from sys import stdout as _stdout
-    def _debug(s,p=tuple()):
-        _stdout.write(s % p)
-else:
-    def _debug(s,p=tuple()):
-        pass
-def _mimport(name):
-    _debug('loading %-16s',(name+':'))
-    try:
-        try:
-            module = __import__(name, globals(), fromlist=[name], level=1).__getattribute__(name)
-        except:
-            module = __import__(name, globals(), fromlist=[name]).__getattribute__(name)
-        _debug(' successful\n')
-        return module
-    except Exception as exc:
-        _debug(' failed: %s\n'%exc)
+def _mimport(filename,name=None,local=locals()):
+    from MDSplus import Device
+    Device._mimport(globals(),local,filename,name)
 
-ACQIPPSETUP = _mimport('ACQIPPSETUP')
-CAENDT5720 = _mimport('CAENDT5720')
-CAENV1740 = _mimport('CAENV1740')
-CONTIPPSETUP = _mimport('CONTIPPSETUP')
-CYGNET4K = _mimport('CYGNET4K')
+_mimport('ACQIPPSETUP')
+_mimport('CAENDT5720')
+_mimport('CAENV1740')
+_mimport('CONTIPPSETUP')
+_mimport('CYGNET4K')
 # DIO
-DIO4 = _mimport('DIO4')
-DIO2_ENCDEC = _mimport('DIO2_ENCDEC')
+_mimport('DIO4')
+_mimport('DIO2_ENCDEC')
 
-FAKECAMERA = _mimport('FAKECAMERA')
-FEMTO = _mimport('FEMTO')
-FLIRSC65X = _mimport('FLIRSC65X')
-MARTE_CONFIG = _mimport('MARTE_CONFIG')
+_mimport('FAKECAMERA')
+_mimport('FEMTO')
+_mimport('FLIRSC65X')
+_mimport('MARTE_CONFIG')
 # MARTE_COMMON
-MARTE_COMMON = _mimport('MARTE_COMMON')
-MARTE_DEVICE = _mimport('MARTE_DEVICE')
-MARTE_RTSM = _mimport('MARTE_RTSM')
+_mimport('MARTE_COMMON')
+_mimport('MARTE_DEVICE')
+_mimport('MARTE_RTSM')
 # MARTE_GENERIC
-MARTE_GENERIC = _mimport('MARTE_GENERIC')
-MARTE = _mimport('MARTE')
-MARTE_BREAKDOWN = _mimport('MARTE_BREAKDOWN')
-MARTE_DEQU = _mimport('MARTE_DEQU')
-MARTE_EDA1 = _mimport('MARTE_EDA1')
-MARTE_EDA1_OUT = _mimport('MARTE_EDA1_OUT')
-MARTE_EDA3 = _mimport('MARTE_EDA3')
-MARTE_EDA3_OUT = _mimport('MARTE_EDA3_OUT')
-MARTE_MHD_AC_BC = _mimport('MARTE_MHD_AC_BC')
-MARTE_MHD_BR = _mimport('MARTE_MHD_BR')
-MARTE_MHD_BT = _mimport('MARTE_MHD_BT')
-MARTE_MHD_CTRL = _mimport('MARTE_MHD_CTRL')
-MARTE_MHD_I = _mimport('MARTE_MHD_I')
-MARTE_NE = _mimport('MARTE_NE')
-MARTE_WAVEGEN = _mimport('MARTE_WAVEGEN')
-MARTE_XRAY = _mimport('MARTE_XRAY')
+_mimport('MARTE_GENERIC')
+_mimport('MARTE')
+_mimport('MARTE_BREAKDOWN')
+_mimport('MARTE_DEQU')
+_mimport('MARTE_EDA1')
+_mimport('MARTE_EDA1_OUT')
+_mimport('MARTE_EDA3')
+_mimport('MARTE_EDA3_OUT')
+_mimport('MARTE_MHD_AC_BC')
+_mimport('MARTE_MHD_BR')
+_mimport('MARTE_MHD_BT')
+_mimport('MARTE_MHD_CTRL')
+_mimport('MARTE_MHD_I')
+_mimport('MARTE_NE')
+_mimport('MARTE_WAVEGEN')
+_mimport('MARTE_XRAY')
 
-MILL3 = _mimport('MILL3')
-NI6259AI = _mimport('NI6259AI')
-NI6368AI = _mimport('NI6368AI')
-NI6682 = _mimport('NI6682')
-REDPYTADC = _mimport('REDPYTADC')
-RFX_PROTECTIONS = _mimport('RFX_PROTECTIONS')
-RFXVICONTROL = _mimport('RFXVICONTROL')
-RFXWAVESETUP = _mimport('RFXWAVESETUP')
-SIS3820 = _mimport('SIS3820')
-SPIDER = _mimport('SPIDER')
-SPIDER_SM = _mimport('SPIDER_SM')
-ZELOS2150GV = _mimport('ZELOS2150GV')
+_mimport('MILL3')
+_mimport('NI6259AI')
+_mimport('NI6368AI')
+_mimport('NI6682')
+_mimport('REDPYTADC')
+_mimport('RFX_PROTECTIONS')
+_mimport('RFXVICONTROL')
+_mimport('RFXWAVESETUP')
+_mimport('SIS3820')
+_mimport('SPIDER')
+_mimport('SPIDER_SM')
+_mimport('ZELOS2150GV')
 print('RfxDevices loaded.')

--- a/tdi/W7xDevices/__init__.py
+++ b/tdi/W7xDevices/__init__.py
@@ -27,5 +27,9 @@ try:
 except:
     __version__='Unknown'
 
-from bnc845 import BNC845
-from qc9200 import QC9200
+def _mimport(filename,name=None,local=locals()):
+    from MDSplus import Device
+    Device._mimport(globals(),local,filename,name)
+
+_mimport('bnc845','BNC845')
+_mimport('qc9200','QC9200')

--- a/tdi/W7xDevices/bnc845.py
+++ b/tdi/W7xDevices/bnc845.py
@@ -46,7 +46,6 @@ def bnc_report (ok) : return ' . . . OK' if ok else ' . . . Not OK'
 
 class BNC845 (MDSplus.Device) :
 	"""Control functions for the BNC generator supplied by FZ Juelich, based on BNCCommunication.py by A. Kraemer-Flecken (a.kraemer-flecken@fz-juelich.de).  Can be tested with script sim_bncgen from the MDSplusW7X project."""
-
 	parts=[{'path': ':HOST',         'type': 'TEXT',    'options':('no_write_shot',), 'value': '192.168.0.100'},
 	       {'path': ':PORT',         'type': 'NUMERIC', 'options':('no_write_shot',), 'value': 18},
 	       {'path': ':TRIG_SRC',     'type': 'TEXT',    'options':('no_write_shot',), 'value': 'external'},

--- a/tdi/W7xDevices/qc9200.py
+++ b/tdi/W7xDevices/qc9200.py
@@ -17,7 +17,6 @@ def qc_talk (ser, msg) :
 
 class QC9200 (Device) :
     """Limited control for the Quantum Composers Sapphire 9200 Series Pulse Generator."""
-    if Device.debug: print('QC9200')
     parts=[{'path': ':PORT',        'type': 'TEXT',    'options':('no_write_shot',), 'value': 'COM3'}, # likely /dev/ttyACM0 on Linux
            {'path': ':TRIG_LEVEL',  'type': 'NUMERIC', 'options':('no_write_shot',), 'value': 2.5},
            {'path': ':TRIG_EDGE',   'type': 'TEXT',    'options':('no_write_shot',), 'value': 'RISING'}, # or FALLING

--- a/tdi/W7xDevices/setup.py
+++ b/tdi/W7xDevices/setup.py
@@ -7,6 +7,7 @@ try:
     else:
         name="mdsplus_%s_w7xdevices" % branch
 except:
+    import os
     if "BRANCH" in os.environ and os.environ["BRANCH"] != "stable":
         branch="_"+os.environ["BRANCH"]
     else:


### PR DESCRIPTION
this allows to test the core shot cycle (dispatcher) independant from
without the devices
importer is wrapped arround static method of the MDSplus.Device

in MitDevices some changes to device dt100 and Acq200 where made to fit
with general schema for MitDevices (upper-case device names)
