### PR TITLE
FIX: ORIGINAL_PART_NAME method should not pass (None), should be ()

### DIFF
--- a/mdsobjects/python/mdsdevice.py
+++ b/mdsobjects/python/mdsdevice.py
@@ -215,7 +215,7 @@ class Device(_treenode.TreeNode):
         @rtype: Device
         """
         if name == 'part_name' or name == 'original_part_name':
-            return self.ORIGINAL_PART_NAME(None)
+            return self.ORIGINAL_PART_NAME()
         try:
             return self.__class__(_treenode.TreeNode(self.part_dict[name]+self.head,self.tree))
         except KeyError:


### PR DESCRIPTION
I am not sure why this did not bite us sooner.  The code in
__getattr__, that pulls out requests for part_name and
original_part_name was calling self.ORIGINAL_PART_NAME with an argument
of (None).  It should have been (), since this method does not take any
arguments.