### PR TITLE
Fix: Use different signing keys for ubuntu14 than ubuntu16

### DIFF
--- a/deploy/platform/debian/debian_docker_build.sh
+++ b/deploy/platform/debian/debian_docker_build.sh
@@ -133,12 +133,19 @@ Architectures: ${arches}
 Components: alpha stable${component}
 Description: MDSplus packages
 EOF
-    if [ -d /sign_keys/.gnupg ]
+    GPG_HOME=""
+    if [ -d /sign_keys/${OS}/.gnupg ]
     then
-        ls -l /sign_keys/.gnupg
-    	echo "SignWith: B1E664BFFCBB6F4614FB4A7C5D83C3E21325A989" >> /release/repo/conf/distributions
+	GPG_HOME="/sign_keys/${OS}"
+    elif [ -d /sign_keys/.gnupg ]
+    then
+	GPG_HOME="/sign_keys"
     fi
-    export HOME=/sign_keys
+    if [ ! -z "$GPG_HOME" ]
+    then
+    	echo "SignWith: MDSplus" >> /release/repo/conf/distributions
+	export HOME="$GPG_HOME"
+    fi
     pushd /release/repo
     reprepro clearvanished
     for deb in $(find /release/${BRANCH}/DEBS/${ARCH} -name "*${major}\.${minor}\.${release}_*")


### PR DESCRIPTION
For some reason Ubuntu14 is unable to sign the debian packages with the
new secure RSA keys now used to sign Ubuntu16 packages. This commit enables the ability
to create signing keys in a ${OS} subdirectory of the signing keys. If the directory is
found it will set HOME to that subdirectory for signing packages. If the directory is not
found it will set HOME to the signing keys directory to use the default keys. A ubuntu16
subdirectory with the secure RSA keys was created and the other repositories use the origina
DSA keys.