### PR TITLE
Fix: improved Exception handling of Python code in Tdi

### DIFF
--- a/camshr/map_data_file.c
+++ b/camshr/map_data_file.c
@@ -49,7 +49,7 @@
 int map_data_file(int dbType)
 {
   char *FileName=0;
-  int db_size, fd=ERROR, *FileIsMapped;
+  int db_size, fd=ERROR, *FileIsMapped = FALSE;
   int status = SUCCESS;
   extern int CTSdbFileIsMapped;
   extern int CRATEdbFileIsMapped;

--- a/include/status.h
+++ b/include/status.h
@@ -4,11 +4,12 @@
 #define B_FALSE 0
 #define C_OK    0
 #define C_ERROR 1
-#define IS_OK(status)     ((status) & SsSUCCESS)
+#define IS_OK(status)     ((status) & 1)
 #define STATUS_OK         IS_OK(status)
 #define IS_NOT_OK(status) (!IS_OK(status))
 #define STATUS_NOT_OK     (!STATUS_OK)
-#define INIT_STATUS       int status = MDSplusSUCCESS
-#define INIT_STATUS_ERROR int status = MDSplusERROR
+#define INIT_STATUS_AS    int status =
+#define INIT_STATUS       INIT_STATUS_AS MDSplusSUCCESS
+#define INIT_STATUS_ERROR INIT_STATUS_AS MDSplusERROR
 #define TO_CODE(status)   (status & (-8))
 #define STATUS_TO_CODE    TO_CODE(status)

--- a/mdsobjects/python/_tdishr.py
+++ b/mdsobjects/python/_tdishr.py
@@ -30,7 +30,9 @@ def _TdiShrFun(function,errormessage,expression,args=None):
     arguments = [_C.byref(descriptor(expression))]+parseArguments(args)+[_C.byref(xd),_C.c_void_p(-1)]
     status = function(*arguments)
     if (status & 1 != 0):
-        return xd.value
+        value = xd.value
+        xd.free()
+        return value
     else:
         raise _Exceptions.statusToException(status)
 

--- a/mdsobjects/python/_treeshr.py
+++ b/mdsobjects/python/_treeshr.py
@@ -242,31 +242,29 @@ def TreeTurnOff(n):
 def TreeOpen(tree,shot):
     ctx=_C.c_void_p(0)
     status = __TreeOpen(_C.byref(ctx),_ver.tobytes(tree),shot,0)
-    if (status & 1):
-        return ctx
-    else:
+    if not (status & 1):
         raise _Exceptions.statusToException(status)
+    return ctx
 
 def TreeOpenReadOnly(tree,shot):
     ctx=_C.c_void_p(0)
     status = __TreeOpen(_C.byref(ctx),_ver.tobytes(tree),shot,1)
-    if (status & 1):
-        return ctx
-    else:
+    if not (status & 1):
         raise _Exceptions.statusToException(status)
+    return ctx
 
 def TreeOpenNew(tree,shot):
     ctx=_C.c_void_p(0)
     status = __TreeOpenNew(_C.byref(ctx),_ver.tobytes(tree),shot)
-    if (status & 1):
-        return ctx
-    else:
-        raise _Exceptions.statusToException(status)
-
-def TreeOpenEdit(tree):
-    status = __TreeOpenEdit(_C.byref(tree.ctx),_ver.tobytes(tree.tree),tree.shot)
     if not (status & 1):
         raise _Exceptions.statusToException(status)
+    return ctx
+
+def TreeOpenEdit(tree,shot,ctx=_C.c_void_p(0)):
+    status = __TreeOpenEdit(_C.byref(ctx),_ver.tobytes(tree),shot)
+    if not (status & 1):
+        raise _Exceptions.statusToException(status)
+    return ctx
 
 def TreeQuitTree(tree):
     status = __TreeQuitTree(_C.byref(tree.ctx),_ver.tobytes(tree.tree),tree.shot)

--- a/mdsobjects/python/compound.py
+++ b/mdsobjects/python/compound.py
@@ -250,7 +250,7 @@ class _Conglom(Compound):
         if model in safe_env:
             cls = safe_env[model]
         else:
-            cls = _device.Device.PyDevice(model,model)
+            cls = _device.Device.PyDevice(model)
         if issubclass(cls,(_device.Device,)):
             return cls if len(args)+len(kwargs)==0 else cls(*args,**kwargs)
         raise _Exceptions.DevPYDEVICE_NOT_FOUND

--- a/mdsobjects/python/mdsExceptions.py
+++ b/mdsobjects/python/mdsExceptions.py
@@ -1,4 +1,3 @@
-
 ########################################################
 # This module was generated using mdsshr/gen_device.py
 # To add new status messages modify one of the
@@ -24,7 +23,7 @@ class MDSplusException(Exception):
     if isinstance(status,int):
       self.status=status
     if not hasattr(self,'status'):
-      self.status=-2
+      self.status=PyUNHANDLED_EXCEPTION.status
       self.msgnam='Unknown'
       self.message='Unknown exception'
       self.fac='MDSplus'

--- a/mdsobjects/python/tests/__init__.py
+++ b/mdsobjects/python/tests/__init__.py
@@ -74,5 +74,8 @@ def test_all(*arg):
 
     return TestSuite(tests)
 
-if __name__=='__main__':
+def run():
     TextTestRunner().run(test_all())
+
+if __name__=='__main__':
+    run()

--- a/mdsobjects/python/tests/dataUnitTest.py
+++ b/mdsobjects/python/tests/dataUnitTest.py
@@ -334,15 +334,17 @@ def suite():
     tests = ['operatorsAndFunction','tdiFunctions','decompile','tdiPythonInterface']
     return TestSuite(map(dataTests,tests))
 
+def run():
+    from unittest import TextTestRunner
+    TextTestRunner().run(suite())
+
 if __name__=='__main__':
     import sys
     if len(sys.argv)>1 and sys.argv[1].lower()=="objgraph":
         import objgraph
     else:      objgraph = None
     import gc;gc.set_debug(gc.DEBUG_UNCOLLECTABLE)
-    from unittest import TextTestRunner
-    TextTestRunner().run(suite())
+    run()
     if objgraph:
          gc.collect()
          objgraph.show_backrefs([a for a in gc.garbage if hasattr(a,'__del__')],filename='%s.png'%__file__[:-3])
-

--- a/mdsobjects/python/tests/devices/TestDevice.py
+++ b/mdsobjects/python/tests/devices/TestDevice.py
@@ -1,6 +1,6 @@
 import time
 
-from MDSplus import Device
+from MDSplus import Device,DevUNKOWN_STATE
 
 class TestDevice(Device):
     parts=[
@@ -13,6 +13,8 @@ class TestDevice(Device):
         {'path': ':ACTIONSERVER:STORE',         'type': 'ACTION',  'options':('no_write_shot','write_once'), 'valueExpr':'Action(node.DISPATCH,node.TASK)'},
         {'path': ':ACTIONSERVER:STORE:DISPATCH','type': 'DISPATCH','options':('no_write_shot','write_once'), 'valueExpr':'Dispatch(head.ACTIONSERVER,"STORE",10)'},
         {'path': ':ACTIONSERVER:STORE:TASK',    'type': 'TASK',    'options':('no_write_shot','write_once'), 'valueExpr':'Method(None,"store",head)'},
+        {'path': ':TASK_TEST',                  'type': 'TASK',    'options':('no_write_shot','write_once'), 'valueExpr':'Method(None,"test",head)'},
+        {'path': ':TASK_ERROR',                 'type': 'TASK',    'options':('no_write_shot','write_once'), 'valueExpr':'Method(None,"error",head)'},
         {'path': ':INIT1_DONE',                 'type': 'NUMERIC', 'options':('no_write_model','write_once')},
         {'path': ':INIT2_DONE',                 'type': 'NUMERIC', 'options':('no_write_model','write_once')},
         {'path': ':PULSE_DONE',                 'type': 'NUMERIC', 'options':('no_write_model','write_once')},
@@ -26,4 +28,8 @@ class TestDevice(Device):
         self.pulse_done.record = time.time()
     def store(self):
         self.store_done.record = time.time()
+    def test(self):
+        return 'TEST'
+    def error(self):
+        raise DevUNKOWN_STATE
 

--- a/mdsobjects/python/tests/exceptionUnitTest.py
+++ b/mdsobjects/python/tests/exceptionUnitTest.py
@@ -36,15 +36,17 @@ class exceptionTests(TestCase):
 def suite():
     return exceptionTests()
 
+def run():
+    from unittest import TextTestRunner
+    TextTestRunner().run(suite())
+
 if __name__=='__main__':
     import sys
     if len(sys.argv)>1 and sys.argv[1].lower()=="objgraph":
         import objgraph
     else:      objgraph = None
     import gc;gc.set_debug(gc.DEBUG_UNCOLLECTABLE)
-    from unittest import TextTestRunner
-    TextTestRunner().run(suite())
+    run()
     if objgraph:
          gc.collect()
          objgraph.show_backrefs([a for a in gc.garbage if hasattr(a,'__del__')],filename='%s.png'%__file__[:-3])
-

--- a/mdsobjects/python/tests/segmentsUnitTest.py
+++ b/mdsobjects/python/tests/segmentsUnitTest.py
@@ -55,15 +55,17 @@ def suite():
     tests = ['arrayDimensionOrder']
     return TestSuite(map(segmentsTests,tests))
 
+def run():
+    from unittest import TextTestRunner
+    TextTestRunner().run(suite())
+
 if __name__=='__main__':
     import sys
     if len(sys.argv)>1 and sys.argv[1].lower()=="objgraph":
         import objgraph
     else:      objgraph = None
     import gc;gc.set_debug(gc.DEBUG_UNCOLLECTABLE)
-    from unittest import TextTestRunner
-    TextTestRunner().run(suite())
+    run()
     if objgraph:
          gc.collect()
          objgraph.show_backrefs([a for a in gc.garbage if hasattr(a,'__del__')],filename='%s.png'%__file__[:-3])
-

--- a/mdsobjects/python/tests/threadsUnitTest.py
+++ b/mdsobjects/python/tests/threadsUnitTest.py
@@ -1,4 +1,4 @@
-from unittest import TestCase,TestSuite
+from unittest import TestCase,TestSuite,TextTestRunner
 from threading import Thread
 from cStringIO import StringIO
 

--- a/mdsobjects/python/tests/threadsUnitTest.py
+++ b/mdsobjects/python/tests/threadsUnitTest.py
@@ -1,4 +1,4 @@
-from unittest import TestCase,TestSuite,TextTestRunner
+from unittest import TestCase,TestSuite
 from threading import Thread
 from cStringIO import StringIO
 
@@ -82,14 +82,17 @@ def suite():
     tests = ['dataThreadTests'] #,'treeThreadTests']
     return TestSuite(map(threadTest, tests))
 
+def run():
+    from unittest import TextTestRunner
+    TextTestRunner().run(suite())
+
 if __name__=='__main__':
     import sys
     if len(sys.argv)>1 and sys.argv[1].lower()=="objgraph":
         import objgraph
     else:      objgraph = None
     import gc;gc.set_debug(gc.DEBUG_UNCOLLECTABLE)
-    TextTestRunner().run(suite())
+    run()
     if objgraph:
          gc.collect()
          objgraph.show_backrefs([a for a in gc.garbage if hasattr(a,'__del__')],filename='%s.png'%__file__[:-3])
-

--- a/mdsobjects/python/tests/treeUnitTest.py
+++ b/mdsobjects/python/tests/treeUnitTest.py
@@ -126,11 +126,11 @@ class treeTests(TestCase):
 
     def openTrees(self):
         pytree = Tree('pytree',self.shot)
-        self.assertEqual(str(pytree),'Tree("PYTREE",'+str(self.shot)+',"Normal")')
+        self.assertEqual(str(pytree),'Tree("PYTREE",%d,"Normal")'%(self.shot,))
         pytree.createPulse(self.shot+1)
         Tree.setCurrent('pytree',self.shot+1)
         pytree2=Tree('pytree',self.shot+1)
-        self.assertEqual(str(pytree2),'Tree("PYTREE",'+str(self.shot+1)+',"Normal")')
+        self.assertEqual(str(pytree2),'Tree("PYTREE",%d,"Normal")'%(self.shot+1,))
 
     def getNode(self):
         pytree=Tree('pytree',self.shot,'ReadOnly')
@@ -302,10 +302,15 @@ class treeTests(TestCase):
         self._doTCLTest('type test','test\n')
         self._doTCLTest('close/all')
         self._doTCLTest('show db','\n')
-        self._doTCLTest('set tree pytree/shot=%d'%self.shot)
+        self._doTCLTest('set tree pytree/shot=%d'%(self.shot,))
         self._doTCLTest('show db','000  PYTREE        shot: %d [\\PYTREE::TOP]   \n\n'%self.shot)
+        self._doTCLTest('edit PYTREE/shot=%d'%(self.shot,))
+        self._doTCLTest('add node TCL_NUM/usage=numeric')
+        self._doTCLTest('add node TCL_PY_DEV/model=TESTDEVICE')
         self._doTCLTest('do TESTDEVICE:TASK_TEST')
         self._doExceptionTest('do TESTDEVICE:TASK_ERROR',Exc.DevUNKOWN_STATE)
+        self._doExceptionTest('close',Exc.TreeWRITEFIRST)
+        self._doTCLTest('write')
         self._doTCLTest('close')
         self._doTCLTest('show db','\n')
         """ tcl exceptions """
@@ -330,10 +335,8 @@ class treeTests(TestCase):
         pytree = Tree('pytree',self.shot)
         pytree.TESTDEVICE.ACTIONSERVER.no_write_shot = False
         pytree.TESTDEVICE.ACTIONSERVER.record = server
-        #pytree.close()
         """ using dispatcher """
         hosts = '%s/mdsip.hosts'%self.root
-        #tcl('set tree pytree/shot=%d'%self.shot,1,1,1)
         log = None
         try:
           if Popen:

--- a/mdsobjects/python/tests/treeUnitTest.py
+++ b/mdsobjects/python/tests/treeUnitTest.py
@@ -241,10 +241,15 @@ class treeTests(TestCase):
         self.assertEqual(ip.no_write_model,ip.isNoWriteModel())
         self.assertEqual(ip.write_once,False)
         self.assertEqual(ip.write_once,ip.isWriteOnce())
-        devs=pytree.getNodeWild('\\PYTREESUB::TOP.***','DEVICE')
-        dev=devs[0].conglomerate_nids
-        self.assertEqual(dev[3].original_part_name,':COMMENT')
-        self.assertEqual(dev[3].original_part_name,dev[3].getOriginalPartName())
+        pydev = pytree.TESTDEVICE
+        part = pydev.conglomerate_nids[1]
+        self.assertEqual(part.PART_NAME(),':ACTIONSERVER')
+        self.assertEqual(part.original_part_name,str(Data.execute('GETNCI($,"ORIGINAL_PART_NAME")',part)))
+        self.assertEqual(pydev.__class__,Device.PyDevice('TestDevice'))
+        devs = pytree.getNodeWild('\\PYTREESUB::TOP.***','DEVICE')
+        part = devs[0].conglomerate_nids[3]
+        self.assertEqual(part.original_part_name,':COMMENT')
+        self.assertEqual(part.original_part_name,str(Data.execute('GETNCI($,"ORIGINAL_PART_NAME")',part)))
         self.assertEqual(ip.owner_id,ip.getOwnerId())
         self.assertEqual(ip.rlength,168)
         self.assertEqual(ip.rlength,ip.getCompressedLength())
@@ -299,6 +304,8 @@ class treeTests(TestCase):
         self._doTCLTest('show db','\n')
         self._doTCLTest('set tree pytree/shot=%d'%self.shot)
         self._doTCLTest('show db','000  PYTREE        shot: %d [\\PYTREE::TOP]   \n\n'%self.shot)
+        self._doTCLTest('do TESTDEVICE:TASK_TEST')
+        self._doExceptionTest('do TESTDEVICE:TASK_ERROR',Exc.DevUNKOWN_STATE)
         self._doTCLTest('close')
         self._doTCLTest('show db','\n')
         """ tcl exceptions """
@@ -323,10 +330,10 @@ class treeTests(TestCase):
         pytree = Tree('pytree',self.shot)
         pytree.TESTDEVICE.ACTIONSERVER.no_write_shot = False
         pytree.TESTDEVICE.ACTIONSERVER.record = server
-        pytree.close()
+        #pytree.close()
         """ using dispatcher """
         hosts = '%s/mdsip.hosts'%self.root
-        tcl('set tree pytree/shot=%d'%self.shot,1,1,1)
+        #tcl('set tree pytree/shot=%d'%self.shot,1,1,1)
         log = None
         try:
           if Popen:

--- a/mdsobjects/python/tests/treeUnitTest.py
+++ b/mdsobjects/python/tests/treeUnitTest.py
@@ -16,7 +16,7 @@ class treeTests(TestCase):
 
     @property
     def shot(self):
-        return self.shotdic[current_thread().ident]
+        return self.__class__.shotdic[current_thread().ident]
 
     def _doTCLTest(self,expr,out=None,err=None,re=False):
         def checkre(pattern,string):
@@ -386,15 +386,17 @@ def suite():
         tests += ['dclInterface','dispatcher']
     return TestSuite(map(treeTests,tests))
 
+def run():
+    from unittest import TextTestRunner
+    TextTestRunner().run(suite())
+
 if __name__=='__main__':
     import sys
     if len(sys.argv)>1 and sys.argv[1].lower()=="objgraph":
         import objgraph
     else:      objgraph = None
     import gc;gc.set_debug(gc.DEBUG_UNCOLLECTABLE)
-    from unittest import TextTestRunner
-    TextTestRunner().run(suite())
+    run()
     if objgraph:
          gc.collect()
          objgraph.show_backrefs([a for a in gc.garbage if hasattr(a,'__del__')],filename='%s.png'%__file__[:-3])
-

--- a/mdsobjects/python/tests/treeUnitTest.py
+++ b/mdsobjects/python/tests/treeUnitTest.py
@@ -3,7 +3,7 @@ import os
 from re import match
 from threading import Lock,current_thread
 
-from MDSplus import Tree,TreeNode,Data,makeArray,Signal,Range,DateToQuad,Device
+from MDSplus import Tree,TreeNode,Data,makeArray,Signal,Range,DateToQuad,Device,Conglom
 from MDSplus import getenv,setenv,dcl,ccl,tcl,cts
 from MDSplus import mdsExceptions as Exc
 
@@ -88,6 +88,7 @@ class treeTests(TestCase):
             node = pytree.addNode('SIG_CMPRS', 'signal')
             node.compress_on_put = True
             Device.PyDevice('TestDevice').Add(pytree,'TESTDEVICE')
+            Device.PyDevice('CYGNET4K').Add(pytree,'CYGNET4K').on=False
             pytree.write()
         with Tree('pytreesub',shot,'new') as pytreesub:
             if pytreesub.shot != shot:
@@ -143,6 +144,8 @@ class treeTests(TestCase):
         self.assertEqual(ip.nid,pytree._IP.nid)
         self.assertEqual(ip.nid,pytree.__PYTREESUB.IP.nid)
         self.assertEqual(ip.nid,pytree.__PYTREESUB__IP.nid)
+        self.assertEqual(pytree.TESTDEVICE.__class__,Device.PyDevice('TESTDEVICE'))
+        self.assertEqual(pytree.CYGNET4K.__class__,Device.PyDevice('CYGNET4K'))
 
     def setDefault(self):
         pytree = Tree('pytree',self.shot,'ReadOnly')

--- a/mdsobjects/python/tree.py
+++ b/mdsobjects/python/tree.py
@@ -217,8 +217,7 @@ class Tree(object):
                 if mode.upper() == 'NORMAL':
                     self.ctx=_treeshr.TreeOpen(tree,shot)
                 elif mode.upper() == 'EDIT':
-                    self.ctx=_treeshr.TreeOpen(tree,shot)
-                    self.edit()
+                    self.ctx=_treeshr.TreeOpenEdit(tree,shot)
                 elif mode.upper() == 'NEW':
                     self.ctx=_treeshr.TreeOpenNew(tree,shot)
                 elif mode.upper() == 'READONLY':
@@ -378,7 +377,7 @@ class Tree(object):
         @rtype: None"""
         Tree.lock()
         try:
-            _treeshr.TreeOpenEdit(self)
+            _treeshr.TreeOpenEdit(self.tree,self.shot,self.ctx)
         finally:
             Tree.unlock()
 

--- a/mdsshr/gen_messages.py
+++ b/mdsshr/gen_messages.py
@@ -105,7 +105,7 @@ class MDSplusException(Exception):
     if isinstance(status,int):
       self.status=status
     if not hasattr(self,'status'):
-      self.status=-2
+      self.status=PyUNHANDLED_EXCEPTION.status
       self.msgnam='Unknown'
       self.message='Unknown exception'
       self.fac='MDSplus'

--- a/mdstcpip/Connections.c
+++ b/mdstcpip/Connections.c
@@ -131,7 +131,7 @@ int NewConnection(char *protocol)
 
 ///
 /// Authorize client by username calling protocol IoRoutine.
-/// 
+///
 /// \param id of the connection to use
 /// \param username of the user to be authorized for access
 /// \return true if authorized user found, false otherwise
@@ -160,7 +160,7 @@ int AcceptConnection(char *protocol, char *info_name, int readfd, void *info, si
     char *user = 0;
     char *user_p = 0;
     int status;
-    
+
     // SET INFO //
     SetConnectionInfo(*id, info_name, readfd, info, info_len);
     m_user = GetMdsMsg(*id, &status);
@@ -170,7 +170,7 @@ int AcceptConnection(char *protocol, char *info_name, int readfd, void *info, si
       return 0;
     }
     m.h.msglen = sizeof(MsgHdr);
-    
+
     // AUTHORIZE //
     if ((status & 1) && (m_user) && (m_user->h.dtype == DTYPE_CSTRING)) {
       user = malloc(m_user->h.length + 1);
@@ -179,22 +179,23 @@ int AcceptConnection(char *protocol, char *info_name, int readfd, void *info, si
     }
     user_p = user ? user : "?";
     ok = AuthorizeClient(*id, user_p);
-    
+
     // SET COMPRESSION //
     if (ok & 1) {
       SetConnectionCompression(*id, m_user->h.status & 0xf);
       *usr = strcpy(malloc(strlen(user_p) + 1), user_p);
     } else
       *usr = 0;
+    if (user) free(user);
     m.h.status = (ok & 1) ? (1 | (GetConnectionCompression(*id) << 1)) : 0;
     m.h.client_type = m_user ? m_user->h.client_type : 0;
-    
+
     if (m_user)
       MdsIpFree(m_user);
-    
+
     // reply to client //
     SendMdsMsg(*id, &m, 0);
-    
+
     if (!(ok & 1)) {
       fprintf(stderr, "Access denied\n");
       DisconnectConnection(*id);

--- a/mitdevices/mitdevices_messages.xml
+++ b/mitdevices/mitdevices_messages.xml
@@ -515,7 +515,7 @@
 	    text="Error reading channel"
 	    facnam="Dsp2904$_" facabb="Dsp2904"/>
      <status name="UNHANDLED_EXCEPTION" value="5287" severity="Error"
-	    text="Python device raised and exception, see log files for more details"
+	    text="Python device raised an exception, see log files for more details"
 	    facnam="Py$_" facabb="Py"/>
      <status name="NO_SAMPLES" value="5297" severity="Error"
 	    text="Module did not acquire any samples"

--- a/servershr/ServerMonitorCheckin.c
+++ b/servershr/ServerMonitorCheckin.c
@@ -1,6 +1,6 @@
 /*------------------------------------------------------------------------------
 
-		Name:   SERVER$MONITOR_CHECKIN   
+		Name:   SERVER$MONITOR_CHECKIN
 
 		Type:   C function
 
@@ -8,11 +8,11 @@
 
 		Date:   23-APR-1992
 
-    		Purpose: Checkin routine for action monitor 
+    		Purpose: Checkin routine for action monitor
 
 ------------------------------------------------------------------------------
 
-	Call sequence: 
+	Call sequence:
 
 int SERVER$MONITOR_CHECKIN(struct dsc$descriptor *server, void (*ast)(), int astparam, void (*link_down)())
 
@@ -41,7 +41,7 @@ static void (*appAst)() = 0;
 static void eventAst(void *astprm, int msglen __attribute__ ((unused)), char *msg) {
   (*appAst)(astprm,msg);
 }
-  
+
 EXPORT int ServerMonitorCheckin(char *server, void (*ast) (), void *astprm)
 {
   static int usingEvents=-1;
@@ -56,26 +56,25 @@ EXPORT int ServerMonitorCheckin(char *server, void (*ast) (), void *astprm)
       appAst=ast;
       usingEvents = MDSEventAst(strdup(mon_env+strlen("event:")),
 			 eventAst, astprm, &evid) & 1;
-    }
-    else {
+    } else {
       usingEvents = 0;
     }
   }
   if (usingEvents)
-    return 1;
+    return MDSplusSUCCESS;
   else {
     struct descrip p1, p2, p3, p4, p5, p6, p7, p8;
     char *cstring = "";
     int zero = 0;
     int mode = MonitorCheckin;
-    return ServerSendMessage(0, server, SrvMonitor, 0, 0, ast, astprm, 0,
-		      8, MakeDescrip(&p1, DTYPE_CSTRING, 0, 0, cstring),
-		      MakeDescrip(&p2, DTYPE_LONG, 0, 0, &zero),
-		      MakeDescrip(&p3, DTYPE_LONG, 0, 0, &zero),
-		      MakeDescrip(&p4, DTYPE_LONG, 0, 0, &zero),
-		      MakeDescrip(&p5, DTYPE_LONG, 0, 0, &zero),
-		      MakeDescrip(&p6, DTYPE_LONG, 0, 0, &mode),
-		      MakeDescrip(&p7, DTYPE_CSTRING, 0, 0, cstring),
-		      MakeDescrip(&p8, DTYPE_LONG, 0, 0, &zero));
+    return ServerSendMessage(0, server, SrvMonitor, 0, 0, ast, astprm, 0, 8,
+      MakeDescrip(&p1, DTYPE_CSTRING, 0, 0, cstring),
+      MakeDescrip(&p2, DTYPE_LONG, 0, 0, &zero),
+      MakeDescrip(&p3, DTYPE_LONG, 0, 0, &zero),
+      MakeDescrip(&p4, DTYPE_LONG, 0, 0, &zero),
+      MakeDescrip(&p5, DTYPE_LONG, 0, 0, &zero),
+      MakeDescrip(&p6, DTYPE_LONG, 0, 0, &mode),
+      MakeDescrip(&p7, DTYPE_CSTRING, 0, 0, cstring),
+      MakeDescrip(&p8, DTYPE_LONG, 0, 0, &zero));
   }
 }

--- a/tcl/tcl_dispatch.c
+++ b/tcl/tcl_dispatch.c
@@ -367,7 +367,7 @@ static void CommandDone(DispatchedCommand * command)
 
 EXPORT int TclDispatch_command(void *ctx, char **error, char **output __attribute__ ((unused)))
 {
-  INIT_STATUS,stat1=0;
+  INIT_STATUS,stat1=ServerPATH_DOWN;
   char *cli = NULL;
   char *ident = NULL;
   DispatchedCommand *command = calloc(1,sizeof(DispatchedCommand));
@@ -381,8 +381,10 @@ EXPORT int TclDispatch_command(void *ctx, char **error, char **output __attribut
       SYNCINIT;
       status = ServerDispatchCommand(SYNCPASS, ident, cli, command->command, CommandDone, command, &stat1, 0);
       if STATUS_OK SYNCWAIT;
-    } else
-      status = ServerDispatchCommand(0, ident, cli, command->command, CommandDone, command, &command->sts, 0);
+    } else {
+     command->sts = ServerPATH_DOWN;
+     status = ServerDispatchCommand(0, ident, cli, command->command, CommandDone, command, &command->sts, 0);
+    }
     if STATUS_NOT_OK {
       char *msg = MdsGetMsg(status);
       *error = malloc(100 + strlen(msg));

--- a/tcl/tcl_do_node.c
+++ b/tcl/tcl_do_node.c
@@ -24,24 +24,23 @@ extern int TdiDoTask();
 	 ***************************************************************/
 EXPORT int TclDoNode(void *ctx, char **error, char **output __attribute__ ((unused)))
 {
-  int sts;
-  char *nodnam = 0;
-  static int retstatus;
-  static int nid;
-  static DESCRIPTOR_NID(niddsc, &nid);
-  static DESCRIPTOR_LONG(retstatus_d, &retstatus);
-
+  INIT_STATUS, retstatus;
+  char *nodnam = NULL;
+  int nid;
+  DESCRIPTOR_NID(niddsc, &nid);
+  DESCRIPTOR_LONG(retstatus_d, &retstatus);
   cli_get_value(ctx, "NODE", &nodnam);
-  if ((sts = TreeFindNode(nodnam, &nid)) & 1) {
-    sts = TdiDoTask(&niddsc, &retstatus_d MDS_END_ARG);
-    if (sts & 1)
-      sts = retstatus;
+  status = TreeFindNode(nodnam, &nid);
+  if STATUS_OK {
+    status = TdiDoTask(&niddsc, &retstatus_d MDS_END_ARG);
+    if STATUS_OK
+      status = retstatus;
   }
-  if (~sts & 1) {
-    char *msg = MdsGetMsg(sts);
+  if STATUS_NOT_OK {
+    char *msg = MdsGetMsg(status);
     *error = malloc(strlen(msg) + strlen(nodnam) + 100);
     sprintf(*error, "Error: problem doing node %s\n" "Error message was: %s\n", nodnam, msg);
   }
   free(nodnam);
-  return sts;
+  return status;
 }

--- a/tdi/dev_support/DevAddDevice.fun
+++ b/tdi/dev_support/DevAddDevice.fun
@@ -1,7 +1,6 @@
 
 public fun DevAddDevice(in _path, in _type, optional out _nidout)
 {
-
    fun private DevAddCalledDevice(in _path, in _type) 
    {
     	_models = MdsDevices();
@@ -15,7 +14,7 @@ public fun DevAddDevice(in _path, in _type, optional out _nidout)
 	_rtn = _type//"__add";
     	_nidout = 0l;
 	_addr = 0Q;
-	_stat=MdsShr->LibFindImageSymbol(descr(_image),descr(_rtn),_addr);
+	_stat = MdsShr->LibFindImageSymbol(descr(_image),descr(_rtn),_addr);
 	if (_stat & 1) { 
     	  _command = '_stat = '//_image//'->'//_type//'__add(descr("'//_path//'"), descr(" "), _nidout)';
     	  _stat = if_error(execute(_command),0);
@@ -24,8 +23,8 @@ public fun DevAddDevice(in _path, in _type, optional out _nidout)
    }	
    _path_q = (extract(0, 1, _path) == '\\') ? '\\'//_path : _path;
    _cmd = "_stat = "//_type//'__add("'//_path_q//'", "'//_type//'")';
-   _stat = if_error(execute(_cmd), DevAddCalledDevice(_path_q, _type));
+   _stat = if_error(execute(_cmd), DevAddCalledDevice(_path_q, _type),0);
    if (~(_stat & 1))
-     _stat=DevAddPythonDevice(_path,_type);
+     _stat = DevAddPythonDevice(_path,_type,_nidout);
    return(_stat);
 }

--- a/tdi/dev_support/DevAddPythonDevice.py
+++ b/tdi/dev_support/DevAddPythonDevice.py
@@ -1,7 +1,7 @@
-from MDSplus import Data, Tree, Device
-from MDSplus.mdsExceptions import DevPYDEVICE_NOT_FOUND,MDSplusException,MDSplusSUCCESS,MDSplusERROR
+from MDSplus import Data, Tree, Device, Ident, Int32
+from MDSplus import DevPYDEVICE_NOT_FOUND,MDSplusException,MDSplusERROR,TreeSUCCESS
 import sys
-def DevAddPythonDevice(path, model):
+def DevAddPythonDevice(path, model, nidout=None):
     """Add a python device to the tree by:
     1) finding the model in the list defined by
        the tdi function, MdsDevices.
@@ -12,46 +12,15 @@ def DevAddPythonDevice(path, model):
     containing blank filled values containing an \0 character embedded.
     These Strings have to be manipulated to produce simple str() values.
     """
-    model = model.data().upper().rstrip()
+    model = str(model.data()).strip()
+    path  = str(path.data()).strip()
     try:
-        mod = Device.importPyDeviceModule(model)
-        path = str(path.data())
-        if mod is not None and model in mod.__dict__:
-            try:
-                mod.__dict__[model].Add(Tree(), path)
-                return
-            except:
-                e=sys.exc_info()[1]
-                if isinstance(e,MDSplusException):
-                    raise e
-                else:
-                    print ("Error adding device instance of %s: %s" % (model, sys.exc_info()[1]))
-                    raise MDSplusERROR
-    except DevPYDEVICE_NOT_FOUND:
-        pass
-
-    models = Data.execute('MdsDevices()')
-    cls = None
-
-    for idx in range(0, len(models), 2):
-        try:
-            modname = models[idx].data().upper().rstrip()
-            package = models[idx+1].data().rstrip()
-            if model == modname:
-                cls = __import__(package).__dict__[model]
-                break
-        except Exception,e:
-            pass
-    if cls is not None:
-        try:
-            cls.Add(Tree(), path)
-            return
-        except:
-            e=sys.exc_info()[1]
-            if isinstance(e,MDSplusException):
-                raise e
-            else:
-                print ("Error adding device instance of %s: %s" % (model, sys.exc_info()[1]))
-                raise MDSplusERROR
-    raise DevPYDEVICE_NOT_FOUND
-
+        node = Device.PyDevice(model).Add(Tree(),path)
+        if isinstance(nidout,(Ident,)):
+            Data.execute("$=$",nidout,Int32(node.nid))
+        return TreeSUCCESS.status
+    except MDSplusException:
+        return sys.exc_info()[1].status
+    except:
+        print ("Error adding device instance of %s: %s" % (model, sys.exc_info()[1]))
+        return MDSplusERROR.status

--- a/tdi/dev_support/DevAddPythonDevice.py
+++ b/tdi/dev_support/DevAddPythonDevice.py
@@ -1,5 +1,5 @@
 from MDSplus import Data, Tree, Device
-from MDSplus.mdsExceptions import DevPYDEVICE_NOT_FOUND,MDSplusException
+from MDSplus.mdsExceptions import DevPYDEVICE_NOT_FOUND,MDSplusException,MDSplusSUCCESS,MDSplusERROR
 import sys
 def DevAddPythonDevice(path, model):
     """Add a python device to the tree by:
@@ -13,20 +13,23 @@ def DevAddPythonDevice(path, model):
     These Strings have to be manipulated to produce simple str() values.
     """
     model = model.data().upper().rstrip()
-    mod = Device.importPyDeviceModule(model)
-    path = str(path.data())
-    if mod is not None and model in mod.__dict__:
-        try:
-            mod.__dict__[model].Add(Tree(), path)
-            return 1
-        except:
-            e=sys.exc_info()[1]
-            if isinstance(e,MDSplusException):
-                return e.status
-            else:
-                print ("Error adding device instance of %s: %s" % (model, sys.exc_info()[1]))
-                return 0
-        
+    try:
+        mod = Device.importPyDeviceModule(model)
+        path = str(path.data())
+        if mod is not None and model in mod.__dict__:
+            try:
+                mod.__dict__[model].Add(Tree(), path)
+                return
+            except:
+                e=sys.exc_info()[1]
+                if isinstance(e,MDSplusException):
+                    raise e
+                else:
+                    print ("Error adding device instance of %s: %s" % (model, sys.exc_info()[1]))
+                    raise MDSplusERROR
+    except DevPYDEVICE_NOT_FOUND:
+        pass
+
     models = Data.execute('MdsDevices()')
     cls = None
 
@@ -42,13 +45,13 @@ def DevAddPythonDevice(path, model):
     if cls is not None:
         try:
             cls.Add(Tree(), path)
-            return 1
+            return
         except:
             e=sys.exc_info()[1]
             if isinstance(e,MDSplusException):
-                return e.status
+                raise e
             else:
                 print ("Error adding device instance of %s: %s" % (model, sys.exc_info()[1]))
-                return 0
-    return DevPYDEVICE_NOT_FOUND.status
-    
+                raise MDSplusERROR
+    raise DevPYDEVICE_NOT_FOUND
+

--- a/tdi/dev_support/PyDoMethod.py
+++ b/tdi/dev_support/PyDoMethod.py
@@ -1,24 +1,20 @@
-from MDSplus import TreeNode, Device, List
-from MDSplus import TreeNOMETHOD,MDSplusException,PyUNHANDLED_EXCEPTION,MDSplusSUCCESS
+from MDSplus import TreeNode, Device, makeData
+from MDSplus import TreeNOMETHOD,MDSplusException,PyUNHANDLED_EXCEPTION
 from sys import stderr,exc_info
 
 def PyDoMethod(n,method,*args):
     def domethod(methodobj,args):
         try:
-            return methodobj(*args)
-        except TypeError:
-            exc = exc_info()[1]
-            print(exc)
+            return makeData(methodobj(*args))
+        except TypeError as exc:
             if exc.message.startswith(method+'()'):
                 print('Your device method %s.%s requires at least one argument.' % (model,method))
                 print('No argument has been provided as it is probably not required by the method.')
                 print('MDSplus does not require device methods to accept an argument anymore.\n')
                 return methodobj(None)
-            else:
-                raise exc
+            else: raise
     method = str(method)
     model = n.__class__.__name__
-    result = None
     try:
         if method in TreeNode.__dict__:
             methodobj = n.__getattribute__(method)
@@ -26,7 +22,6 @@ def PyDoMethod(n,method,*args):
             device = n.conglomerate_nids[0]
             c = device.record
             model = str(c.model)
-            result = None
             if not isinstance(device, (Device,)):
                 device = c.getDevice(device)
             try:
@@ -35,11 +30,10 @@ def PyDoMethod(n,method,*args):
                 raise TreeNOMETHOD()
             if not method in Device.__dict__:
                 print("doing %s(%s).%s(%s)"%(device,model,method,','.join(map(str,args))))
-        result = domethod(methodobj,args)
-        status = MDSplusSUCCESS.status
-    except MDSplusException as exc:
-        status = exc.status
+        return makeData(domethod(methodobj,args))
+    except MDSplusException:
+        raise
     except Exception as exc:
         stderr.write("Python error in %s.%s:\n%s\n\n" % (model,method,str(exc)))
-        status = PyUNHANDLED_EXCEPTION.status
-    return List([status,result])
+        raise PyUNHANDLED_EXCEPTION
+

--- a/tdi/dev_support/PyDoMethod.py
+++ b/tdi/dev_support/PyDoMethod.py
@@ -1,11 +1,12 @@
-from MDSplus import TreeNode, Device, makeData
+from MDSplus import TreeNode, Device, List
 from MDSplus import TreeNOMETHOD,MDSplusException,PyUNHANDLED_EXCEPTION
 from sys import stderr,exc_info
 
 def PyDoMethod(n,method,*args):
+    print(("PyDoMethod",n,method,args))
     def domethod(methodobj,args):
         try:
-            return makeData(methodobj(*args))
+            return methodobj(*args)
         except TypeError as exc:
             if exc.message.startswith(method+'()'):
                 print('Your device method %s.%s requires at least one argument.' % (model,method))
@@ -30,10 +31,10 @@ def PyDoMethod(n,method,*args):
                 raise TreeNOMETHOD()
             if not method in Device.__dict__:
                 print("doing %s(%s).%s(%s)"%(device,model,method,','.join(map(str,args))))
-        return makeData(domethod(methodobj,args))
-    except MDSplusException:
-        raise
+        return List([1,domethod(methodobj,args)])
+    except MDSplusException as exc:
+        return List([exc.status,None])
     except Exception as exc:
         stderr.write("Python error in %s.%s:\n%s\n\n" % (model,method,str(exc)))
-        raise PyUNHANDLED_EXCEPTION
+        return List([PyUNHANDLED_EXCEPTION.status,None])
 

--- a/tdi/dev_support/PyDoMethod.py
+++ b/tdi/dev_support/PyDoMethod.py
@@ -1,9 +1,8 @@
-from MDSplus import TreeNode, Device, List
+from MDSplus import TreeNode, Device
 from MDSplus import TreeNOMETHOD,MDSplusException,PyUNHANDLED_EXCEPTION
 from sys import stderr,exc_info
 
 def PyDoMethod(n,method,*args):
-    print(("PyDoMethod",n,method,args))
     def domethod(methodobj,args):
         try:
             return methodobj(*args)
@@ -28,13 +27,13 @@ def PyDoMethod(n,method,*args):
             try:
                 methodobj = device.__getattribute__(method)
             except AttributeError:
-                raise TreeNOMETHOD()
+                raise TreeNOMETHOD
             if not method in Device.__dict__:
                 print("doing %s(%s).%s(%s)"%(device,model,method,','.join(map(str,args))))
-        return List([1,domethod(methodobj,args)])
-    except MDSplusException as exc:
-        return List([exc.status,None])
+        return domethod(methodobj,args)
+    except MDSplusException:
+        raise
     except Exception as exc:
         stderr.write("Python error in %s.%s:\n%s\n\n" % (model,method,str(exc)))
-        return List([PyUNHANDLED_EXCEPTION.status,None])
+        raise PyUNHANDLED_EXCEPTION
 

--- a/tdishr/TdiCompile.c
+++ b/tdishr/TdiCompile.c
@@ -78,13 +78,12 @@ int Tdi1Compile(int opcode __attribute__ ((unused)), int narg, struct descriptor
       TdiThreadStatic()->compiler_recursing = 1;
       if (!TdiRefZone.l_zone)
 	status = LibCreateVmZone(&TdiRefZone.l_zone);
-
-	/****************************************
-                  In case we bomb out, probably not needed.
-        ****************************************/
+      /****************************************
+      In case we bomb out, probably not needed.
+      ****************************************/
       TdiRefZone.l_status = TdiBOMB;
       if (TdiRefZone.a_begin)
-	free(TdiRefZone.a_begin);
+        free(TdiRefZone.a_begin);
       TdiRefZone.a_begin = TdiRefZone.a_cur =
 	  memcpy(malloc(text_ptr->length), text_ptr->pointer, text_ptr->length);
       TdiRefZone.a_end = TdiRefZone.a_cur + text_ptr->length;
@@ -99,10 +98,9 @@ int Tdi1Compile(int opcode __attribute__ ((unused)), int narg, struct descriptor
 	else
 	  status = TdiRefZone.l_status;
       }
-
-	/************************
-                  Move from temporary zone.
-        ************************/
+      /************************
+      Move from temporary zone.
+      ************************/
       if STATUS_OK {
 	if (TdiRefZone.a_result == 0)
 	  MdsFree1Dx(out_ptr, NULL);
@@ -111,26 +109,26 @@ int Tdi1Compile(int opcode __attribute__ ((unused)), int narg, struct descriptor
       }
       LibResetVmZone(&TdiRefZone.l_zone);
       TdiThreadStatic()->compiler_recursing = 0;
-    } else
-      MdsFree1Dx(out_ptr, NULL);
+    }
   }
   MdsFree1Dx(&tmp, NULL);
+  if STATUS_NOT_OK MdsFree1Dx(out_ptr, NULL);
   UnlockMdsShrMutex(&yacc_mutex);
   return (status);
 }
 
 /*-------------------------------------------------------
-        Compile and evaluate an expression.
-                result = EXECUTE(string, [arg1,...])
+  Compile and evaluate an expression.
+      result = EXECUTE(string, [arg1,...])
 */
 int Tdi1Execute(int opcode __attribute__ ((unused)), int narg, struct descriptor *list[], struct descriptor_xd *out_ptr)
 {
   INIT_STATUS;
   struct descriptor_xd tmp = EMPTY_XD;
-
   status = TdiIntrinsic(OpcCompile, narg, list, &tmp);
   if STATUS_OK
     status = TdiEvaluate(tmp.pointer, out_ptr MDS_END_ARG);
   MdsFree1Dx(&tmp, NULL);
+  if STATUS_NOT_OK MdsFree1Dx(out_ptr, NULL);
   return status;
 }

--- a/tdishr/TdiDoTask.c
+++ b/tdishr/TdiDoTask.c
@@ -60,7 +60,8 @@ STATIC_ROUTINE void TASK_AST(int astpar, int r0, int r1, int *pc, int psl)
 
 STATIC_ROUTINE int Doit(struct descriptor_routine *ptask, struct descriptor_xd *out_ptr)
 {
-  int dtype, ndesc, j, status;
+  INIT_STATUS;
+  int dtype, ndesc, j;
   void **arglist[256];
   ndesc = ptask->ndesc;
   while (ndesc > 3 && ptask->arguments[ndesc - 4] == 0)
@@ -85,8 +86,8 @@ STATIC_ROUTINE int Doit(struct descriptor_routine *ptask, struct descriptor_xd *
 	arglist[j] = (void *)pmethod->arguments[j - 3];
       arglist[ndesc] = (void *)out_ptr;
       arglist[ndesc + 1] = MdsEND_ARG;
-      void* result = LibCallg(arglist, TreeDoMethod);
-      status = TdiPutLong((int*)&result, out_ptr);
+      status = (int)((char *)LibCallg(arglist, TreeDoMethod) - (char *)0);
+      status = TdiPutLong(&status, out_ptr);
       StrFree1Dx(&method_d);
       break;
     }

--- a/tdishr/TdiEvaluate.c
+++ b/tdishr/TdiEvaluate.c
@@ -43,19 +43,19 @@ int Tdi1Evaluate(int opcode __attribute__ ((unused)),
   struct descriptor_function *pfun;
   int nid, *pnid;
 
-	/*****************************
-        Cannot evaluate a null pointer
-        *****************************/
+  /*****************************
+  Cannot evaluate a null pointer
+  *****************************/
   if (list[0] == 0)
     return MdsCopyDxXd(&missing, out_ptr);
 
   switch (list[0]->class) {
   case CLASS_XD:
-		/***************************************************
-                If input is an class XD and dtype DSC and points to
-                real stuff, we can just copy its descriptor.
-                Release any lingering output unless it is our input.
-                ***************************************************/
+    /***************************************************
+    If input is an class XD and dtype DSC and points to
+    real stuff, we can just copy its descriptor.
+    Release any lingering output unless it is our input.
+    ***************************************************/
     switch (list[0]->dtype) {
     case DTYPE_DSC:
       if (list[0]->pointer == 0)
@@ -82,9 +82,9 @@ int Tdi1Evaluate(int opcode __attribute__ ((unused)),
       }
       break;
     }
-/*****************************************************************************
-WARNING falls through if an XD but not DSC of usable data (no known examples).
-*****************************************************************************/
+  /*****************************************************************************
+  WARNING falls through if an XD but not DSC of usable data (no known examples).
+  *****************************************************************************/
   case CLASS_S:
   case CLASS_D:
   case CLASS_XS:
@@ -125,7 +125,7 @@ WARNING falls through if an XD but not DSC of usable data (no known examples).
     case DTYPE_FUNCTION:
       pfun = (struct descriptor_function *)list[0];
       status = TdiIntrinsic(*(unsigned short *)pfun->pointer,
-			    pfun->ndesc, pfun->arguments, out_ptr);
+          pfun->ndesc, pfun->arguments, out_ptr);
       break;
     case DTYPE_PARAM:
     case DTYPE_SIGNAL:
@@ -153,9 +153,9 @@ WARNING falls through if an XD but not DSC of usable data (no known examples).
 		  pfun->arguments, out_ptr);
       break;
     default:
-			/***********************
-                        NEED error if full list.
-                        ***********************/
+      /***********************
+      NEED error if full list.
+      ***********************/
       if (list[0]->dtype < DTYPE_PARAM)
 	status = TdiINVCLADTY;
       else
@@ -163,19 +163,19 @@ WARNING falls through if an XD but not DSC of usable data (no known examples).
       break;
     }
     break;
-	/***************************************
-        Must expand compressed data. 24-Apr-1991
-        ***************************************/
   case CLASS_CA:
+    /***************************************
+    Must expand compressed data. 24-Apr-1991
+    ***************************************/
     status = TdiEvaluate(list[0]->pointer, out_ptr MDS_END_ARG);
     if STATUS_OK
       status = TdiImpose(list[0], out_ptr);
     break;
   case CLASS_A:
-		/*******************************
-                Arrays of most types.
-                NEED array(dsc/nid/path)=?
-                *******************************/
+    /*************************
+    Arrays of most types.
+    NEED array(dsc/nid/path)=?
+    *************************/
     status = SsINTERNAL;
     break;
   case CLASS_APD:
@@ -195,10 +195,10 @@ WARNING falls through if an XD but not DSC of usable data (no known examples).
     status = TdiINVCLADSC;
     break;
   }
-	/****************************
-        VMS type or MDS special type.
-        Make a descriptor, class XD.
-        ****************************/
+  /****************************
+  VMS type or MDS special type.
+  Make a descriptor, class XD.
+  ****************************/
   if (status == SsINTERNAL)
     status = MdsCopyDxXd(list[0], out_ptr);
   if (list[0]->pointer)

--- a/tdishr/TdiExtPython.c
+++ b/tdishr/TdiExtPython.c
@@ -1,3 +1,4 @@
+
 #include <config.h>
 #include <dlfcn.h>
 #include <stdio.h>
@@ -16,7 +17,6 @@
 #ifdef HAVE_ALLOCA_H
 #include <alloca.h>
 #endif
-
 #define Py_None _Py_NoneStruct
 
 #define loadrtn(name,check) name=dlsym(handle,#name);   \
@@ -27,6 +27,7 @@
 typedef void* PyThreadState;
 static PyThreadState *(*PyGILState_Ensure)() = NULL;
 static void (*PyGILState_Release)(PyThreadState *) = NULL;
+extern int MdsGetStdMsg();
 
 typedef void* PyObject;
 typedef ssize_t Py_ssize_t;
@@ -345,6 +346,12 @@ int TdiExtPython(struct descriptor *modname_d,
               PyObject *status_obj = (*PyObject_GetAttrString)(exc, "status");
               status = (int)(*PyLong_AsLong)(status_obj);
               (*Py_DecRef)(status_obj);
+              if STATUS_NOT_OK {
+                char *fac_out=NULL, *msgnam_out=NULL, *text_out=NULL;
+                const char *f = "WSEIF???";
+                MdsGetStdMsg(status,&fac_out,&msgnam_out,&text_out);
+                printf("%%%s-%c-%s: %s\n",fac_out,f[status&7],msgnam_out,text_out);
+               }
             } else {
               printf("Error calling fun in %s\n", filename);
               (*PyErr_Print)();

--- a/tdishr/TdiExtPython.c
+++ b/tdishr/TdiExtPython.c
@@ -347,7 +347,6 @@ int TdiExtPython(struct descriptor *modname_d,
       addToPath(dirspec);
       free(dirspec);
       pyFunction = getFunction(filename, filename);
-      free(filename);
       if (pyFunction) {
         pyArgs = argsToTuple(nargs, args);
         ans = (*PyObject_CallObject)(pyFunction, pyArgs);
@@ -368,6 +367,7 @@ int TdiExtPython(struct descriptor *modname_d,
         (*Py_DecRef)(pyArgs);
         (*Py_DecRef)(pyFunction);
       } else status = TdiUNKNOWN_VAR;
+      free(filename);
       (*PyGILState_Release)(GIL);
     }
   } else status = TdiUNKNOWN_VAR;

--- a/tdishr/TdiGetData.c
+++ b/tdishr/TdiGetData.c
@@ -468,7 +468,7 @@ extern EXPORT int TdiGetNid(struct descriptor *in_ptr, int *nid_ptr)
   };
 
   status = TdiGetData(omits, in_ptr, &tmp);
-  if STATUS_OK
+  if STATUS_OK {
     switch (tmp.pointer->dtype) {
     case DTYPE_T:
     case DTYPE_PATH:
@@ -485,6 +485,8 @@ extern EXPORT int TdiGetNid(struct descriptor *in_ptr, int *nid_ptr)
       status = TdiINVDTYDSC;
       break;
     }
+    MdsFree1Dx(&tmp, NULL);
+  }
   return status;
 }
 

--- a/testing/MitDevices
+++ b/testing/MitDevices
@@ -1,0 +1,1 @@
+../tdi/MitDevices

--- a/testing/RfxDevices
+++ b/testing/RfxDevices
@@ -1,0 +1,1 @@
+../tdi/RfxDevices

--- a/testing/TutorialDevices
+++ b/testing/TutorialDevices
@@ -1,0 +1,1 @@
+../tdi/TutorialDevices

--- a/testing/W7xDevices
+++ b/testing/W7xDevices
@@ -1,0 +1,1 @@
+../tdi/W7xDevices

--- a/testing/testing.py
+++ b/testing/testing.py
@@ -23,6 +23,13 @@ class testing(object):
     tap_file = os.getenv(TEST_TAPFILE, os.path.splitext(os.path.basename(sys.argv[1]))[0]+'.tap')
     xml_file = os.getenv(TEST_XMLFILE, os.path.splitext(os.path.basename(sys.argv[1]))[0]+'.xml')
 
+    def check_unittest_version(self, module_name ):
+        if module_name.startswith('thread'):
+            import unittest
+            if '__version__' in unittest.__dict__:
+                return float(unittest.__version__)>=2.7
+        return True
+
     def check_module(self, module_name ):
         from modulefinder import ModuleFinder
         finder = ModuleFinder(debug=2)
@@ -131,17 +138,21 @@ def check_arch(file_name):
     else:
         lib   = 'lib%s.so'
         pylib = 'python%d.%d'
+    module_name = os.path.basename(file_name)
     try:
         ts.check_loadlib(lib%'MdsShr')
     except OSError:
-        ts.skip_test(os.path.basename(file_name),
+        ts.skip_test(module_name,
                      'Unable to load MDSplus core libs')
     try:
         pylib = lib%(pylib%sys.version_info[0:2])
         ts.check_loadlib(pylib)
     except OSError:
-        ts.skip_test(os.path.basename(file_name),
+        ts.skip_test(module_name,
                      'Unable to load python lib "%s"'%(pylib,))
+    if not ts.check_unittest_version(module_name):
+        ts.skip_test(module_name,
+                     'Unfit unittest version < 2.7')
 
 
 if __name__ == '__main__':

--- a/treeshr/TreeAddNode.c
+++ b/treeshr/TreeAddNode.c
@@ -96,7 +96,6 @@ int _TreeAddNode(void *dbid, char const *name, int *nid_out, char usage)
 *****************************************************/
   if (!IS_OPEN_FOR_EDIT(dblist))
     return TreeNOEDIT;
-
   upcase_name = (char *)malloc(len + 1);
   for (i = 0; i < len; i++)
     upcase_name[i] = toupper(name[i]);
@@ -140,7 +139,6 @@ int _TreeAddNode(void *dbid, char const *name, int *nid_out, char usage)
 	  strncpy(new_ptr->name, node_name, sizeof(new_ptr->name));
 	  for (i = strlen(node_name); i < sizeof(new_ptr->name); i++)
 	    new_ptr->name[i] = ' ';
-	  free(node_name);
 	  new_ptr->child = 0;
 	  LoadShort(idx, &new_ptr->conglomerate_elt);
 	  if (node_type == BROTHER_TYPE_NOWILD || usage == TreeUSAGE_STRUCTURE
@@ -175,6 +173,7 @@ int _TreeAddNode(void *dbid, char const *name, int *nid_out, char usage)
       } else
 	status = TreeINVPATH;
     }
+    free(node_name);
   }
   if STATUS_OK
     dblist->modified = 1;

--- a/treeshr/TreeCreatePulseFile.c
+++ b/treeshr/TreeCreatePulseFile.c
@@ -64,8 +64,7 @@ int TreeCreatePulseFile(int shotid, int numnids_in, int *nids_in)
 int _TreeCreatePulseFile(void *dbid, int shotid, int numnids_in, int *nids_in)
 {
   PINO_DATABASE *dblist = (PINO_DATABASE *) dbid;
-  int status = 1;
-  int retstatus;
+  INIT_STATUS, retstatus = MDSplusERROR;
   int num;
   int nids[256];
   int i;
@@ -105,7 +104,7 @@ int _TreeCreatePulseFile(void *dbid, int shotid, int numnids_in, int *nids_in)
     shot = TreeGetCurrentShotId(dblist->experiment);
 
   retstatus = status;
-  if (status & 1) {
+  if STATUS_OK {
     for (i = 0; i < num && (retstatus & 1); i++) {
       int skip = 0;
       char name[13];
@@ -126,9 +125,9 @@ int _TreeCreatePulseFile(void *dbid, int shotid, int numnids_in, int *nids_in)
       } else {
 	strcpy(name, dblist->experiment);
       }
-      if (status & 1 && !(skip))
+      if (STATUS_OK && !(skip))
 	status = TreeCreateTreeFiles(name, shot, source_shot);
-      if (!(status & 1) && (i == 0))
+      if (STATUS_NOT_OK && (i == 0))
 	retstatus = status;
     }
   }
@@ -137,6 +136,7 @@ int _TreeCreatePulseFile(void *dbid, int shotid, int numnids_in, int *nids_in)
 
 int TreeCreateTreeFiles(char *tree, int shot, int source_shot)
 {
+  INIT_STATUS;
   size_t len = strlen(tree);
   char tree_lower[13];
   char pathname[32];
@@ -145,7 +145,6 @@ int TreeCreateTreeFiles(char *tree, int shot, int source_shot)
   size_t pathlen;
   char name[32];
   size_t i;
-  int status = 1;
   int itype;
   char *types[] = { ".tree", ".characteristics", ".datafile" };
   for (i = 0; i < len && i < 12; i++)
@@ -156,7 +155,7 @@ int TreeCreateTreeFiles(char *tree, int shot, int source_shot)
   pathin = TranslateLogical(pathname);
   if (pathin) {
     pathlen = strlen(pathin);
-    for (itype = 0; itype < 3 && (status & 1); itype++) {
+    for (itype = 0; itype < 3 && STATUS_OK; itype++) {
       char *srcfile = 0;
       char *dstfile = 0;
       char *type = types[itype];
@@ -263,8 +262,7 @@ int TreeCreateTreeFiles(char *tree, int shot, int source_shot)
 
 STATIC_ROUTINE int _CopyFile(char *src, char *dst, int lock_it)
 {
-  int status;
-
+  INIT_STATUS_ERROR;
   int src_fd = MDS_IO_OPEN(src, O_RDONLY | O_BINARY | O_RANDOM, 0);
   if (src_fd != -1) {
     ssize_t src_len = MDS_IO_LSEEK(src_fd, 0, SEEK_END);

--- a/treeshr/TreeDoMethod.c
+++ b/treeshr/TreeDoMethod.c
@@ -90,7 +90,7 @@ int TreeDoFun(struct descriptor *funname, int nargs, struct descriptor **args,
 int _TreeDoMethod(void *dbid, struct descriptor *nid_dsc, struct descriptor *method_ptr, ...)
 {
   va_list incrmtr;
-  int status = TreeNOMETHOD;
+  INIT_STATUS;
   static short conglomerate_elt;
   static unsigned char data_type;
   static int head_nid;
@@ -100,7 +100,7 @@ int _TreeDoMethod(void *dbid, struct descriptor *nid_dsc, struct descriptor *met
   {0, NciEND_OF_LIST, 0, 0}
   };
   void (*addr) ();
-  static int (*TdiExecute) () = 0;
+  static int (*TdiExecute) () = NULL;
   STATIC_CONSTANT DESCRIPTOR(close, "$)");
   STATIC_CONSTANT DESCRIPTOR(arg, "$,");
   STATIC_CONSTANT DESCRIPTOR(tdishr, "TdiShr");
@@ -113,14 +113,12 @@ int _TreeDoMethod(void *dbid, struct descriptor *nid_dsc, struct descriptor *met
   void *arglist[256];
   count(nargs);
   arglist[0] = arglist_nargs(nargs);
-
   if (nid_dsc->dtype != DTYPE_NID || (!nid_dsc->pointer))
     return TreeNOMETHOD;
   head_nid = 0;
   status = _TreeGetNci(dbid, *(int *)nid_dsc->pointer, itmlst);
-  if (!(status & 1))
+  if (STATUS_NOT_OK)
     return status;
-
   if (conglomerate_elt || (data_type == DTYPE_CONGLOM)) {
     int i;
     arglist[1] = nid_dsc;
@@ -130,7 +128,7 @@ int _TreeDoMethod(void *dbid, struct descriptor *nid_dsc, struct descriptor *met
       arglist[i + 1] = va_arg(incrmtr, struct descriptor *);
     va_end(incrmtr);
     status = _TreeGetRecord(dbid, head_nid ? head_nid : *((int *)nid_dsc->pointer), &xd);
-    if (!(status & 1))
+    if (STATUS_NOT_OK)
       return status;
     conglom_ptr = (struct descriptor_conglom *)xd.pointer;
     if (conglom_ptr->dtype != DTYPE_CONGLOM)
@@ -143,21 +141,18 @@ int _TreeDoMethod(void *dbid, struct descriptor *nid_dsc, struct descriptor *met
       STATIC_CONSTANT DESCRIPTOR(open, "PyDoMethod(");
       StrCopyDx((struct descriptor *)&exp, (struct descriptor *)&open);
       if (nargs == 4 && method_ptr->length == strlen("DW_SETUP")
-	  && strncmp(method_ptr->pointer, "DW_SETUP", strlen("DW_SETUP")) == 0) {
+       && strncmp(method_ptr->pointer, "DW_SETUP", strlen("DW_SETUP")) == 0) {
 	arglist[3] = arglist[4];
 	nargs--;
       }
       for (i = 1; i < nargs - 1; i++)
 	StrAppend(&exp, (struct descriptor *)&arg);
       StrAppend(&exp, (struct descriptor *)&close);
-      if (TdiExecute == 0)
+      if (!TdiExecute)
 	status = LibFindImageSymbol(&tdishr, &tdiexecute, &TdiExecute);
-      if (status & 1) {
-	EMPTYXD(list_xd);
+      if (STATUS_OK) {
 	struct descriptor_xd *ans_xd=arglist[nargs];
-	DESCRIPTOR_LONG(stat_d,&status);
-	static DESCRIPTOR(dollar_d,"$");
-	arglist[nargs]=&list_xd;
+	arglist[nargs]=&ans_xd;
 	for (i = nargs; i > 0; i--)
 	  arglist[i + 1] = arglist[i];
 	nargs += 2;
@@ -165,38 +160,19 @@ int _TreeDoMethod(void *dbid, struct descriptor *nid_dsc, struct descriptor *met
 	arglist[1] = &exp;
 	arglist[nargs] = MdsEND_ARG;
 	status = (int)((char *)LibCallg(arglist, TdiExecute) - (char *)0);
-        if (status & 1) {
-	  struct descriptor_a *list = (struct descriptor_a *)list_xd.pointer;
-	  if (list && list->dtype == DTYPE_LIST && list->arsize == (sizeof(void *)*2)) {
-	    struct descriptor *statd = ((struct descriptor **)list->pointer)[0];
-	    struct descriptor *ansd  = ((struct descriptor **)list->pointer)[1];
-	    if (ansd) {
-	      (*TdiExecute)(&dollar_d, ansd,ans_xd, MdsEND_ARG);
-	    } else {
-	      (*TdiExecute)(&dollar_d,statd,ans_xd, MdsEND_ARG);
-	    }
-            if (statd) status = *(int*)statd->pointer;
-	  }
-	  else {
-	    (*TdiExecute)(&dollar_d,&stat_d,ans_xd, MdsEND_ARG);
-	    status = 0;
-	  }
-	  MdsFree1Dx(&list_xd,0);
-	}
       }
       StrFree1Dx(&exp);
       *TreeCtx() = dbid;
       return status;
     }
-    StrConcat((struct descriptor *)&method, conglom_ptr->model, (struct descriptor *)&underunder,
-	      method_ptr MDS_END_ARG);
+    StrConcat((struct descriptor *)&method, conglom_ptr->model, (struct descriptor *)&underunder, method_ptr MDS_END_ARG);
     for (i = 0; i < method.length; i++)
       method.pointer[i] = tolower(method.pointer[i]);
     if (conglom_ptr->image && conglom_ptr->image->dtype == DTYPE_T)
       status = LibFindImageSymbol(conglom_ptr->image, &method, &addr);
     else
-      status = 0;
-    if (status & 1) {
+      status = MDSplusERROR;
+    if (STATUS_OK) {
       void *old_dbid = *TreeCtx();
       *TreeCtx() = dbid;
       status = (int)((char *)LibCallg(arglist, addr) - (char *)0);
@@ -213,17 +189,12 @@ int _TreeDoMethod(void *dbid, struct descriptor *nid_dsc, struct descriptor *met
       }
     } else {
       /**** Try tdi fun ***/
-      status =
-	  TreeDoFun((struct descriptor *)&method, nargs - 1, (struct descriptor **)&arglist[1],
-		    (struct descriptor_xd *)arglist[nargs]);
+      status = TreeDoFun((struct descriptor *)&method, nargs - 1, (struct descriptor **)&arglist[1], (struct descriptor_xd *)arglist[nargs]);
       if (status == TdiUNKNOWN_VAR)
-	status = TreeNOMETHOD;
+	return TreeNOMETHOD;
     }
   } else
-    status = TreeNOMETHOD;
-  /*
-     if (!(status&1)) lib$signal(status, 0);
-   */
+    return TreeNOMETHOD;
   return status;
 }
 


### PR DESCRIPTION
* If python code excepts with an MDSplusException, the status is used as STATUS code.
* fixed use after free issue in TdiExtPython (filename)
* PyDoMethod.py does not need to return a List object anymore and can simply raise Exceptions.
* cleaned up code using status.h
* included related tests to treeUnitTest.py
* fixed ErrorCode on dcl_dispatch if server is down