### PR TITLE
Fix: Color of make help now resets to terminal default fg

### DIFF
--- a/configure
+++ b/configure
@@ -4636,10 +4636,10 @@ SELFHELP_FUNC = \\\\
     print "\\\\n"; \\\\
     print "| \${HELP_DESCRIPTION}\\\\n"; \\\\
     print "| \\\\n"; \\\\
-    print "| \${SH_GREEN}usage: make target\${SH_WHITE}\\\\n"; \\\\
+    print "| \${SH_GREEN}usage: make target\${SH_RESET}\\\\n"; \\\\
     print "| \\\\n"; \\\\
     for ( sort keys %help ) { \\\\
-	print "| \${SH_YELLOW}\$\$_\${SH_WHITE}:\\\\n"; \\\\
+	print "| \${SH_YELLOW}\$\$_:\${SH_RESET}\\\\n"; \\\\
 	printf("|   %-20s %-60s\\\\n", \$\$_->[0], \$\$_->[1]) for @{\$\$help{\$\$_}}; \\\\
 	print "| \\\\n"; \\\\
     } \\\\

--- a/m4/ax_target_selfhelp.m4
+++ b/m4/ax_target_selfhelp.m4
@@ -29,10 +29,10 @@ SELFHELP_FUNC = \\\\
     print "\\\\n"; \\\\
     print "| \${HELP_DESCRIPTION}\\\\n"; \\\\
     print "| \\\\n"; \\\\
-    print "| \${SH_GREEN}usage: make [target]\${SH_WHITE}\\\\n"; \\\\
+    print "| \${SH_GREEN}usage: make [target]\${SH_RESET}\\\\n"; \\\\
     print "| \\\\n"; \\\\
     for ( sort keys %help ) { \\\\
-	print "| \${SH_YELLOW}\$\$_\${SH_WHITE}:\\\\n"; \\\\
+	print "| \${SH_YELLOW}\$\$_:\${SH_RESET}\\\\n"; \\\\
 	printf("|   %-20s %-60s\\\\n", \$\$_->[[0]], \$\$_->[[1]]) for @{\$\$help{\$\$_}}; \\\\
 	print "| \\\\n"; \\\\
     } \\\\


### PR DESCRIPTION
Color of make help now resets to terminal default fg