### PR TITLE
updates to Camac Devices for sweden

### DIFF
--- a/javadevices/A3248Setup.form
+++ b/javadevices/A3248Setup.form
@@ -220,7 +220,7 @@
                   </StringArray>
                 </Property>
                 <Property name="identifier" type="java.lang.String" value=""/>
-                <Property name="labelString" type="java.lang.String" value="Clock Freq (Hz).:"/>
+                <Property name="labelString" type="java.lang.String" value="Clock Freq (KHz).:"/>
                 <Property name="offsetNid" type="int" value="4"/>
                 <Property name="updateIdentifier" type="java.lang.String" value=""/>
               </Properties>

--- a/javadevices/A3248Setup.java
+++ b/javadevices/A3248Setup.java
@@ -130,7 +130,7 @@ public class A3248Setup extends DeviceSetup {
         deviceChoice1.setChoiceIntValues(new int[] {10000, 6670, 5000, 4000, 3330, 2860, 2500, 1000, 667, 500, 400, 333, 286, 250});
         deviceChoice1.setChoiceItems(new String[] {"10000", "6670", "5000", "4000", "3330", "2860", "2500", "1000", "667", "500", "400", "333", "286", "250"});
         deviceChoice1.setIdentifier("");
-        deviceChoice1.setLabelString("Clock Freq (Hz).:");
+        deviceChoice1.setLabelString("Clock Freq (KHz).:");
         deviceChoice1.setOffsetNid(4);
         deviceChoice1.setUpdateIdentifier("");
         jPanel3.add(deviceChoice1);

--- a/tdi/MitDevices/a3248.py
+++ b/tdi/MitDevices/a3248.py
@@ -181,11 +181,11 @@ class A3248(Device):
             start=0
             end=pts-1
             try:
-                start = max(int(self.__getattr__('input_%1.1d_startidx'%(chan+1,))),0)
+                start = max(int(self.__getattr__('input_%1.1d_start_idx'%(chan+1,))),0)
             except:
                 pass
             try:
-                end = min(int(self.__getattr__('input_%1.1d_endidx'%(chan+1,))),pts-1)
+                end = min(int(self.__getattr__('input_%1.1d_end_idx'%(chan+1,))),pts-1)
             except:
                 pass
             if self.debug:
@@ -197,9 +197,10 @@ class A3248(Device):
 	        print "gain = %d"%gain
                 print "offset =%d"%offset
                 print "dim is %s"% str(dim)
+                print "start is %d end is %d"%(start, end,)
             dat = MDSplus.Data.compile(
                         'build_signal(build_with_units(($value - $2)*.02/$1, "V") ,build_with_units($3,"Counts"),$4)',
-                        gain, offset, buf, dim) 
+                        gain, offset, buf[start : end], dim) 
             exec('c=self.input_'+'%1d'%(chan+1,)+'.record=dat')
 
     def help(self):

--- a/tdi/MitDevices/jrg_adc32a__init.fun
+++ b/tdi/MitDevices/jrg_adc32a__init.fun
@@ -43,8 +43,9 @@ public fun JRG_ADC32A__INIT(as_is _nid, optional _method) {
   _status_reg = _status_reg | 1 << 8;   /* burst mode*/
 /* next bit multiburst = 0 */  /* single burst */
   _ext_clock = DevNodeRef(_nid,_N_EXT_CLOCK);
-  _is_ext_clock = getnci(_ext_clock,"LENGTH") > 0;
-  _status_reg = _status_reg | (_is_ext_clock << 10);
+  if(getnci(_ext_clock,"LENGTH") > 0) {
+    _status_reg |= (1 << 10);
+  }
   _status_reg = _status_reg | (1 << 11); /* separate gains */
 /* next bit common gain = 0 */
   DevCamChk(_name,CamPiow(_name,0wu,16wu,_status_reg,16wu),1,1);  /* write status register */


### PR DESCRIPTION
   A3248Setup - change label of clock from Hz to KHz
   a3248.py   - use correct names for start_idx, end_idx
   jrg_adc32a__init.fun - set the external clock bit