### PR TITLE
Build: Fix cleanup of mdsplus python modules during upgrades

### DIFF
--- a/deploy/packaging/linux.xml
+++ b/deploy/packaging/linux.xml
@@ -571,7 +571,7 @@ fi
     <requires external="true" package="numpy"/>
     <include dir="/usr/local/mdsplus/mdsobjects/python"/>
     <postinst>
-      packages=$(find %{python_sitelib} -maxdepth 1 -name mdsplus* | grep -iv devices)
+      packages=$(find %{python_sitelib} -maxdepth 1 -name 'mdsplus*' | grep -iv devices)
       rm -Rf $packages %{python_sitelib}/MDSplus
       pushd __INSTALL_PREFIX__/mdsplus/mdsobjects/python &gt;/dev/null 2&gt;&amp;1
       python setup.py -q install
@@ -597,7 +597,7 @@ fi
 
       if [ "$1" == "0" ]
       then
-          packages=$(find %{python_sitelib} -maxdepth 1 -name mdsplus* | grep -iv devices)
+          packages=$(find %{python_sitelib} -maxdepth 1 -name 'mdsplus*' | grep -iv devices)
          rm -Rf $packages %{python_sitelib}/MDSplus
       fi
 


### PR DESCRIPTION
The postinstall script used to remove the older mdsplus python modules
when updating the python rpm was using an mdsplus* wildcard in the shell
command which works fine unless there is a file/directory in the / directory
where the script is executed. The mdsplus* string has to be quoted otherwise
the shell does the substitution too early instead of applying the wildcard in
the find command. Subtle!