### PR TITLE
New feature:: add MDSIP_CONNECT_TIMEOUT environment variable

### DIFF
--- a/envsyms.in
+++ b/envsyms.in
@@ -26,6 +26,10 @@ XAPPLRESDIR ${MDSPLUS} <:
 #
 IDL_PATH \+${MDSPLUS}/idl <:
 #
+# MDSIP_CONNECT_TIMEOUT - default timeout for MDSIP connects
+#
+MDSIP_CONNECT_TIMEOUT 1
+#
 # LIBRARY path
 #
 @LIBPATH@ ${MDSPLUS}/lib <:

--- a/mdstcpip/GetSetSettings.c
+++ b/mdstcpip/GetSetSettings.c
@@ -164,7 +164,7 @@ int GetCompressionLevel()
 //  CONNECTION TIMEOUT  ////////////////////////////////////////////////////////
 ////////////////////////////////////////////////////////////////////////////////
 
-static int connect_timeout = 0;
+static int connect_timeout = -1;
 int SetMdsConnectTimeout(int sec)
 {
   int old = connect_timeout;
@@ -179,6 +179,14 @@ int SetMdsConnectTimeout(int sec)
 
 int GetMdsConnectTimeout()
 {
+  if (connect_timeout == -1) {
+    char *timeout=getenv("MDSIP_CONNECT_TIMEOUT");
+    if (timeout){
+      connect_timeout = atoi(timeout); 
+    } else {
+      connect_timeout = 0;
+    }
+  }
   return connect_timeout;
 }
 

--- a/rpm/mdsplus.conf.template
+++ b/rpm/mdsplus.conf.template
@@ -16,3 +16,7 @@ subtree_path /usr/local/mdsplus/trees/subtree >;
 # Put mdsplus in beginning of PATH
 #
 PATH /usr/local/mdsplus/bin <:
+#
+# MDSIP_CONNECT_TIMEOUT - default timeout for MDSIP connects
+#
+MDSIP_CONNECT_TIMEOUT 1


### PR DESCRIPTION
The mdstcl dispatch commands potentially hang when trying to connect
to servers that are on the network but not responsive.

MdsIpShr has a connect_timeout parameter
set with:
  SetMdsConnectTimeout(int sec)
and retrieved with:
  GetMdsConnectTimeout()

This change uses the environment variable MDSIP_CONNECT_TIMEOUT to
set the default value for this parameter.  If it is undefined then
the original default of 0 is used.

Set this in envsyms with:
  MDSIP_CONNECT_TIMEOUT 1

or from the shell
  export MDSIP_CONNECT_TIMEOUT=1