### PR TITLE
FIX: TreeWriteTree was not returning an error when output disk full

### DIFF
--- a/include/treeshr_messages.h
+++ b/include/treeshr_messages.h
@@ -95,3 +95,4 @@
 #define TreeMOVEERROR            0xfd1907a
 #define TreeOPENEDITERR          0xfd19082
 #define TreeREADONLY_TREE        0xfd1908a
+#define TreeWRITETREEERR         0xfd19092

--- a/mdsobjects/python/mdsExceptions.py
+++ b/mdsobjects/python/mdsExceptions.py
@@ -2326,6 +2326,14 @@ class TreeREADONLY_TREE(_TreeException):
 
 MDSplusException.statusDict[265392264] = TreeREADONLY_TREE
 
+
+class TreeWRITETREEERR(_TreeException):
+  status=265392274
+  message="Error writing .tree file"
+  msgnam="WRITETREEERR"
+
+MDSplusException.statusDict[265392272] = TreeWRITETREEERR
+
 ########################### generated from mdsshr_messages.xml ########################
 
 

--- a/mdsshr/MdsGetStdMsg.c
+++ b/mdsshr/MdsGetStdMsg.c
@@ -2714,6 +2714,16 @@ int MdsGetStdMsg(int status, const char **fac_out, const char **msgnam_out, cons
         sts = 1;}
         break;
 
+/* TreeWRITETREEERR */
+      case 0xfd19090:
+        {static const char *text="Error writing .tree file";
+        static const char *msgnam="WRITETREEERR";
+        *fac_out = FAC_TREE;
+        *msgnam_out = msgnam;
+        *text_out = text;
+        sts = 1;}
+        break;
+
 /* LibINSVIRMEM */
       case 0x158210:
         {static const char *text="Insufficient virtual memory";

--- a/treeshr/TreeAddNode.c
+++ b/treeshr/TreeAddNode.c
@@ -695,8 +695,10 @@ int _TreeWriteTree(void **dbid, char const *exp_ptr, int shotid)
                 TREE_HEADER *header = HeaderOut(info_ptr->header);
                 num = MDS_IO_WRITE(ntreefd, header, 512 * header_pages);
                 FreeHeaderOut(header);
-                if (num != (ssize_t)(header_pages * 512))
+                status = TreeWRITETREEERR;
+                if (num != (ssize_t)(header_pages * 512)) {
                     goto error_exit;
+                }
                 num = MDS_IO_WRITE(ntreefd, info_ptr->node, 512 * node_pages);
                 if (num != (ssize_t)(node_pages * 512))
                     goto error_exit;
@@ -712,6 +714,7 @@ int _TreeWriteTree(void **dbid, char const *exp_ptr, int shotid)
                 status = TreeWriteNci(info_ptr);
                 if ((status & 1) == 0)
                     goto error_exit;
+                status = TreeNORMAL;
                 if (info_ptr->channel > -1)
                     status = MDS_IO_CLOSE(info_ptr->channel);
                 info_ptr->channel = -2;

--- a/treeshr/treeshr_messages.xml
+++ b/treeshr/treeshr_messages.xml
@@ -88,6 +88,6 @@
     <status name="MOVEERROR" value="4623" severity="Error" text="Error replacing original treefile with new one."/>
     <status name="OPENEDITERR" value="4624" severity="Error" text="Error reopening new treefile for write access."/>
     <status name="READONLY_TREE" value="4625" severity="Error" text="Tree is marked as readonly. No write operations permitted."/>
-    
+    <status name="WRITETREEERR" value="4626" severity="Error" text="Error writing .tree file"/>    
   </facility>
 </messages>


### PR DESCRIPTION
The error_exit code in TreeWriteTree  did not set status before returning.
When the code detected an error writing to the tree file, it returned, but
status was 1.  So the calling application thought the write operation was
successfull

Added new tree error code TreeWRITETREEERR  to be returned under these
conditions.