### PR TITLE
Build: Remove --key-id option on rpmsign

### DIFF
--- a/deploy/platform/redhat/redhat_build_rpms.py
+++ b/deploy/platform/redhat/redhat_build_rpms.py
@@ -198,7 +198,7 @@ Buildarch: noarch
     try:
         os.stat('/sign_keys/.gnupg')
         try:
-            cmd="/bin/sh -c 'HOME=/sign_keys rpmsign --addsign --key-id=674D9C60 /release/%(branch)s/RPMS/*/*%(major)d.%(minor)d-%(release)d*.rpm'" % info
+            cmd="/bin/sh -c 'HOME=/sign_keys rpmsign --addsign /release/%(branch)s/RPMS/*/*%(major)d.%(minor)d-%(release)d*.rpm'" % info
             child = pexpect.spawn(cmd,timeout=60,logfile=sys.stdout)
             child.expect("Enter pass phrase: ")
             child.sendline("")


### PR DESCRIPTION
When adding the new RSA signing keys for debian packages the --key-id option was
added to the redhat rpmsign command to ensure the original key was used to sign
the rpms. It turns out that the --key-id option is not supported on redhat distributions
earlier than rhel7 and the switch to use different directories to separate the signing
keys removed the need to use the --key-id option.