### PR TITLE
Build: Use stdint definitions and sys instead of linux for headers

### DIFF
--- a/camshr/ScsiCamac.h
+++ b/camshr/ScsiCamac.h
@@ -12,7 +12,10 @@
 
 #if OS == LINUX
 // for Linux of x86
-#include <linux/types.h>
+#include <stdint.h>
+#define __u8 uint8_t
+#define __u16 uint16_t
+#define __u32 uint32_t
 #endif
 
 #define QSTOP_MODE        		0

--- a/mitdevices/acq32ioctl.h
+++ b/mitdevices/acq32ioctl.h
@@ -74,7 +74,7 @@
 #ifndef _ACQ32IOCTL_H_
 #define _ACQ32IOCTL_H_
 
-#include <linux/ioctl.h>
+#include <sys/ioctl.h>
 
 /*
  * whence arg for seek


### PR DESCRIPTION
The camshr code used very old definitions of integer types which are
no longer available on newer systems (i.e. alpine). This change replaces
types such as __u8 with stdint types such as uint8_t.

The acq32ioctl.h included a header from the linux/ directory but in existing
systems and systems such as alpine have these headers in a sys/ directory.
The #include was changed from <linux/ioctl.h> to <sys/ioctl.h>