### PR TITLE
return status value of PyDoMethod if available

### DIFF
--- a/treeshr/TreeDoMethod.c
+++ b/treeshr/TreeDoMethod.c
@@ -175,6 +175,7 @@ int _TreeDoMethod(void *dbid, struct descriptor *nid_dsc, struct descriptor *met
 	    } else {
 	      (*TdiExecute)(&dollar_d,statd,ans_xd, MdsEND_ARG);
 	    }
+            if (statd) status = *(int*)statd->pointer;
 	  }
 	  else {
 	    (*TdiExecute)(&dollar_d,&stat_d,ans_xd, MdsEND_ARG);


### PR DESCRIPTION
before TreeDoMethod would not recognize a failing python method