### PR TITLE
Although shutdown is supposed to cancel the recvfrom used in the hand…

### DIFF
--- a/mdsshr/UdpEvents.c
+++ b/mdsshr/UdpEvents.c
@@ -379,10 +379,16 @@ int MDSUdpEventCan(int eventid)
 {
   EventList *ev = popEvent(eventid);
   if (ev) {
+#ifdef _WIN32
+    // For some reason shutdown does not abort the recvfrom and hangs the process joining
+    // the handleMessage thread. closesocket seems to work though.
+    closesocket(ev->socket);
+#else
     shutdown(ev->socket, SHUT_RDWR);
     close(ev->socket);
+#endif
 //    pthread_cancel(ev->thread);
-    pthread_join(ev->thread,0);    
+    pthread_join(ev->thread,0);
     free(ev);
     return 1;
   } else {


### PR DESCRIPTION
…leMessage thread of UdpEvents.c

it does not on windows. This caused the MdsEventCan on the event to hang waiting for the
handleMessage thread to complete. Performing a windows closesocket on the socket does abort the
recvfrom and fixes the problem.