### PR TITLE
Verify tag_release operation

### DIFF
--- a/deploy/trigger.sh
+++ b/deploy/trigger.sh
@@ -326,7 +326,7 @@ then
 	. ${SRCDIR}/trigger.version
 	if [ "$NEW_RELEASE" = "yes" ]
 	then
-	   curl --data @- "https://api.github.com/repos/MDSplus/mdsplus/releases?access_token=$(cat $KEYS/.git_token)" >/dev/null <<EOF
+	   curl --data @- "https://api.github.com/repos/MDSplus/mdsplus/releases?access_token=$(cat $KEYS/.git_token)" > ${WORKSPACE}/tag_release.log 2>&1 <<EOF
 {
   "tag_name":"${RELEASE_TAG}",
   "target_commitish":"${BRANCH}",
@@ -335,6 +335,22 @@ then
 $(git log --decorate=full ${LAST_RELEASE_COMMIT}..HEAD | awk '{print $0"\\n"}')"
 }
 EOF
+	   if ( ! grep tag_name ${WORKSPACE}/tag_release.log > /dev/null )
+	   then
+	       RED $COLOR
+	       cat <<EOF >&2
+=========================================================
+
+Failed to tag a new release on github. Response/error
+content follows.
+FAILURE
+
+=========================================================
+EOF
+	       cat ${WORKSPACE}/tag_release.log
+	       NORMAL $COLOR
+	       exit 1
+	   fi
 	fi
     else
 	RED $COLOR


### PR DESCRIPTION
The release tagging operation sends a post to github using curl.
If there is a problem such as an invalid/expired github access token
used for tagging, curl returns a success status but the content of
the returned message contains the error information. If the tagging
succeeds the returned message contains information of the release tag.
This change now inspects the returned message to determine if the
operation was successful or not. New releases will not be published
unless the tagging was successful.