### PR TITLE
Build: Add distclean target to top Makefile

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -31,7 +31,7 @@ HDF5_APS = hdf5
 D3D_PACKAGE = d3dshr
 
 PARTS = \
-        mdsshr \
+mdsshr \
         treeshr \
         tdishr \
         tditest \
@@ -96,7 +96,21 @@ $(clean_DIRS):
 clean_DOCS: ##@docs clean generated documentation
 	$(MAKE) -C docs clean
 
+.PHONY: distclean
 
+distclean: ##@build make source directory look like original sources
+	@cpwd=$$(pwd); \
+	cd @top_srcdir@; \
+	if [ -r .git ]; \
+	then \
+	  git clean -x -f -d -q; \
+	else \
+	  if [ "$$(pwd)" == "$$cpwd" ]; \
+	     then make full_clean > /dev/null; \
+	  fi; \
+	  rm -Rf ./mdsobjects/python/build; \
+	fi; \
+	cd $$cpwd
 
 # Testing 
 
@@ -117,18 +131,14 @@ clean_TESTS: ##@tests clean all tests results and compiled tests objects
 
 .PHONY: full_clean
 full_clean: ##@build perform deep clean of build directories
-full_clean: ./devscripts/rm_if clean
-	@ $< bin bin64 bin32 bin_x86 bin_x86_64
-	@ $< etc
-	@ $< lib lib64 lib32
-	@ $< java/classes
-	@ $< java
-	@ $< uid uid64 uid32
-	@ $< config.cache
-	@ $< config.log
-	@ $< `find . -name '*.in' | \
-	      grep -v configure.in | grep -v makekit.in | \
-	      $(AWK) '{print substr($$1,0,length($$1)-3)}'`
+full_clean: clean
+	@rm -Rf bin bin64 bin32 bin_x86 bin_x86_64 etc \
+		lib lib64 lib32 java uid uid64 uid32 \
+		config.cache config.log config.status aclocal.m4 \
+		include/stamp-h1 autom4te.cache \
+		$$(find . -name '.deps') \
+		`find . -name '*.in' | \
+	      	$(AWK) '{print substr($$1,0,length($$1)-3)}'`
 
 .PHONY: depend
 depend:

--- a/javaclient/Makefile.am
+++ b/javaclient/Makefile.am
@@ -13,3 +13,6 @@ MdsPlus.jar: classjava.stamp
 	$(JAR) c0f $@ $(CLASSES)
 
 CLEANFILES = $(CLASSES) MdsPlus.jar
+
+clean-local:
+	-rm -rf $(JAVAROOT)/MdsPlus

--- a/javaclient/Makefile.in
+++ b/javaclient/Makefile.in
@@ -628,7 +628,7 @@ maintainer-clean-generic:
 	@echo "it deletes files that may require special tools to rebuild."
 clean: clean-am
 
-clean-am: clean-generic clean-javaJAVA mostlyclean-am
+clean-am: clean-generic clean-javaJAVA clean-local mostlyclean-am
 
 distclean: distclean-am
 	-rm -f Makefile
@@ -695,21 +695,25 @@ uninstall-am: uninstall-javaDATA uninstall-javaJAVA
 .MAKE: install-am install-strip
 
 .PHONY: all all-am check check-am clean clean-generic clean-javaJAVA \
-	cscopelist-am ctags-am distclean distclean-generic distdir dvi \
-	dvi-am html html-am info info-am install install-am \
-	install-data install-data-am install-dvi install-dvi-am \
-	install-exec install-exec-am install-html install-html-am \
-	install-info install-info-am install-javaDATA install-javaJAVA \
-	install-man install-pdf install-pdf-am install-ps \
-	install-ps-am install-strip installcheck installcheck-am \
-	installdirs maintainer-clean maintainer-clean-generic \
-	mostlyclean mostlyclean-generic pdf pdf-am ps ps-am tags-am \
-	uninstall uninstall-am uninstall-javaDATA uninstall-javaJAVA
+	clean-local cscopelist-am ctags-am distclean distclean-generic \
+	distdir dvi dvi-am html html-am info info-am install \
+	install-am install-data install-data-am install-dvi \
+	install-dvi-am install-exec install-exec-am install-html \
+	install-html-am install-info install-info-am install-javaDATA \
+	install-javaJAVA install-man install-pdf install-pdf-am \
+	install-ps install-ps-am install-strip installcheck \
+	installcheck-am installdirs maintainer-clean \
+	maintainer-clean-generic mostlyclean mostlyclean-generic pdf \
+	pdf-am ps ps-am tags-am uninstall uninstall-am \
+	uninstall-javaDATA uninstall-javaJAVA
 
 .PRECIOUS: Makefile
 
 MdsPlus.jar: classjava.stamp
 	$(JAR) c0f $@ $(CLASSES)
+
+clean-local:
+	-rm -rf $(JAVAROOT)/MdsPlus
 
 # Tell versions [3.59,3.63) of GNU make to not export all variables.
 # Otherwise a system limit (for SysV at least) may be exceeded.

--- a/javadispatcher/Makefile.am
+++ b/javadispatcher/Makefile.am
@@ -39,7 +39,6 @@ java_DATA = jDispatcher.jar
 jDispatcher.jar: classjava.stamp
 	$(JAR) c0f $@ $(CLASSES)
 
-CLEANFILES = $(CLASSES) jDispatcher.jar
 
 if MINGW 
 bin_SCRIPTS = jDispatcherIp.bat jDispatchMonitor.bat jServer.bat
@@ -47,6 +46,8 @@ else
 bin_SCRIPTS = jDispatcherIp jDispatchMonitor jServer
 EXTRA_DIST = jDispatcherIp.template jDispatchMonitor.template jServer.template
 endif
+
+CLEANFILES = $(CLASSES) jDispatcher.jar $(bin_SCRIPTS)
 
 jDispatcherIp jDispatchMonitor jServer: %: %.template
 	cp $^ $@

--- a/javadispatcher/Makefile.in
+++ b/javadispatcher/Makefile.in
@@ -483,10 +483,10 @@ java_JAVA = Action.java ActionServer.java Balancer.java \
 	ServersInfoPanel.java
 dist_java_DATA = jDispatcher.properties
 java_DATA = jDispatcher.jar
-CLEANFILES = $(CLASSES) jDispatcher.jar
 @MINGW_FALSE@bin_SCRIPTS = jDispatcherIp jDispatchMonitor jServer
 @MINGW_TRUE@bin_SCRIPTS = jDispatcherIp.bat jDispatchMonitor.bat jServer.bat
 @MINGW_FALSE@EXTRA_DIST = jDispatcherIp.template jDispatchMonitor.template jServer.template
+CLEANFILES = $(CLASSES) jDispatcher.jar $(bin_SCRIPTS)
 all: all-am
 
 .SUFFIXES:

--- a/javascope/Makefile.am
+++ b/javascope/Makefile.am
@@ -16,6 +16,10 @@ CLEANFILES += $(bin_SCRIPTS)
 $(bin_SCRIPTS): jScope.template
 	$(INSTALL) -d scripts
 	$(INSTALL) $< $@
+
+clean-local:
+	-rm -rf scripts
+
 endif
 
 

--- a/javascope/Makefile.in
+++ b/javascope/Makefile.in
@@ -808,9 +808,10 @@ distclean-generic:
 maintainer-clean-generic:
 	@echo "This command is intended for maintainers to use"
 	@echo "it deletes files that may require special tools to rebuild."
+@MINGW_TRUE@clean-local:
 clean: clean-am
 
-clean-am: clean-generic clean-javaJAVA mostlyclean-am
+clean-am: clean-generic clean-javaJAVA clean-local mostlyclean-am
 
 distclean: distclean-am
 	-rm -f Makefile
@@ -880,9 +881,9 @@ uninstall-am: uninstall-binSCRIPTS uninstall-dist_docsDATA \
 .MAKE: install-am install-strip
 
 .PHONY: all all-am check check-am clean clean-generic clean-javaJAVA \
-	cscopelist-am ctags-am distclean distclean-generic distdir dvi \
-	dvi-am html html-am info info-am install install-am \
-	install-binSCRIPTS install-data install-data-am \
+	clean-local cscopelist-am ctags-am distclean distclean-generic \
+	distdir dvi dvi-am html html-am info info-am install \
+	install-am install-binSCRIPTS install-data install-data-am \
 	install-dist_docsDATA install-dist_javaDATA \
 	install-dist_javaJAVA install-dvi install-dvi-am install-exec \
 	install-exec-am install-html install-html-am install-info \
@@ -901,6 +902,9 @@ uninstall-am: uninstall-binSCRIPTS uninstall-dist_docsDATA \
 @MINGW_FALSE@$(bin_SCRIPTS): jScope.template
 @MINGW_FALSE@	$(INSTALL) -d scripts
 @MINGW_FALSE@	$(INSTALL) $< $@
+
+@MINGW_FALSE@clean-local:
+@MINGW_FALSE@	-rm -rf scripts
 $(java_DATA): classjava.stamp
 jScope.jar: colors1.tbl
 	$(MKDIR_P) @builddir@/jdocs

--- a/mdsobjects/java/Makefile.am
+++ b/mdsobjects/java/Makefile.am
@@ -1,4 +1,4 @@
-CLEANFILES = $(java_DATA)
+CLEANFILES = $(java_DATA) MDSplus/*.class
 AM_JAVACFLAGS = $(JAVAVERSION)
 JAVAROOT = $(builddir)
 CLASSPATH_ENV = CLASSPATH=.:$(top_builddir)/javascope/jScope.jar

--- a/mdsobjects/java/Makefile.in
+++ b/mdsobjects/java/Makefile.in
@@ -478,7 +478,7 @@ top_build_prefix = @top_build_prefix@
 top_builddir = @top_builddir@
 top_srcdir = @top_srcdir@
 uiddir = @uiddir@
-CLEANFILES = $(java_DATA)
+CLEANFILES = $(java_DATA) MDSplus/*.class
 AM_JAVACFLAGS = $(JAVAVERSION)
 JAVAROOT = $(builddir)
 CLASSPATH_ENV = CLASSPATH=.:$(top_builddir)/javascope/jScope.jar


### PR DESCRIPTION
This commit adds the distclean target to the top directory Makefile.
The command "make distclean" should clean the directory tree of any
files or directory not in the original source tree. If the sources
where obtained via git it will use the "git clean" command to remove
the files otherwise it will use "make fullclean" if the "make distclean"
command was issued from the top source directory. It is now recommended
that configure and make be performed from a build directory outside
of the source tree which should leave the source directory tree in
a clean state.

This commit is to address git issue:

https://github.com/MDSplus/mdsplus/issues/680