### PR TITLE
Build: Remove santize and valgrind test options from os/*.opts

### DIFF
--- a/deploy/os/debian_wheezy.opts
+++ b/deploy/os/debian_wheezy.opts
@@ -1,1 +1,1 @@
---platform=debian --valgrind=memcheck,helgrind --dockerimage=mdsplus/docker:debian_wheezy-32,mdsplus/docker:debian_wheezy-64 --distname=DebianWheezy --arch=i386,amd64
+--platform=debian --dockerimage=mdsplus/docker:debian_wheezy-32,mdsplus/docker:debian_wheezy-64 --distname=DebianWheezy --arch=i386,amd64

--- a/deploy/os/fc17.opts
+++ b/deploy/os/fc17.opts
@@ -1,1 +1,1 @@
---platform=redhat --valgrind=memcheck,helgrind --dockerimage=mdsplus/docker:fc17 --distname=fc17
+--platform=redhat --dockerimage=mdsplus/docker:fc17 --distname=fc17

--- a/deploy/os/fc18.opts
+++ b/deploy/os/fc18.opts
@@ -1,1 +1,1 @@
---platform=redhat --valgrind=memcheck,helgrind --sanitize=address,undefined,thread --dockerimage=mdsplus/docker:fc18 --distname=fc18
+--platform=redhat --dockerimage=mdsplus/docker:fc18 --distname=fc18

--- a/deploy/os/fc20.opts
+++ b/deploy/os/fc20.opts
@@ -1,1 +1,1 @@
---platform=redhat --valgrind=memcheck,helgrind --sanitize=address,undefined,thread --dockerimage=mdsplus/docker:fc20 --distname=fc20
+--platform=redhat --dockerimage=mdsplus/docker:fc20 --distname=fc20

--- a/deploy/os/fc21.opts
+++ b/deploy/os/fc21.opts
@@ -1,1 +1,1 @@
---platform=redhat --valgrind=memcheck,helgrind --sanitize=address,undefined,thread --dockerimage=mdsplus/docker:fc21 --distname=fc21
+--platform=redhat --dockerimage=mdsplus/docker:fc21 --distname=fc21

--- a/deploy/os/fc22.opts
+++ b/deploy/os/fc22.opts
@@ -1,1 +1,1 @@
---platform=redhat --valgrind=memcheck,helgrind --sanitize=address,undefined,thread --dockerimage=mdsplus/docker:fc22 --distname=fc22
+--platform=redhat --dockerimage=mdsplus/docker:fc22 --distname=fc22

--- a/deploy/os/fc23.opts
+++ b/deploy/os/fc23.opts
@@ -1,1 +1,1 @@
---platform=redhat --valgrind=memcheck,helgrind --sanitize=address,undefined,thread --dockerimage=mdsplus/docker:fc23 --distname=fc23
+--platform=redhat --dockerimage=mdsplus/docker:fc23 --distname=fc23

--- a/deploy/os/fc25.opts
+++ b/deploy/os/fc25.opts
@@ -1,1 +1,1 @@
---platform=redhat --valgrind=memcheck,helgrind --sanitize=address,undefined,thread --dockerimage=mdsplus/docker:fc25 --distname=fc25
+--platform=redhat --dockerimage=mdsplus/docker:fc25 --distname=fc25

--- a/deploy/os/rhel5.opts
+++ b/deploy/os/rhel5.opts
@@ -1,1 +1,1 @@
---platform=redhat --valgrind=memcheck,helgrind --sanitize=address,undefined,thread --dockerimage=mdsplus/docker:rhel5 --distname=el5
+--platform=redhat --dockerimage=mdsplus/docker:rhel5 --distname=el5

--- a/deploy/os/rhel6.opts
+++ b/deploy/os/rhel6.opts
@@ -1,1 +1,1 @@
---platform=redhat --valgrind=memcheck,helgrind --sanitize=address,undefined,thread --dockerimage=mdsplus/docker:rhel6 --distname=el6
+--platform=redhat --dockerimage=mdsplus/docker:rhel6 --distname=el6

--- a/deploy/os/rhel7.opts
+++ b/deploy/os/rhel7.opts
@@ -1,1 +1,1 @@
---platform=redhat --valgrind=memcheck,helgrind --sanitize=address,undefined,thread --dockerimage=mdsplus/docker:rhel7 --distname=el7
+--platform=redhat --dockerimage=mdsplus/docker:rhel7 --distname=el7

--- a/deploy/os/ubuntu12.opts
+++ b/deploy/os/ubuntu12.opts
@@ -1,1 +1,1 @@
---platform=debian --valgrind=memcheck,helgrind --dockerimage=mdsplus/docker:ubuntu12-32,mdsplus/docker:ubuntu12-64 --distname=Ubuntu12 --arch=i386,amd64
+--platform=debian --dockerimage=mdsplus/docker:ubuntu12-32,mdsplus/docker:ubuntu12-64 --distname=Ubuntu12 --arch=i386,amd64

--- a/deploy/os/ubuntu14.opts
+++ b/deploy/os/ubuntu14.opts
@@ -1,1 +1,1 @@
---platform=debian --valgrind=memcheck,helgrind --dockerimage=mdsplus/docker:ubuntu14-32,mdsplus/docker:ubuntu14-64 --distname=Ubuntu14 --arch=i386,amd64
+--platform=debian --dockerimage=mdsplus/docker:ubuntu14-32,mdsplus/docker:ubuntu14-64 --distname=Ubuntu14 --arch=i386,amd64

--- a/deploy/os/ubuntu16.opts
+++ b/deploy/os/ubuntu16.opts
@@ -1,1 +1,1 @@
---platform=debian --valgrind=memcheck,helgrind --dockerimage=mdsplus/docker:ubuntu16-32,mdsplus/docker:ubuntu16-64 --distname=Ubuntu16 --arch=i386,amd64
+--platform=debian --dockerimage=mdsplus/docker:ubuntu16-32,mdsplus/docker:ubuntu16-64 --distname=Ubuntu16 --arch=i386,amd64


### PR DESCRIPTION
Instead of putting the test options in the source code they will
be added to the jenkins build jobs. This will enable us to change
how many and which build jobs will perform these tests without
making modifications to the source files.