### PR TITLE
Build: Add more fixes to enable alpine compilation to succeed

### DIFF
--- a/testing/testing.h
+++ b/testing/testing.h
@@ -11,7 +11,7 @@
 #define __STRING(x)	#x
 #else
 #include <sys/cdefs.h>
-#ifdef __arm__
+#ifndef __THROW
 #define __THROW
 #endif
 #endif


### PR DESCRIPTION
This commit moves the commit used for the 3rd-party-apis to the current
head of the master branch. A fix was added to the idl header file because it
uses a macro which is not defined by alpine system headers.

It also includes a fix to testing/testing.h which used the __THROW macro
which also is not defined by alpine system headers.