### PR TITLE
Make configure library tests use TARGET_ARCH for searching for libraries

### DIFF
--- a/configure
+++ b/configure
@@ -6655,13 +6655,6 @@ $as_echo "**********VISIBILITY*********$CFLAG_VISIBILITY*******************" >&6
 #	CFLAGS="$CFLAGS $CFLAG_VISIBILITY"
 #fi
 
-
-
-
-
-
-
-
 #FIXME: Remove this when Makefile.inc goes away
 #AS_CASE(["$MKDIR_P"],
 #        [*install-sh*], [MKDIR_P="\$(top_srcdir)/$MKDIR_P"])
@@ -8206,10 +8199,13 @@ case "$host" in
                      X_EXTRA_LIBS="-lXmu";;
 esac
 
+#
+# Add TARGET_ARCH to CFLAGS so that all library searches will look for libraries of the correct arch
+#
+CFLAGS="${CFLAGS} ${TARGET_ARCH}"
+#
 
-  CFLAGS_s="$CFLAGS"
-  CFLAGS="$TARGET_ARCH $CFLAGS"
-  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for dc1394_new  in -ldc1394" >&5
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for dc1394_new  in -ldc1394" >&5
 $as_echo_n "checking for dc1394_new  in -ldc1394... " >&6; }
 if ${ac_cv_lib_dc1394_dc1394_new_+:} false; then :
   $as_echo_n "(cached) " >&6
@@ -8249,12 +8245,7 @@ if test "x$ac_cv_lib_dc1394_dc1394_new_" = xyes; then :
   dc1394_v2=yes
 fi
 
-  CFLAGS="$CFLAGS_s"
-
-
-  CFLAGS_s="$CFLAGS"
-  CFLAGS="$TARGET_ARCH $CFLAGS"
-  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for dc1394_get_camera_info  in -ldc1394" >&5
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for dc1394_get_camera_info  in -ldc1394" >&5
 $as_echo_n "checking for dc1394_get_camera_info  in -ldc1394... " >&6; }
 if ${ac_cv_lib_dc1394_dc1394_get_camera_info_+:} false; then :
   $as_echo_n "(cached) " >&6
@@ -8294,12 +8285,7 @@ if test "x$ac_cv_lib_dc1394_dc1394_get_camera_info_" = xyes; then :
   dc1394_v1=yes
 fi
 
-  CFLAGS="$CFLAGS_s"
-
-
-  CFLAGS_s="$CFLAGS"
-  CFLAGS="$TARGET_ARCH $CFLAGS"
-  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for raw1394_get_libversion  in -lraw1394" >&5
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for raw1394_get_libversion  in -lraw1394" >&5
 $as_echo_n "checking for raw1394_get_libversion  in -lraw1394... " >&6; }
 if ${ac_cv_lib_raw1394_raw1394_get_libversion_+:} false; then :
   $as_echo_n "(cached) " >&6
@@ -8338,8 +8324,6 @@ $as_echo "$ac_cv_lib_raw1394_raw1394_get_libversion_" >&6; }
 if test "x$ac_cv_lib_raw1394_raw1394_get_libversion_" = xyes; then :
   raw1394=yes
 fi
-
-  CFLAGS="$CFLAGS_s"
 
 if test "$dc1394_v2" = "yes" -a "$raw1394"="yes"; then
   DC1394_SUPPORT2="${MAKESHLIBDIR}libdc1394_support2$SHARETYPE"
@@ -8451,10 +8435,7 @@ fi
 
 
 
-
-  CFLAGS_s="$CFLAGS"
-  CFLAGS="$TARGET_ARCH $CFLAGS"
-  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for library containing gethostbyname" >&5
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for library containing gethostbyname" >&5
 $as_echo_n "checking for library containing gethostbyname... " >&6; }
 if ${ac_cv_search_gethostbyname+:} false; then :
   $as_echo_n "(cached) " >&6
@@ -8541,13 +8522,8 @@ rm -f core conftest.err conftest.$ac_objext \
                 LIBS=$mds_old_LIBS
 fi
 
-  CFLAGS="$CFLAGS_s"
 
-
-
-  CFLAGS_s="$CFLAGS"
-  CFLAGS="$TARGET_ARCH $CFLAGS"
-  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for pow in -lm" >&5
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for pow in -lm" >&5
 $as_echo_n "checking for pow in -lm... " >&6; }
 if ${ac_cv_lib_m_pow+:} false; then :
   $as_echo_n "(cached) " >&6
@@ -8589,12 +8565,7 @@ else
   LIBM=""
 fi
 
-  CFLAGS="$CFLAGS_s"
-
-
-  CFLAGS_s="$CFLAGS"
-  CFLAGS="$TARGET_ARCH $CFLAGS"
-  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for __dn_skipname in -lresolv" >&5
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for __dn_skipname in -lresolv" >&5
 $as_echo_n "checking for __dn_skipname in -lresolv... " >&6; }
 if ${ac_cv_lib_resolv___dn_skipname+:} false; then :
   $as_echo_n "(cached) " >&6
@@ -8636,12 +8607,7 @@ else
   LIBRESOLV=""
 fi
 
-  CFLAGS="$CFLAGS_s"
-
-
-  CFLAGS_s="$CFLAGS"
-  CFLAGS="$TARGET_ARCH $CFLAGS"
-  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for dlopen in -ldl" >&5
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for dlopen in -ldl" >&5
 $as_echo_n "checking for dlopen in -ldl... " >&6; }
 if ${ac_cv_lib_dl_dlopen+:} false; then :
   $as_echo_n "(cached) " >&6
@@ -8683,12 +8649,7 @@ else
   LIBDL=""
 fi
 
-  CFLAGS="$CFLAGS_s"
-
-
-  CFLAGS_s="$CFLAGS"
-  CFLAGS="$TARGET_ARCH $CFLAGS"
-  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for getgrgid in -lc" >&5
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for getgrgid in -lc" >&5
 $as_echo_n "checking for getgrgid in -lc... " >&6; }
 if ${ac_cv_lib_c_getgrgid+:} false; then :
   $as_echo_n "(cached) " >&6
@@ -8730,12 +8691,7 @@ $as_echo "#define HAVE_GETGRGID /**/" >>confdefs.h
 
 fi
 
-  CFLAGS="$CFLAGS_s"
-
-
-  CFLAGS_s="$CFLAGS"
-  CFLAGS="$TARGET_ARCH $CFLAGS"
-  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for getpwuid in -lc" >&5
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for getpwuid in -lc" >&5
 $as_echo_n "checking for getpwuid in -lc... " >&6; }
 if ${ac_cv_lib_c_getpwuid+:} false; then :
   $as_echo_n "(cached) " >&6
@@ -8777,12 +8733,7 @@ $as_echo "#define HAVE_GETPWUID /**/" >>confdefs.h
 
 fi
 
-  CFLAGS="$CFLAGS_s"
-
-
-  CFLAGS_s="$CFLAGS"
-  CFLAGS="$TARGET_ARCH $CFLAGS"
-  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for gethostbyname in -ldnet_stub" >&5
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for gethostbyname in -ldnet_stub" >&5
 $as_echo_n "checking for gethostbyname in -ldnet_stub... " >&6; }
 if ${ac_cv_lib_dnet_stub_gethostbyname+:} false; then :
   $as_echo_n "(cached) " >&6
@@ -8824,13 +8775,8 @@ else
   DNET_STUB=""
 fi
 
-  CFLAGS="$CFLAGS_s"
-
 OLDLIBS="$LIBS"
-
-  CFLAGS_s="$CFLAGS"
-  CFLAGS="$TARGET_ARCH $CFLAGS"
-  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for library containing clock_gettime" >&5
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for library containing clock_gettime" >&5
 $as_echo_n "checking for library containing clock_gettime... " >&6; }
 if ${ac_cv_search_clock_gettime+:} false; then :
   $as_echo_n "(cached) " >&6
@@ -8886,8 +8832,6 @@ if test "$ac_res" != no; then :
 
 fi
 
-  CFLAGS="$CFLAGS_s"
-
 LIBS="$OLDLIBS"
 CLOCK_GETTIME_LIB=""
 if test "$ac_cv_search_clock_gettime" != "no"
@@ -8904,10 +8848,7 @@ fi
 
 
 
-
-  CFLAGS_s="$CFLAGS"
-  CFLAGS="$TARGET_ARCH $CFLAGS"
-  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for gettimeofday in -lc" >&5
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for gettimeofday in -lc" >&5
 $as_echo_n "checking for gettimeofday in -lc... " >&6; }
 if ${ac_cv_lib_c_gettimeofday+:} false; then :
   $as_echo_n "(cached) " >&6
@@ -8949,12 +8890,7 @@ $as_echo "#define HAVE_GETTIMEOFDAY /**/" >>confdefs.h
 
 fi
 
-  CFLAGS="$CFLAGS_s"
-
-
-  CFLAGS_s="$CFLAGS"
-  CFLAGS="$TARGET_ARCH $CFLAGS"
-  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for getaddrinfo in -lc" >&5
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for getaddrinfo in -lc" >&5
 $as_echo_n "checking for getaddrinfo in -lc... " >&6; }
 if ${ac_cv_lib_c_getaddrinfo+:} false; then :
   $as_echo_n "(cached) " >&6
@@ -8996,12 +8932,7 @@ $as_echo "#define HAVE_GETADDRINFO /**/" >>confdefs.h
 
 fi
 
-  CFLAGS="$CFLAGS_s"
-
-
-  CFLAGS_s="$CFLAGS"
-  CFLAGS="$TARGET_ARCH $CFLAGS"
-  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for strsep in -lc" >&5
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for strsep in -lc" >&5
 $as_echo_n "checking for strsep in -lc... " >&6; }
 if ${ac_cv_lib_c_strsep+:} false; then :
   $as_echo_n "(cached) " >&6
@@ -9043,12 +8974,7 @@ $as_echo "#define HAVE_STRSEP /**/" >>confdefs.h
 
 fi
 
-  CFLAGS="$CFLAGS_s"
-
-
-  CFLAGS_s="$CFLAGS"
-  CFLAGS="$TARGET_ARCH $CFLAGS"
-  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for getrusage in -lc" >&5
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for getrusage in -lc" >&5
 $as_echo_n "checking for getrusage in -lc... " >&6; }
 if ${ac_cv_lib_c_getrusage+:} false; then :
   $as_echo_n "(cached) " >&6
@@ -9089,8 +9015,6 @@ if test "x$ac_cv_lib_c_getrusage" = xyes; then :
 $as_echo "#define HAVE_GETRUSAGE /**/" >>confdefs.h
 
 fi
-
-  CFLAGS="$CFLAGS_s"
 
 # Check whether --enable-d3d was given.
 if test "${enable_d3d+set}" = set; then :
@@ -9152,10 +9076,7 @@ fi
         { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether readline via \"$_combo\" is present and sane" >&5
 $as_echo_n "checking whether readline via \"$_combo\" is present and sane... " >&6; }
                         	if test "$cross_compiling" = yes; then :
-
-  CFLAGS_s="$CFLAGS"
-  CFLAGS="$TARGET_ARCH $CFLAGS"
-  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for library containing readline" >&5
+                                            { $as_echo "$as_me:${as_lineno-$LINENO}: checking for library containing readline" >&5
 $as_echo_n "checking for library containing readline... " >&6; }
 if ${ac_cv_search_readline+:} false; then :
   $as_echo_n "(cached) " >&6
@@ -9212,8 +9133,6 @@ if test "$ac_res" != no; then :
 else
   have_readline=no
 fi
-
-  CFLAGS="$CFLAGS_s"
 
 
 else
@@ -9949,9 +9868,6 @@ fi
 done
 
 if test "$DO_HDF5" = yes; then
-
-  CFLAGS_s="$CFLAGS"
-  CFLAGS="$TARGET_ARCH $CFLAGS"
   { $as_echo "$as_me:${as_lineno-$LINENO}: checking for H5Fopen in -lhdf5" >&5
 $as_echo_n "checking for H5Fopen in -lhdf5... " >&6; }
 if ${ac_cv_lib_hdf5_H5Fopen+:} false; then :
@@ -9993,8 +9909,6 @@ if test "x$ac_cv_lib_hdf5_H5Fopen" = xyes; then :
 else
   DO_HDF5="no"
 fi
-
-  CFLAGS="$CFLAGS_s"
 
   if test "$DO_HDF5" = yes; then
     HDF5_APS="\$(HDF5_APS)"
@@ -10576,10 +10490,7 @@ then
     SYBASE_INC=""
     SYBASE_LIB=""
     OLDLIBS="$LIBS"
-
-  CFLAGS_s="$CFLAGS"
-  CFLAGS="$TARGET_ARCH $CFLAGS"
-  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for library containing dbsqlexec" >&5
+    { $as_echo "$as_me:${as_lineno-$LINENO}: checking for library containing dbsqlexec" >&5
 $as_echo_n "checking for library containing dbsqlexec... " >&6; }
 if ${ac_cv_search_dbsqlexec+:} false; then :
   $as_echo_n "(cached) " >&6
@@ -10634,8 +10545,6 @@ if test "$ac_res" != no; then :
   test "$ac_res" = "none required" || LIBS="$ac_res $LIBS"
   SYBASE_LIB="-lsybdb";SYBASE_INC="-DSYBASE";SYBASE="SYBASE",SYBASE_LIB=""
 fi
-
-  CFLAGS="$CFLAGS_s"
 
     LIBS="$OLDLIBS"
     if test "$SYBASE_LIB" = ""
@@ -11214,9 +11123,6 @@ _ACEOF
 if ac_fn_c_try_link "$LINENO"; then :
 
 else
-
-  CFLAGS_s="$CFLAGS"
-  CFLAGS="$TARGET_ARCH $CFLAGS"
   { $as_echo "$as_me:${as_lineno-$LINENO}: checking for dnet_ntoa in -ldnet" >&5
 $as_echo_n "checking for dnet_ntoa in -ldnet... " >&6; }
 if ${ac_cv_lib_dnet_dnet_ntoa+:} false; then :
@@ -11257,13 +11163,8 @@ if test "x$ac_cv_lib_dnet_dnet_ntoa" = xyes; then :
   X_EXTRA_LIBS="$X_EXTRA_LIBS -ldnet"
 fi
 
-  CFLAGS="$CFLAGS_s"
-
     if test $ac_cv_lib_dnet_dnet_ntoa = no; then
-
-  CFLAGS_s="$CFLAGS"
-  CFLAGS="$TARGET_ARCH $CFLAGS"
-  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for dnet_ntoa in -ldnet_stub" >&5
+      { $as_echo "$as_me:${as_lineno-$LINENO}: checking for dnet_ntoa in -ldnet_stub" >&5
 $as_echo_n "checking for dnet_ntoa in -ldnet_stub... " >&6; }
 if ${ac_cv_lib_dnet_stub_dnet_ntoa+:} false; then :
   $as_echo_n "(cached) " >&6
@@ -11303,8 +11204,6 @@ if test "x$ac_cv_lib_dnet_stub_dnet_ntoa" = xyes; then :
   X_EXTRA_LIBS="$X_EXTRA_LIBS -ldnet_stub"
 fi
 
-  CFLAGS="$CFLAGS_s"
-
     fi
 fi
 rm -f core conftest.err conftest.$ac_objext \
@@ -11325,10 +11224,7 @@ if test "x$ac_cv_func_gethostbyname" = xyes; then :
 fi
 
     if test $ac_cv_func_gethostbyname = no; then
-
-  CFLAGS_s="$CFLAGS"
-  CFLAGS="$TARGET_ARCH $CFLAGS"
-  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for gethostbyname in -lnsl" >&5
+      { $as_echo "$as_me:${as_lineno-$LINENO}: checking for gethostbyname in -lnsl" >&5
 $as_echo_n "checking for gethostbyname in -lnsl... " >&6; }
 if ${ac_cv_lib_nsl_gethostbyname+:} false; then :
   $as_echo_n "(cached) " >&6
@@ -11368,13 +11264,8 @@ if test "x$ac_cv_lib_nsl_gethostbyname" = xyes; then :
   X_EXTRA_LIBS="$X_EXTRA_LIBS -lnsl"
 fi
 
-  CFLAGS="$CFLAGS_s"
-
       if test $ac_cv_lib_nsl_gethostbyname = no; then
-
-  CFLAGS_s="$CFLAGS"
-  CFLAGS="$TARGET_ARCH $CFLAGS"
-  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for gethostbyname in -lbsd" >&5
+	{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for gethostbyname in -lbsd" >&5
 $as_echo_n "checking for gethostbyname in -lbsd... " >&6; }
 if ${ac_cv_lib_bsd_gethostbyname+:} false; then :
   $as_echo_n "(cached) " >&6
@@ -11414,8 +11305,6 @@ if test "x$ac_cv_lib_bsd_gethostbyname" = xyes; then :
   X_EXTRA_LIBS="$X_EXTRA_LIBS -lbsd"
 fi
 
-  CFLAGS="$CFLAGS_s"
-
       fi
     fi
 
@@ -11432,16 +11321,13 @@ if test "x$ac_cv_func_connect" = xyes; then :
 fi
 
     if test $ac_cv_func_connect = no; then
-
-  CFLAGS_s="$CFLAGS"
-  CFLAGS="$TARGET_ARCH $CFLAGS"
-  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for connect in -lsocket" >&5
+      { $as_echo "$as_me:${as_lineno-$LINENO}: checking for connect in -lsocket" >&5
 $as_echo_n "checking for connect in -lsocket... " >&6; }
 if ${ac_cv_lib_socket_connect+:} false; then :
   $as_echo_n "(cached) " >&6
 else
   ac_check_lib_save_LIBS=$LIBS
-LIBS="-lsocket  $LIBS"
+LIBS="-lsocket $X_EXTRA_LIBS $LIBS"
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
@@ -11475,8 +11361,6 @@ if test "x$ac_cv_lib_socket_connect" = xyes; then :
   X_EXTRA_LIBS="-lsocket $X_EXTRA_LIBS"
 fi
 
-  CFLAGS="$CFLAGS_s"
-
     fi
 
     # Guillermo Gomez says -lposix is necessary on A/UX.
@@ -11486,10 +11370,7 @@ if test "x$ac_cv_func_remove" = xyes; then :
 fi
 
     if test $ac_cv_func_remove = no; then
-
-  CFLAGS_s="$CFLAGS"
-  CFLAGS="$TARGET_ARCH $CFLAGS"
-  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for remove in -lposix" >&5
+      { $as_echo "$as_me:${as_lineno-$LINENO}: checking for remove in -lposix" >&5
 $as_echo_n "checking for remove in -lposix... " >&6; }
 if ${ac_cv_lib_posix_remove+:} false; then :
   $as_echo_n "(cached) " >&6
@@ -11529,8 +11410,6 @@ if test "x$ac_cv_lib_posix_remove" = xyes; then :
   X_EXTRA_LIBS="$X_EXTRA_LIBS -lposix"
 fi
 
-  CFLAGS="$CFLAGS_s"
-
     fi
 
     # BSDI BSD/OS 2.1 needs -lipc for XOpenDisplay.
@@ -11540,10 +11419,7 @@ if test "x$ac_cv_func_shmat" = xyes; then :
 fi
 
     if test $ac_cv_func_shmat = no; then
-
-  CFLAGS_s="$CFLAGS"
-  CFLAGS="$TARGET_ARCH $CFLAGS"
-  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for shmat in -lipc" >&5
+      { $as_echo "$as_me:${as_lineno-$LINENO}: checking for shmat in -lipc" >&5
 $as_echo_n "checking for shmat in -lipc... " >&6; }
 if ${ac_cv_lib_ipc_shmat+:} false; then :
   $as_echo_n "(cached) " >&6
@@ -11583,8 +11459,6 @@ if test "x$ac_cv_lib_ipc_shmat" = xyes; then :
   X_EXTRA_LIBS="$X_EXTRA_LIBS -lipc"
 fi
 
-  CFLAGS="$CFLAGS_s"
-
     fi
   fi
 
@@ -11597,16 +11471,13 @@ fi
   # These have to be linked with before -lX11, unlike the other
   # libraries we check for below, so use a different variable.
   # John Interrante, Karl Berry
-
-  CFLAGS_s="$CFLAGS"
-  CFLAGS="$TARGET_ARCH $CFLAGS"
   { $as_echo "$as_me:${as_lineno-$LINENO}: checking for IceConnectionNumber in -lICE" >&5
 $as_echo_n "checking for IceConnectionNumber in -lICE... " >&6; }
 if ${ac_cv_lib_ICE_IceConnectionNumber+:} false; then :
   $as_echo_n "(cached) " >&6
 else
   ac_check_lib_save_LIBS=$LIBS
-LIBS="-lICE  $LIBS"
+LIBS="-lICE $X_EXTRA_LIBS $LIBS"
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
@@ -11639,8 +11510,6 @@ $as_echo "$ac_cv_lib_ICE_IceConnectionNumber" >&6; }
 if test "x$ac_cv_lib_ICE_IceConnectionNumber" = xyes; then :
   X_PRE_LIBS="$X_PRE_LIBS -lSM -lICE"
 fi
-
-  CFLAGS="$CFLAGS_s"
 
   LDFLAGS=$ac_save_LDFLAGS
 
@@ -11730,10 +11599,7 @@ fi
 
 
 XM_LIBS="-lMrm -lXm"
-
-  CFLAGS_s="$CFLAGS"
-  CFLAGS="$TARGET_ARCH $CFLAGS"
-  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for XextAddDisplay in -lXext" >&5
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for XextAddDisplay in -lXext" >&5
 $as_echo_n "checking for XextAddDisplay in -lXext... " >&6; }
 if ${ac_cv_lib_Xext_XextAddDisplay+:} false; then :
   $as_echo_n "(cached) " >&6
@@ -11775,12 +11641,7 @@ else
   LIBXEXT=""
 fi
 
-  CFLAGS="$CFLAGS_s"
-
-
-  CFLAGS_s="$CFLAGS"
-  CFLAGS="$TARGET_ARCH $CFLAGS"
-  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for XpGetDocumentData in -lXp" >&5
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for XpGetDocumentData in -lXp" >&5
 $as_echo_n "checking for XpGetDocumentData in -lXp... " >&6; }
 if ${ac_cv_lib_Xp_XpGetDocumentData+:} false; then :
   $as_echo_n "(cached) " >&6
@@ -11821,8 +11682,6 @@ if test "x$ac_cv_lib_Xp_XpGetDocumentData" = xyes; then :
 else
   LIBXP=""
 fi
-
-  CFLAGS="$CFLAGS_s"
 
 
 ## ////////////////////////////////////////////////////////////////////////// ##
@@ -12184,10 +12043,7 @@ _ACEOF
 fi
 done
 
-
-  CFLAGS_s="$CFLAGS"
-  CFLAGS="$TARGET_ARCH $CFLAGS"
-  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for clock_gettime, timer_create, timer_settime, timer_delete in -lrt" >&5
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for clock_gettime, timer_create, timer_settime, timer_delete in -lrt" >&5
 $as_echo_n "checking for clock_gettime, timer_create, timer_settime, timer_delete in -lrt... " >&6; }
 if ${ac_cv_lib_rt_clock_gettime__timer_create__timer_settime__timer_delete+:} false; then :
   $as_echo_n "(cached) " >&6
@@ -12228,8 +12084,6 @@ if test "x$ac_cv_lib_rt_clock_gettime__timer_create__timer_settime__timer_delete
 else
   LIBRT=""
 fi
-
-  CFLAGS="$CFLAGS_s"
 
 
 
@@ -13952,10 +13806,7 @@ $as_echo "no, gcc 4.8.0 or higher required" >&6; }
 
 
      LDD=ldd
-
-  CFLAGS_s="$CFLAGS"
-  CFLAGS="$TARGET_ARCH $CFLAGS"
-  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for _init in -lasan" >&5
+     { $as_echo "$as_me:${as_lineno-$LINENO}: checking for _init in -lasan" >&5
 $as_echo_n "checking for _init in -lasan... " >&6; }
 if ${ac_cv_lib_asan__init+:} false; then :
   $as_echo_n "(cached) " >&6
@@ -13994,8 +13845,6 @@ $as_echo "$ac_cv_lib_asan__init" >&6; }
 if test "x$ac_cv_lib_asan__init" = xyes; then :
   have_asan=yes
 fi
-
-  CFLAGS="$CFLAGS_s"
 
      if test "x$have_asan" = xyes; then :
   CPPFLAGS_save=$CPPFLAGS
@@ -14050,10 +13899,7 @@ fi
 
 
      LDD=ldd
-
-  CFLAGS_s="$CFLAGS"
-  CFLAGS="$TARGET_ARCH $CFLAGS"
-  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for _init in -ltsan" >&5
+     { $as_echo "$as_me:${as_lineno-$LINENO}: checking for _init in -ltsan" >&5
 $as_echo_n "checking for _init in -ltsan... " >&6; }
 if ${ac_cv_lib_tsan__init+:} false; then :
   $as_echo_n "(cached) " >&6
@@ -14092,8 +13938,6 @@ $as_echo "$ac_cv_lib_tsan__init" >&6; }
 if test "x$ac_cv_lib_tsan__init" = xyes; then :
   have_tsan=yes
 fi
-
-  CFLAGS="$CFLAGS_s"
 
      if test "x$have_tsan" = xyes; then :
   CPPFLAGS_save=$CPPFLAGS
@@ -14141,10 +13985,7 @@ else
 
 
      LDD=ldd
-
-  CFLAGS_s="$CFLAGS"
-  CFLAGS="$TARGET_ARCH $CFLAGS"
-  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for _init in -ltsan" >&5
+     { $as_echo "$as_me:${as_lineno-$LINENO}: checking for _init in -ltsan" >&5
 $as_echo_n "checking for _init in -ltsan... " >&6; }
 if ${ac_cv_lib_tsan__init+:} false; then :
   $as_echo_n "(cached) " >&6
@@ -14183,8 +14024,6 @@ $as_echo "$ac_cv_lib_tsan__init" >&6; }
 if test "x$ac_cv_lib_tsan__init" = xyes; then :
   have_tsan=yes
 fi
-
-  CFLAGS="$CFLAGS_s"
 
      if test "x$have_tsan" = xyes; then :
   CPPFLAGS_save=$CPPFLAGS
@@ -14243,10 +14082,7 @@ fi
 
 
      LDD=ldd
-
-  CFLAGS_s="$CFLAGS"
-  CFLAGS="$TARGET_ARCH $CFLAGS"
-  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for _init in -lubsan" >&5
+     { $as_echo "$as_me:${as_lineno-$LINENO}: checking for _init in -lubsan" >&5
 $as_echo_n "checking for _init in -lubsan... " >&6; }
 if ${ac_cv_lib_ubsan__init+:} false; then :
   $as_echo_n "(cached) " >&6
@@ -14285,8 +14121,6 @@ $as_echo "$ac_cv_lib_ubsan__init" >&6; }
 if test "x$ac_cv_lib_ubsan__init" = xyes; then :
   have_ubsan=yes
 fi
-
-  CFLAGS="$CFLAGS_s"
 
      if test "x$have_ubsan" = xyes; then :
   CPPFLAGS_save=$CPPFLAGS
@@ -16790,6 +16624,13 @@ esac
 #echo DX_FLAG_ps=$DX_FLAG_ps
 #echo DX_ENV=$DX_ENV
 
+
+#
+# All library searches should be done at this point so remote TARGET_ARCH
+# from CFLAGS as the Make macros will insert TARGET_ARCH later as needed.
+#
+CFLAGS=`echo "${CFLAGS}" | ${AWK} '{gsub("'${TARGET_ARCH}'","");print $0;}'`
+#
 
 # //////////////////////////////////////////////////////////////////////////// #
 # ////// RELEASE INFO //////////////////////////////////////////////////////// #

--- a/configure.ac
+++ b/configure.ac
@@ -70,25 +70,6 @@ AC_MSG_RESULT([**********VISIBILITY*********$CFLAG_VISIBILITY*******************
 #if test -n "$CFLAG_VISIBILITY" && test "$is_w32" != yes; then
 #	CFLAGS="$CFLAGS $CFLAG_VISIBILITY"
 #fi
-m4_pattern_allow([AC_CHECK_LIB])
-m4_rename([AC_CHECK_LIB],[ORIGINAL_AC_CHECK_LIB])
-AC_DEFUN([AC_CHECK_LIB],
-[
-  CFLAGS_s="$CFLAGS"
-  CFLAGS="$TARGET_ARCH $CFLAGS"
-  ORIGINAL_AC_CHECK_LIB([$1],[$2],[$3],[$4])
-  CFLAGS="$CFLAGS_s"
-  ])
-
-m4_pattern_allow([AC_SEARCH_LIBS])
-m4_rename([AC_SEARCH_LIBS],[ORIGINAL_AC_SEARCH_LIBS])
-AC_DEFUN([AC_SEARCH_LIBS],
-[
-  CFLAGS_s="$CFLAGS"
-  CFLAGS="$TARGET_ARCH $CFLAGS"
-  ORIGINAL_AC_SEARCH_LIBS([$1],[$2],[$3],[$4])
-  CFLAGS="$CFLAGS_s"
-  ])
 
 #FIXME: Remove this when Makefile.inc goes away
 #AS_CASE(["$MKDIR_P"],
@@ -562,6 +543,12 @@ case "$host" in
        dnl HDF5_DIR="/usr/local";
        X_EXTRA_LIBS="-lXmu";;
 esac
+
+#
+# Add TARGET_ARCH to CFLAGS so that all library searches will look for libraries of the correct arch
+#
+CFLAGS="${CFLAGS} ${TARGET_ARCH}"
+#
 
 dnl see if we have libdc1394 libraries and what version
 AC_CHECK_LIB(dc1394,dc1394_new ,dc1394_v2=yes)
@@ -1100,6 +1087,13 @@ DX_PS_FEATURE(OFF)
 
 ## refers to ax_prog_doxygen.m4 macro expansion 
 DX_INIT_DOXYGEN(mdsplus, doxygen.cfg)
+
+#
+# All library searches should be done at this point so remote TARGET_ARCH
+# from CFLAGS as the Make macros will insert TARGET_ARCH later as needed.
+#
+CFLAGS=`echo "${CFLAGS}" | ${AWK} '{gsub("'${TARGET_ARCH}'","");print $0;}'`
+#
 
 # //////////////////////////////////////////////////////////////////////////// #
 # ////// RELEASE INFO //////////////////////////////////////////////////////// #

--- a/mdstcpip/IoRoutinesGsi.c
+++ b/mdstcpip/IoRoutinesGsi.c
@@ -17,6 +17,9 @@
 #ifdef _GNU_SOURCE
 #undef _GNU_SOURCE
 #endif
+#ifdef SIZEOF_LONG
+#undef SIZEOF_LONG
+#endif
 
 #include <STATICdef.h>
 #include <signal.h>
@@ -24,7 +27,6 @@
 #include <stdlib.h>
 #include <string.h>
 #include <errno.h>
-#include <config.h>
 #include <time.h>
 #include <sys/wait.h>
 

--- a/roam/roam_gridmap_callout.c
+++ b/roam/roam_gridmap_callout.c
@@ -13,6 +13,9 @@
 #ifdef HAVE_GETPWUID
 #undef HAVE_GETPWUID
 #endif
+#ifdef SIZEOF_LONG
+#undef SIZEOF_LONG
+#endif
 
 #include <mdsdescrip.h>
 #include <mds_stdarg.h>


### PR DESCRIPTION
Instead of overriding standard autoconf macros simply add TARGET_ARCH
to CFLAGS which is used in library testing. Reset CFLAGS to original
setting when library tests are complete to avoid TARGET_ARCH flags from
being duplicated by standard Make compiles and link operations.