### PR TITLE
set default to a less site specific value

### DIFF
--- a/actions/actmon.c
+++ b/actions/actmon.c
@@ -177,10 +177,9 @@ int main(int argc, String * argv)
 
   MrmType class;
   static XrmOptionDescRec options[] = { {"-monitor", "*monitor", XrmoptionSepArg, NULL} };
-  static XtResource resources[] =
-      { {"monitor", "Monitor", XtRString, sizeof(String), 0, XtRString, "CMOD_MONITOR"}
-  ,
-  {"images", "Images", XtRString, sizeof(String), sizeof(String), XtRString, ""}
+  static XtResource resources[] = {
+    {"monitor", "Monitor", XtRString, sizeof(String), 0, XtRString, "ACTION_MONITOR"},
+    {"images",  "Images",  XtRString, sizeof(String), sizeof(String), XtRString, ""}
   };
   MrmHierarchy drm_hierarchy;
   struct {


### PR DESCRIPTION
since CMOD is out of operation it maybe makes sence to set the default value for the monitor to something more generic