### PR TITLE
Buildxx: Check for valid commit titles

### DIFF
--- a/deploy/commit_type_check.sh
+++ b/deploy/commit_type_check.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+#
+# Check commit title format of all commits since original commit.
+#
+# The original commit is passed in as an argument ("origin" for pull requests and
+# the last release tag for release builds.
+# 
+# The second argument to this script should be the filespec of the contents of an
+# email to be sent to the person who created a commit with an invalid title.
+#
+
+git log $1..HEAD --no-merges --decorate=short --pretty=format:"%<(80,trunc)%s%n%ce" |
+    awk -v EMAILMSG="$2" -F: '{ IGNORECASE=1
+               if ( VERSION == "" ) {
+                 VERSION="SAME"
+                 FAIL="FALSE"
+               }
+               TITLE=$0 
+               switch ($1) { 
+               case "Feature":
+                 VERSION="MINOR"
+                 OK="1"
+                 break
+               case "Fix":
+                 if ( VERSION == "SAME" ) {
+                   VERSION="PATCH"
+                 }
+                 OK="1"
+                 break 
+               case "Tests": 
+               case "Docs": 
+               case "Build":
+                 OK="1"
+                 break
+               default:
+                 OK="0"
+                 FAIL="TRUE"
+                 break
+               }
+               getline
+               EMAIL=$0
+               if (OK != "1") {
+                 system("mail -s \"" TITLE "\" "  EMAIL " < " EMAILMSG )
+               }
+            }
+            END {
+              if ( FAIL == "TRUE" ) {
+                print("BADCOMMIT")
+              } else {
+                print(VERSION)
+              }
+            }'
+

--- a/deploy/inv_commit_title.msg
+++ b/deploy/inv_commit_title.msg
@@ -1,0 +1,38 @@
+You have specified an invalid title for the commit mentioned in the subject of this email.
+This is only a warning for now but in the not too distant future we will be requiring
+properly formatted commit messages. The commit message should have the following format:
+
+<commit-type>: <commit-title>
+<blank line>
+<commit details>
+
+Where:
+
+<commit-type> is one of (note the type must be followed by a colon with no spaces):
+
+  Feature  (commit is introducing a new feature to MDSplus. 
+            Will eventually trigger "minor" version increment.)
+  Fix      (commit is to fix an existing bug in MDSplus.
+            Will eventually trigger "path" version increment.)
+  Build    (commit affects build/deploy scripts and configurations.
+            Does not trigger a new release version.)
+  Docs     (commit affects MDSplus documentation.
+            Does not trigger a new release version.)
+  Test     (changes to or additional regression tests.
+            Does not trigger a new release version.)
+
+The check on the <commit-type> is case insensitive.
+
+<commit-title> is a short but meaningful title of the change being made.
+<commit-details> is one or more lines describing the commit in detail. While
+                 the purpose and details of the commit are fully understood
+                 by the author of the commit at the time of the commit it
+                 may not be that obvious to other developers and even less
+                 so as time passes.
+
+Eventually it is planned to automatically generate a formatted release notes
+document from the commit messages. If you are adding a series of commits
+to add a new feature or fix a bug etc. it would be best to either squash
+the commits into one commit or use the same commit type and title in the
+commits so the release notes generator can consolidate the details.
+ 


### PR DESCRIPTION
This is to begin the implementation of using commit titles to
determine new release numbers (minor vs path increments) and
to provide commit category specifications for generating release
notes.