### PR TITLE
Fix fc23 builds with the sanitize option.

### DIFF
--- a/testing/testing.py
+++ b/testing/testing.py
@@ -3,7 +3,8 @@
 
 import __future__
 import sys,os
-os.environ.pop("LD_PRELOAD")
+if "LD_PRELOAD" in os.environ:
+    os.environ.pop("LD_PRELOAD")
 
 
 class testing(object):    

--- a/testing/testing.py
+++ b/testing/testing.py
@@ -3,6 +3,7 @@
 
 import __future__
 import sys,os
+os.environ.pop("LD_PRELOAD")
 
 
 class testing(object):    


### PR DESCRIPTION
On fc23 there seems to be a problem with the mechanism that
ctypes uses to find libraries when running sanitize tests are
performed. When performing sanitize tests using python it is
necessary to define LD_PRELOAD to point to the appropriate
sanitize shared library to ensure the library is preloaded prior
to accessing any library compiled and built using the sanitize
option. In fc23 there is a problem with the way ctypes loads
libraries because it spawns a gcc command. This command
intermittent hangs if LD_PRELOAD is defined. This change remove
the LD_PRELOAD environment variable early in the test to prevent
the ctypes library load problem.