### PR TITLE
fix: fixed original_part_name of Python devices

### DIFF
--- a/mdsobjects/python/mdsdevice.py
+++ b/mdsobjects/python/mdsdevice.py
@@ -185,27 +185,7 @@ class Device(_treenode.TreeNode):
         @rtype: None
         """
         if isinstance(node,_treenode.TreeNode):
-            try:
-                self.nids=node.conglomerate_nids.nid_number
-                self.head=int(self.nids[0])
-            except Exception:
-                self.head=node.nid
             super(Device,self).__init__(node.nid,node.tree)
-
-    def ORIGINAL_PART_NAME(self):
-        """Method to return the original part name.
-        Will return blank string if part_name class attribute not defined or node used to create instance is the head node or past the end of part_names tuple.
-        @return: Part name of this node
-        @rtype: str
-        """
-        name = ""
-        if self.nid != self.head:
-            try:
-                name = self.part_names[self.nid-self.head-1].upper()
-            except:
-                pass
-        return name
-    PART_NAME=ORIGINAL_PART_NAME
 
     def __getattr__(self,name):
         """Return TreeNode of subpart if name matches mangled node name.

--- a/mdsobjects/python/tree.py
+++ b/mdsobjects/python/tree.py
@@ -227,7 +227,7 @@ class Tree(object):
                     raise AttributeError('Invalid mode specificed, use "Normal","Edit","New" or "ReadOnly".')
                 opened = True
             if not isinstance(self.ctx,_C.c_void_p) or self.ctx.value is None:
-                raise _exc.MDSplusError
+                raise _Exceptions.MDSplusError
             _setActiveTree(self.ctx.value)
             _treeshr.switchDbid(self.ctx.value)
             self.tctx = _TreeCtx(self.ctx.value,opened)

--- a/mdsobjects/python/treenode.py
+++ b/mdsobjects/python/treenode.py
@@ -46,7 +46,7 @@ class TreeNode(_data.Data):
     @ivar tree: Tree instance that this node belongs to.
     @type tree: Tree
     """
-
+    _original_part_name=None
     def __new__(cls,nid,tree=None):
         """Create class instance. Initialize part_dict class attribute if necessary.
         @param node: Node of device
@@ -78,6 +78,36 @@ class TreeNode(_data.Data):
             self.tree=_tree.Tree()
         else:
             self.tree=tree
+        if self.conglomerate_elt>0:
+            nids=self.conglomerate_nids.nid_number
+            self.head=int(nids[0])
+            if self.head==self.nid:
+                self._original_part_name = ""
+            else:
+                try:
+                    dev = TreeNode(self.head,self.tree)
+                    dev = dev.record.getDevice(dev)
+                    idx = self.nid-self.head-1
+                    self._original_part_name = dev.part_names[idx]
+                except Exception as e:
+                    print(e)
+        else:
+            self.head=None
+
+    def ORIGINAL_PART_NAME(self):
+        """Method to return the original part name.
+        Will return blank string if part_name class attribute not defined or node used to create instance is the head node or past the end of part_names tuple.
+        @return: Part name of this node
+        @rtype: str
+        """
+        if self.head is None:
+            return None
+        if self.head == self.nid:
+            return ""
+        if self._original_part_name is None:
+            self._original_part_name = self.original_part_name
+        return self._original_part_name
+    PART_NAME=ORIGINAL_PART_NAME
 
     def __hasBadTreeReferences__(self,tree):
        return self.tree != tree

--- a/tdi/dev_support/PyDoMethod.py
+++ b/tdi/dev_support/PyDoMethod.py
@@ -1,5 +1,5 @@
-from MDSplus import Device, List
-from MDSplus import TreeNOMETHOD,DevPYDEVICE_NOT_FOUND,MDSplusException,PyUNHANDLED_EXCEPTION,MDSplusSUCCESS
+from MDSplus import TreeNode, Device, List
+from MDSplus import TreeNOMETHOD,MDSplusException,PyUNHANDLED_EXCEPTION,MDSplusSUCCESS
 from sys import stderr,exc_info
 
 def PyDoMethod(n,method,*args):
@@ -16,20 +16,25 @@ def PyDoMethod(n,method,*args):
                 return methodobj(None)
             else:
                 raise exc
+    method = str(method)
+    model = n.__class__.__name__
+    result = None
     try:
-        device = n.conglomerate_nids[0]
-        c = device.record
-        model = str(c.model)
-        method = str(method)
-        result = None
-        if not hasattr(Device,method):
-            print("doing %s(%s).%s(%s)"%(device,model,method,','.join(map(str,args))))
-        if not isinstance(device, (Device,)):
-            device = c.getDevice(device)
-        try:
-            methodobj = device.__getattribute__(method)
-        except AttributeError:
-            raise TreeNOMETHOD()
+        if method in TreeNode.__dict__:
+            methodobj = n.__getattribute__(method)
+        else:
+            device = n.conglomerate_nids[0]
+            c = device.record
+            model = str(c.model)
+            result = None
+            if not isinstance(device, (Device,)):
+                device = c.getDevice(device)
+            try:
+                methodobj = device.__getattribute__(method)
+            except AttributeError:
+                raise TreeNOMETHOD()
+            if not method in Device.__dict__:
+                print("doing %s(%s).%s(%s)"%(device,model,method,','.join(map(str,args))))
         result = domethod(methodobj,args)
         status = MDSplusSUCCESS.status
     except MDSplusException as exc:


### PR DESCRIPTION
TCL> DIR/FULL DEVICE_NODE:*
 does now show original part names