### PR TITLE
Build: Use more secure keys to sign MDSplus packages

### DIFF
--- a/deploy/platform/debian/debian_docker_build.sh
+++ b/deploy/platform/debian/debian_docker_build.sh
@@ -136,7 +136,7 @@ EOF
     if [ -d /sign_keys/.gnupg ]
     then
         ls -l /sign_keys/.gnupg
-    	echo "SignWith: MDSplus" >> /release/repo/conf/distributions
+    	echo "SignWith: B1E664BFFCBB6F4614FB4A7C5D83C3E21325A989" >> /release/repo/conf/distributions
     fi
     export HOME=/sign_keys
     pushd /release/repo

--- a/deploy/platform/redhat/redhat_build_rpms.py
+++ b/deploy/platform/redhat/redhat_build_rpms.py
@@ -198,7 +198,7 @@ Buildarch: noarch
     try:
         os.stat('/sign_keys/.gnupg')
         try:
-            cmd="/bin/sh -c 'HOME=/sign_keys rpmsign --addsign --define=\"_signature gpg\" --define=\"_gpg_name MDSplus\" /release/%(branch)s/RPMS/*/*%(major)d.%(minor)d-%(release)d*.rpm'" % info
+            cmd="/bin/sh -c 'HOME=/sign_keys rpmsign --addsign --key-id=674D9C60 /release/%(branch)s/RPMS/*/*%(major)d.%(minor)d-%(release)d*.rpm'" % info
             child = pexpect.spawn(cmd,timeout=60,logfile=sys.stdout)
             child.expect("Enter pass phrase: ")
             child.sendline("")


### PR DESCRIPTION
Installer utilities are warning about the keys used to sign MDSplus
packages being to weak. This change will use more secure signing keys
when signing packages. This is to address the following github issue:

https://github.com/MDSplus/mdsplus/issues/647