### PR TITLE
Prevent the MDSplus directory path from recursing

### DIFF
--- a/mdsobjects/python/tests/__init__.py
+++ b/mdsobjects/python/tests/__init__.py
@@ -12,13 +12,14 @@ MDSplus_path=os.path.dirname(os.path.abspath(__file__))
 if sys.path[0] != MDSplus_path:
     sys.path.insert(0,MDSplus_path)
 
-from MDSplus.tests.treeUnitTest import treeTests
-from MDSplus.tests.threadsUnitTest import suite as threadsSuite
-from MDSplus.tests.dataUnitTest import suite as dataSuite
-from MDSplus.tests.exceptionUnitTest import exceptionTests
-from MDSplus.tests.connectionUnitTest import suite as connectionsSuite
-from MDSplus.tests.segmentsUnitTest import suite as segmentsSuite
+from treeUnitTest import treeTests
+from threadsUnitTest import suite as threadsSuite
+from dataUnitTest import suite as dataSuite
+from exceptionUnitTest import exceptionTests
+from connectionUnitTest import suite as connectionsSuite
+from segmentsUnitTest import suite as segmentsSuite
 from MDSplus import setenv,getenv
+setenv("PYTHONPATH",MDSplus_path)
 
 class cleanup(TestCase):
     dir=None

--- a/mdsobjects/python/tests/dataUnitTest.py
+++ b/mdsobjects/python/tests/dataUnitTest.py
@@ -1,10 +1,6 @@
 from unittest import TestCase,TestSuite
 import sys,os
 
-MDSplus_path=os.path.dirname(os.path.abspath(__file__))
-if sys.path[0] != MDSplus_path:
-    sys.path.insert(0,MDSplus_path)
-
 from MDSplus import Data,makeData,makeArray,Uint8,String,setenv
 import MDSplus as m
 
@@ -13,7 +9,6 @@ if os.name=='nt':
     setenv("PyLib","python%d%d"  % sys.version_info[0:2])
 else:
     setenv("PyLib","python%d.%d" % sys.version_info[0:2])
-setenv("PYTHONPATH",MDSplus_path)
 
 class dataTests(TestCase):
     def _doThreeTest(self,tdiexpr,pyexpr,ans,almost=False):

--- a/mdsobjects/python/tests/exceptionUnitTest.py
+++ b/mdsobjects/python/tests/exceptionUnitTest.py
@@ -1,10 +1,6 @@
 from unittest import TestCase
 import sys,os
 
-MDSplus_path=os.path.dirname(os.path.abspath(__file__))
-if sys.path[0] != MDSplus_path:
-    sys.path.insert(0,MDSplus_path)
-
 from MDSplus import DevNOT_TRIGGERED, TclNORMAL
 
 

--- a/mdsobjects/python/tests/segmentsUnitTest.py
+++ b/mdsobjects/python/tests/segmentsUnitTest.py
@@ -1,10 +1,6 @@
 from unittest import TestCase,TestSuite
 import sys,os
 
-MDSplus_path=os.path.dirname(os.path.abspath(__file__))
-if sys.path[0] != MDSplus_path:
-    sys.path.insert(0,MDSplus_path)
-
 from MDSplus import Tree,Float32,Float32Array,Int16Array,setenv
 
 

--- a/mdsobjects/python/tests/simulateSegfault.py
+++ b/mdsobjects/python/tests/simulateSegfault.py
@@ -4,10 +4,6 @@
 from unittest import TestCase,TestSuite
 import sys,os
 
-MDSplus_path=os.path.dirname(os.path.abspath(__file__))
-if sys.path[0] != MDSplus_path:
-    sys.path.insert(0,MDSplus_path)
-
 from MDSplus import Data
 
 

--- a/mdsobjects/python/tests/threadsUnitTest.py
+++ b/mdsobjects/python/tests/threadsUnitTest.py
@@ -2,10 +2,6 @@ from unittest import TestCase,TestSuite,TestResult
 from threading import Thread
 import sys,os
 
-MDSplus_path=os.path.dirname(os.path.abspath(__file__))
-if sys.path[0] != MDSplus_path:
-    sys.path.insert(0,MDSplus_path)
-
 from MDSplus import Tree,getenv
 from MDSplus.tests import treeUnitTest,dataUnitTest
 

--- a/mdsobjects/python/tests/treeUnitTest.py
+++ b/mdsobjects/python/tests/treeUnitTest.py
@@ -2,8 +2,7 @@ from unittest import TestCase
 import sys,os
 
 MDSplus_path=os.path.dirname(os.path.abspath(__file__))
-if sys.path[0] != MDSplus_path:
-    sys.path.insert(0,MDSplus_path)
+print(MDSplus_path)
 
 from MDSplus import Tree,TreeNode,Data,makeArray,Signal,Range,DateToQuad
 from MDSplus import getenv,setenv,tcl

--- a/mdsobjects/python/tests/treeUnitTest.py
+++ b/mdsobjects/python/tests/treeUnitTest.py
@@ -1,9 +1,6 @@
 from unittest import TestCase
 import sys,os
 
-MDSplus_path=os.path.dirname(os.path.abspath(__file__))
-print(MDSplus_path)
-
 from MDSplus import Tree,TreeNode,Data,makeArray,Signal,Range,DateToQuad
 from MDSplus import getenv,setenv,tcl
 from MDSplus import mdsExceptions as Exc


### PR DESCRIPTION
When running the python tests the directory where the
test modules were located kept recursing with:
   MDSplus/tests/MDSplus/tests... when the tests were loaded

This was caused because the tests/__init__py module referred
to itself by referencing from MDSplus.tests import xxxx