### PR TITLE
Fix authentication problem with uploading python package to PYPI

### DIFF
--- a/deploy/trigger.sh
+++ b/deploy/trigger.sh
@@ -382,7 +382,7 @@ EOF
 	    ${WORKSPACE}/configure --disable-java >/dev/null 2>&1
 	    rsync -a ${WORKSPACE}/mdsobjects/python mdsobjects/
 	    cd mdsobjects/python
-	    python setup.py sdist upload
+	    HOME=${KEYS} python setup.py sdist upload
 	    cd $WORKSPACE
 	    rm -Rf $tmpdir
 	fi


### PR DESCRIPTION
For the python setup tools to upload to pypi it is necessary
to have a $HOME/.pypirc file for authenticating.
(See: https://docs.python.org/2/distutils/packageindex.html).
For the jenkins builds this file is present in the
/mdsplus/certs/jenkins directory on the jenkins server so when
doing the upload $HOME must point at this directory.