### PR TITLE
Zck treadsafe tcl dispatch and command

### DIFF
--- a/servershr/ServerSendMessage.c
+++ b/servershr/ServerSendMessage.c
@@ -151,93 +151,91 @@ static SOCKET getSocket(int conid)
 int ServerSendMessage(int *msgid, char *server, int op, int *retstatus, int *conid_out,
 		      void (*ast) (), void *astparam, void (*before_ast) (), int numargs_in, ...)
 {
-  static unsigned int addr = 0;
   short port = 0;
   int conid;
+  if (!StartReceiver(&port) || ((conid = ServerConnect(server)) < 0)) {
+    if (ast)
+      ast(astparam);
+    return ServerPATH_DOWN;
+  }
+  INIT_STATUS;
   int flags = 0;
-  int status = ServerPATH_DOWN;
   int jobid;
   int i;
-
-  if (StartReceiver(&port) && ((conid = ServerConnect(server)) >= 0)) {
-    char cmd[4096];
-    unsigned char numargs = max(0, min(numargs_in, 8));
-    unsigned char idx = 0;
-    char dtype;
-    short len;
-    char ndims;
-    int dims[8];
-    int numbytes;
-    int *dptr;
-    va_list vlist;
-    void *mem = NULL;
-    struct descrip *arg;
-    if (conid_out)
-      *conid_out = conid;
-    if (!addr) {
-      int sock = getSocket(conid);
-      struct sockaddr_in addr_struct = {0};
-      socklen_t len = sizeof(addr_struct);
-      if (getsockname(sock, (struct sockaddr *)&addr_struct, &len) == 0)
-	addr = *(int *)&addr_struct.sin_addr;
-      if (!addr) {
-        perror("Error getting the address the socket is bound to.\n");
-        if (ast)
-          ast(astparam);
-        return ServerSOCKET_ADDR_ERROR;
-      }
-    }
-    jobid = RegisterJob(msgid, retstatus, ast, astparam, before_ast, conid);
-    if (before_ast)
-      flags |= SrvJobBEFORE_NOTIFY;
-    sprintf(cmd, "MdsServerShr->ServerQAction(%d,%dwu,%d,%d,%d", addr, port, op, flags, jobid);
-    va_start(vlist, numargs_in);
-    for (i = 0; i < numargs; i++) {
-      strcat(cmd, ",");
-      arg = va_arg(vlist, struct descrip *);
-      if (op == SrvMonitor && numargs == 8 && i == 5 && arg->dtype == DTYPE_LONG
-	  && *(int *)arg->ptr == MonitorCheckin)
-	MonJob = jobid;
-      switch (arg->dtype) {
-      case DTYPE_CSTRING:
-	{
-	  int j;
-	  int k;
-	  char *c = (char *)arg->ptr;
-	  int len = strlen(c);
-	  strcat(cmd, "\"");
-	  for (j = 0, k = strlen(cmd); j < len; j++, k++) {
-	    if (c[j] == '"' || c[j] == '\\')
-	      cmd[k++] = '\\';
-	    cmd[k] = c[j];
-	  }
-	  cmd[k] = 0;
-	  strcat(cmd, "\"");
-	  break;
-	}
-      case DTYPE_LONG:
-	sprintf(&cmd[strlen(cmd)], "%d", *(int *)arg->ptr);
-	break;
-      case DTYPE_CHAR:
-	sprintf(&cmd[strlen(cmd)], "%d", (int)*(char *)arg->ptr);
-	break;
-      default:
-	printf("shouldn't get here! ServerSendMessage dtype = %d\n", arg->dtype);
-      }
-    }
-    strcat(cmd, ")");
-    status = SendArg(conid, idx++, DTYPE_CSTRING, 1, (short)strlen(cmd), 0, 0, cmd);
-    if STATUS_NOT_OK {
-        perror("Error sending message to server");
-        CleanupJob(status, jobid);
-        return status;
-    }
-    status = GetAnswerInfoTS(conid, &dtype, &len, &ndims, dims, &numbytes, (void **)&dptr, &mem);
-    if STATUS_NOT_OK
-        perror("Error: no response from server");
-    if (mem)
-      free(mem);
+  unsigned int addr = 0;
+  char cmd[4096];
+  unsigned char numargs = max(0, min(numargs_in, 8));
+  unsigned char idx = 0;
+  char dtype;
+  char ndims;
+  int dims[8];
+  int numbytes;
+  int *dptr;
+  va_list vlist;
+  void *mem = NULL;
+  struct descrip *arg;
+  if (conid_out)
+    *conid_out = conid;
+  int sock = getSocket(conid);
+  struct sockaddr_in addr_struct = {0};
+  socklen_t len = sizeof(addr_struct);
+  if (getsockname(sock, (struct sockaddr *)&addr_struct, &len) == 0)
+    addr = *(int *)&addr_struct.sin_addr;
+  if (!addr) {
+    perror("Error getting the address the socket is bound to.\n");
+    if (ast)
+      ast(astparam);
+    return ServerSOCKET_ADDR_ERROR;
   }
+  jobid = RegisterJob(msgid, retstatus, ast, astparam, before_ast, conid);
+  if (before_ast)
+    flags |= SrvJobBEFORE_NOTIFY;
+  sprintf(cmd, "MdsServerShr->ServerQAction(%d,%dwu,%d,%d,%d", addr, port, op, flags, jobid);
+  va_start(vlist, numargs_in);
+  for (i = 0; i < numargs; i++) {
+    strcat(cmd, ",");
+    arg = va_arg(vlist, struct descrip *);
+    if (op == SrvMonitor && numargs == 8 && i == 5 && arg->dtype == DTYPE_LONG
+        && *(int *)arg->ptr == MonitorCheckin)
+      MonJob = jobid;
+    switch (arg->dtype) {
+      case DTYPE_CSTRING: {
+        int j;
+        int k;
+        char *c = (char *)arg->ptr;
+        int len = strlen(c);
+        strcat(cmd, "\"");
+        for (j = 0, k = strlen(cmd); j < len; j++, k++) {
+          if (c[j] == '"' || c[j] == '\\')
+            cmd[k++] = '\\';
+            cmd[k] = c[j];
+          }
+          cmd[k] = 0;
+          strcat(cmd, "\"");
+          break;
+        }
+      case DTYPE_LONG:
+        sprintf(&cmd[strlen(cmd)], "%d", *(int *)arg->ptr);
+        break;
+      case DTYPE_CHAR:
+        sprintf(&cmd[strlen(cmd)], "%d", (int)*(char *)arg->ptr);
+        break;
+      default:
+        printf("shouldn't get here! ServerSendMessage dtype = %d\n", arg->dtype);
+    }
+  }
+  strcat(cmd, ")");
+  status = SendArg(conid, idx++, DTYPE_CSTRING, 1, (short)strlen(cmd), 0, 0, cmd);
+  if STATUS_NOT_OK {
+      perror("Error sending message to server");
+      CleanupJob(status, jobid);
+      return status;
+  }
+  status = GetAnswerInfoTS(conid, &dtype, &len, &ndims, dims, &numbytes, (void **)&dptr, &mem);
+  if STATUS_NOT_OK
+      perror("Error: no response from server");
+  if (mem)
+    free(mem);
   return status;
 }
 

--- a/tcl/tcl_dispatch.c
+++ b/tcl/tcl_dispatch.c
@@ -34,12 +34,14 @@ extern int TdiData();
 
 #define IS_WILD(T)   (strcspn(T,"*%") < strlen(T))
 
-static int SyncEfnInit = 0;
 #ifdef vms
-static int SyncEfn = 0;
+#define SYNCINIT
+#define SYNCPASS NULL
+#define SYNCWAIT ServerWait(0)
 #else
-static int SyncId;
-static int *SyncEfn = &SyncId;
+#define SYNCINIT int SyncId = 0
+#define SYNCPASS &SyncId
+#define SYNCWAIT ServerWait(SyncId)
 #endif
 
 static void *dispatch_table = 0;
@@ -48,9 +50,9 @@ extern int ServerFailedEssential();
 
 extern int TdiIdentOf();
 
-	/****************************************************************
-	 * TclDispatch_close:
-	 ****************************************************************/
+/****************************************************************
+ * TclDispatch_close:
+ ****************************************************************/
 EXPORT int TclDispatch_close(void *ctx, char **error __attribute__ ((unused)), char **output __attribute__ ((unused)))
 {
   char *ident = 0;
@@ -66,9 +68,9 @@ EXPORT int TclDispatch_close(void *ctx, char **error __attribute__ ((unused)), c
   return 1;
 }
 
-	/**************************************************************
-	 * TclDispatch_build:
-	 **************************************************************/
+/**************************************************************
+ * TclDispatch_build:
+ **************************************************************/
 EXPORT int TclDispatch_build(void *ctx, char **error, char **output __attribute__ ((unused)))
 {
   int sts;
@@ -90,20 +92,9 @@ EXPORT int TclDispatch_build(void *ctx, char **error, char **output __attribute_
   return sts;
 }
 
-	/***************************************************************
-	 * TclDispatch:
-	 ***************************************************************/
-
-static void InitSyncEfn()
-{
-  SyncEfnInit = 1;
-}
-
-static void WaitfrEf(int *id)
-{
-  ServerWait(*id);
-}
-
+/***************************************************************
+ * TclDispatch:
+ ***************************************************************/
 EXPORT int TclDispatch(void *ctx, char **error, char **output __attribute__ ((unused)))
 {
   char *treenode = 0;
@@ -112,8 +103,6 @@ EXPORT int TclDispatch(void *ctx, char **error, char **output __attribute__ ((un
   int nid;
   int waiting = cli_present(ctx, "WAIT") != MdsdclNEGATED;
   cli_get_value(ctx, "NODE", &treenode);
-  if (!SyncEfnInit)
-    InitSyncEfn();
   sts = TreeFindNode(treenode, &nid);
   if (sts & 1) {
     struct descriptor niddsc = { 4, DTYPE_NID, CLASS_S, (char *)0 };
@@ -134,12 +123,13 @@ EXPORT int TclDispatch(void *ctx, char **error, char **output __attribute__ ((un
       };
       TreeGetDbi(itmlst);
       StrAppend(&ident, (struct descriptor *)&nullstr);
+      SYNCINIT;
       sts =
-	  ServerDispatchAction(SyncEfn, ident.pointer, treename, shot, nid, 0, 0,
+	  ServerDispatchAction(SYNCPASS, ident.pointer, treename, shot, nid, 0, 0,
 			       waiting ? &iostatus : 0, 0, 0);
       if (sts & 1) {
 	if (waiting) {
-	  WaitfrEf(SyncEfn);
+	  SYNCWAIT;
 	  sts = iostatus;
 	}
       }
@@ -156,11 +146,11 @@ EXPORT int TclDispatch(void *ctx, char **error, char **output __attribute__ ((un
   return sts;
 }
 
-	/**************************************************************
-	 * TclDispatch_abort_server:
-	 * TclDispatch_stop_server:
-	 * TclDispatch_start_server:
-	 **************************************************************/
+/**************************************************************
+ * TclDispatch_abort_server:
+ * TclDispatch_stop_server:
+ * TclDispatch_start_server:
+ **************************************************************/
 EXPORT int TclDispatch_abort_server(void *ctx, char **error, char **output __attribute__ ((unused)))
 {
   int sts = 1;
@@ -225,9 +215,9 @@ EXPORT int TclDispatch_start_server(void *ctx, char **error, char **output __att
   return sts;
 }
 
-	/***************************************************************
-	 * TclDispatch_set_server:
-	 ***************************************************************/
+/***************************************************************
+ * TclDispatch_set_server:
+ ***************************************************************/
 EXPORT int TclDispatch_set_server(void *ctx, char **error, char **output __attribute__ ((unused)))
 {
   int sts = 1;
@@ -263,9 +253,9 @@ EXPORT int TclDispatch_set_server(void *ctx, char **error, char **output __attri
   return sts;
 }
 
-	/**************************************************************
-	 * TclDispatch_show_server:
-	 **************************************************************/
+/**************************************************************
+ * TclDispatch_show_server:
+ **************************************************************/
 EXPORT int TclDispatch_show_server(void *ctx, char **error __attribute__ ((unused)), char **output)
 {
   int sts = 1;
@@ -318,9 +308,9 @@ static void printIt(char *output)
   fprintf(stdout, "%s\n", output);
 }
 
-	/*****************************************************************
-	 * TclDispatch_phase:
-	 *****************************************************************/
+/*****************************************************************
+ * TclDispatch_phase:
+ *****************************************************************/
 EXPORT int TclDispatch_phase(void *ctx, char **error, char **output __attribute__ ((unused)))
 {
   char *phase = 0;
@@ -332,14 +322,12 @@ EXPORT int TclDispatch_phase(void *ctx, char **error, char **output __attribute_
   void (*output_rtn) () = cli_present(ctx, "LOG") & 1 ? printIt : 0;
 
   cli_get_value(ctx, "MONITOR", &monitor);
-  if (!SyncEfnInit)
-    InitSyncEfn();
   cli_get_value(ctx, "PHASE_NAME", &phase);
   cli_get_value(ctx, "SYNCH", &synch_str);
   sscanf(synch_str, "%d", &synch);
   synch = synch >= 1 ? synch : 1;
   if (dispatch_table)
-    sts = ServerDispatchPhase(SyncEfn, dispatch_table,
+    sts = ServerDispatchPhase(NULL, dispatch_table,
 			      phase, (char)noaction, synch, output_rtn, monitor);
   else
     *error = strdup("Error: No dispatch table found. Forgot to do DISPATCH/BUILD?\n");
@@ -357,9 +345,9 @@ EXPORT int TclDispatch_phase(void *ctx, char **error, char **output __attribute_
   return sts;
 }
 
-	/**************************************************************
-	 * TclDispatch_command:
-	 **************************************************************/
+/**************************************************************
+ * TclDispatch_command:
+ **************************************************************/
 typedef struct {
   int sts;
   char *command;
@@ -383,36 +371,31 @@ EXPORT int TclDispatch_command(void *ctx, char **error, char **output __attribut
   char *cli = NULL;
   char *ident = NULL;
   DispatchedCommand *command = calloc(1,sizeof(DispatchedCommand));
-
-  if (!SyncEfnInit)
-    InitSyncEfn();
   cli_get_value(ctx, "SERVER", &ident);
   cli_get_value(ctx, "TABLE", &cli);
   cli_get_value(ctx, "P1", &command->command);
   if(command->command){
-    if (cli_present(ctx, "WAIT") & 1) {
-      if STATUS_OK {
-        status = ServerDispatchCommand(SyncEfn, ident, cli, command->command, 0, 0, &command->sts, 0);
-        if STATUS_OK {
-	  WaitfrEf(SyncEfn);
-	  status = command->sts;
-        }
-      }
-      if STATUS_NOT_OK {
+    command->sts = MDSplusERROR;
+    int sync = IS_OK(cli_present(ctx, "WAIT"));
+    if (sync) {
+      SYNCINIT;
+      status = ServerDispatchCommand(SYNCPASS, ident, cli, command->command, 0, 0, &command->sts, 0);
+      if STATUS_OK
+        SYNCWAIT;
+      else {
         char *msg = MdsGetMsg(status);
-        *error = malloc(strlen(msg) + 100);
-        sprintf(*error, "Error: Problem dispatching command\n" "Error message was: %s\n", msg);
+        *error = malloc(100 + strlen(command->command) + strlen(msg));
+        sprintf(*error, "Error: Problem dispatching command: %s\n" "Error message was: %s\n", command->command, msg);
       }
+      status = command->sts;
       free(command->command);
       free(command);
     } else {
       status = ServerDispatchCommand(0, ident, cli, command->command, CommandDone, command, &command->sts, 0);
       if STATUS_NOT_OK {
         char *msg = MdsGetMsg(status);
-        *error = malloc(strlen(msg) + 100);
-        sprintf(*error, "Error: Problem dispatching command\n" "Error message was: %s\n", msg);
-        free(command->command);
-        free(command);
+        *error = malloc(100 + strlen(msg));
+        sprintf(*error, "Error: Problem dispatching async command.\n" "Error message was: %s\n", msg);
       }
     }
   } else {
@@ -426,9 +409,9 @@ EXPORT int TclDispatch_command(void *ctx, char **error, char **output __attribut
   return status;
 }
 
-	/***************************************************************
-	 * TclDispatch_check:
-	 ***************************************************************/
+/***************************************************************
+ * TclDispatch_check:
+ ***************************************************************/
 EXPORT int TclDispatch_check(void *ctx, char **error, char **output __attribute__ ((unused)))
 {
   if (ServerFailedEssential(dispatch_table, cli_present(ctx, "RESET") & 1)) {


### PR DESCRIPTION
- replaces the static locals SyncId and SyncEfn with MAKROS (non static SyncId) SYNCINIT, SYNCWAIT, and 
SYNCWAIT
- reused error handling for both sync and async communication
- Always pass cleanup method "CommandDone" to "ServerDispatchCommand" so ServerSendMessage can take care of the required free operations
- clean up of ServerSendMessage:
-* take care of free using ast(astparam) on ADDR_ERROR
-* replaced SndArgChk with inline code and dropped the use of goto send_error for better readability
-* removed unreachable code near the end: " if (!addr) .."

