### PR TITLE
Fix: Add dev_data_support directory to redhat kernel.arch packaging

### DIFF
--- a/deploy/packaging/redhat/kernel.noarch
+++ b/deploy/packaging/redhat/kernel.noarch
@@ -47,6 +47,7 @@
 ./usr/local/mdsplus/tdi/cacheshr
 ./usr/local/mdsplus/tdi/cacheshr/GetCheckedSegment.fun
 ./usr/local/mdsplus/tdi/cvttime.fun
+./usr/local/mdsplus/tdi/dev_data_support
 ./usr/local/mdsplus/tdi/dev_data_support/a14_adjust.fun
 ./usr/local/mdsplus/tdi/dev_data_support/a14_clock_divide.fun
 ./usr/local/mdsplus/tdi/dev_support


### PR DESCRIPTION
The previous commit added new tdi functions to a new subdirectory of tdi
but the package contents files for redhat need a line for just the directory
in addition to the lines for the new files in that directory.