### PR TITLE
Build: __THROW causes problems with armhf compilers

### DIFF
--- a/testing/testing.h
+++ b/testing/testing.h
@@ -11,6 +11,9 @@
 #define __STRING(x)	#x
 #else
 #include <sys/cdefs.h>
+#ifdef __arm__
+#define __THROW
+#endif
 #endif
 
 # ifndef EXPORT


### PR DESCRIPTION
The testing.h header uses __THROW keyword which the armhf compiler does not
understand. This fix checks for __arm__ and defines __THROW to be nothing.