### PR TITLE
Add the use of TARGET_ARCH in library tests in configure

### DIFF
--- a/configure
+++ b/configure
@@ -6655,13 +6655,6 @@ $as_echo "**********VISIBILITY*********$CFLAG_VISIBILITY*******************" >&6
 #	CFLAGS="$CFLAGS $CFLAG_VISIBILITY"
 #fi
 
-
-
-
-
-
-
-
 #FIXME: Remove this when Makefile.inc goes away
 #AS_CASE(["$MKDIR_P"],
 #        [*install-sh*], [MKDIR_P="\$(top_srcdir)/$MKDIR_P"])
@@ -8206,16 +8199,22 @@ case "$host" in
                      X_EXTRA_LIBS="-lXmu";;
 esac
 
+#
+# Add TARGET_ARCH to CFLAGS so that all library searches will look for libraries of the correct arch
+#
+CFLAGS="${CFLAGS} ${TARGET_ARCH}"
+#
 
-  CFLAGS_s="$CFLAGS"
-  CFLAGS="$TARGET_ARCH $CFLAGS"
-  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for dc1394_new  in -ldc1394" >&5
-$as_echo_n "checking for dc1394_new  in -ldc1394... " >&6; }
-if ${ac_cv_lib_dc1394_dc1394_new_+:} false; then :
+
+
+
+	LIBS_SAVE=${LIBS}
+	{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for library containing raw1394_get_libversion" >&5
+$as_echo_n "checking for library containing raw1394_get_libversion... " >&6; }
+if ${ac_cv_search_raw1394_get_libversion+:} false; then :
   $as_echo_n "(cached) " >&6
 else
-  ac_check_lib_save_LIBS=$LIBS
-LIBS="-ldc1394  $LIBS"
+  ac_func_search_save_LIBS=$LIBS
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
@@ -8225,42 +8224,53 @@ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 #ifdef __cplusplus
 extern "C"
 #endif
-char dc1394_new  ();
+char raw1394_get_libversion ();
 int
 main ()
 {
-return dc1394_new  ();
+return raw1394_get_libversion ();
   ;
   return 0;
 }
 _ACEOF
-if ac_fn_c_try_link "$LINENO"; then :
-  ac_cv_lib_dc1394_dc1394_new_=yes
-else
-  ac_cv_lib_dc1394_dc1394_new_=no
+for ac_lib in '' raw1394; do
+  if test -z "$ac_lib"; then
+    ac_res="none required"
+  else
+    ac_res=-l$ac_lib
+    LIBS="-l$ac_lib  $ac_func_search_save_LIBS"
+  fi
+  if ac_fn_c_try_link "$LINENO"; then :
+  ac_cv_search_raw1394_get_libversion=$ac_res
 fi
 rm -f core conftest.err conftest.$ac_objext \
-    conftest$ac_exeext conftest.$ac_ext
-LIBS=$ac_check_lib_save_LIBS
+    conftest$ac_exeext
+  if ${ac_cv_search_raw1394_get_libversion+:} false; then :
+  break
 fi
-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_dc1394_dc1394_new_" >&5
-$as_echo "$ac_cv_lib_dc1394_dc1394_new_" >&6; }
-if test "x$ac_cv_lib_dc1394_dc1394_new_" = xyes; then :
-  dc1394_v2=yes
+done
+if ${ac_cv_search_raw1394_get_libversion+:} false; then :
+
+else
+  ac_cv_search_raw1394_get_libversion=no
 fi
+rm conftest.$ac_ext
+LIBS=$ac_func_search_save_LIBS
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_search_raw1394_get_libversion" >&5
+$as_echo "$ac_cv_search_raw1394_get_libversion" >&6; }
+ac_res=$ac_cv_search_raw1394_get_libversion
+if test "$ac_res" != no; then :
+  test "$ac_res" = "none required" || LIBS="$ac_res $LIBS"
 
-  CFLAGS="$CFLAGS_s"
 
-
-  CFLAGS_s="$CFLAGS"
-  CFLAGS="$TARGET_ARCH $CFLAGS"
-  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for dc1394_get_camera_info  in -ldc1394" >&5
-$as_echo_n "checking for dc1394_get_camera_info  in -ldc1394... " >&6; }
-if ${ac_cv_lib_dc1394_dc1394_get_camera_info_+:} false; then :
+	LIBS_SAVE=${LIBS}
+	{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for library containing dc1394_new" >&5
+$as_echo_n "checking for library containing dc1394_new... " >&6; }
+if ${ac_cv_search_dc1394_new+:} false; then :
   $as_echo_n "(cached) " >&6
 else
-  ac_check_lib_save_LIBS=$LIBS
-LIBS="-ldc1394  $LIBS"
+  ac_func_search_save_LIBS=$LIBS
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
@@ -8270,42 +8280,57 @@ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 #ifdef __cplusplus
 extern "C"
 #endif
-char dc1394_get_camera_info  ();
+char dc1394_new ();
 int
 main ()
 {
-return dc1394_get_camera_info  ();
+return dc1394_new ();
   ;
   return 0;
 }
 _ACEOF
-if ac_fn_c_try_link "$LINENO"; then :
-  ac_cv_lib_dc1394_dc1394_get_camera_info_=yes
-else
-  ac_cv_lib_dc1394_dc1394_get_camera_info_=no
+for ac_lib in '' dc1394; do
+  if test -z "$ac_lib"; then
+    ac_res="none required"
+  else
+    ac_res=-l$ac_lib
+    LIBS="-l$ac_lib  $ac_func_search_save_LIBS"
+  fi
+  if ac_fn_c_try_link "$LINENO"; then :
+  ac_cv_search_dc1394_new=$ac_res
 fi
 rm -f core conftest.err conftest.$ac_objext \
-    conftest$ac_exeext conftest.$ac_ext
-LIBS=$ac_check_lib_save_LIBS
+    conftest$ac_exeext
+  if ${ac_cv_search_dc1394_new+:} false; then :
+  break
 fi
-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_dc1394_dc1394_get_camera_info_" >&5
-$as_echo "$ac_cv_lib_dc1394_dc1394_get_camera_info_" >&6; }
-if test "x$ac_cv_lib_dc1394_dc1394_get_camera_info_" = xyes; then :
-  dc1394_v1=yes
+done
+if ${ac_cv_search_dc1394_new+:} false; then :
+
+else
+  ac_cv_search_dc1394_new=no
+fi
+rm conftest.$ac_ext
+LIBS=$ac_func_search_save_LIBS
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_search_dc1394_new" >&5
+$as_echo "$ac_cv_search_dc1394_new" >&6; }
+ac_res=$ac_cv_search_dc1394_new
+if test "$ac_res" != no; then :
+  test "$ac_res" = "none required" || LIBS="$ac_res $LIBS"
+   DC1394_SUPPORT2="${MAKESHLIBDIR}libdc1394_support2$SHARETYPE"
 fi
 
-  CFLAGS="$CFLAGS_s"
+	LIBS=${LIBS_SAVE}
 
 
-  CFLAGS_s="$CFLAGS"
-  CFLAGS="$TARGET_ARCH $CFLAGS"
-  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for raw1394_get_libversion  in -lraw1394" >&5
-$as_echo_n "checking for raw1394_get_libversion  in -lraw1394... " >&6; }
-if ${ac_cv_lib_raw1394_raw1394_get_libversion_+:} false; then :
+	LIBS_SAVE=${LIBS}
+	{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for library containing dc1394_get_camera_info" >&5
+$as_echo_n "checking for library containing dc1394_get_camera_info... " >&6; }
+if ${ac_cv_search_dc1394_get_camera_info+:} false; then :
   $as_echo_n "(cached) " >&6
 else
-  ac_check_lib_save_LIBS=$LIBS
-LIBS="-lraw1394  $LIBS"
+  ac_func_search_save_LIBS=$LIBS
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
@@ -8315,42 +8340,54 @@ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 #ifdef __cplusplus
 extern "C"
 #endif
-char raw1394_get_libversion  ();
+char dc1394_get_camera_info ();
 int
 main ()
 {
-return raw1394_get_libversion  ();
+return dc1394_get_camera_info ();
   ;
   return 0;
 }
 _ACEOF
-if ac_fn_c_try_link "$LINENO"; then :
-  ac_cv_lib_raw1394_raw1394_get_libversion_=yes
-else
-  ac_cv_lib_raw1394_raw1394_get_libversion_=no
+for ac_lib in '' dc1394; do
+  if test -z "$ac_lib"; then
+    ac_res="none required"
+  else
+    ac_res=-l$ac_lib
+    LIBS="-l$ac_lib  $ac_func_search_save_LIBS"
+  fi
+  if ac_fn_c_try_link "$LINENO"; then :
+  ac_cv_search_dc1394_get_camera_info=$ac_res
 fi
 rm -f core conftest.err conftest.$ac_objext \
-    conftest$ac_exeext conftest.$ac_ext
-LIBS=$ac_check_lib_save_LIBS
+    conftest$ac_exeext
+  if ${ac_cv_search_dc1394_get_camera_info+:} false; then :
+  break
 fi
-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_raw1394_raw1394_get_libversion_" >&5
-$as_echo "$ac_cv_lib_raw1394_raw1394_get_libversion_" >&6; }
-if test "x$ac_cv_lib_raw1394_raw1394_get_libversion_" = xyes; then :
-  raw1394=yes
+done
+if ${ac_cv_search_dc1394_get_camera_info+:} false; then :
+
+else
+  ac_cv_search_dc1394_get_camera_info=no
+fi
+rm conftest.$ac_ext
+LIBS=$ac_func_search_save_LIBS
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_search_dc1394_get_camera_info" >&5
+$as_echo "$ac_cv_search_dc1394_get_camera_info" >&6; }
+ac_res=$ac_cv_search_dc1394_get_camera_info
+if test "$ac_res" != no; then :
+  test "$ac_res" = "none required" || LIBS="$ac_res $LIBS"
+   DC1394_SUPPORT="${MAKESHLIBDIR}libdc1394_support$SHARETYPE"
 fi
 
-  CFLAGS="$CFLAGS_s"
+	LIBS=${LIBS_SAVE}
 
-if test "$dc1394_v2" = "yes" -a "$raw1394"="yes"; then
-  DC1394_SUPPORT2="${MAKESHLIBDIR}libdc1394_support2$SHARETYPE"
-else
-  DC1394_SUPPORT2=""
+
 fi
-if test "$dc1394_v1" = "yes" -a "$raw1394"="yes"; then
-  DC1394_SUPPORT="${MAKESHLIBDIR}libdc1394_support$SHARETYPE"
-else
-  DC1394_SUPPORT=""
-fi
+
+	LIBS=${LIBS_SAVE}
+
 
 # The cast to long int works around a bug in the HP C Compiler
 # version HP92453-01 B.11.11.23709.GP, which incorrectly rejects
@@ -8451,10 +8488,7 @@ fi
 
 
 
-
-  CFLAGS_s="$CFLAGS"
-  CFLAGS="$TARGET_ARCH $CFLAGS"
-  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for library containing gethostbyname" >&5
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for library containing gethostbyname" >&5
 $as_echo_n "checking for library containing gethostbyname... " >&6; }
 if ${ac_cv_search_gethostbyname+:} false; then :
   $as_echo_n "(cached) " >&6
@@ -8541,19 +8575,15 @@ rm -f core conftest.err conftest.$ac_objext \
                 LIBS=$mds_old_LIBS
 fi
 
-  CFLAGS="$CFLAGS_s"
 
 
-
-  CFLAGS_s="$CFLAGS"
-  CFLAGS="$TARGET_ARCH $CFLAGS"
-  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for pow in -lm" >&5
-$as_echo_n "checking for pow in -lm... " >&6; }
-if ${ac_cv_lib_m_pow+:} false; then :
+	LIBS_SAVE=${LIBS}
+	{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for library containing pow" >&5
+$as_echo_n "checking for library containing pow... " >&6; }
+if ${ac_cv_search_pow+:} false; then :
   $as_echo_n "(cached) " >&6
 else
-  ac_check_lib_save_LIBS=$LIBS
-LIBS="-lm  $LIBS"
+  ac_func_search_save_LIBS=$LIBS
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
@@ -8572,35 +8602,50 @@ return pow ();
   return 0;
 }
 _ACEOF
-if ac_fn_c_try_link "$LINENO"; then :
-  ac_cv_lib_m_pow=yes
-else
-  ac_cv_lib_m_pow=no
+for ac_lib in '' m; do
+  if test -z "$ac_lib"; then
+    ac_res="none required"
+  else
+    ac_res=-l$ac_lib
+    LIBS="-l$ac_lib  $ac_func_search_save_LIBS"
+  fi
+  if ac_fn_c_try_link "$LINENO"; then :
+  ac_cv_search_pow=$ac_res
 fi
 rm -f core conftest.err conftest.$ac_objext \
-    conftest$ac_exeext conftest.$ac_ext
-LIBS=$ac_check_lib_save_LIBS
+    conftest$ac_exeext
+  if ${ac_cv_search_pow+:} false; then :
+  break
 fi
-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_m_pow" >&5
-$as_echo "$ac_cv_lib_m_pow" >&6; }
-if test "x$ac_cv_lib_m_pow" = xyes; then :
+done
+if ${ac_cv_search_pow+:} false; then :
+
+else
+  ac_cv_search_pow=no
+fi
+rm conftest.$ac_ext
+LIBS=$ac_func_search_save_LIBS
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_search_pow" >&5
+$as_echo "$ac_cv_search_pow" >&6; }
+ac_res=$ac_cv_search_pow
+if test "$ac_res" != no; then :
+  test "$ac_res" = "none required" || LIBS="$ac_res $LIBS"
   LIBM="-lm"
 else
   LIBM=""
 fi
 
-  CFLAGS="$CFLAGS_s"
+	LIBS=${LIBS_SAVE}
 
 
-  CFLAGS_s="$CFLAGS"
-  CFLAGS="$TARGET_ARCH $CFLAGS"
-  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for __dn_skipname in -lresolv" >&5
-$as_echo_n "checking for __dn_skipname in -lresolv... " >&6; }
-if ${ac_cv_lib_resolv___dn_skipname+:} false; then :
+	LIBS_SAVE=${LIBS}
+	{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for library containing __dn_skipname" >&5
+$as_echo_n "checking for library containing __dn_skipname... " >&6; }
+if ${ac_cv_search___dn_skipname+:} false; then :
   $as_echo_n "(cached) " >&6
 else
-  ac_check_lib_save_LIBS=$LIBS
-LIBS="-lresolv  $LIBS"
+  ac_func_search_save_LIBS=$LIBS
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
@@ -8619,35 +8664,50 @@ return __dn_skipname ();
   return 0;
 }
 _ACEOF
-if ac_fn_c_try_link "$LINENO"; then :
-  ac_cv_lib_resolv___dn_skipname=yes
-else
-  ac_cv_lib_resolv___dn_skipname=no
+for ac_lib in '' resolv; do
+  if test -z "$ac_lib"; then
+    ac_res="none required"
+  else
+    ac_res=-l$ac_lib
+    LIBS="-l$ac_lib  $ac_func_search_save_LIBS"
+  fi
+  if ac_fn_c_try_link "$LINENO"; then :
+  ac_cv_search___dn_skipname=$ac_res
 fi
 rm -f core conftest.err conftest.$ac_objext \
-    conftest$ac_exeext conftest.$ac_ext
-LIBS=$ac_check_lib_save_LIBS
+    conftest$ac_exeext
+  if ${ac_cv_search___dn_skipname+:} false; then :
+  break
 fi
-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_resolv___dn_skipname" >&5
-$as_echo "$ac_cv_lib_resolv___dn_skipname" >&6; }
-if test "x$ac_cv_lib_resolv___dn_skipname" = xyes; then :
+done
+if ${ac_cv_search___dn_skipname+:} false; then :
+
+else
+  ac_cv_search___dn_skipname=no
+fi
+rm conftest.$ac_ext
+LIBS=$ac_func_search_save_LIBS
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_search___dn_skipname" >&5
+$as_echo "$ac_cv_search___dn_skipname" >&6; }
+ac_res=$ac_cv_search___dn_skipname
+if test "$ac_res" != no; then :
+  test "$ac_res" = "none required" || LIBS="$ac_res $LIBS"
   LIBRESOLV="-lresolv"
 else
   LIBRESOLV=""
 fi
 
-  CFLAGS="$CFLAGS_s"
+	LIBS=${LIBS_SAVE}
 
 
-  CFLAGS_s="$CFLAGS"
-  CFLAGS="$TARGET_ARCH $CFLAGS"
-  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for dlopen in -ldl" >&5
-$as_echo_n "checking for dlopen in -ldl... " >&6; }
-if ${ac_cv_lib_dl_dlopen+:} false; then :
+	LIBS_SAVE=${LIBS}
+	{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for library containing dlopen" >&5
+$as_echo_n "checking for library containing dlopen... " >&6; }
+if ${ac_cv_search_dlopen+:} false; then :
   $as_echo_n "(cached) " >&6
 else
-  ac_check_lib_save_LIBS=$LIBS
-LIBS="-ldl  $LIBS"
+  ac_func_search_save_LIBS=$LIBS
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
@@ -8666,35 +8726,50 @@ return dlopen ();
   return 0;
 }
 _ACEOF
-if ac_fn_c_try_link "$LINENO"; then :
-  ac_cv_lib_dl_dlopen=yes
-else
-  ac_cv_lib_dl_dlopen=no
+for ac_lib in '' dl; do
+  if test -z "$ac_lib"; then
+    ac_res="none required"
+  else
+    ac_res=-l$ac_lib
+    LIBS="-l$ac_lib  $ac_func_search_save_LIBS"
+  fi
+  if ac_fn_c_try_link "$LINENO"; then :
+  ac_cv_search_dlopen=$ac_res
 fi
 rm -f core conftest.err conftest.$ac_objext \
-    conftest$ac_exeext conftest.$ac_ext
-LIBS=$ac_check_lib_save_LIBS
+    conftest$ac_exeext
+  if ${ac_cv_search_dlopen+:} false; then :
+  break
 fi
-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_dl_dlopen" >&5
-$as_echo "$ac_cv_lib_dl_dlopen" >&6; }
-if test "x$ac_cv_lib_dl_dlopen" = xyes; then :
+done
+if ${ac_cv_search_dlopen+:} false; then :
+
+else
+  ac_cv_search_dlopen=no
+fi
+rm conftest.$ac_ext
+LIBS=$ac_func_search_save_LIBS
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_search_dlopen" >&5
+$as_echo "$ac_cv_search_dlopen" >&6; }
+ac_res=$ac_cv_search_dlopen
+if test "$ac_res" != no; then :
+  test "$ac_res" = "none required" || LIBS="$ac_res $LIBS"
   LIBDL="-ldl"
 else
   LIBDL=""
 fi
 
-  CFLAGS="$CFLAGS_s"
+	LIBS=${LIBS_SAVE}
 
 
-  CFLAGS_s="$CFLAGS"
-  CFLAGS="$TARGET_ARCH $CFLAGS"
-  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for getgrgid in -lc" >&5
-$as_echo_n "checking for getgrgid in -lc... " >&6; }
-if ${ac_cv_lib_c_getgrgid+:} false; then :
+	LIBS_SAVE=${LIBS}
+	{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for library containing getgrgid" >&5
+$as_echo_n "checking for library containing getgrgid... " >&6; }
+if ${ac_cv_search_getgrgid+:} false; then :
   $as_echo_n "(cached) " >&6
 else
-  ac_check_lib_save_LIBS=$LIBS
-LIBS="-lc  $LIBS"
+  ac_func_search_save_LIBS=$LIBS
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
@@ -8713,35 +8788,50 @@ return getgrgid ();
   return 0;
 }
 _ACEOF
-if ac_fn_c_try_link "$LINENO"; then :
-  ac_cv_lib_c_getgrgid=yes
-else
-  ac_cv_lib_c_getgrgid=no
+for ac_lib in '' c; do
+  if test -z "$ac_lib"; then
+    ac_res="none required"
+  else
+    ac_res=-l$ac_lib
+    LIBS="-l$ac_lib  $ac_func_search_save_LIBS"
+  fi
+  if ac_fn_c_try_link "$LINENO"; then :
+  ac_cv_search_getgrgid=$ac_res
 fi
 rm -f core conftest.err conftest.$ac_objext \
-    conftest$ac_exeext conftest.$ac_ext
-LIBS=$ac_check_lib_save_LIBS
+    conftest$ac_exeext
+  if ${ac_cv_search_getgrgid+:} false; then :
+  break
 fi
-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_c_getgrgid" >&5
-$as_echo "$ac_cv_lib_c_getgrgid" >&6; }
-if test "x$ac_cv_lib_c_getgrgid" = xyes; then :
+done
+if ${ac_cv_search_getgrgid+:} false; then :
+
+else
+  ac_cv_search_getgrgid=no
+fi
+rm conftest.$ac_ext
+LIBS=$ac_func_search_save_LIBS
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_search_getgrgid" >&5
+$as_echo "$ac_cv_search_getgrgid" >&6; }
+ac_res=$ac_cv_search_getgrgid
+if test "$ac_res" != no; then :
+  test "$ac_res" = "none required" || LIBS="$ac_res $LIBS"
 
 $as_echo "#define HAVE_GETGRGID /**/" >>confdefs.h
 
 fi
 
-  CFLAGS="$CFLAGS_s"
+	LIBS=${LIBS_SAVE}
 
 
-  CFLAGS_s="$CFLAGS"
-  CFLAGS="$TARGET_ARCH $CFLAGS"
-  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for getpwuid in -lc" >&5
-$as_echo_n "checking for getpwuid in -lc... " >&6; }
-if ${ac_cv_lib_c_getpwuid+:} false; then :
+	LIBS_SAVE=${LIBS}
+	{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for library containing getpwuid" >&5
+$as_echo_n "checking for library containing getpwuid... " >&6; }
+if ${ac_cv_search_getpwuid+:} false; then :
   $as_echo_n "(cached) " >&6
 else
-  ac_check_lib_save_LIBS=$LIBS
-LIBS="-lc  $LIBS"
+  ac_func_search_save_LIBS=$LIBS
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
@@ -8760,35 +8850,50 @@ return getpwuid ();
   return 0;
 }
 _ACEOF
-if ac_fn_c_try_link "$LINENO"; then :
-  ac_cv_lib_c_getpwuid=yes
-else
-  ac_cv_lib_c_getpwuid=no
+for ac_lib in '' c; do
+  if test -z "$ac_lib"; then
+    ac_res="none required"
+  else
+    ac_res=-l$ac_lib
+    LIBS="-l$ac_lib  $ac_func_search_save_LIBS"
+  fi
+  if ac_fn_c_try_link "$LINENO"; then :
+  ac_cv_search_getpwuid=$ac_res
 fi
 rm -f core conftest.err conftest.$ac_objext \
-    conftest$ac_exeext conftest.$ac_ext
-LIBS=$ac_check_lib_save_LIBS
+    conftest$ac_exeext
+  if ${ac_cv_search_getpwuid+:} false; then :
+  break
 fi
-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_c_getpwuid" >&5
-$as_echo "$ac_cv_lib_c_getpwuid" >&6; }
-if test "x$ac_cv_lib_c_getpwuid" = xyes; then :
+done
+if ${ac_cv_search_getpwuid+:} false; then :
+
+else
+  ac_cv_search_getpwuid=no
+fi
+rm conftest.$ac_ext
+LIBS=$ac_func_search_save_LIBS
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_search_getpwuid" >&5
+$as_echo "$ac_cv_search_getpwuid" >&6; }
+ac_res=$ac_cv_search_getpwuid
+if test "$ac_res" != no; then :
+  test "$ac_res" = "none required" || LIBS="$ac_res $LIBS"
 
 $as_echo "#define HAVE_GETPWUID /**/" >>confdefs.h
 
 fi
 
-  CFLAGS="$CFLAGS_s"
+	LIBS=${LIBS_SAVE}
 
 
-  CFLAGS_s="$CFLAGS"
-  CFLAGS="$TARGET_ARCH $CFLAGS"
-  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for gethostbyname in -ldnet_stub" >&5
-$as_echo_n "checking for gethostbyname in -ldnet_stub... " >&6; }
-if ${ac_cv_lib_dnet_stub_gethostbyname+:} false; then :
+	LIBS_SAVE=${LIBS}
+	{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for library containing gethostbyname" >&5
+$as_echo_n "checking for library containing gethostbyname... " >&6; }
+if ${ac_cv_search_gethostbyname+:} false; then :
   $as_echo_n "(cached) " >&6
 else
-  ac_check_lib_save_LIBS=$LIBS
-LIBS="-ldnet_stub  $LIBS"
+  ac_func_search_save_LIBS=$LIBS
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
@@ -8807,30 +8912,45 @@ return gethostbyname ();
   return 0;
 }
 _ACEOF
-if ac_fn_c_try_link "$LINENO"; then :
-  ac_cv_lib_dnet_stub_gethostbyname=yes
-else
-  ac_cv_lib_dnet_stub_gethostbyname=no
+for ac_lib in '' dnet_stub; do
+  if test -z "$ac_lib"; then
+    ac_res="none required"
+  else
+    ac_res=-l$ac_lib
+    LIBS="-l$ac_lib  $ac_func_search_save_LIBS"
+  fi
+  if ac_fn_c_try_link "$LINENO"; then :
+  ac_cv_search_gethostbyname=$ac_res
 fi
 rm -f core conftest.err conftest.$ac_objext \
-    conftest$ac_exeext conftest.$ac_ext
-LIBS=$ac_check_lib_save_LIBS
+    conftest$ac_exeext
+  if ${ac_cv_search_gethostbyname+:} false; then :
+  break
 fi
-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_dnet_stub_gethostbyname" >&5
-$as_echo "$ac_cv_lib_dnet_stub_gethostbyname" >&6; }
-if test "x$ac_cv_lib_dnet_stub_gethostbyname" = xyes; then :
+done
+if ${ac_cv_search_gethostbyname+:} false; then :
+
+else
+  ac_cv_search_gethostbyname=no
+fi
+rm conftest.$ac_ext
+LIBS=$ac_func_search_save_LIBS
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_search_gethostbyname" >&5
+$as_echo "$ac_cv_search_gethostbyname" >&6; }
+ac_res=$ac_cv_search_gethostbyname
+if test "$ac_res" != no; then :
+  test "$ac_res" = "none required" || LIBS="$ac_res $LIBS"
   DNET_STUB="-ldnet_stub"
 else
   DNET_STUB=""
 fi
 
-  CFLAGS="$CFLAGS_s"
+	LIBS=${LIBS_SAVE}
 
-OLDLIBS="$LIBS"
 
-  CFLAGS_s="$CFLAGS"
-  CFLAGS="$TARGET_ARCH $CFLAGS"
-  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for library containing clock_gettime" >&5
+	LIBS_SAVE=${LIBS}
+	{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for library containing clock_gettime" >&5
 $as_echo_n "checking for library containing clock_gettime... " >&6; }
 if ${ac_cv_search_clock_gettime+:} false; then :
   $as_echo_n "(cached) " >&6
@@ -8886,9 +9006,8 @@ if test "$ac_res" != no; then :
 
 fi
 
-  CFLAGS="$CFLAGS_s"
+	LIBS=${LIBS_SAVE}
 
-LIBS="$OLDLIBS"
 CLOCK_GETTIME_LIB=""
 if test "$ac_cv_search_clock_gettime" != "no"
 then
@@ -8905,15 +9024,13 @@ fi
 
 
 
-  CFLAGS_s="$CFLAGS"
-  CFLAGS="$TARGET_ARCH $CFLAGS"
-  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for gettimeofday in -lc" >&5
-$as_echo_n "checking for gettimeofday in -lc... " >&6; }
-if ${ac_cv_lib_c_gettimeofday+:} false; then :
+	LIBS_SAVE=${LIBS}
+	{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for library containing gettimeofday" >&5
+$as_echo_n "checking for library containing gettimeofday... " >&6; }
+if ${ac_cv_search_gettimeofday+:} false; then :
   $as_echo_n "(cached) " >&6
 else
-  ac_check_lib_save_LIBS=$LIBS
-LIBS="-lc  $LIBS"
+  ac_func_search_save_LIBS=$LIBS
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
@@ -8932,35 +9049,50 @@ return gettimeofday ();
   return 0;
 }
 _ACEOF
-if ac_fn_c_try_link "$LINENO"; then :
-  ac_cv_lib_c_gettimeofday=yes
-else
-  ac_cv_lib_c_gettimeofday=no
+for ac_lib in '' c; do
+  if test -z "$ac_lib"; then
+    ac_res="none required"
+  else
+    ac_res=-l$ac_lib
+    LIBS="-l$ac_lib  $ac_func_search_save_LIBS"
+  fi
+  if ac_fn_c_try_link "$LINENO"; then :
+  ac_cv_search_gettimeofday=$ac_res
 fi
 rm -f core conftest.err conftest.$ac_objext \
-    conftest$ac_exeext conftest.$ac_ext
-LIBS=$ac_check_lib_save_LIBS
+    conftest$ac_exeext
+  if ${ac_cv_search_gettimeofday+:} false; then :
+  break
 fi
-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_c_gettimeofday" >&5
-$as_echo "$ac_cv_lib_c_gettimeofday" >&6; }
-if test "x$ac_cv_lib_c_gettimeofday" = xyes; then :
+done
+if ${ac_cv_search_gettimeofday+:} false; then :
+
+else
+  ac_cv_search_gettimeofday=no
+fi
+rm conftest.$ac_ext
+LIBS=$ac_func_search_save_LIBS
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_search_gettimeofday" >&5
+$as_echo "$ac_cv_search_gettimeofday" >&6; }
+ac_res=$ac_cv_search_gettimeofday
+if test "$ac_res" != no; then :
+  test "$ac_res" = "none required" || LIBS="$ac_res $LIBS"
 
 $as_echo "#define HAVE_GETTIMEOFDAY /**/" >>confdefs.h
 
 fi
 
-  CFLAGS="$CFLAGS_s"
+	LIBS=${LIBS_SAVE}
 
 
-  CFLAGS_s="$CFLAGS"
-  CFLAGS="$TARGET_ARCH $CFLAGS"
-  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for getaddrinfo in -lc" >&5
-$as_echo_n "checking for getaddrinfo in -lc... " >&6; }
-if ${ac_cv_lib_c_getaddrinfo+:} false; then :
+	LIBS_SAVE=${LIBS}
+	{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for library containing getaddrinfo" >&5
+$as_echo_n "checking for library containing getaddrinfo... " >&6; }
+if ${ac_cv_search_getaddrinfo+:} false; then :
   $as_echo_n "(cached) " >&6
 else
-  ac_check_lib_save_LIBS=$LIBS
-LIBS="-lc  $LIBS"
+  ac_func_search_save_LIBS=$LIBS
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
@@ -8979,35 +9111,50 @@ return getaddrinfo ();
   return 0;
 }
 _ACEOF
-if ac_fn_c_try_link "$LINENO"; then :
-  ac_cv_lib_c_getaddrinfo=yes
-else
-  ac_cv_lib_c_getaddrinfo=no
+for ac_lib in '' c; do
+  if test -z "$ac_lib"; then
+    ac_res="none required"
+  else
+    ac_res=-l$ac_lib
+    LIBS="-l$ac_lib  $ac_func_search_save_LIBS"
+  fi
+  if ac_fn_c_try_link "$LINENO"; then :
+  ac_cv_search_getaddrinfo=$ac_res
 fi
 rm -f core conftest.err conftest.$ac_objext \
-    conftest$ac_exeext conftest.$ac_ext
-LIBS=$ac_check_lib_save_LIBS
+    conftest$ac_exeext
+  if ${ac_cv_search_getaddrinfo+:} false; then :
+  break
 fi
-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_c_getaddrinfo" >&5
-$as_echo "$ac_cv_lib_c_getaddrinfo" >&6; }
-if test "x$ac_cv_lib_c_getaddrinfo" = xyes; then :
+done
+if ${ac_cv_search_getaddrinfo+:} false; then :
+
+else
+  ac_cv_search_getaddrinfo=no
+fi
+rm conftest.$ac_ext
+LIBS=$ac_func_search_save_LIBS
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_search_getaddrinfo" >&5
+$as_echo "$ac_cv_search_getaddrinfo" >&6; }
+ac_res=$ac_cv_search_getaddrinfo
+if test "$ac_res" != no; then :
+  test "$ac_res" = "none required" || LIBS="$ac_res $LIBS"
 
 $as_echo "#define HAVE_GETADDRINFO /**/" >>confdefs.h
 
 fi
 
-  CFLAGS="$CFLAGS_s"
+	LIBS=${LIBS_SAVE}
 
 
-  CFLAGS_s="$CFLAGS"
-  CFLAGS="$TARGET_ARCH $CFLAGS"
-  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for strsep in -lc" >&5
-$as_echo_n "checking for strsep in -lc... " >&6; }
-if ${ac_cv_lib_c_strsep+:} false; then :
+	LIBS_SAVE=${LIBS}
+	{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for library containing strsep" >&5
+$as_echo_n "checking for library containing strsep... " >&6; }
+if ${ac_cv_search_strsep+:} false; then :
   $as_echo_n "(cached) " >&6
 else
-  ac_check_lib_save_LIBS=$LIBS
-LIBS="-lc  $LIBS"
+  ac_func_search_save_LIBS=$LIBS
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
@@ -9026,35 +9173,50 @@ return strsep ();
   return 0;
 }
 _ACEOF
-if ac_fn_c_try_link "$LINENO"; then :
-  ac_cv_lib_c_strsep=yes
-else
-  ac_cv_lib_c_strsep=no
+for ac_lib in '' c; do
+  if test -z "$ac_lib"; then
+    ac_res="none required"
+  else
+    ac_res=-l$ac_lib
+    LIBS="-l$ac_lib  $ac_func_search_save_LIBS"
+  fi
+  if ac_fn_c_try_link "$LINENO"; then :
+  ac_cv_search_strsep=$ac_res
 fi
 rm -f core conftest.err conftest.$ac_objext \
-    conftest$ac_exeext conftest.$ac_ext
-LIBS=$ac_check_lib_save_LIBS
+    conftest$ac_exeext
+  if ${ac_cv_search_strsep+:} false; then :
+  break
 fi
-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_c_strsep" >&5
-$as_echo "$ac_cv_lib_c_strsep" >&6; }
-if test "x$ac_cv_lib_c_strsep" = xyes; then :
+done
+if ${ac_cv_search_strsep+:} false; then :
+
+else
+  ac_cv_search_strsep=no
+fi
+rm conftest.$ac_ext
+LIBS=$ac_func_search_save_LIBS
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_search_strsep" >&5
+$as_echo "$ac_cv_search_strsep" >&6; }
+ac_res=$ac_cv_search_strsep
+if test "$ac_res" != no; then :
+  test "$ac_res" = "none required" || LIBS="$ac_res $LIBS"
 
 $as_echo "#define HAVE_STRSEP /**/" >>confdefs.h
 
 fi
 
-  CFLAGS="$CFLAGS_s"
+	LIBS=${LIBS_SAVE}
 
 
-  CFLAGS_s="$CFLAGS"
-  CFLAGS="$TARGET_ARCH $CFLAGS"
-  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for getrusage in -lc" >&5
-$as_echo_n "checking for getrusage in -lc... " >&6; }
-if ${ac_cv_lib_c_getrusage+:} false; then :
+	LIBS_SAVE=${LIBS}
+	{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for library containing getrusage" >&5
+$as_echo_n "checking for library containing getrusage... " >&6; }
+if ${ac_cv_search_getrusage+:} false; then :
   $as_echo_n "(cached) " >&6
 else
-  ac_check_lib_save_LIBS=$LIBS
-LIBS="-lc  $LIBS"
+  ac_func_search_save_LIBS=$LIBS
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
@@ -9073,24 +9235,41 @@ return getrusage ();
   return 0;
 }
 _ACEOF
-if ac_fn_c_try_link "$LINENO"; then :
-  ac_cv_lib_c_getrusage=yes
-else
-  ac_cv_lib_c_getrusage=no
+for ac_lib in '' c; do
+  if test -z "$ac_lib"; then
+    ac_res="none required"
+  else
+    ac_res=-l$ac_lib
+    LIBS="-l$ac_lib  $ac_func_search_save_LIBS"
+  fi
+  if ac_fn_c_try_link "$LINENO"; then :
+  ac_cv_search_getrusage=$ac_res
 fi
 rm -f core conftest.err conftest.$ac_objext \
-    conftest$ac_exeext conftest.$ac_ext
-LIBS=$ac_check_lib_save_LIBS
+    conftest$ac_exeext
+  if ${ac_cv_search_getrusage+:} false; then :
+  break
 fi
-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_c_getrusage" >&5
-$as_echo "$ac_cv_lib_c_getrusage" >&6; }
-if test "x$ac_cv_lib_c_getrusage" = xyes; then :
+done
+if ${ac_cv_search_getrusage+:} false; then :
+
+else
+  ac_cv_search_getrusage=no
+fi
+rm conftest.$ac_ext
+LIBS=$ac_func_search_save_LIBS
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_search_getrusage" >&5
+$as_echo "$ac_cv_search_getrusage" >&6; }
+ac_res=$ac_cv_search_getrusage
+if test "$ac_res" != no; then :
+  test "$ac_res" = "none required" || LIBS="$ac_res $LIBS"
 
 $as_echo "#define HAVE_GETRUSAGE /**/" >>confdefs.h
 
 fi
 
-  CFLAGS="$CFLAGS_s"
+	LIBS=${LIBS_SAVE}
 
 # Check whether --enable-d3d was given.
 if test "${enable_d3d+set}" = set; then :
@@ -9152,10 +9331,7 @@ fi
         { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether readline via \"$_combo\" is present and sane" >&5
 $as_echo_n "checking whether readline via \"$_combo\" is present and sane... " >&6; }
                         	if test "$cross_compiling" = yes; then :
-
-  CFLAGS_s="$CFLAGS"
-  CFLAGS="$TARGET_ARCH $CFLAGS"
-  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for library containing readline" >&5
+                                            { $as_echo "$as_me:${as_lineno-$LINENO}: checking for library containing readline" >&5
 $as_echo_n "checking for library containing readline... " >&6; }
 if ${ac_cv_search_readline+:} false; then :
   $as_echo_n "(cached) " >&6
@@ -9212,8 +9388,6 @@ if test "$ac_res" != no; then :
 else
   have_readline=no
 fi
-
-  CFLAGS="$CFLAGS_s"
 
 
 else
@@ -9323,8 +9497,6 @@ done
 else
   as_fn_error $? "readline library was not found and must be installed." "$LINENO" 5
 fi
-
-
 
 ## ////////////////////////////////////////////////////////////////////////// ##
 ## //  LIBXML  ////////////////////////////////////////////////////////////// ##
@@ -9935,30 +10107,28 @@ fi
 done
 
 
-HDF5_APS=""
-for ac_header in hdf5.h
+if test -n "$HDF5_DIR" -a -r "$HDF5_DIR"
+then
+      HDF5_APS="\$(HDF5_APS)"
+      HDF5_INCS="-I$HDF5_DIR/include"
+      HDF5_LIBS="$HDF5_LIBS -L$HDF5_DIR/lib"
+else
+  for ac_header in hdf5.h
 do :
   ac_fn_c_check_header_mongrel "$LINENO" "hdf5.h" "ac_cv_header_hdf5_h" "$ac_includes_default"
 if test "x$ac_cv_header_hdf5_h" = xyes; then :
   cat >>confdefs.h <<_ACEOF
 #define HAVE_HDF5_H 1
 _ACEOF
- DO_HDF5="yes"
-fi
 
-done
 
-if test "$DO_HDF5" = yes; then
-
-  CFLAGS_s="$CFLAGS"
-  CFLAGS="$TARGET_ARCH $CFLAGS"
-  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for H5Fopen in -lhdf5" >&5
-$as_echo_n "checking for H5Fopen in -lhdf5... " >&6; }
-if ${ac_cv_lib_hdf5_H5Fopen+:} false; then :
+	LIBS_SAVE=${LIBS}
+	{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for library containing H5Fopen" >&5
+$as_echo_n "checking for library containing H5Fopen... " >&6; }
+if ${ac_cv_search_H5Fopen+:} false; then :
   $as_echo_n "(cached) " >&6
 else
-  ac_check_lib_save_LIBS=$LIBS
-LIBS="-lhdf5  $LIBS"
+  ac_func_search_save_LIBS=$LIBS
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
@@ -9977,37 +10147,49 @@ return H5Fopen ();
   return 0;
 }
 _ACEOF
-if ac_fn_c_try_link "$LINENO"; then :
-  ac_cv_lib_hdf5_H5Fopen=yes
-else
-  ac_cv_lib_hdf5_H5Fopen=no
+for ac_lib in '' hdf5; do
+  if test -z "$ac_lib"; then
+    ac_res="none required"
+  else
+    ac_res=-l$ac_lib
+    LIBS="-l$ac_lib  $ac_func_search_save_LIBS"
+  fi
+  if ac_fn_c_try_link "$LINENO"; then :
+  ac_cv_search_H5Fopen=$ac_res
 fi
 rm -f core conftest.err conftest.$ac_objext \
-    conftest$ac_exeext conftest.$ac_ext
-LIBS=$ac_check_lib_save_LIBS
+    conftest$ac_exeext
+  if ${ac_cv_search_H5Fopen+:} false; then :
+  break
 fi
-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_hdf5_H5Fopen" >&5
-$as_echo "$ac_cv_lib_hdf5_H5Fopen" >&6; }
-if test "x$ac_cv_lib_hdf5_H5Fopen" = xyes; then :
-  DO_HDF5="yes"
+done
+if ${ac_cv_search_H5Fopen+:} false; then :
+
 else
-  DO_HDF5="no"
+  ac_cv_search_H5Fopen=no
 fi
+rm conftest.$ac_ext
+LIBS=$ac_func_search_save_LIBS
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_search_H5Fopen" >&5
+$as_echo "$ac_cv_search_H5Fopen" >&6; }
+ac_res=$ac_cv_search_H5Fopen
+if test "$ac_res" != no; then :
+  test "$ac_res" = "none required" || LIBS="$ac_res $LIBS"
 
-  CFLAGS="$CFLAGS_s"
-
-  if test "$DO_HDF5" = yes; then
-    HDF5_APS="\$(HDF5_APS)"
-    HDF5_INCS=""
-    HDF5_LIBS=""
-  fi
-
-if test -n "$HDF5_DIR" -a -r "$HDF5_DIR"
-then
       HDF5_APS="\$(HDF5_APS)"
-      HDF5_INCS="-I$HDF5_DIR/include"
-      HDF5_LIBS="$HDF5_LIBS -L$HDF5_DIR/lib"
+      HDF5_INCS=""
+      HDF5_LIBS=""
+
 fi
+
+	LIBS=${LIBS_SAVE}
+
+
+fi
+
+done
+
 fi
 
 OLD_CPPFLAGS=$CPPFLAGS
@@ -10575,11 +10757,9 @@ elif test "$(echo $SYBASE_LIB | grep '\-L')" = ""
 then
     SYBASE_INC=""
     SYBASE_LIB=""
-    OLDLIBS="$LIBS"
 
-  CFLAGS_s="$CFLAGS"
-  CFLAGS="$TARGET_ARCH $CFLAGS"
-  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for library containing dbsqlexec" >&5
+	LIBS_SAVE=${LIBS}
+	{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for library containing dbsqlexec" >&5
 $as_echo_n "checking for library containing dbsqlexec... " >&6; }
 if ${ac_cv_search_dbsqlexec+:} false; then :
   $as_echo_n "(cached) " >&6
@@ -10635,9 +10815,8 @@ if test "$ac_res" != no; then :
   SYBASE_LIB="-lsybdb";SYBASE_INC="-DSYBASE";SYBASE="SYBASE",SYBASE_LIB=""
 fi
 
-  CFLAGS="$CFLAGS_s"
+	LIBS=${LIBS_SAVE}
 
-    LIBS="$OLDLIBS"
     if test "$SYBASE_LIB" = ""
     then
       { $as_echo "$as_me:${as_lineno-$LINENO}: checking for SYBASE open/client or freetds" >&5
@@ -11214,9 +11393,6 @@ _ACEOF
 if ac_fn_c_try_link "$LINENO"; then :
 
 else
-
-  CFLAGS_s="$CFLAGS"
-  CFLAGS="$TARGET_ARCH $CFLAGS"
   { $as_echo "$as_me:${as_lineno-$LINENO}: checking for dnet_ntoa in -ldnet" >&5
 $as_echo_n "checking for dnet_ntoa in -ldnet... " >&6; }
 if ${ac_cv_lib_dnet_dnet_ntoa+:} false; then :
@@ -11257,13 +11433,8 @@ if test "x$ac_cv_lib_dnet_dnet_ntoa" = xyes; then :
   X_EXTRA_LIBS="$X_EXTRA_LIBS -ldnet"
 fi
 
-  CFLAGS="$CFLAGS_s"
-
     if test $ac_cv_lib_dnet_dnet_ntoa = no; then
-
-  CFLAGS_s="$CFLAGS"
-  CFLAGS="$TARGET_ARCH $CFLAGS"
-  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for dnet_ntoa in -ldnet_stub" >&5
+      { $as_echo "$as_me:${as_lineno-$LINENO}: checking for dnet_ntoa in -ldnet_stub" >&5
 $as_echo_n "checking for dnet_ntoa in -ldnet_stub... " >&6; }
 if ${ac_cv_lib_dnet_stub_dnet_ntoa+:} false; then :
   $as_echo_n "(cached) " >&6
@@ -11303,8 +11474,6 @@ if test "x$ac_cv_lib_dnet_stub_dnet_ntoa" = xyes; then :
   X_EXTRA_LIBS="$X_EXTRA_LIBS -ldnet_stub"
 fi
 
-  CFLAGS="$CFLAGS_s"
-
     fi
 fi
 rm -f core conftest.err conftest.$ac_objext \
@@ -11325,10 +11494,7 @@ if test "x$ac_cv_func_gethostbyname" = xyes; then :
 fi
 
     if test $ac_cv_func_gethostbyname = no; then
-
-  CFLAGS_s="$CFLAGS"
-  CFLAGS="$TARGET_ARCH $CFLAGS"
-  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for gethostbyname in -lnsl" >&5
+      { $as_echo "$as_me:${as_lineno-$LINENO}: checking for gethostbyname in -lnsl" >&5
 $as_echo_n "checking for gethostbyname in -lnsl... " >&6; }
 if ${ac_cv_lib_nsl_gethostbyname+:} false; then :
   $as_echo_n "(cached) " >&6
@@ -11368,13 +11534,8 @@ if test "x$ac_cv_lib_nsl_gethostbyname" = xyes; then :
   X_EXTRA_LIBS="$X_EXTRA_LIBS -lnsl"
 fi
 
-  CFLAGS="$CFLAGS_s"
-
       if test $ac_cv_lib_nsl_gethostbyname = no; then
-
-  CFLAGS_s="$CFLAGS"
-  CFLAGS="$TARGET_ARCH $CFLAGS"
-  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for gethostbyname in -lbsd" >&5
+	{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for gethostbyname in -lbsd" >&5
 $as_echo_n "checking for gethostbyname in -lbsd... " >&6; }
 if ${ac_cv_lib_bsd_gethostbyname+:} false; then :
   $as_echo_n "(cached) " >&6
@@ -11414,8 +11575,6 @@ if test "x$ac_cv_lib_bsd_gethostbyname" = xyes; then :
   X_EXTRA_LIBS="$X_EXTRA_LIBS -lbsd"
 fi
 
-  CFLAGS="$CFLAGS_s"
-
       fi
     fi
 
@@ -11432,16 +11591,13 @@ if test "x$ac_cv_func_connect" = xyes; then :
 fi
 
     if test $ac_cv_func_connect = no; then
-
-  CFLAGS_s="$CFLAGS"
-  CFLAGS="$TARGET_ARCH $CFLAGS"
-  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for connect in -lsocket" >&5
+      { $as_echo "$as_me:${as_lineno-$LINENO}: checking for connect in -lsocket" >&5
 $as_echo_n "checking for connect in -lsocket... " >&6; }
 if ${ac_cv_lib_socket_connect+:} false; then :
   $as_echo_n "(cached) " >&6
 else
   ac_check_lib_save_LIBS=$LIBS
-LIBS="-lsocket  $LIBS"
+LIBS="-lsocket $X_EXTRA_LIBS $LIBS"
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
@@ -11475,8 +11631,6 @@ if test "x$ac_cv_lib_socket_connect" = xyes; then :
   X_EXTRA_LIBS="-lsocket $X_EXTRA_LIBS"
 fi
 
-  CFLAGS="$CFLAGS_s"
-
     fi
 
     # Guillermo Gomez says -lposix is necessary on A/UX.
@@ -11486,10 +11640,7 @@ if test "x$ac_cv_func_remove" = xyes; then :
 fi
 
     if test $ac_cv_func_remove = no; then
-
-  CFLAGS_s="$CFLAGS"
-  CFLAGS="$TARGET_ARCH $CFLAGS"
-  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for remove in -lposix" >&5
+      { $as_echo "$as_me:${as_lineno-$LINENO}: checking for remove in -lposix" >&5
 $as_echo_n "checking for remove in -lposix... " >&6; }
 if ${ac_cv_lib_posix_remove+:} false; then :
   $as_echo_n "(cached) " >&6
@@ -11529,8 +11680,6 @@ if test "x$ac_cv_lib_posix_remove" = xyes; then :
   X_EXTRA_LIBS="$X_EXTRA_LIBS -lposix"
 fi
 
-  CFLAGS="$CFLAGS_s"
-
     fi
 
     # BSDI BSD/OS 2.1 needs -lipc for XOpenDisplay.
@@ -11540,10 +11689,7 @@ if test "x$ac_cv_func_shmat" = xyes; then :
 fi
 
     if test $ac_cv_func_shmat = no; then
-
-  CFLAGS_s="$CFLAGS"
-  CFLAGS="$TARGET_ARCH $CFLAGS"
-  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for shmat in -lipc" >&5
+      { $as_echo "$as_me:${as_lineno-$LINENO}: checking for shmat in -lipc" >&5
 $as_echo_n "checking for shmat in -lipc... " >&6; }
 if ${ac_cv_lib_ipc_shmat+:} false; then :
   $as_echo_n "(cached) " >&6
@@ -11583,8 +11729,6 @@ if test "x$ac_cv_lib_ipc_shmat" = xyes; then :
   X_EXTRA_LIBS="$X_EXTRA_LIBS -lipc"
 fi
 
-  CFLAGS="$CFLAGS_s"
-
     fi
   fi
 
@@ -11597,16 +11741,13 @@ fi
   # These have to be linked with before -lX11, unlike the other
   # libraries we check for below, so use a different variable.
   # John Interrante, Karl Berry
-
-  CFLAGS_s="$CFLAGS"
-  CFLAGS="$TARGET_ARCH $CFLAGS"
   { $as_echo "$as_me:${as_lineno-$LINENO}: checking for IceConnectionNumber in -lICE" >&5
 $as_echo_n "checking for IceConnectionNumber in -lICE... " >&6; }
 if ${ac_cv_lib_ICE_IceConnectionNumber+:} false; then :
   $as_echo_n "(cached) " >&6
 else
   ac_check_lib_save_LIBS=$LIBS
-LIBS="-lICE  $LIBS"
+LIBS="-lICE $X_EXTRA_LIBS $LIBS"
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
@@ -11639,8 +11780,6 @@ $as_echo "$ac_cv_lib_ICE_IceConnectionNumber" >&6; }
 if test "x$ac_cv_lib_ICE_IceConnectionNumber" = xyes; then :
   X_PRE_LIBS="$X_PRE_LIBS -lSM -lICE"
 fi
-
-  CFLAGS="$CFLAGS_s"
 
   LDFLAGS=$ac_save_LDFLAGS
 
@@ -11731,15 +11870,13 @@ fi
 
 XM_LIBS="-lMrm -lXm"
 
-  CFLAGS_s="$CFLAGS"
-  CFLAGS="$TARGET_ARCH $CFLAGS"
-  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for XextAddDisplay in -lXext" >&5
-$as_echo_n "checking for XextAddDisplay in -lXext... " >&6; }
-if ${ac_cv_lib_Xext_XextAddDisplay+:} false; then :
+	LIBS_SAVE=${LIBS}
+	{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for library containing XextAddDisplay" >&5
+$as_echo_n "checking for library containing XextAddDisplay... " >&6; }
+if ${ac_cv_search_XextAddDisplay+:} false; then :
   $as_echo_n "(cached) " >&6
 else
-  ac_check_lib_save_LIBS=$LIBS
-LIBS="-lXext  $LIBS"
+  ac_func_search_save_LIBS=$LIBS
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
@@ -11758,35 +11895,50 @@ return XextAddDisplay ();
   return 0;
 }
 _ACEOF
-if ac_fn_c_try_link "$LINENO"; then :
-  ac_cv_lib_Xext_XextAddDisplay=yes
-else
-  ac_cv_lib_Xext_XextAddDisplay=no
+for ac_lib in '' Xext; do
+  if test -z "$ac_lib"; then
+    ac_res="none required"
+  else
+    ac_res=-l$ac_lib
+    LIBS="-l$ac_lib  $ac_func_search_save_LIBS"
+  fi
+  if ac_fn_c_try_link "$LINENO"; then :
+  ac_cv_search_XextAddDisplay=$ac_res
 fi
 rm -f core conftest.err conftest.$ac_objext \
-    conftest$ac_exeext conftest.$ac_ext
-LIBS=$ac_check_lib_save_LIBS
+    conftest$ac_exeext
+  if ${ac_cv_search_XextAddDisplay+:} false; then :
+  break
 fi
-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_Xext_XextAddDisplay" >&5
-$as_echo "$ac_cv_lib_Xext_XextAddDisplay" >&6; }
-if test "x$ac_cv_lib_Xext_XextAddDisplay" = xyes; then :
+done
+if ${ac_cv_search_XextAddDisplay+:} false; then :
+
+else
+  ac_cv_search_XextAddDisplay=no
+fi
+rm conftest.$ac_ext
+LIBS=$ac_func_search_save_LIBS
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_search_XextAddDisplay" >&5
+$as_echo "$ac_cv_search_XextAddDisplay" >&6; }
+ac_res=$ac_cv_search_XextAddDisplay
+if test "$ac_res" != no; then :
+  test "$ac_res" = "none required" || LIBS="$ac_res $LIBS"
   LIBXEXT="-lXext"
 else
   LIBXEXT=""
 fi
 
-  CFLAGS="$CFLAGS_s"
+	LIBS=${LIBS_SAVE}
 
 
-  CFLAGS_s="$CFLAGS"
-  CFLAGS="$TARGET_ARCH $CFLAGS"
-  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for XpGetDocumentData in -lXp" >&5
-$as_echo_n "checking for XpGetDocumentData in -lXp... " >&6; }
-if ${ac_cv_lib_Xp_XpGetDocumentData+:} false; then :
+	LIBS_SAVE=${LIBS}
+	{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for library containing XpGetDocumentData" >&5
+$as_echo_n "checking for library containing XpGetDocumentData... " >&6; }
+if ${ac_cv_search_XpGetDocumentData+:} false; then :
   $as_echo_n "(cached) " >&6
 else
-  ac_check_lib_save_LIBS=$LIBS
-LIBS="-lXp  $LIBS"
+  ac_func_search_save_LIBS=$LIBS
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
@@ -11805,24 +11957,41 @@ return XpGetDocumentData ();
   return 0;
 }
 _ACEOF
-if ac_fn_c_try_link "$LINENO"; then :
-  ac_cv_lib_Xp_XpGetDocumentData=yes
-else
-  ac_cv_lib_Xp_XpGetDocumentData=no
+for ac_lib in '' Xp; do
+  if test -z "$ac_lib"; then
+    ac_res="none required"
+  else
+    ac_res=-l$ac_lib
+    LIBS="-l$ac_lib  $ac_func_search_save_LIBS"
+  fi
+  if ac_fn_c_try_link "$LINENO"; then :
+  ac_cv_search_XpGetDocumentData=$ac_res
 fi
 rm -f core conftest.err conftest.$ac_objext \
-    conftest$ac_exeext conftest.$ac_ext
-LIBS=$ac_check_lib_save_LIBS
+    conftest$ac_exeext
+  if ${ac_cv_search_XpGetDocumentData+:} false; then :
+  break
 fi
-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_Xp_XpGetDocumentData" >&5
-$as_echo "$ac_cv_lib_Xp_XpGetDocumentData" >&6; }
-if test "x$ac_cv_lib_Xp_XpGetDocumentData" = xyes; then :
+done
+if ${ac_cv_search_XpGetDocumentData+:} false; then :
+
+else
+  ac_cv_search_XpGetDocumentData=no
+fi
+rm conftest.$ac_ext
+LIBS=$ac_func_search_save_LIBS
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_search_XpGetDocumentData" >&5
+$as_echo "$ac_cv_search_XpGetDocumentData" >&6; }
+ac_res=$ac_cv_search_XpGetDocumentData
+if test "$ac_res" != no; then :
+  test "$ac_res" = "none required" || LIBS="$ac_res $LIBS"
   LIBXP="-lXp"
 else
   LIBXP=""
 fi
 
-  CFLAGS="$CFLAGS_s"
+	LIBS=${LIBS_SAVE}
 
 
 ## ////////////////////////////////////////////////////////////////////////// ##
@@ -12185,15 +12354,14 @@ fi
 done
 
 
-  CFLAGS_s="$CFLAGS"
-  CFLAGS="$TARGET_ARCH $CFLAGS"
-  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for clock_gettime, timer_create, timer_settime, timer_delete in -lrt" >&5
-$as_echo_n "checking for clock_gettime, timer_create, timer_settime, timer_delete in -lrt... " >&6; }
-if ${ac_cv_lib_rt_clock_gettime__timer_create__timer_settime__timer_delete+:} false; then :
+
+	LIBS_SAVE=${LIBS}
+	{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for library containing clock_gettime, timer_create, timer_settime, timer_delete" >&5
+$as_echo_n "checking for library containing clock_gettime, timer_create, timer_settime, timer_delete... " >&6; }
+if ${ac_cv_search_clock_gettime__timer_create__timer_settime__timer_delete+:} false; then :
   $as_echo_n "(cached) " >&6
 else
-  ac_check_lib_save_LIBS=$LIBS
-LIBS="-lrt  $LIBS"
+  ac_func_search_save_LIBS=$LIBS
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
@@ -12212,24 +12380,41 @@ return clock_gettime, timer_create, timer_settime, timer_delete ();
   return 0;
 }
 _ACEOF
-if ac_fn_c_try_link "$LINENO"; then :
-  ac_cv_lib_rt_clock_gettime__timer_create__timer_settime__timer_delete=yes
-else
-  ac_cv_lib_rt_clock_gettime__timer_create__timer_settime__timer_delete=no
+for ac_lib in '' rt; do
+  if test -z "$ac_lib"; then
+    ac_res="none required"
+  else
+    ac_res=-l$ac_lib
+    LIBS="-l$ac_lib  $ac_func_search_save_LIBS"
+  fi
+  if ac_fn_c_try_link "$LINENO"; then :
+  ac_cv_search_clock_gettime__timer_create__timer_settime__timer_delete=$ac_res
 fi
 rm -f core conftest.err conftest.$ac_objext \
-    conftest$ac_exeext conftest.$ac_ext
-LIBS=$ac_check_lib_save_LIBS
+    conftest$ac_exeext
+  if ${ac_cv_search_clock_gettime__timer_create__timer_settime__timer_delete+:} false; then :
+  break
 fi
-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_rt_clock_gettime__timer_create__timer_settime__timer_delete" >&5
-$as_echo "$ac_cv_lib_rt_clock_gettime__timer_create__timer_settime__timer_delete" >&6; }
-if test "x$ac_cv_lib_rt_clock_gettime__timer_create__timer_settime__timer_delete" = xyes; then :
+done
+if ${ac_cv_search_clock_gettime__timer_create__timer_settime__timer_delete+:} false; then :
+
+else
+  ac_cv_search_clock_gettime__timer_create__timer_settime__timer_delete=no
+fi
+rm conftest.$ac_ext
+LIBS=$ac_func_search_save_LIBS
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_search_clock_gettime__timer_create__timer_settime__timer_delete" >&5
+$as_echo "$ac_cv_search_clock_gettime__timer_create__timer_settime__timer_delete" >&6; }
+ac_res=$ac_cv_search_clock_gettime__timer_create__timer_settime__timer_delete
+if test "$ac_res" != no; then :
+  test "$ac_res" = "none required" || LIBS="$ac_res $LIBS"
   LIBRT="-lrt"
 else
   LIBRT=""
 fi
 
-  CFLAGS="$CFLAGS_s"
+	LIBS=${LIBS_SAVE}
 
 
 
@@ -13952,10 +14137,7 @@ $as_echo "no, gcc 4.8.0 or higher required" >&6; }
 
 
      LDD=ldd
-
-  CFLAGS_s="$CFLAGS"
-  CFLAGS="$TARGET_ARCH $CFLAGS"
-  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for _init in -lasan" >&5
+     { $as_echo "$as_me:${as_lineno-$LINENO}: checking for _init in -lasan" >&5
 $as_echo_n "checking for _init in -lasan... " >&6; }
 if ${ac_cv_lib_asan__init+:} false; then :
   $as_echo_n "(cached) " >&6
@@ -13994,8 +14176,6 @@ $as_echo "$ac_cv_lib_asan__init" >&6; }
 if test "x$ac_cv_lib_asan__init" = xyes; then :
   have_asan=yes
 fi
-
-  CFLAGS="$CFLAGS_s"
 
      if test "x$have_asan" = xyes; then :
   CPPFLAGS_save=$CPPFLAGS
@@ -14050,10 +14230,7 @@ fi
 
 
      LDD=ldd
-
-  CFLAGS_s="$CFLAGS"
-  CFLAGS="$TARGET_ARCH $CFLAGS"
-  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for _init in -ltsan" >&5
+     { $as_echo "$as_me:${as_lineno-$LINENO}: checking for _init in -ltsan" >&5
 $as_echo_n "checking for _init in -ltsan... " >&6; }
 if ${ac_cv_lib_tsan__init+:} false; then :
   $as_echo_n "(cached) " >&6
@@ -14092,8 +14269,6 @@ $as_echo "$ac_cv_lib_tsan__init" >&6; }
 if test "x$ac_cv_lib_tsan__init" = xyes; then :
   have_tsan=yes
 fi
-
-  CFLAGS="$CFLAGS_s"
 
      if test "x$have_tsan" = xyes; then :
   CPPFLAGS_save=$CPPFLAGS
@@ -14141,10 +14316,7 @@ else
 
 
      LDD=ldd
-
-  CFLAGS_s="$CFLAGS"
-  CFLAGS="$TARGET_ARCH $CFLAGS"
-  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for _init in -ltsan" >&5
+     { $as_echo "$as_me:${as_lineno-$LINENO}: checking for _init in -ltsan" >&5
 $as_echo_n "checking for _init in -ltsan... " >&6; }
 if ${ac_cv_lib_tsan__init+:} false; then :
   $as_echo_n "(cached) " >&6
@@ -14183,8 +14355,6 @@ $as_echo "$ac_cv_lib_tsan__init" >&6; }
 if test "x$ac_cv_lib_tsan__init" = xyes; then :
   have_tsan=yes
 fi
-
-  CFLAGS="$CFLAGS_s"
 
      if test "x$have_tsan" = xyes; then :
   CPPFLAGS_save=$CPPFLAGS
@@ -14243,10 +14413,7 @@ fi
 
 
      LDD=ldd
-
-  CFLAGS_s="$CFLAGS"
-  CFLAGS="$TARGET_ARCH $CFLAGS"
-  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for _init in -lubsan" >&5
+     { $as_echo "$as_me:${as_lineno-$LINENO}: checking for _init in -lubsan" >&5
 $as_echo_n "checking for _init in -lubsan... " >&6; }
 if ${ac_cv_lib_ubsan__init+:} false; then :
   $as_echo_n "(cached) " >&6
@@ -14285,8 +14452,6 @@ $as_echo "$ac_cv_lib_ubsan__init" >&6; }
 if test "x$ac_cv_lib_ubsan__init" = xyes; then :
   have_ubsan=yes
 fi
-
-  CFLAGS="$CFLAGS_s"
 
      if test "x$have_ubsan" = xyes; then :
   CPPFLAGS_save=$CPPFLAGS
@@ -16833,6 +16998,13 @@ esac
 
 { $as_echo "$as_me:${as_lineno-$LINENO}: result: $enable_werror" >&5
 $as_echo "$enable_werror" >&6; }
+
+#
+# All library searches should be done at this point so remote TARGET_ARCH
+# from CFLAGS as the Make macros will insert TARGET_ARCH later as needed.
+#
+CFLAGS=`echo "${CFLAGS}" | ${AWK} '{gsub("'${TARGET_ARCH}'","");print $0;}'`
+#
 
 # //////////////////////////////////////////////////////////////////////////// #
 # ///  CONFIG_H  ///////////////////////////////////////////////////////////// #

--- a/configure.ac
+++ b/configure.ac
@@ -70,25 +70,6 @@ AC_MSG_RESULT([**********VISIBILITY*********$CFLAG_VISIBILITY*******************
 #if test -n "$CFLAG_VISIBILITY" && test "$is_w32" != yes; then
 #	CFLAGS="$CFLAGS $CFLAG_VISIBILITY"
 #fi
-m4_pattern_allow([AC_CHECK_LIB])
-m4_rename([AC_CHECK_LIB],[ORIGINAL_AC_CHECK_LIB])
-AC_DEFUN([AC_CHECK_LIB],
-[
-  CFLAGS_s="$CFLAGS"
-  CFLAGS="$TARGET_ARCH $CFLAGS"
-  ORIGINAL_AC_CHECK_LIB([$1],[$2],[$3],[$4])
-  CFLAGS="$CFLAGS_s"
-  ])
-
-m4_pattern_allow([AC_SEARCH_LIBS])
-m4_rename([AC_SEARCH_LIBS],[ORIGINAL_AC_SEARCH_LIBS])
-AC_DEFUN([AC_SEARCH_LIBS],
-[
-  CFLAGS_s="$CFLAGS"
-  CFLAGS="$TARGET_ARCH $CFLAGS"
-  ORIGINAL_AC_SEARCH_LIBS([$1],[$2],[$3],[$4])
-  CFLAGS="$CFLAGS_s"
-  ])
 
 #FIXME: Remove this when Makefile.inc goes away
 #AS_CASE(["$MKDIR_P"],
@@ -563,20 +544,26 @@ case "$host" in
        X_EXTRA_LIBS="-lXmu";;
 esac
 
+#
+# Add TARGET_ARCH to CFLAGS so that all library searches will look for libraries of the correct arch
+#
+CFLAGS="${CFLAGS} ${TARGET_ARCH}"
+#
+
+AC_DEFUN([MDS_SEARCH_LIBS],[
+	LIBS_SAVE=${LIBS}
+	AC_SEARCH_LIBS([$1],[$2],[$3],[$4],[$5])
+	LIBS=${LIBS_SAVE}
+	])
+
 dnl see if we have libdc1394 libraries and what version
-AC_CHECK_LIB(dc1394,dc1394_new ,dc1394_v2=yes)
-AC_CHECK_LIB(dc1394,dc1394_get_camera_info ,dc1394_v1=yes)
-AC_CHECK_LIB(raw1394,raw1394_get_libversion ,raw1394=yes)
-if test "$dc1394_v2" = "yes" -a "$raw1394"="yes"; then
-  DC1394_SUPPORT2="${MAKESHLIBDIR}libdc1394_support2$SHARETYPE"
-else
-  DC1394_SUPPORT2=""
-fi
-if test "$dc1394_v1" = "yes" -a "$raw1394"="yes"; then
-  DC1394_SUPPORT="${MAKESHLIBDIR}libdc1394_support$SHARETYPE"
-else
-  DC1394_SUPPORT=""
-fi
+MDS_SEARCH_LIBS([raw1394_get_libversion],[raw1394],
+[
+  MDS_SEARCH_LIBS([dc1394_new],[dc1394],
+  [ DC1394_SUPPORT2="${MAKESHLIBDIR}libdc1394_support2$SHARETYPE" ])
+  MDS_SEARCH_LIBS([dc1394_get_camera_info],[dc1394],
+  [ DC1394_SUPPORT="${MAKESHLIBDIR}libdc1394_support$SHARETYPE" ])
+])
 
 AC_CHECK_SIZEOF(long)
 
@@ -628,15 +615,13 @@ AC_SEARCH_LIBS([gethostbyname], [nsl socket],
                                [AC_MSG_RESULT([no]); AS_UNSET([LIBSOCKET])])
                 LIBS=$mds_old_LIBS])
 AC_SUBST([LIBSOCKET])
-AC_CHECK_LIB([m], [pow], [LIBM="-lm"], [LIBM=""])
-AC_CHECK_LIB(resolv,__dn_skipname,LIBRESOLV="-lresolv",LIBRESOLV="")
-AC_CHECK_LIB(dl,dlopen,LIBDL="-ldl",LIBDL="")
-AC_CHECK_LIB(c,getgrgid,AC_DEFINE(HAVE_GETGRGID,[],"Define if you have getgrgid to get group name."))
-AC_CHECK_LIB(c,getpwuid,AC_DEFINE(HAVE_GETPWUID,[],"Define if you have getpwuid."))
-AC_CHECK_LIB(dnet_stub,gethostbyname,DNET_STUB="-ldnet_stub",DNET_STUB="")
-OLDLIBS="$LIBS"
-AC_SEARCH_LIBS([clock_gettime],[rt],,,)
-LIBS="$OLDLIBS"
+MDS_SEARCH_LIBS([pow],[m], [LIBM="-lm"], [LIBM=""])
+MDS_SEARCH_LIBS([__dn_skipname],[resolv],LIBRESOLV="-lresolv",LIBRESOLV="")
+MDS_SEARCH_LIBS([dlopen],[dl],LIBDL="-ldl",LIBDL="")
+MDS_SEARCH_LIBS([getgrgid],[c],[AC_DEFINE(HAVE_GETGRGID,[],"Define if you have getgrgid to get group name.")])
+MDS_SEARCH_LIBS([getpwuid],[c],[AC_DEFINE(HAVE_GETPWUID,[],"Define if you have getpwuid.")])
+MDS_SEARCH_LIBS([gethostbyname],[dnet_stub],[DNET_STUB="-ldnet_stub"],[DNET_STUB=""])
+MDS_SEARCH_LIBS([clock_gettime],[rt])
 CLOCK_GETTIME_LIB=""
 if test "$ac_cv_search_clock_gettime" != "no"
 then
@@ -650,10 +635,10 @@ fi
 
 
 
-AC_CHECK_LIB(c,gettimeofday,AC_DEFINE(HAVE_GETTIMEOFDAY,,"Define if you have the gettimeofday function."))
-AC_CHECK_LIB(c,getaddrinfo,AC_DEFINE(HAVE_GETADDRINFO,,"Define if you have the getaddrinfo routine"))
-AC_CHECK_LIB(c,strsep,AC_DEFINE(HAVE_STRSEP,,"Define if you have the strsep routine"))
-AC_CHECK_LIB(c,getrusage,AC_DEFINE(HAVE_GETRUSAGE,,"Define if you have the getrusage routine"))
+MDS_SEARCH_LIBS([gettimeofday],[c],[AC_DEFINE(HAVE_GETTIMEOFDAY,,"Define if you have the gettimeofday function.")])
+MDS_SEARCH_LIBS([getaddrinfo],[c],[AC_DEFINE(HAVE_GETADDRINFO,,"Define if you have the getaddrinfo routine")])
+MDS_SEARCH_LIBS([strsep],[c],[AC_DEFINE(HAVE_STRSEP,,"Define if you have the strsep routine")])
+MDS_SEARCH_LIBS([getrusage],[c],[AC_DEFINE(HAVE_GETRUSAGE,,"Define if you have the getrusage routine")])
 AC_ARG_ENABLE(d3d,
 	[  --enable-d3d            build d3d ptdata access library ],
 	if test "$enableval" = yes; then
@@ -695,23 +680,6 @@ if test x"$have_readline" = x"yes"; then
 else
   AC_MSG_ERROR(readline library was not found and must be installed.)
 fi
-
-dnl //// discontinued implementation ////
-dnl LIBS_save="$LIBS"
-dnl   AC_SEARCH_LIBS([readline],[readline 'readline -lcurses'])
-dnl LIBS="$LIBS_save"
-dnl if test "$ac_cv_search_readline" = "no"
-dnl then
-dnl   AC_MSG_RESULT("libreadline is not available so the build of tdic will be skipped") 
-dnl   TDIC=""
-dnl   LIBREADLINE=""
-dnl else
-dnl   LIBREADLINE="$ac_cv_search_readline"
-dnl   TDIC="tdic"
-dnl fi
-dnl AC_SEARCH_LIBS([rl_set_signals],[readline 'readline -lcurses'],AC_DEFINE(HAVE_RL_SET_SIGNALS,,"define variable in code"))
-dnl AC_CHECK_HEADERS(readline/readline.h readline/history.h)
-
 
 ## ////////////////////////////////////////////////////////////////////////// ##
 ## //  LIBXML  ////////////////////////////////////////////////////////////// ##
@@ -772,24 +740,23 @@ fi
 
 AC_CHECK_HEADERS([stdint.h])
 
-dnl Check for default hdf5 header and library
-HDF5_APS=""
-AC_CHECK_HEADERS(hdf5.h,DO_HDF5="yes")
-if test "$DO_HDF5" = yes; then
-  AC_CHECK_LIB(hdf5,H5Fopen,DO_HDF5="yes",DO_HDF5="no")
-  if test "$DO_HDF5" = yes; then
-    HDF5_APS="\$(HDF5_APS)"
-    HDF5_INCS=""
-    HDF5_LIBS=""
-  fi
-
 dnl Check for user specified  hdf5 header and library
 if test -n "$HDF5_DIR" -a -r "$HDF5_DIR"
 then
       HDF5_APS="\$(HDF5_APS)"
       HDF5_INCS="-I$HDF5_DIR/include"
       HDF5_LIBS="$HDF5_LIBS -L$HDF5_DIR/lib"
-fi	
+else	
+dnl Check for default hdf5 header and library
+  AC_CHECK_HEADERS(hdf5.h,
+  [
+    MDS_SEARCH_LIBS([H5Fopen],[hdf5],
+    [
+      HDF5_APS="\$(HDF5_APS)"
+      HDF5_INCS=""
+      HDF5_LIBS=""
+    ])
+  ])
 fi
 
 dnl Check for jdk files
@@ -882,9 +849,7 @@ elif test "$(echo $SYBASE_LIB | grep '\-L')" = ""
 then
     SYBASE_INC=""
     SYBASE_LIB=""
-    OLDLIBS="$LIBS"
-    AC_SEARCH_LIBS([dbsqlexec],[sybdb],[SYBASE_LIB="-lsybdb";SYBASE_INC="-DSYBASE";SYBASE="SYBASE",SYBASE_LIB=""],)
-    LIBS="$OLDLIBS"
+    MDS_SEARCH_LIBS([dbsqlexec],[sybdb],[SYBASE_LIB="-lsybdb";SYBASE_INC="-DSYBASE";SYBASE="SYBASE",SYBASE_LIB=""],)
     if test "$SYBASE_LIB" = ""
     then
       AC_MSG_CHECKING(for SYBASE open/client or freetds)
@@ -967,8 +932,8 @@ fi
 
 
 XM_LIBS="-lMrm -lXm"
-AC_CHECK_LIB(Xext,XextAddDisplay,LIBXEXT="-lXext",LIBXEXT="")
-AC_CHECK_LIB(Xp,XpGetDocumentData,LIBXP="-lXp",LIBXP="")
+MDS_SEARCH_LIBS([XextAddDisplay],[Xext],[LIBXEXT="-lXext"],[LIBXEXT=""])
+MDS_SEARCH_LIBS([XpGetDocumentData],[Xp],[LIBXP="-lXp"],[LIBXP=""])
 
 ## ////////////////////////////////////////////////////////////////////////// ##
 ## //  PYTHON   ///////////////////////////////////////////////////////////// ##
@@ -994,7 +959,8 @@ AC_SUBST(PYTHON_ARCHITECTURE)
 ## MdsTestShr CHECK backend related ##
 AC_CHECK_FUNCS(mkstemp)
 AC_CHECK_FUNCS(fork)
-AC_CHECK_LIB([rt],  [clock_gettime, timer_create, timer_settime, timer_delete], 
+
+MDS_SEARCH_LIBS([clock_gettime, timer_create, timer_settime, timer_delete],[rt], 
              [LIBRT="-lrt"],[LIBRT=""])
 
 
@@ -1136,6 +1102,13 @@ AS_CASE([$enable_werror],
         [])
 AC_SUBST([WARNFLAGS])
 AC_MSG_RESULT([$enable_werror])
+
+#
+# All library searches should be done at this point so remote TARGET_ARCH
+# from CFLAGS as the Make macros will insert TARGET_ARCH later as needed.
+#
+CFLAGS=`echo "${CFLAGS}" | ${AWK} '{gsub("'${TARGET_ARCH}'","");print $0;}'`
+#
 
 # //////////////////////////////////////////////////////////////////////////// #
 # ///  CONFIG_H  ///////////////////////////////////////////////////////////// #


### PR DESCRIPTION
All searches for libraries in configure should search for libraries
in the architecture it is building. This change adds TARGET_ARCH
to CFLAGS early in the configure script and removes it after all
library checks are completed since Make adds TARGET_ARCH flags
to compiles and links automatically.

In addition all AC_CHECK_LIB calls have been changed to use
AC_SEARCH_LIBS since it is the recommended approach. To prevent
AC_SEARCH_LIBS from appending libraries to the global LIBS setting
an MDS_SEARCH_LIBS macro was defined to save LIBS, do AC_SEARCH_LIBS
and then restore original LIBS.