### PR TITLE
Build: Better sanitize and valgrind build option handling

### DIFF
--- a/deploy/build.sh
+++ b/deploy/build.sh
@@ -203,6 +203,9 @@ OPTIONS WITH OS SPECIFIC DEFAULT
        operation. The default --distname option will be set if using a
        supported operating system.
 
+    --valgrind
+       Enable valgrind testing for this build.
+
     --valgrind=tests
        Select a set of valgrind tests to perform on the MDSplus code if
        the --test option is included. This is a comma delimited list of
@@ -211,6 +214,9 @@ OPTIONS WITH OS SPECIFIC DEFAULT
        supported operating system a default list of tests supported for
        that operating system will be used unless overriden in the
        command line.
+
+    --sanitize
+       Enable sanitize testing for this build.
 
     --sanitize=tests
        Select a set of sanitize tests to perform on the MDSplus code if
@@ -280,14 +286,20 @@ parsecmd() {
 	    --platform=*)
 		PLATFORM="${i#*=}"
 		;;
+	    --valgrind)
+		ENABLE_VALGRIND=yes
+		;;
 	    --valgrind=*)
-		if [ -z "$VALGRIND_TOOLS" ]
+		if [ "${ENABLE_VALGRIND}" = "yes" ]
 		then
 		    VALGRIND_TOOLS="${i#*=}"
 		fi
 		;;
+	    --sanitize)
+		ENABLE_SANITIZE=yes
+		;;
 	    --sanitize=*)
-		if [ -z "$SANITIZE" ]
+		if [ "$ENABLE_SANITIZE" = "yes" ]
 		then
 		    SANITIZE="${i#*=}"
 		fi


### PR DESCRIPTION
The sanitize and valgrind tests supported by the operating system
and the docker used to build for that operating system are specified
in the os/*.opts files. Before this change, these os opts were overriding
the test selections so there was no way to skip these tests. This change
requires the --sanitize (with no test list) or --valgrind options to be
set or none of the tests will be executed. If sanitize or valgrind tests
are desired the trigger.sh and/or build.sh scripts should contain these
options without test lists to enable the tests.