### PR TITLE
Remove old rmic stuff in build; fix jtraverser make bug

### DIFF
--- a/javatraverser/Makefile.am
+++ b/javatraverser/Makefile.am
@@ -22,13 +22,11 @@ CLASSPATH_ENV = CLASSPATH=$(top_builddir)/javascope/jScope.jar
 java_JAVA = $(SOURCES)
 
 # Build the final jar
-java_DATA = jTraverser.jar DeviceBeans.jar TreeServer_Stub.class
+java_DATA = jTraverser.jar DeviceBeans.jar 
 
-TreeServer_Stub.class: classjava.stamp
-	$(RMIC) TreeServer
 
-jTraverser.jar: TreeServer_Stub.class $(GIFS) classjava.stamp
-	$(JAR) c0f $@ $(java_JAVA:.java=*.class) $< $(addprefix -C ${srcdir} ,$(GIFS))
+jTraverser.jar: $(GIFS) classjava.stamp
+	$(JAR) c0f $@ $(java_JAVA:.java=*.class) $(addprefix -C ${srcdir} ,$(GIFS))
 
 DeviceBeans.jar: classjava.stamp $(GIFS) DeviceBeansManifest.mf
 	$(JAR) c0fm $@ ${srcdir}/DeviceBeansManifest.mf $(java_JAVA:.java=*.class) $(addprefix -C ${srcdir} ,$(GIFS))
@@ -156,7 +154,6 @@ SOURCES = \
 	Tree.java\
 	TreeDialog.java\
 	TreeNode.java\
-	TreeServer.java\
 	UnsupportedDataException.java\
 	WindowData.java\
 	WindowEditor.java\

--- a/javatraverser/Makefile.in
+++ b/javatraverser/Makefile.in
@@ -499,7 +499,7 @@ CLASSPATH_ENV = CLASSPATH=$(top_builddir)/javascope/jScope.jar
 java_JAVA = $(SOURCES)
 
 # Build the final jar
-java_DATA = jTraverser.jar DeviceBeans.jar TreeServer_Stub.class
+java_DATA = jTraverser.jar DeviceBeans.jar 
 
 # Giant list of source files follow
 SOURCES = \
@@ -623,7 +623,6 @@ SOURCES = \
 	Tree.java\
 	TreeDialog.java\
 	TreeNode.java\
-	TreeServer.java\
 	UnsupportedDataException.java\
 	WindowData.java\
 	WindowEditor.java\
@@ -1004,11 +1003,9 @@ uninstall-am: uninstall-binSCRIPTS uninstall-javaDATA \
 @MINGW_FALSE@$(bin_SCRIPTS): $(srcdir)/jTraverser.template
 @MINGW_FALSE@	cp $< $@
 
-TreeServer_Stub.class: classjava.stamp
-	$(RMIC) TreeServer
 
-jTraverser.jar: TreeServer_Stub.class $(GIFS) classjava.stamp
-	$(JAR) c0f $@ $(java_JAVA:.java=*.class) $< $(addprefix -C ${srcdir} ,$(GIFS))
+jTraverser.jar: $(GIFS) classjava.stamp
+	$(JAR) c0f $@ $(java_JAVA:.java=*.class) $(addprefix -C ${srcdir} ,$(GIFS))
 
 DeviceBeans.jar: classjava.stamp $(GIFS) DeviceBeansManifest.mf
 	$(JAR) c0fm $@ ${srcdir}/DeviceBeansManifest.mf $(java_JAVA:.java=*.class) $(addprefix -C ${srcdir} ,$(GIFS))


### PR DESCRIPTION
On some systems the old and unused rmic raised errors in make, now removed
A fix to recent bug introduced in jTraverser Makefile.am