### PR TITLE
fixes tdi string operations sanitizer drop outs

### DIFF
--- a/mdsshr/librtl.c
+++ b/mdsshr/librtl.c
@@ -552,7 +552,7 @@ EXPORT int LibFindImageSymbol_C(const char *filename_in, const char *symbol, voi
     status = 1;
   dlopen_unlock();
   return status;
-}  
+}
 
 EXPORT int LibFindImageSymbol(struct descriptor *filename, struct descriptor *symbol, void **symbol_value)
 {
@@ -963,7 +963,7 @@ EXPORT int LibTimeToVMSTime(const time_t * time_in, int64_t * time_out)
     tv.tv_usec = 0;
   else
     gettimeofday(&tv,0);
-  
+
 #ifdef USE_TM_GMTOFF
   tz_offset = tmval->tm_gmtoff;
 #else
@@ -1054,11 +1054,12 @@ EXPORT int LibSysAscTim(unsigned short *len, struct descriptor *str, int *time_i
 EXPORT int StrAppend(struct descriptor_d *out, struct descriptor *tail)
 {
   if (tail->length != 0 && tail->pointer != NULL) {
-    struct descriptor_d new = { 0, DTYPE_T, CLASS_D, 0 };
-    unsigned short len = (unsigned short)(out->length + tail->length);
-    if (((unsigned int)out->length + (unsigned int)tail->length) > 0xffff)
+    int len = (int)out->length + (int)tail->length;
+    if (len > 0xffff)
       return StrSTRTOOLON;
-    StrGet1Dx(&len, &new);
+    struct descriptor_d new = { 0, DTYPE_T, CLASS_D, 0 };
+    unsigned short us_len = (unsigned short)len;
+    StrGet1Dx(&us_len, &new);
     if (out->pointer) {
       memcpy(new.pointer, out->pointer, out->length);
     }

--- a/tdishr/TdiIntrinsic.c
+++ b/tdishr/TdiIntrinsic.c
@@ -365,9 +365,9 @@ int TdiIntrinsic(int opcode, int narg, struct descriptor *list[], struct descrip
       struct descriptor body = { 0, DTYPE_T, CLASS_S, 0 };
       struct descriptor post = { 0, DTYPE_T, CLASS_S, 0 };
       pre.length = (unsigned short)npre;
-      pre.pointer = cur - nbody - npre;
+      pre.pointer = npre>0 ? cur - nbody - npre : NULL;
       body.length = (unsigned short)nbody;
-      body.pointer = cur - nbody;
+      body.pointer = nbody>0 ? cur - nbody : NULL;
       post.length = (unsigned short)npost;
       post.pointer = cur;
       StrConcat((struct descriptor *)message,
@@ -375,7 +375,6 @@ int TdiIntrinsic(int opcode, int narg, struct descriptor *list[], struct descrip
 		&body, &hilite, &post, &newline MDS_END_ARG);
     }
   }
-
   if (out_ptr)
     MdsFree1Dx(out_ptr, NULL);
  notmp:MdsFree1Dx(&tmp, NULL);

--- a/tdishr/TdiYacc.c
+++ b/tdishr/TdiYacc.c
@@ -840,6 +840,7 @@ int yyparse()
   if (allocate_stacks())
     YYABORT;
 #endif
+  yyval.mark.w_ok=0;
   //    yypv = &yyv[-1];
   yypv = yyv - 1;
   //    yyps = &yys[-1];
@@ -1025,18 +1026,15 @@ int yyparse()
       switch (yyerrflag) {
       case 0:			/* new error */
 	yyerror((nl_msg(30003, "syntax error")));
-	yynerrs++;
-	goto skip_init;
 	// yyerrlab:
 	/*
 	 ** get globals into registers.
 	 ** we have a user generated syntax type error
-	 */
 	yy_pv = yypv;
 	yy_ps = yyps;
 	yy_state = yystate;
+	 */
 	yynerrs++;
- skip_init:
       case 1:
       case 2:			/* incompletely recovered error */
 	/* try again... */

--- a/tditest/tditest.c
+++ b/tditest/tditest.c
@@ -43,7 +43,7 @@ int main(int argc, char **argv)
       TdiExecute((struct descriptor *)&reset_output_unit, &output_unit, &ans MDS_END_ARG);
       tdiputs(line_in);
     }
-    while (line_in[len - 2] == '\\') {
+    if ( len>1 ) while ( line_in[len - 2] == '\\' ){
       fgets(&line_in[len - 2], MAXEXPR - len + 2, in);
       if (!comment)
 	tdiputs(&line_in[len - 2]);
@@ -56,14 +56,6 @@ int main(int argc, char **argv)
       strcat(expr, line_in);
       strcat(line_in, " = ");
       expr_dsc.length = strlen(expr);
-/*
-      expr_dsc.length = strlen(expr)-1;    
-      expr_dsc.length = strlen(expr)-1;    
-      expr[expr_dsc.length++] = ')';
-      expr[expr_dsc.length++] = ')';
-      expr[expr_dsc.length++] = ')';
-      expr[expr_dsc.length++] = ')';
-*/
       status = TdiExecute((struct descriptor *)&expr_dsc, &ans MDS_END_ARG);
       if (status & 1)
 	TdiExecute((struct descriptor *)&clear_errors, &output_unit, &ans, &ans MDS_END_ARG);


### PR DESCRIPTION
-tditest: executing empty command
-tditest: executing command with syntax error on first position
-correct calculation of expected string length in StrAppend (do not map to short before check)
possibly more