### PR TITLE
Twf deploy fixes

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -149,6 +149,7 @@ install: $(install_DIRS)
 		--exclude='*.pyc' \
 		--exclude=__pycache__ \
 		--exclude=python/build \
+                --exclude=tdi/*Devices/build \
 		--exclude='*egg-info' \
 		--exclude='*\.in' \
 		--exclude='Makefile\.*' \

--- a/deploy/platform/debian/debian_docker_build.sh
+++ b/deploy/platform/debian/debian_docker_build.sh
@@ -445,7 +445,7 @@ then
 	else
 	    set +e
 	    echo "Checking contents of $(basename $deb)"
-	    if ( makelist $deb | diff - ${checkfile} )
+	    if ( diff <(makelist $deb) <(sort ${checkfile}) )
 	    then
 		echo "Contents of $(basename $deb) is correct."
 	    else

--- a/deploy/platform/redhat/redhat_docker_build.sh
+++ b/deploy/platform/redhat/redhat_docker_build.sh
@@ -447,7 +447,7 @@ EOF
 	else
 	    set +e
 	    echo "Checking contents of $(basename $rpm)"
-	    if ( makelist $rpm | diff - ${checkfile} )
+	    if ( diff <(makelist $rpm) <(sort ${checkfile}) )
 	    then
 		echo "Contents of $(basename $rpm) is correct."
 	    else


### PR DESCRIPTION
Fix for main Makefile to prevent /build directories from getting into install directories if a python setup.py was done in one of the python module directories manually. (i.e. mdsobjects/python and tdi/*Devices). While this will not happen during normal release builds, it can cause problem when the script to update the package contents is run on a source directory tainted with /build directories.

Also changed the package content checker to again sort the expected contents files when validating package contents. If a package content file is updated manually instead of using the updatepkg.sh script then the content checker may fail if the change was not put in the correct sort location.