### PR TITLE
Tests: Fix python testing

### DIFF
--- a/configure
+++ b/configure
@@ -14535,7 +14535,7 @@ fi
  abs_srcdir=$(cd ${srcdir}; pwd)
 
 
- as_fn_append PY_LOG_COMPILER "sh -c LD_PRELOAD=${ENABLE_SANITIZE_LIBPATH} ${PYTHON} -B \$(top_srcdir)/testing/testing.py"
+ as_fn_append PY_LOG_COMPILER "sh -c \"LD_PRELOAD=${ENABLE_SANITIZE_LIBPATH} ${PYTHON} -B \$(top_srcdir)/testing/testing.py\""
  as_fn_append PY_LOG_FLAGS ""
 
  case "${build_os}:${host}" in #(

--- a/javatraverser/Makefile.in
+++ b/javatraverser/Makefile.in
@@ -1003,7 +1003,6 @@ uninstall-am: uninstall-binSCRIPTS uninstall-javaDATA \
 @MINGW_FALSE@$(bin_SCRIPTS): $(srcdir)/jTraverser.template
 @MINGW_FALSE@	cp $< $@
 
-
 jTraverser.jar: $(GIFS) classjava.stamp
 	$(JAR) c0f $@ $(java_JAVA:.java=*.class) $(addprefix -C ${srcdir} ,$(GIFS))
 

--- a/m4/m4_ax_mdsplus_testing.m4
+++ b/m4/m4_ax_mdsplus_testing.m4
@@ -141,7 +141,7 @@ AC_DEFUN([TS_SELECT],[
  dnl TS_CHECK_PYTHON_TAP( [$PYTHON],,
  dnl  [AC_MSG_WARN("Tap plugin for python-nose not found")])
 
- AS_VAR_APPEND([PY_LOG_COMPILER],  ["sh -c LD_PRELOAD=${ENABLE_SANITIZE_LIBPATH} ${PYTHON} -B \$(top_srcdir)/testing/testing.py"])
+ AS_VAR_APPEND([PY_LOG_COMPILER],  ["sh -c \"LD_PRELOAD=${ENABLE_SANITIZE_LIBPATH} ${PYTHON} -B \$(top_srcdir)/testing/testing.py\""])
  AS_VAR_APPEND([PY_LOG_FLAGS], [""])
 
  AS_CASE(["${build_os}:${host}"],


### PR DESCRIPTION
The earlier fix to deal with the use of sanitize with python caused a problem
of environment variables not being properly set preventing the tests from being executed. This should fix that.