### PR TITLE
add help target using @TARGET_SELFHELP@ from ax_target_selfhelp.m4

### DIFF
--- a/LabView/Makefile.in
+++ b/LabView/Makefile.in
@@ -96,6 +96,7 @@ am__aclocal_m4_deps = $(top_srcdir)/m4/ac_defun_local.m4 \
 	$(top_srcdir)/m4/ax_compare_version.m4 \
 	$(top_srcdir)/m4/ax_compiler_vendor.m4 \
 	$(top_srcdir)/m4/ax_compiler_version.m4 \
+	$(top_srcdir)/m4/ax_target_selfhelp.m4 \
 	$(top_srcdir)/m4/m4_ac_search_readline.m4 \
 	$(top_srcdir)/m4/m4_am_path_xml2.m4 \
 	$(top_srcdir)/m4/m4_ax_check_enable_debug.m4 \

--- a/Makefile.in
+++ b/Makefile.in
@@ -7,6 +7,10 @@ srcdir=@srcdir@
 builddir=@builddir@
 VPATH=@srcdir@
 
+# selfhelp target
+@TARGET_SELFHELP@
+HELP_DESCRIPTION = This is MDSplus build system, documented targets follow:
+
 JAVA_APS = javamds \
 	   javascope \
            javatraverser \
@@ -65,6 +69,7 @@ PARTS = \
 
 
 .PHONY: all $(PARTS)
+all: ##@build build all active submodules
 all: $(PARTS)
 
 DIRECTORIES = $(sort @MAKEBINDIR@ @MAKELIBDIR@ @MAKESHLIBDIR@ @MAKEUIDDIR@)
@@ -73,7 +78,7 @@ $(PARTS): $(DIRECTORIES)
 	$(MAKE) -C $@
 
 .PHONY: docs
-docs:
+docs:   ##@docs build documentation using doxygen (ref to docs directory)
 	$(MAKE) -C docs install
 
 
@@ -81,13 +86,14 @@ docs:
 clean_DIRS = $(addprefix clean_, $(PARTS))
 
 .PHONY: clean
+clean: ##@build recusively clean all built objects in submodules
 clean: $(clean_DIRS) clean_TESTS clean_DOCS
 
 .PHONY: $(clean_DIRS)
 $(clean_DIRS):
 	$(MAKE) -C $(@:clean_%=%) clean
 
-clean_DOCS:
+clean_DOCS: ##@docs clean generated documentation
 	$(MAKE) -C docs clean
 
 
@@ -95,24 +101,22 @@ clean_DOCS:
 # Testing 
 
 .PHONY: tests
-tests:
+tests: ##@tests recursively perform tests in submodules
 @ENABLE_TESTS_TRUE@	$(MAKE) $(AM_MAKEFLAGS) -C testing all tests
 @ENABLE_TESTS_FALSE@	@echo "Tests disabled"
 
 .PHONY: tests-valgrind
-tests-valgrind:
+tests-valgrind: ##@tests recursively perform tests using valgrind tool
 @ENABLE_TESTS_TRUE@	$(MAKE) $(AM_MAKEFLAGS) -C testing all tests-valgrind
 @ENABLE_TESTS_FALSE@	@echo "Tests disabled"
 
 .PHONY: $(clean_TESTS)
-clean_TESTS:
+clean_TESTS: ##@tests clean all tests results and compiled tests objects
 @ENABLE_TESTS_TRUE@	$(MAKE) -C testing tests-clean
 
 
-
-
-
 .PHONY: full_clean
+full_clean: ##@build perform deep clean of build directories
 full_clean: ./devscripts/rm_if clean
 	@ $< bin bin64 bin32 bin_x86 bin_x86_64
 	@ $< etc
@@ -140,6 +144,7 @@ $(install_DIRS):
 	$(MAKE) -C $(@:install_%=%) install
 
 .PHONY: install
+install: ##@build build and install active modules to prefix directory
 install: $(install_DIRS)
 	- find $(prefix)/java -name '*.class' -delete #### No need to include class files
 	$(MKDIR_P) $(prefix)/local/tdi
@@ -159,6 +164,7 @@ install: $(install_DIRS)
 	if [ ! -z "$$MDSPLUS_VERSION" ]; then echo "mdsplus_version='$$MDSPLUS_VERSION'" > $(exec_prefix)/mdsobjects/python/mdsplus_version.py; fi
 	$(INSTALL) ${top_srcdir}/MDSplus-License.txt ${top_srcdir}/MDSplus-License.rtf $(exec_prefix)
 	(cd $(exec_prefix); chmod -R 755 $(MISC_PARTS))
+
 
 # Interdependent directories:
 actions: mdsshr tdishr treeshr xmdsshr mdstcpip servershr

--- a/actions/Makefile.in
+++ b/actions/Makefile.in
@@ -100,6 +100,7 @@ am__aclocal_m4_deps = $(top_srcdir)/m4/ac_defun_local.m4 \
 	$(top_srcdir)/m4/ax_compare_version.m4 \
 	$(top_srcdir)/m4/ax_compiler_vendor.m4 \
 	$(top_srcdir)/m4/ax_compiler_version.m4 \
+	$(top_srcdir)/m4/ax_target_selfhelp.m4 \
 	$(top_srcdir)/m4/m4_ac_search_readline.m4 \
 	$(top_srcdir)/m4/m4_am_path_xml2.m4 \
 	$(top_srcdir)/m4/m4_ax_check_enable_debug.m4 \

--- a/configure
+++ b/configure
@@ -890,6 +890,7 @@ CPPFLAGS
 LDFLAGS
 CXXFLAGS
 CXX
+TARGET_SELFHELP
 MAINT
 MAINTAINER_MODE_FALSE
 MAINTAINER_MODE_TRUE
@@ -3522,7 +3523,6 @@ shell:
 	docker exec -ti --user \${USER} \${DOCKER_CONTAINER} \
 	 \${SHELL} -c "cd \$(shell pwd); export MAKESHELL=\${SHELL}; bash"
 
-
 endif
 
 
@@ -3781,7 +3781,6 @@ shell:
 	@echo "Starting docker shell";
 	docker exec -ti --user \${USER} \${DOCKER_CONTAINER} \
 	 \${SHELL} -c "cd \$(shell pwd); export MAKESHELL=\${SHELL}; bash"
-
 
 endif
 
@@ -4608,6 +4607,54 @@ $as_echo "#define NDEBUG /**/" >>confdefs.h
 
 fi
     ax_enable_debug=$enable_debug
+
+
+
+
+
+
+
+read -d '' TARGET_SELFHELP << _as_read_EOF
+
+
+SH_GREEN  ?= \$(shell tput -Txterm setaf 2)
+SH_WHITE  ?= \$(shell tput -Txterm setaf 7)
+SH_YELLOW ?= \$(shell tput -Txterm setaf 3)
+SH_RESET  ?= \$(shell tput -Txterm sgr0)
+
+HELP_DESCRIPTION ?= Documented targets follow
+
+ifndef SELFHELP_FUNC
+SELFHELP_FUNC = \\\\
+    %help; \\\\
+    while(<>) { \\\\
+	if(/^([a-z0-9_-]+):.*\\\\#\\\\#(?:@(\\\\w+))?\\\\s(.*)\$\$/) { \\\\
+	    push(@{\$\$help{\$\$2}}, [\$\$1, \$\$3]); \\\\
+	} \\\\
+    }; \\\\
+    print "\\\\n"; \\\\
+    print "| \${HELP_DESCRIPTION}\\\\n"; \\\\
+    print "| \\\\n"; \\\\
+    print "| \${SH_GREEN}usage: make target\${SH_WHITE}\\\\n"; \\\\
+    print "| \\\\n"; \\\\
+    for ( sort keys %help ) { \\\\
+	print "| \${SH_YELLOW}\$\$_\${SH_WHITE}:\\\\n"; \\\\
+	printf("|   %-20s %-60s\\\\n", \$\$_->[0], \$\$_->[1]) for @{\$\$help{\$\$_}}; \\\\
+	print "| \\\\n"; \\\\
+    } \\\\
+    print "\\\\n";
+
+help:   ##@miscellaneous Show this help.
+	@perl -e '\$(SELFHELP_FUNC)' \$(MAKEFILE_LIST)
+endif
+
+
+_as_read_EOF
+
+
+
+
+
 
 
 

--- a/configure.ac
+++ b/configure.ac
@@ -47,6 +47,10 @@ dnl   [IS-RELEASE],[DEFAULT_RELEASE_FLAGS])
 AX_CHECK_ENABLE_DEBUG([no],,,,[-g -O2])
 
 
+dnl AX_TARGET_SELFHELP /////////////////////////////////////////////////////////
+AX_TARGET_SELFHELP
+
+
 # Checks for programs.
 AC_PROG_AWK
 AC_PROG_CXX

--- a/docs/Makefile.in
+++ b/docs/Makefile.in
@@ -125,6 +125,7 @@ am__aclocal_m4_deps = $(top_srcdir)/m4/ac_defun_local.m4 \
 	$(top_srcdir)/m4/ax_compare_version.m4 \
 	$(top_srcdir)/m4/ax_compiler_vendor.m4 \
 	$(top_srcdir)/m4/ax_compiler_version.m4 \
+	$(top_srcdir)/m4/ax_target_selfhelp.m4 \
 	$(top_srcdir)/m4/m4_ac_search_readline.m4 \
 	$(top_srcdir)/m4/m4_am_path_xml2.m4 \
 	$(top_srcdir)/m4/m4_ax_check_enable_debug.m4 \

--- a/dwscope/Makefile.in
+++ b/dwscope/Makefile.in
@@ -99,6 +99,7 @@ am__aclocal_m4_deps = $(top_srcdir)/m4/ac_defun_local.m4 \
 	$(top_srcdir)/m4/ax_compare_version.m4 \
 	$(top_srcdir)/m4/ax_compiler_vendor.m4 \
 	$(top_srcdir)/m4/ax_compiler_version.m4 \
+	$(top_srcdir)/m4/ax_target_selfhelp.m4 \
 	$(top_srcdir)/m4/m4_ac_search_readline.m4 \
 	$(top_srcdir)/m4/m4_am_path_xml2.m4 \
 	$(top_srcdir)/m4/m4_ax_check_enable_debug.m4 \

--- a/icons/Makefile.in
+++ b/icons/Makefile.in
@@ -97,6 +97,7 @@ am__aclocal_m4_deps = $(top_srcdir)/m4/ac_defun_local.m4 \
 	$(top_srcdir)/m4/ax_compare_version.m4 \
 	$(top_srcdir)/m4/ax_compiler_vendor.m4 \
 	$(top_srcdir)/m4/ax_compiler_version.m4 \
+	$(top_srcdir)/m4/ax_target_selfhelp.m4 \
 	$(top_srcdir)/m4/m4_ac_search_readline.m4 \
 	$(top_srcdir)/m4/m4_am_path_xml2.m4 \
 	$(top_srcdir)/m4/m4_ax_check_enable_debug.m4 \

--- a/javaclient/Makefile.in
+++ b/javaclient/Makefile.in
@@ -96,6 +96,7 @@ am__aclocal_m4_deps = $(top_srcdir)/m4/ac_defun_local.m4 \
 	$(top_srcdir)/m4/ax_compare_version.m4 \
 	$(top_srcdir)/m4/ax_compiler_vendor.m4 \
 	$(top_srcdir)/m4/ax_compiler_version.m4 \
+	$(top_srcdir)/m4/ax_target_selfhelp.m4 \
 	$(top_srcdir)/m4/m4_ac_search_readline.m4 \
 	$(top_srcdir)/m4/m4_am_path_xml2.m4 \
 	$(top_srcdir)/m4/m4_ax_check_enable_debug.m4 \

--- a/javadevices/Makefile.in
+++ b/javadevices/Makefile.in
@@ -96,6 +96,7 @@ am__aclocal_m4_deps = $(top_srcdir)/m4/ac_defun_local.m4 \
 	$(top_srcdir)/m4/ax_compare_version.m4 \
 	$(top_srcdir)/m4/ax_compiler_vendor.m4 \
 	$(top_srcdir)/m4/ax_compiler_version.m4 \
+	$(top_srcdir)/m4/ax_target_selfhelp.m4 \
 	$(top_srcdir)/m4/m4_ac_search_readline.m4 \
 	$(top_srcdir)/m4/m4_am_path_xml2.m4 \
 	$(top_srcdir)/m4/m4_ax_check_enable_debug.m4 \

--- a/javadispatcher/Makefile.in
+++ b/javadispatcher/Makefile.in
@@ -97,6 +97,7 @@ am__aclocal_m4_deps = $(top_srcdir)/m4/ac_defun_local.m4 \
 	$(top_srcdir)/m4/ax_compare_version.m4 \
 	$(top_srcdir)/m4/ax_compiler_vendor.m4 \
 	$(top_srcdir)/m4/ax_compiler_version.m4 \
+	$(top_srcdir)/m4/ax_target_selfhelp.m4 \
 	$(top_srcdir)/m4/m4_ac_search_readline.m4 \
 	$(top_srcdir)/m4/m4_am_path_xml2.m4 \
 	$(top_srcdir)/m4/m4_ax_check_enable_debug.m4 \

--- a/javascope/Makefile.in
+++ b/javascope/Makefile.in
@@ -99,6 +99,7 @@ am__aclocal_m4_deps = $(top_srcdir)/m4/ac_defun_local.m4 \
 	$(top_srcdir)/m4/ax_compare_version.m4 \
 	$(top_srcdir)/m4/ax_compiler_vendor.m4 \
 	$(top_srcdir)/m4/ax_compiler_version.m4 \
+	$(top_srcdir)/m4/ax_target_selfhelp.m4 \
 	$(top_srcdir)/m4/m4_ac_search_readline.m4 \
 	$(top_srcdir)/m4/m4_am_path_xml2.m4 \
 	$(top_srcdir)/m4/m4_ax_check_enable_debug.m4 \

--- a/javatraverser/Makefile.in
+++ b/javatraverser/Makefile.in
@@ -99,6 +99,7 @@ am__aclocal_m4_deps = $(top_srcdir)/m4/ac_defun_local.m4 \
 	$(top_srcdir)/m4/ax_compare_version.m4 \
 	$(top_srcdir)/m4/ax_compiler_vendor.m4 \
 	$(top_srcdir)/m4/ax_compiler_version.m4 \
+	$(top_srcdir)/m4/ax_target_selfhelp.m4 \
 	$(top_srcdir)/m4/m4_ac_search_readline.m4 \
 	$(top_srcdir)/m4/m4_am_path_xml2.m4 \
 	$(top_srcdir)/m4/m4_ax_check_enable_debug.m4 \

--- a/m4/ax_target_selfhelp.m4
+++ b/m4/ax_target_selfhelp.m4
@@ -1,0 +1,72 @@
+
+
+
+AC_DEFUN([AX_TARGET_SELFHELP],[
+  AC_PUSH_LOCAL([ax_target_selfhelp])
+  SET_SELFHELP([uno],[due])
+  AC_POP_LOCAL([ax_target_selfhelp])
+])
+
+
+AC_DEFUN_LOCAL([ax_target_selfhelp],[SET_SELFHELP],[
+AS_VAR_READ([TARGET_SELFHELP],[
+
+SH_GREEN  ?= \$(shell tput -Txterm setaf 2)
+SH_WHITE  ?= \$(shell tput -Txterm setaf 7)
+SH_YELLOW ?= \$(shell tput -Txterm setaf 3)
+SH_RESET  ?= \$(shell tput -Txterm sgr0)
+
+HELP_DESCRIPTION ?= Documented targets follow
+
+ifndef SELFHELP_FUNC
+SELFHELP_FUNC = \\\\
+    %help; \\\\
+    while(<>) { \\\\
+	if(/^([[a-z0-9_-]]+):.*\\\\[#]\\\\[#](?:@(\\\\w+))?\\\\s(.*)\$\$/) { \\\\
+	    push(@{\$\$help{\$\$[2]}}, @<:@\$\$[1], \$\$[3]@:>@); \\\\
+	} \\\\
+    }; \\\\
+    print "\\\\n"; \\\\
+    print "| \${HELP_DESCRIPTION}\\\\n"; \\\\
+    print "| \\\\n"; \\\\
+    print "| \${SH_GREEN}usage: make [target]\${SH_WHITE}\\\\n"; \\\\
+    print "| \\\\n"; \\\\
+    for ( sort keys %help ) { \\\\
+	print "| \${SH_YELLOW}\$\$_\${SH_WHITE}:\\\\n"; \\\\
+	printf("|   %-20s %-60s\\\\n", \$\$_->[[0]], \$\$_->[[1]]) for @{\$\$help{\$\$_}}; \\\\
+	print "| \\\\n"; \\\\
+    } \\\\
+    print "\\\\n";
+
+help:   ##@miscellaneous Show this help.
+	@perl -e '\$(SELFHELP_FUNC)' \$(MAKEFILE_LIST)
+endif
+
+])
+ AC_SUBST([TARGET_SELFHELP])
+ m4_ifdef([AM_SUBST_NOTMAKE], [AM_SUBST_NOTMAKE([TARGET_SELFHELP])])
+])
+
+
+AC_DEFUN_LOCAL([ax_target_selfhelp],[AS_VAR_READ],[
+read -d '' $1 << _as_read_EOF
+$2
+_as_read_EOF
+])
+
+
+
+
+dnl SELFHELP_FUNC = \
+dnl    %help; \
+dnl    while(<>) { \
+dnl        if(/^([a-z0-9_-]+):.*\#\#(?:@(\w+))?\s(.*)$$/) { \
+dnl 	   push(@{$$help{$$2}}, [$$1, $$3]); \
+dnl        } \
+dnl    }; \
+dnl    print "${GREEN}usage: make [target]${WHITE}\n\n"; \
+dnl    for ( sort keys %help ) { \
+dnl        print "${YELLOW}$$_${WHITE}:\n"; \
+dnl        printf("  %-20s %s\n", $$_->[0], $$_->[1]) for @{$$help{$$_}}; \
+dnl        print "\n"; \
+dnl    }

--- a/macosx/Makefile.in
+++ b/macosx/Makefile.in
@@ -97,6 +97,7 @@ am__aclocal_m4_deps = $(top_srcdir)/m4/ac_defun_local.m4 \
 	$(top_srcdir)/m4/ax_compare_version.m4 \
 	$(top_srcdir)/m4/ax_compiler_vendor.m4 \
 	$(top_srcdir)/m4/ax_compiler_version.m4 \
+	$(top_srcdir)/m4/ax_target_selfhelp.m4 \
 	$(top_srcdir)/m4/m4_ac_search_readline.m4 \
 	$(top_srcdir)/m4/m4_am_path_xml2.m4 \
 	$(top_srcdir)/m4/m4_ax_check_enable_debug.m4 \

--- a/manpages/Makefile.in
+++ b/manpages/Makefile.in
@@ -95,6 +95,7 @@ am__aclocal_m4_deps = $(top_srcdir)/m4/ac_defun_local.m4 \
 	$(top_srcdir)/m4/ax_compare_version.m4 \
 	$(top_srcdir)/m4/ax_compiler_vendor.m4 \
 	$(top_srcdir)/m4/ax_compiler_version.m4 \
+	$(top_srcdir)/m4/ax_target_selfhelp.m4 \
 	$(top_srcdir)/m4/m4_ac_search_readline.m4 \
 	$(top_srcdir)/m4/m4_am_path_xml2.m4 \
 	$(top_srcdir)/m4/m4_ax_check_enable_debug.m4 \

--- a/mdslib/docs/Makefile.in
+++ b/mdslib/docs/Makefile.in
@@ -125,6 +125,7 @@ am__aclocal_m4_deps = $(top_srcdir)/m4/ac_defun_local.m4 \
 	$(top_srcdir)/m4/ax_compare_version.m4 \
 	$(top_srcdir)/m4/ax_compiler_vendor.m4 \
 	$(top_srcdir)/m4/ax_compiler_version.m4 \
+	$(top_srcdir)/m4/ax_target_selfhelp.m4 \
 	$(top_srcdir)/m4/m4_ac_search_readline.m4 \
 	$(top_srcdir)/m4/m4_am_path_xml2.m4 \
 	$(top_srcdir)/m4/m4_ax_check_enable_debug.m4 \

--- a/mdslib/testing/Makefile.in
+++ b/mdslib/testing/Makefile.in
@@ -109,6 +109,7 @@ am__aclocal_m4_deps = $(top_srcdir)/m4/ac_defun_local.m4 \
 	$(top_srcdir)/m4/ax_compare_version.m4 \
 	$(top_srcdir)/m4/ax_compiler_vendor.m4 \
 	$(top_srcdir)/m4/ax_compiler_version.m4 \
+	$(top_srcdir)/m4/ax_target_selfhelp.m4 \
 	$(top_srcdir)/m4/m4_ac_search_readline.m4 \
 	$(top_srcdir)/m4/m4_am_path_xml2.m4 \
 	$(top_srcdir)/m4/m4_ax_check_enable_debug.m4 \

--- a/mdsobjects/cpp/docs/Makefile.in
+++ b/mdsobjects/cpp/docs/Makefile.in
@@ -125,6 +125,7 @@ am__aclocal_m4_deps = $(top_srcdir)/m4/ac_defun_local.m4 \
 	$(top_srcdir)/m4/ax_compare_version.m4 \
 	$(top_srcdir)/m4/ax_compiler_vendor.m4 \
 	$(top_srcdir)/m4/ax_compiler_version.m4 \
+	$(top_srcdir)/m4/ax_target_selfhelp.m4 \
 	$(top_srcdir)/m4/m4_ac_search_readline.m4 \
 	$(top_srcdir)/m4/m4_am_path_xml2.m4 \
 	$(top_srcdir)/m4/m4_ax_check_enable_debug.m4 \

--- a/mdsobjects/cpp/testing/Makefile.in
+++ b/mdsobjects/cpp/testing/Makefile.in
@@ -121,6 +121,7 @@ am__aclocal_m4_deps = $(top_srcdir)/m4/ac_defun_local.m4 \
 	$(top_srcdir)/m4/ax_compare_version.m4 \
 	$(top_srcdir)/m4/ax_compiler_vendor.m4 \
 	$(top_srcdir)/m4/ax_compiler_version.m4 \
+	$(top_srcdir)/m4/ax_target_selfhelp.m4 \
 	$(top_srcdir)/m4/m4_ac_search_readline.m4 \
 	$(top_srcdir)/m4/m4_am_path_xml2.m4 \
 	$(top_srcdir)/m4/m4_ax_check_enable_debug.m4 \

--- a/mdsobjects/cpp/testing/testutils/Makefile.in
+++ b/mdsobjects/cpp/testing/testutils/Makefile.in
@@ -97,6 +97,7 @@ am__aclocal_m4_deps = $(top_srcdir)/m4/ac_defun_local.m4 \
 	$(top_srcdir)/m4/ax_compare_version.m4 \
 	$(top_srcdir)/m4/ax_compiler_vendor.m4 \
 	$(top_srcdir)/m4/ax_compiler_version.m4 \
+	$(top_srcdir)/m4/ax_target_selfhelp.m4 \
 	$(top_srcdir)/m4/m4_ac_search_readline.m4 \
 	$(top_srcdir)/m4/m4_am_path_xml2.m4 \
 	$(top_srcdir)/m4/m4_ax_check_enable_debug.m4 \

--- a/mdsobjects/java/Makefile.in
+++ b/mdsobjects/java/Makefile.in
@@ -96,6 +96,7 @@ am__aclocal_m4_deps = $(top_srcdir)/m4/ac_defun_local.m4 \
 	$(top_srcdir)/m4/ax_compare_version.m4 \
 	$(top_srcdir)/m4/ax_compiler_vendor.m4 \
 	$(top_srcdir)/m4/ax_compiler_version.m4 \
+	$(top_srcdir)/m4/ax_target_selfhelp.m4 \
 	$(top_srcdir)/m4/m4_ac_search_readline.m4 \
 	$(top_srcdir)/m4/m4_am_path_xml2.m4 \
 	$(top_srcdir)/m4/m4_ax_check_enable_debug.m4 \

--- a/mdsobjects/java/docs/Makefile.in
+++ b/mdsobjects/java/docs/Makefile.in
@@ -125,6 +125,7 @@ am__aclocal_m4_deps = $(top_srcdir)/m4/ac_defun_local.m4 \
 	$(top_srcdir)/m4/ax_compare_version.m4 \
 	$(top_srcdir)/m4/ax_compiler_vendor.m4 \
 	$(top_srcdir)/m4/ax_compiler_version.m4 \
+	$(top_srcdir)/m4/ax_target_selfhelp.m4 \
 	$(top_srcdir)/m4/m4_ac_search_readline.m4 \
 	$(top_srcdir)/m4/m4_am_path_xml2.m4 \
 	$(top_srcdir)/m4/m4_ax_check_enable_debug.m4 \

--- a/mdsobjects/python/docs/Makefile.in
+++ b/mdsobjects/python/docs/Makefile.in
@@ -125,6 +125,7 @@ am__aclocal_m4_deps = $(top_srcdir)/m4/ac_defun_local.m4 \
 	$(top_srcdir)/m4/ax_compare_version.m4 \
 	$(top_srcdir)/m4/ax_compiler_vendor.m4 \
 	$(top_srcdir)/m4/ax_compiler_version.m4 \
+	$(top_srcdir)/m4/ax_target_selfhelp.m4 \
 	$(top_srcdir)/m4/m4_ac_search_readline.m4 \
 	$(top_srcdir)/m4/m4_am_path_xml2.m4 \
 	$(top_srcdir)/m4/m4_ax_check_enable_debug.m4 \

--- a/mdsobjects/python/tests/Makefile.in
+++ b/mdsobjects/python/tests/Makefile.in
@@ -108,6 +108,7 @@ am__aclocal_m4_deps = $(top_srcdir)/m4/ac_defun_local.m4 \
 	$(top_srcdir)/m4/ax_compare_version.m4 \
 	$(top_srcdir)/m4/ax_compiler_vendor.m4 \
 	$(top_srcdir)/m4/ax_compiler_version.m4 \
+	$(top_srcdir)/m4/ax_target_selfhelp.m4 \
 	$(top_srcdir)/m4/m4_ac_search_readline.m4 \
 	$(top_srcdir)/m4/m4_am_path_xml2.m4 \
 	$(top_srcdir)/m4/m4_ax_check_enable_debug.m4 \

--- a/mdsshr/docs/Makefile.in
+++ b/mdsshr/docs/Makefile.in
@@ -125,6 +125,7 @@ am__aclocal_m4_deps = $(top_srcdir)/m4/ac_defun_local.m4 \
 	$(top_srcdir)/m4/ax_compare_version.m4 \
 	$(top_srcdir)/m4/ax_compiler_vendor.m4 \
 	$(top_srcdir)/m4/ax_compiler_version.m4 \
+	$(top_srcdir)/m4/ax_target_selfhelp.m4 \
 	$(top_srcdir)/m4/m4_ac_search_readline.m4 \
 	$(top_srcdir)/m4/m4_am_path_xml2.m4 \
 	$(top_srcdir)/m4/m4_ax_check_enable_debug.m4 \

--- a/mdsshr/testing/Makefile.in
+++ b/mdsshr/testing/Makefile.in
@@ -109,6 +109,7 @@ am__aclocal_m4_deps = $(top_srcdir)/m4/ac_defun_local.m4 \
 	$(top_srcdir)/m4/ax_compare_version.m4 \
 	$(top_srcdir)/m4/ax_compiler_vendor.m4 \
 	$(top_srcdir)/m4/ax_compiler_version.m4 \
+	$(top_srcdir)/m4/ax_target_selfhelp.m4 \
 	$(top_srcdir)/m4/m4_ac_search_readline.m4 \
 	$(top_srcdir)/m4/m4_am_path_xml2.m4 \
 	$(top_srcdir)/m4/m4_ax_check_enable_debug.m4 \

--- a/mdstcpip/docs/Makefile.in
+++ b/mdstcpip/docs/Makefile.in
@@ -125,6 +125,7 @@ am__aclocal_m4_deps = $(top_srcdir)/m4/ac_defun_local.m4 \
 	$(top_srcdir)/m4/ax_compare_version.m4 \
 	$(top_srcdir)/m4/ax_compiler_vendor.m4 \
 	$(top_srcdir)/m4/ax_compiler_version.m4 \
+	$(top_srcdir)/m4/ax_target_selfhelp.m4 \
 	$(top_srcdir)/m4/m4_ac_search_readline.m4 \
 	$(top_srcdir)/m4/m4_am_path_xml2.m4 \
 	$(top_srcdir)/m4/m4_ax_check_enable_debug.m4 \

--- a/mdstcpip/docs/img/Makefile.in
+++ b/mdstcpip/docs/img/Makefile.in
@@ -95,6 +95,7 @@ am__aclocal_m4_deps = $(top_srcdir)/m4/ac_defun_local.m4 \
 	$(top_srcdir)/m4/ax_compare_version.m4 \
 	$(top_srcdir)/m4/ax_compiler_vendor.m4 \
 	$(top_srcdir)/m4/ax_compiler_version.m4 \
+	$(top_srcdir)/m4/ax_target_selfhelp.m4 \
 	$(top_srcdir)/m4/m4_ac_search_readline.m4 \
 	$(top_srcdir)/m4/m4_am_path_xml2.m4 \
 	$(top_srcdir)/m4/m4_ax_check_enable_debug.m4 \

--- a/mdstcpip/zlib/Makefile.in
+++ b/mdstcpip/zlib/Makefile.in
@@ -97,6 +97,7 @@ am__aclocal_m4_deps = $(top_srcdir)/m4/ac_defun_local.m4 \
 	$(top_srcdir)/m4/ax_compare_version.m4 \
 	$(top_srcdir)/m4/ax_compiler_vendor.m4 \
 	$(top_srcdir)/m4/ax_compiler_version.m4 \
+	$(top_srcdir)/m4/ax_target_selfhelp.m4 \
 	$(top_srcdir)/m4/m4_ac_search_readline.m4 \
 	$(top_srcdir)/m4/m4_am_path_xml2.m4 \
 	$(top_srcdir)/m4/m4_ax_check_enable_debug.m4 \

--- a/rpm/Makefile.in
+++ b/rpm/Makefile.in
@@ -97,6 +97,7 @@ am__aclocal_m4_deps = $(top_srcdir)/m4/ac_defun_local.m4 \
 	$(top_srcdir)/m4/ax_compare_version.m4 \
 	$(top_srcdir)/m4/ax_compiler_vendor.m4 \
 	$(top_srcdir)/m4/ax_compiler_version.m4 \
+	$(top_srcdir)/m4/ax_target_selfhelp.m4 \
 	$(top_srcdir)/m4/m4_ac_search_readline.m4 \
 	$(top_srcdir)/m4/m4_am_path_xml2.m4 \
 	$(top_srcdir)/m4/m4_ax_check_enable_debug.m4 \

--- a/scripts/Makefile.in
+++ b/scripts/Makefile.in
@@ -96,6 +96,7 @@ am__aclocal_m4_deps = $(top_srcdir)/m4/ac_defun_local.m4 \
 	$(top_srcdir)/m4/ax_compare_version.m4 \
 	$(top_srcdir)/m4/ax_compiler_vendor.m4 \
 	$(top_srcdir)/m4/ax_compiler_version.m4 \
+	$(top_srcdir)/m4/ax_target_selfhelp.m4 \
 	$(top_srcdir)/m4/m4_ac_search_readline.m4 \
 	$(top_srcdir)/m4/m4_am_path_xml2.m4 \
 	$(top_srcdir)/m4/m4_ax_check_enable_debug.m4 \

--- a/setevent/Makefile.in
+++ b/setevent/Makefile.in
@@ -97,6 +97,7 @@ am__aclocal_m4_deps = $(top_srcdir)/m4/ac_defun_local.m4 \
 	$(top_srcdir)/m4/ax_compare_version.m4 \
 	$(top_srcdir)/m4/ax_compiler_vendor.m4 \
 	$(top_srcdir)/m4/ax_compiler_version.m4 \
+	$(top_srcdir)/m4/ax_target_selfhelp.m4 \
 	$(top_srcdir)/m4/m4_ac_search_readline.m4 \
 	$(top_srcdir)/m4/m4_am_path_xml2.m4 \
 	$(top_srcdir)/m4/m4_ax_check_enable_debug.m4 \

--- a/tdishr/testing/Makefile.in
+++ b/tdishr/testing/Makefile.in
@@ -109,6 +109,7 @@ am__aclocal_m4_deps = $(top_srcdir)/m4/ac_defun_local.m4 \
 	$(top_srcdir)/m4/ax_compare_version.m4 \
 	$(top_srcdir)/m4/ax_compiler_vendor.m4 \
 	$(top_srcdir)/m4/ax_compiler_version.m4 \
+	$(top_srcdir)/m4/ax_target_selfhelp.m4 \
 	$(top_srcdir)/m4/m4_ac_search_readline.m4 \
 	$(top_srcdir)/m4/m4_am_path_xml2.m4 \
 	$(top_srcdir)/m4/m4_ax_check_enable_debug.m4 \

--- a/testing/Makefile.in
+++ b/testing/Makefile.in
@@ -96,6 +96,7 @@ am__aclocal_m4_deps = $(top_srcdir)/m4/ac_defun_local.m4 \
 	$(top_srcdir)/m4/ax_compare_version.m4 \
 	$(top_srcdir)/m4/ax_compiler_vendor.m4 \
 	$(top_srcdir)/m4/ax_compiler_version.m4 \
+	$(top_srcdir)/m4/ax_target_selfhelp.m4 \
 	$(top_srcdir)/m4/m4_ac_search_readline.m4 \
 	$(top_srcdir)/m4/m4_am_path_xml2.m4 \
 	$(top_srcdir)/m4/m4_ax_check_enable_debug.m4 \

--- a/testing/backends/check/Makefile.in
+++ b/testing/backends/check/Makefile.in
@@ -98,6 +98,7 @@ am__aclocal_m4_deps = $(top_srcdir)/m4/ac_defun_local.m4 \
 	$(top_srcdir)/m4/ax_compare_version.m4 \
 	$(top_srcdir)/m4/ax_compiler_vendor.m4 \
 	$(top_srcdir)/m4/ax_compiler_version.m4 \
+	$(top_srcdir)/m4/ax_target_selfhelp.m4 \
 	$(top_srcdir)/m4/m4_ac_search_readline.m4 \
 	$(top_srcdir)/m4/m4_am_path_xml2.m4 \
 	$(top_srcdir)/m4/m4_ax_check_enable_debug.m4 \

--- a/testing/selftest/Makefile.in
+++ b/testing/selftest/Makefile.in
@@ -111,6 +111,7 @@ am__aclocal_m4_deps = $(top_srcdir)/m4/ac_defun_local.m4 \
 	$(top_srcdir)/m4/ax_compare_version.m4 \
 	$(top_srcdir)/m4/ax_compiler_vendor.m4 \
 	$(top_srcdir)/m4/ax_compiler_version.m4 \
+	$(top_srcdir)/m4/ax_target_selfhelp.m4 \
 	$(top_srcdir)/m4/m4_ac_search_readline.m4 \
 	$(top_srcdir)/m4/m4_am_path_xml2.m4 \
 	$(top_srcdir)/m4/m4_ax_check_enable_debug.m4 \

--- a/treeshr/testing/Makefile.in
+++ b/treeshr/testing/Makefile.in
@@ -109,6 +109,7 @@ am__aclocal_m4_deps = $(top_srcdir)/m4/ac_defun_local.m4 \
 	$(top_srcdir)/m4/ax_compare_version.m4 \
 	$(top_srcdir)/m4/ax_compiler_vendor.m4 \
 	$(top_srcdir)/m4/ax_compiler_version.m4 \
+	$(top_srcdir)/m4/ax_target_selfhelp.m4 \
 	$(top_srcdir)/m4/m4_ac_search_readline.m4 \
 	$(top_srcdir)/m4/m4_am_path_xml2.m4 \
 	$(top_srcdir)/m4/m4_ax_check_enable_debug.m4 \

--- a/wfevent/Makefile.in
+++ b/wfevent/Makefile.in
@@ -97,6 +97,7 @@ am__aclocal_m4_deps = $(top_srcdir)/m4/ac_defun_local.m4 \
 	$(top_srcdir)/m4/ax_compare_version.m4 \
 	$(top_srcdir)/m4/ax_compiler_vendor.m4 \
 	$(top_srcdir)/m4/ax_compiler_version.m4 \
+	$(top_srcdir)/m4/ax_target_selfhelp.m4 \
 	$(top_srcdir)/m4/m4_ac_search_readline.m4 \
 	$(top_srcdir)/m4/m4_am_path_xml2.m4 \
 	$(top_srcdir)/m4/m4_ax_check_enable_debug.m4 \


### PR DESCRIPTION
This will add a help automation on target using a perl script injected into Makefile ...

To add a inline help on a target just write in Makefile:

target1: <normal dependencies> ##@[key] [help string 1]
         
target2: ##@[key] [help string 2]
target2: <normal dependencies>

this will be converted to a string like:

key:
    target1        help string 1
    target2        help string 2

for ref see changes in Makefile.in

hope this helps :-)


