### PR TITLE
Lengthen waits in tests to avoid intermittent failures

### DIFF
--- a/mdsobjects/python/tests/treeUnitTest.py
+++ b/mdsobjects/python/tests/treeUnitTest.py
@@ -333,7 +333,7 @@ class treeTests(TestCase):
               mdsip = Popen(['mdsip','-s','-p',str(port),'-h',hosts],env=self.env,
                              stdout=log,stderr=STDOUT)
           try:
-            sleep(.1)
+            sleep(5)
             if Popen:
                 self.assertEqual(mdsip.poll(),None)
             """ tcl dispatch """
@@ -342,13 +342,13 @@ class treeTests(TestCase):
             testDispatchCommand('type test')
             self._doTCLTest('dispatch/build')
             self._doTCLTest('dispatch/phase INIT')
-            sleep(.01)
+            sleep(1)
             self._doTCLTest('show server %s'%server,out=show_server,re=True)
             self._doTCLTest('dispatch/phase PULSE')
-            sleep(.01)
+            sleep(1)
             self._doTCLTest('show server %s'%server,out=show_server,re=True)
             self._doTCLTest('dispatch/phase STORE')
-            sleep(.01)
+            sleep(1)
             self._doTCLTest('show server %s'%server,out=show_server,re=True)
             """ tcl exceptions """
             self._doExceptionTest('dispatch/command/server=%s '%server,Exc.MdsdclIVVERB)

--- a/mdsshr/testing/UdpEventsTest.c
+++ b/mdsshr/testing/UdpEventsTest.c
@@ -60,7 +60,7 @@ void eventAstSecond(void *arg, int len __attribute__ ((unused)), char *buf __att
 
 
 static void wait() {
-    static const struct timespec tspec = {0,10000000};
+    static const struct timespec tspec = {0,100000000};
     nanosleep(&tspec,0);
 }
 


### PR DESCRIPTION
We are experiencing intermittent failure of some of the tests particularly
in those where subprocesses are started and then communication occurs
between the parent process and the subprocess. During pull request tests
and release builds these tests are performed in parallel during the build
and test for over a dozen different platforms on the same server and it is
suspected that under the heavy load the existing wait periods in the tests
may not be sufficient. This pull request increases time period of the waits
already built into the tests.