### PR TITLE
Use symbolic links for mdsip plugins which use tunnel protocol

### DIFF
--- a/mdstcpip/Makefile.in
+++ b/mdstcpip/Makefile.in
@@ -170,9 +170,12 @@ install: $(bindir) $(libdir) $(sysconfdir)
 	$(INSTALL) -m 755 $(MdsIpTunnel) @libdir@
 	$(INSTALL) -m 755 $(MdsIpTCP) @libdir@
 @MINGW_FALSE@	$(INSTALL) -m 755 $(IPV6_UDT) @libdir@
-	$(INSTALL) -m 755 $(MdsIpSSH) @libdir@
-	$(INSTALL) -m 755 $(MdsIpHTTP) @libdir@
-	$(INSTALL) -m 755 $(MdsIpLOCAL) @libdir@
+@MINGW_TRUE@	$(INSTALL) -m 755 $(MdsIpSSH) @libdir@
+@MINGW_TRUE@	$(INSTALL) -m 755 $(MdsIpHTTP) @libdir@
+@MINGW_TRUE@	$(INSTALL) -m 755 $(MdsIpLOCAL) @libdir@
+@MINGW_FALSE@	ln -sf $$(basename $(MdsIpTunnel)) @libdir@/$$(basename $(MdsIpSSH))
+@MINGW_FALSE@	ln -sf $$(basename $(MdsIpTunnel)) @libdir@/$$(basename $(MdsIpHTTP))
+@MINGW_FALSE@	ln -sf $$(basename $(MdsIpTunnel)) @libdir@/$$(basename $(MdsIpLOCAL))
         ifdef MdsIpGSI
 		$(INSTALL) -m 755 $(MdsIpGSI) @libdir@
         endif


### PR DESCRIPTION
The make of mdstcpip created symlinks for plugins like libMdsIpSSH.so
which point to libMdsIpTunnel.so. This feature tunnels mdsip messaging
through shell scripts which can be used for setting up communications
between the client and server. These symlinks were replaced by copies
of the shared library when performing make install because the
/usr/bin/install application was used to install these libraries in
the installation root. The rules for installing these tunneling libraries
now create symlinks instead of using /usr/bin/install.