### PR TITLE
Fixes for CAMAC used in Sweden

### DIFF
--- a/tdi/MitDevices/aeon_getchannel.fun
+++ b/tdi/MitDevices/aeon_getchannel.fun
@@ -6,5 +6,6 @@ public fun aeon_getchannel(in _name, in _addr, in _chan, in _points)
   DevCamChk(CamPiow(_name, 1, 17, _addr, 16),1,1);
   _buffer = zero(_points, 0W);
   DevCamChk(CamStopw(_name, _chan, 2, _points, _buffer, 16),1,1);
+  _buffer &= 0xFF;
   return(_buffer);
 }

--- a/tdi/MitDevices/jrg_adc32a__store.fun
+++ b/tdi/MitDevices/jrg_adc32a__store.fun
@@ -24,7 +24,6 @@ public fun jrg_adc32a__store(as_is _nid, optional _method) {
   _trigger       = DevNodeRef(_nid,_N_TRIGGER);  /* get trigger */
   _active_chan       = DevNodeRef(_nid,_N_ACTIVE_CHAN);  /* get number of samples */
   _active_mem = DevNodeRef(_nid, _N_ACTIVE_MEM);
-
   _module_id = 0L;
 
   /* Read Module ID */
@@ -83,7 +82,7 @@ public fun jrg_adc32a__store(as_is _nid, optional _method) {
 /*  _data_buffer = set_range([_memsize],_data_buffer); */
 
   if (_ext_clock) {
-    _clock = _ext_clock;
+    _clock = DevNodeRef(_nid, _N_EXT_CLOCK);
   } else {
     _clock = make_range(* , * , _active_chan*10E-6);
   }


### PR DESCRIPTION
   A3248 - shifts by mds integer types value 0 return 0 should be 1 - for now use ints
   aeon_getchannel - probably extra but clear the high 8 bits of the data
   jrg_adc32a__store  - use the external clock record, not the value 1 - there is an external clock record