### PR TITLE
Zck deploy

### DIFF
--- a/deploy/packaging/debian/camac_bin.amd64
+++ b/deploy/packaging/debian/camac_bin.amd64
@@ -1,7 +1,7 @@
 ./usr/local/mdsplus/bin/mdsccl
 ./usr/local/mdsplus/bin/mdscts
-./usr/local/mdsplus/lib/libCamShr.so -> libCamShr.so.1
-./usr/local/mdsplus/lib/libCamShr.so.1 -> libCamShr.so.1.8
+./usr/local/mdsplus/lib/libCamShr.so
+./usr/local/mdsplus/lib/libCamShr.so.1
 ./usr/local/mdsplus/lib/libCamShr.so.1.8
 ./usr/local/mdsplus/lib/libRemCamShr.so
 ./usr/local/mdsplus/lib/libccl_commands.so

--- a/deploy/packaging/debian/camac_bin.i386
+++ b/deploy/packaging/debian/camac_bin.i386
@@ -1,7 +1,7 @@
 ./usr/local/mdsplus/bin/mdsccl
 ./usr/local/mdsplus/bin/mdscts
-./usr/local/mdsplus/lib/libCamShr.so -> libCamShr.so.1
-./usr/local/mdsplus/lib/libCamShr.so.1 -> libCamShr.so.1.8
+./usr/local/mdsplus/lib/libCamShr.so
+./usr/local/mdsplus/lib/libCamShr.so.1
 ./usr/local/mdsplus/lib/libCamShr.so.1.8
 ./usr/local/mdsplus/lib/libRemCamShr.so
 ./usr/local/mdsplus/lib/libccl_commands.so

--- a/deploy/packaging/debian/gsi_bin.amd64
+++ b/deploy/packaging/debian/gsi_bin.amd64
@@ -1,5 +1,5 @@
 ./usr/local/mdsplus/bin/mdsipsd
 ./usr/local/mdsplus/bin/roam_check_access
 ./usr/local/mdsplus/lib/libMdsIpGSI.so
-./usr/local/mdsplus/lib/libRoam.so -> libRoam_gcc64.so
+./usr/local/mdsplus/lib/libRoam.so
 ./usr/local/mdsplus/lib/libRoam_gcc64.so

--- a/deploy/packaging/debian/gsi_bin.i386
+++ b/deploy/packaging/debian/gsi_bin.i386
@@ -1,5 +1,5 @@
 ./usr/local/mdsplus/bin/mdsipsd
 ./usr/local/mdsplus/bin/roam_check_access
 ./usr/local/mdsplus/lib/libMdsIpGSI.so
-./usr/local/mdsplus/lib/libRoam.so -> libRoam_gcc64.so
+./usr/local/mdsplus/lib/libRoam.so
 ./usr/local/mdsplus/lib/libRoam_gcc64.so

--- a/deploy/packaging/debian/mitdevices_bin.amd64
+++ b/deploy/packaging/debian/mitdevices_bin.amd64
@@ -3,7 +3,7 @@
 ./usr/local/mdsplus/bin/reboot_dtaq_satelite
 ./usr/local/mdsplus/lib/acq_root_filesystem.tgz
 ./usr/local/mdsplus/lib/acq_root_filesystem.tgz_ffs
-./usr/local/mdsplus/lib/libMIT$DEVICES.so -> libMitDevices.so
+./usr/local/mdsplus/lib/libMIT$DEVICES.so
 ./usr/local/mdsplus/lib/libMitDevices.so
 ./usr/local/mdsplus/lib/libMitDevicesIO.so
 ./usr/local/mdsplus/lib/libMitDevicesMsg.so

--- a/deploy/packaging/debian/mitdevices_bin.i386
+++ b/deploy/packaging/debian/mitdevices_bin.i386
@@ -3,7 +3,7 @@
 ./usr/local/mdsplus/bin/reboot_dtaq_satelite
 ./usr/local/mdsplus/lib/acq_root_filesystem.tgz
 ./usr/local/mdsplus/lib/acq_root_filesystem.tgz_ffs
-./usr/local/mdsplus/lib/libMIT$DEVICES.so -> libMitDevices.so
+./usr/local/mdsplus/lib/libMIT$DEVICES.so
 ./usr/local/mdsplus/lib/libMitDevices.so
 ./usr/local/mdsplus/lib/libMitDevicesIO.so
 ./usr/local/mdsplus/lib/libMitDevicesMsg.so

--- a/deploy/packaging/debian/python.amd64
+++ b/deploy/packaging/debian/python.amd64
@@ -160,7 +160,6 @@
 ./usr/local/mdsplus/mdsobjects/python/tdibuiltins/builtins_other.py
 ./usr/local/mdsplus/mdsobjects/python/tdibuiltins/constants.py
 ./usr/local/mdsplus/mdsobjects/python/tdibuiltins/mathops.py
-./usr/local/mdsplus/mdsobjects/python/tests/MDSplus
 ./usr/local/mdsplus/mdsobjects/python/tests/__init__.py
 ./usr/local/mdsplus/mdsobjects/python/tests/check_python_arch.py
 ./usr/local/mdsplus/mdsobjects/python/tests/connectionUnitTest.py

--- a/deploy/packaging/debian/python.i386
+++ b/deploy/packaging/debian/python.i386
@@ -160,7 +160,6 @@
 ./usr/local/mdsplus/mdsobjects/python/tdibuiltins/builtins_other.py
 ./usr/local/mdsplus/mdsobjects/python/tdibuiltins/constants.py
 ./usr/local/mdsplus/mdsobjects/python/tdibuiltins/mathops.py
-./usr/local/mdsplus/mdsobjects/python/tests/MDSplus
 ./usr/local/mdsplus/mdsobjects/python/tests/__init__.py
 ./usr/local/mdsplus/mdsobjects/python/tests/check_python_arch.py
 ./usr/local/mdsplus/mdsobjects/python/tests/connectionUnitTest.py

--- a/deploy/platform/debian/debian_docker_build.sh
+++ b/deploy/platform/debian/debian_docker_build.sh
@@ -37,6 +37,7 @@ makelist(){
     grep -v egg-info | \
     grep -v '/$' | \
     awk '{for (i=6; i<NF; i++) printf $i " "; print $NF}' | \
+    awk '{split($0,a," -> "); print a[1]}' | \
     sort
 }
 debtopkg() {

--- a/mdsobjects/python/setup.py
+++ b/mdsobjects/python/setup.py
@@ -72,6 +72,7 @@ setup(name=name,
                   pname+'.wsgi',
                   pname+'.mdsExceptions'],
       package_data = {'':['doc/*.*','widgets/*.glade','js/*.js','html/*.html','wsgi/*.tbl']},
+      data_files={'link': ['tests/MDSplus']},
       include_package_data = True,
       classifiers = [
       'Programming Language :: Python',

--- a/tdishr/TdiCall.c
+++ b/tdishr/TdiCall.c
@@ -119,7 +119,7 @@ int TdiCall(int opcode, int narg, struct descriptor *list[], struct descriptor_x
   int status = 1;
   struct descriptor_function *pfun;
   struct descriptor_xd image = EMPTY_XD, entry = EMPTY_XD, tmp[255];
-  int j, max, ntmp = 0, (*routine) ();
+  int j, max = 0, ntmp = 0, (*routine) ();
   struct descriptor *result[2] = { 0, 0 };
   unsigned short code;
   struct descriptor *newdsc[256];


### PR DESCRIPTION
fixes packaging for debian
dpkg -c shows links as "link_path -> target_path"
stripping -> target_path