### PR TITLE
Revert "fixed TdiExtPython handling None"

### DIFF
--- a/tdishr/TdiExtPython.c
+++ b/tdishr/TdiExtPython.c
@@ -43,7 +43,6 @@ static PyObject *(*PyImport_ImportModule) () = 0;
 static PyObject *(*PyModule_GetDict) () = 0;
 static PyObject *(*PyDict_GetItemString) () = 0;
 static PyObject *(*Py_BuildValue) () = 0;
-static PyObject *Py_None;
 static PyObject *_Py_NoneStruct;
 static PyObject *(*PyList_Insert) () = 0;
 static PyObject *(*PyObject_CallFunction) () = 0;
@@ -111,7 +110,6 @@ static int Initialize()
     loadrtn(PyGILState_Release, 1);
     /*** load python functions ***/
     loadrtn(Py_DecRef, 1);
-    loadrtn(Py_None, 1);
     loadrtn(PyTuple_New, 1);
     loadrtn(PyString_FromString, 0);
     if (!PyString_FromString) {
@@ -292,11 +290,7 @@ static void getAnswer(PyObject * value, struct descriptor_xd *outptr)
   if (dataObj) {
     PyObject *descr = (*PyObject_GetAttrString)(dataObj, "descriptor");
     if (descr) {
-      PyObject* descrPtr;
-      if (descr==Py_None)
-          descrPtr = NULL;
-      else
-          descrPtr = (*PyObject_GetAttrString)(descr, "addressof");
+      PyObject *descrPtr = (*PyObject_GetAttrString)(descr, "addressof");
       if (descrPtr) {
 	MdsCopyDxXd((struct descriptor *)(*PyLong_AsVoidPtr)(descrPtr), outptr);
 	(*Py_DecRef)(descrPtr);


### PR DESCRIPTION
Reverts MDSplus/mdsplus#716

This change does not work! Py_None is not a symbol in libpython and therefore cannot be loaded. It is defined in a macro and currently the python headers are not required to build MDSplus.