### PR TITLE
Twf fix windows vs build

### DIFF
--- a/deploy/build.sh
+++ b/deploy/build.sh
@@ -328,7 +328,7 @@ parsecmd() {
 		COLOR=yes
 		;;
 	    --winhost=*)
-		WINDOWSHOST="${i#*=}"
+		WINHOST="${i#*=}"
 		;;
 	    --winbld=*)
 		WINBLD="${i#*=}"

--- a/include/mdsobjects.h
+++ b/include/mdsobjects.h
@@ -13,7 +13,9 @@
 
 #ifdef _MSC_VER
 #include <windows.h>
+#define UNUSED_ARGUMENT
 #else
+#define UNUSED_ARGUMENT __attribute__ ((unused))
 #include <sys/types.h>
 //#include <sys/ipc.h>
 //#include <sys/sem.h>
@@ -308,7 +310,7 @@ public:
     }
 
     /// \return true if this and data match, false otherwise and as default
-    virtual bool equals(Data *data __attribute__ ((unused))) { return false; }
+    virtual bool equals(Data *data UNUSED_ARGUMENT) { return false; }
 
     /// \return Return the result of TDI evaluate
     Data *evaluate();
@@ -371,7 +373,7 @@ public:
     virtual std::vector<uint64_t> getLongUnsignedArray();
     virtual double * getDoubleArray(int *numElements);
     virtual std::vector<double> getDoubleArray();
-    virtual std::complex<double> * getComplexArray(int *numElements __attribute__ ((unused))) {
+    virtual std::complex<double> * getComplexArray(int *numElements UNUSED_ARGUMENT) {
         throw MdsException("getComplexArray() not supported for non Complex data types"); }
     virtual std::vector<std::complex<double> > getComplexArray();
     virtual char ** getStringArray(int *numElements) {
@@ -926,7 +928,7 @@ public:
         init(val, std::string(val).size(), units, error, help, validation);
     }
 
-    String(unsigned char *uval, int len __attribute__ ((unused)), Data *units = 0, Data *error = 0, Data *help = 0, Data *validation = 0) {
+    String(unsigned char *uval, int len UNUSED_ARGUMENT, Data *units = 0, Data *error = 0, Data *help = 0, Data *validation = 0) {
         // FIXME: Hack to handle broken LabView types that use unsigned char (as uint8) instead of char
         // FIXME: Warning: Do not use this constructor in user code
         char * val = reinterpret_cast<char *>(uval);
@@ -934,7 +936,7 @@ public:
     }
 
     //GAB  definition in order to avoid breaking LabVIEW
-    String(unsigned char *uval, int numDims __attribute__ ((unused)), int *dims __attribute__ ((unused)), Data *units = 0, Data *error = 0, Data *help = 0, Data *validation = 0) {
+    String(unsigned char *uval, int numDims UNUSED_ARGUMENT, int *dims UNUSED_ARGUMENT, Data *units = 0, Data *error = 0, Data *help = 0, Data *validation = 0) {
         char * val = reinterpret_cast<char *>(uval);
         init(val, std::string(val).size(), units, error, help, validation);
     }
@@ -3812,7 +3814,7 @@ public:
     ~Connection();
     void openTree(char *tree, int shot);
     void closeAllTrees();
-    void closeTree(char *tree __attribute__ ((unused)), int shot __attribute__ ((unused)))
+    void closeTree(char *tree UNUSED_ARGUMENT, int shot UNUSED_ARGUMENT)
     {
         closeAllTrees();
     }

--- a/include/mdsplus/numeric_cast.hpp
+++ b/include/mdsplus/numeric_cast.hpp
@@ -6,7 +6,11 @@
 #include <cmath>
 #include <limits>
 #include <stdexcept>
-
+#ifdef _MSC_VER
+#define UNUSED_ARGUMENT
+#else
+#define UNUSED_ARGUMENT __attribute__ ((unused))
+#endif
 
 #include "mdsplus/Traits.hpp"
 
@@ -93,7 +97,7 @@ struct numeric_cast_min_rule {
 template < typename Target, typename Source, typename EnableIf = void >
 struct numeric_cast_precision_rule {
     typedef numeric_cast_trait<Target,Source> trait;
-  static inline void apply(Source value __attribute__ ((unused))) {
+  static inline void apply(Source value UNUSED_ARGUMENT) {
     //        if( trait::is_coercion ) {
     //            if( value > (Source)(1<<numeric_limits<Target>::digits) )
     //                throw(std::range_error("scalar loss of precision for digit overflow") );

--- a/mdsobjects/cpp/datastreams.cpp
+++ b/mdsobjects/cpp/datastreams.cpp
@@ -331,7 +331,7 @@ EXPORT void *getNewSamplesSerializedXd()
 
 
 ///Periodically check the list of registered data items for new data availability
-void *monitorStreamInfo(void *par __attribute__ ((unused)))
+void *monitorStreamInfo(void *par UNUSED_ARGUMENT)
 {
 	struct timespec waitTime;
 	waitTime.tv_sec = 0;

--- a/mdsobjects/cpp/mdsdata.c
+++ b/mdsobjects/cpp/mdsdata.c
@@ -98,7 +98,12 @@ void *convertToArrayDsc(int clazz, int dtype, int length, int arsize, int nDims,
 }
 
 #define MAX_ARGS 128
-void *convertToCompoundDsc(int clazz __attribute__ ((unused)), int dtype, int length, void *ptr, int ndescs, void **descs)
+
+#ifndef _MSC_VER
+#define unused __attribute__ ((unused))
+#endif
+
+void *convertToCompoundDsc(int clazz unused, int dtype, int length, void *ptr, int ndescs, void **descs)
 {
   EMPTYXD(emptyXd);
   struct descriptor_xd *xds[MAX_ARGS];

--- a/mdsobjects/cpp/mdsdata.c
+++ b/mdsobjects/cpp/mdsdata.c
@@ -100,12 +100,12 @@ void *convertToArrayDsc(int clazz, int dtype, int length, int arsize, int nDims,
 #define MAX_ARGS 128
 
 #ifdef _MSC_VER
-#define unused
+#define UNUSED_ARGUMENT
 #else
-#define unused __attribute__ ((unused))
+#define UNUSED_ARGUMENT __attribute__ ((unused))
 #endif
 
-void *convertToCompoundDsc(int clazz unused, int dtype, int length, void *ptr, int ndescs, void **descs)
+void *convertToCompoundDsc(int clazz UNUSED_ARGUMENT, int dtype, int length, void *ptr, int ndescs, void **descs)
 {
   EMPTYXD(emptyXd);
   struct descriptor_xd *xds[MAX_ARGS];

--- a/mdsobjects/cpp/mdsdata.c
+++ b/mdsobjects/cpp/mdsdata.c
@@ -99,7 +99,9 @@ void *convertToArrayDsc(int clazz, int dtype, int length, int arsize, int nDims,
 
 #define MAX_ARGS 128
 
-#ifndef _MSC_VER
+#ifdef _MSC_VER
+#define unused
+#else
 #define unused __attribute__ ((unused))
 #endif
 

--- a/mdsobjects/cpp/mdsdataobjects.cpp
+++ b/mdsobjects/cpp/mdsdataobjects.cpp
@@ -626,7 +626,7 @@ double Data::getDouble()
 	return scalar.ptr->getDouble();
 }
 
-Data * Data::getDimensionAt(int dimIdx __attribute__ ((unused))) {
+Data * Data::getDimensionAt(int dimIdx UNUSED_ARGUMENT) {
 	return executeWithArgs("DIM_OF($)", 1, this);
 }
 

--- a/mdsobjects/cpp/mdsipobjects.cpp
+++ b/mdsobjects/cpp/mdsipobjects.cpp
@@ -523,7 +523,7 @@ void GetMany::append(char *name, char *expr, Data **args, int nArgs) {
 	insert(len(), name, expr, args, nArgs);
 }
 
-void GetMany::insert(char * beforeName __attribute__ ((unused)), char *name, char *expr, Data **args, int nArgs)
+void GetMany::insert(char * beforeName UNUSED_ARGUMENT, char *name, char *expr, Data **args, int nArgs)
 {
 	int nItems = len();
 	int idx;
@@ -618,7 +618,7 @@ void PutMany::append(char *name, char *expr, Data **args, int nArgs) {
 	insert(len(), name, expr, args, nArgs);
 }
 
-void PutMany::insert(char * beforeName __attribute__ ((unused)), char *nodeName, char *expr, Data **args, int nArgs) {
+void PutMany::insert(char * beforeName UNUSED_ARGUMENT, char *nodeName, char *expr, Data **args, int nArgs) {
 	int nItems = len();
 	int idx;
 	String nameKey("node");

--- a/mdsobjects/cpp/testing/MdsActionTest.cpp
+++ b/mdsobjects/cpp/testing/MdsActionTest.cpp
@@ -9,7 +9,7 @@ using namespace MDSplus;
 using namespace testing;
 
 
-int main(int argc __attribute__ ((unused)), char *argv[] __attribute__ ((unused)))
+int main(int argc UNUSED_ARGUMENT, char *argv[] UNUSED_ARGUMENT)
 {    
     BEGIN_TESTING(Action);
     SKIP_TEST("Action test is not implemented yet");

--- a/mdsobjects/cpp/testing/MdsApdTest.cpp
+++ b/mdsobjects/cpp/testing/MdsApdTest.cpp
@@ -9,7 +9,7 @@ using namespace MDSplus;
 using namespace testing;
 
 
-int main(int argc __attribute__ ((unused)), char *argv[] __attribute__ ((unused)))
+int main(int argc UNUSED_ARGUMENT, char *argv[] UNUSED_ARGUMENT)
 {
     BEGIN_TESTING(Apd);
     SKIP_TEST("Apd test is not implemented yet");

--- a/mdsobjects/cpp/testing/MdsCallTest.cpp
+++ b/mdsobjects/cpp/testing/MdsCallTest.cpp
@@ -15,7 +15,7 @@ using namespace testing;
 /// This test refers to three C functions compiled into a shared library that 
 /// should be present in ./testutils/libMdsTestDummy.so
 
-int main(int,char **argv __attribute__ ((unused))) {
+int main(int,char **argv UNUSED_ARGUMENT) {
     BEGIN_TESTING(Call);
 
     SKIP_TEST("Skipping this tests for now .. call fails if a full .so path is passed");

--- a/mdsobjects/cpp/testing/MdsCompoundTest.cpp
+++ b/mdsobjects/cpp/testing/MdsCompoundTest.cpp
@@ -39,7 +39,7 @@ using namespace testing;
 //    void * convertToDsc();
 //    virtual ~Compound();
 
-int main(int argc __attribute__ ((unused)), char *argv[] __attribute__ ((unused)))
+int main(int argc UNUSED_ARGUMENT, char *argv[] UNUSED_ARGUMENT)
 {
     BEGIN_TESTING(Compound);
 

--- a/mdsobjects/cpp/testing/MdsConglomTest.cpp
+++ b/mdsobjects/cpp/testing/MdsConglomTest.cpp
@@ -35,7 +35,7 @@ using namespace testing;
 //    void setQualifiers(Data *qualifiers) {assignDescAt(qualifiers, 3);}
 //};
 
-int main(int argc __attribute__ ((unused)), char **argv __attribute__ ((unused))) {
+int main(int argc UNUSED_ARGUMENT, char **argv UNUSED_ARGUMENT) {
     BEGIN_TESTING(Conglom);                
     
     { // CTR

--- a/mdsobjects/cpp/testing/MdsConnectionSuppression.cpp
+++ b/mdsobjects/cpp/testing/MdsConnectionSuppression.cpp
@@ -20,7 +20,7 @@ using namespace testing;
 
 
 
-int main(int argc __attribute__ ((unused)), char *argv[] __attribute__ ((unused)))
+int main(int argc UNUSED_ARGUMENT, char *argv[] UNUSED_ARGUMENT)
 {
     
     Connection cnx((char*)"udt://localhost:8000",0);    

--- a/mdsobjects/cpp/testing/MdsConnectionTest.cpp
+++ b/mdsobjects/cpp/testing/MdsConnectionTest.cpp
@@ -1,7 +1,7 @@
 // if windows skip this test .. //
 #ifdef _WIN32
 #include "testing.h"
-int main(int argc __attribute__ ((unused)), char *argv[] __attribute__ ((unused))) { SKIP_TEST("Connection test requires fork") }
+int main(int argc UNUSED_ARGUMENT, char *argv[] UNUSED_ARGUMENT) { SKIP_TEST("Connection test requires fork") }
 #else 
 
 
@@ -78,7 +78,7 @@ void test_tree_open(const char *prot)
 
 
 
-int main(int argc __attribute__ ((unused)), char *argv[] __attribute__ ((unused)))
+int main(int argc UNUSED_ARGUMENT, char *argv[] UNUSED_ARGUMENT)
 {
     BEGIN_TESTING(Connection);
         

--- a/mdsobjects/cpp/testing/MdsDataTest.cpp
+++ b/mdsobjects/cpp/testing/MdsDataTest.cpp
@@ -22,7 +22,7 @@
 using namespace MDSplus;
 using namespace testing;
 
-int main(int argc __attribute__ ((unused)), char *argv[] __attribute__ ((unused)))
+int main(int argc UNUSED_ARGUMENT, char *argv[] UNUSED_ARGUMENT)
 {
     BEGIN_TESTING(Mds Data Test);
  

--- a/mdsobjects/cpp/testing/MdsEventSuppression.cpp
+++ b/mdsobjects/cpp/testing/MdsEventSuppression.cpp
@@ -9,7 +9,7 @@
 using namespace MDSplus;
 using namespace testing;
 
-int main(int argc __attribute__ ((unused)), char *argv[] __attribute__ ((unused)))
+int main(int argc UNUSED_ARGUMENT, char *argv[] UNUSED_ARGUMENT)
 {
     
     {

--- a/mdsobjects/cpp/testing/MdsEventTest.cpp
+++ b/mdsobjects/cpp/testing/MdsEventTest.cpp
@@ -124,7 +124,7 @@ public:
 };
 
 
-int main(int argc __attribute__ ((unused)), char *argv[] __attribute__ ((unused)))
+int main(int argc UNUSED_ARGUMENT, char *argv[] UNUSED_ARGUMENT)
 {
     BEGIN_TESTING(Event);
 #   ifdef _WIN32

--- a/mdsobjects/cpp/testing/MdsExpressionCompileTest.cpp
+++ b/mdsobjects/cpp/testing/MdsExpressionCompileTest.cpp
@@ -5,7 +5,7 @@ using namespace MDSplus;
 
 
 
-int main(int argc __attribute__ ((unused)), char *argv[] __attribute__ ((unused)))
+int main(int argc UNUSED_ARGUMENT, char *argv[] UNUSED_ARGUMENT)
 {
     BEGIN_TESTING(ExpressionCompile);
            

--- a/mdsobjects/cpp/testing/MdsFunctionTest.cpp
+++ b/mdsobjects/cpp/testing/MdsFunctionTest.cpp
@@ -20,7 +20,7 @@ void PrintOpcodes () {
 
 
 
-int main(int argc __attribute__ ((unused)), char **argv) {
+int main(int argc UNUSED_ARGUMENT, char **argv) {
     BEGIN_TESTING(Function);
             
     if( argc > 1 && std::string(argv[1]) == std::string("print")) {

--- a/mdsobjects/cpp/testing/MdsScalarTest_NumericConversion.cpp
+++ b/mdsobjects/cpp/testing/MdsScalarTest_NumericConversion.cpp
@@ -310,7 +310,7 @@ void test_Complex64Array() {
 ////////////////////////////////////////////////////////////////////////////////
 
 
-int main(int argc __attribute__ ((unused)), char *argv[] __attribute__ ((unused)))
+int main(int argc UNUSED_ARGUMENT, char *argv[] UNUSED_ARGUMENT)
 {
     BEGIN_TESTING(Data);
 

--- a/mdsobjects/cpp/testing/MdsScalarTest_NumericLimits.cpp
+++ b/mdsobjects/cpp/testing/MdsScalarTest_NumericLimits.cpp
@@ -141,7 +141,7 @@ public:
 
 
 
-int main(int argc __attribute__ ((unused)), char *argv[] __attribute__ ((unused)))
+int main(int argc UNUSED_ARGUMENT, char *argv[] UNUSED_ARGUMENT)
 {
     BEGIN_TESTING(Data);
 

--- a/mdsobjects/cpp/testing/MdsScalarTest_ScalarCast.cpp
+++ b/mdsobjects/cpp/testing/MdsScalarTest_ScalarCast.cpp
@@ -54,7 +54,7 @@ numeric_cast_test() {
 
 
 /// this may trigger an exception where overflow should be thrown by numeric_cast
-int main(int argc __attribute__ ((unused)), char *argv[] __attribute__ ((unused)))
+int main(int argc UNUSED_ARGUMENT, char *argv[] UNUSED_ARGUMENT)
 {
     BEGIN_TESTING(ScalarCast);
 

--- a/mdsobjects/cpp/testing/MdsSignalTest.cpp
+++ b/mdsobjects/cpp/testing/MdsSignalTest.cpp
@@ -37,7 +37,7 @@ using namespace testing;
 //};
 
 
-int main(int argc __attribute__ ((unused)), char *argv[] __attribute__ ((unused)))
+int main(int argc UNUSED_ARGUMENT, char *argv[] UNUSED_ARGUMENT)
 {
     BEGIN_TESTING(Signal);
 

--- a/mdsobjects/cpp/testing/MdsStringTest.cpp
+++ b/mdsobjects/cpp/testing/MdsStringTest.cpp
@@ -31,7 +31,7 @@ using namespace testing;
 //};
 
 
-int main(int argc __attribute__ ((unused)), char *argv[] __attribute__ ((unused)))
+int main(int argc UNUSED_ARGUMENT, char *argv[] UNUSED_ARGUMENT)
 {
     BEGIN_TESTING(String);
 

--- a/mdsobjects/cpp/testing/MdsTreeNodeTest.cpp
+++ b/mdsobjects/cpp/testing/MdsTreeNodeTest.cpp
@@ -82,7 +82,7 @@ void print_segment_info(TreeNode *node, int segment = -1)
 #endif
 
 
-int main(int argc __attribute__ ((unused)), char *argv[] __attribute__ ((unused)))
+int main(int argc UNUSED_ARGUMENT, char *argv[] UNUSED_ARGUMENT)
 {
     BEGIN_TESTING(TreeNode);
 
@@ -228,7 +228,7 @@ int main(int argc __attribute__ ((unused)), char *argv[] __attribute__ ((unused)
         data = node->getData();
         TEST1( data->getInt() == 5552368 );
 
-        int len __attribute__ ((unused)) = node->getLength();
+        int len UNUSED_ARGUMENT = node->getLength();
 
         // getLength()  Nci length of Int32 is 12
         TEST1( node->getLength() == 12 );

--- a/mdsobjects/cpp/testing/MdsTreeSuppression.cpp
+++ b/mdsobjects/cpp/testing/MdsTreeSuppression.cpp
@@ -24,7 +24,7 @@ using namespace testing;
 
 // this seems to catch a leak in treeshr
 
-int main(int argc __attribute__ ((unused)), char *argv[] __attribute__ ((unused)))
+int main(int argc UNUSED_ARGUMENT, char *argv[] UNUSED_ARGUMENT)
 {
     BEGIN_TESTING(MDSTreeSuppression);
 #ifdef _WIN32

--- a/mdsobjects/cpp/testing/MdsTreeTest.cpp
+++ b/mdsobjects/cpp/testing/MdsTreeTest.cpp
@@ -90,7 +90,7 @@ using namespace testing;
 
 
 
-int main(int argc __attribute__ ((unused)), char *argv[] __attribute__ ((unused)))
+int main(int argc UNUSED_ARGUMENT, char *argv[] UNUSED_ARGUMENT)
 {
     BEGIN_TESTING(Tree);
 

--- a/mdsobjects/cpp/testing/buildtest.cpp
+++ b/mdsobjects/cpp/testing/buildtest.cpp
@@ -5,7 +5,7 @@
 
 #include <limits>
 
-int main(int argc __attribute__ ((unused)), char *argv[] __attribute__ ((unused)))
+int main(int argc UNUSED_ARGUMENT, char *argv[] UNUSED_ARGUMENT)
 {
     BEGIN_TESTING(build);
     


### PR DESCRIPTION
Enable building of Visual Studio version of the MDSobjectsCppShr-VS.dll. Fixes problems caused by the removal of GNU compiler warnings by using compiler specific syntax.