### PR TITLE
Fix mdsdcl help command which causes segfault on no help errors.

### DIFF
--- a/mdsdcl/cmdHelp.c
+++ b/mdsdcl/cmdHelp.c
@@ -179,8 +179,9 @@ int mdsdcl_do_help(const char *command, char **error, char **output)
     }
   }
   if (helpFound == 0) {
-    if (*output)
-      free(*output);
+    if (*output) {
+      strcpy(*output,"");
+    }
     *error = strdup("No help available for that command.\n");
   }
   if (command == NULL)


### PR DESCRIPTION
When the parameter specified with the help command in mdsdcl
does not match a command the code was clearing the output buffer
and overwriting memory that had been freed often causing a segfault.
This fixes that problem.