### PR TITLE
Zck tdishr TdiRefZone

### DIFF
--- a/deploy/packaging/debian/devel.noarch
+++ b/deploy/packaging/debian/devel.noarch
@@ -60,6 +60,7 @@
 ./usr/local/mdsplus/include/msc_stdint.h
 ./usr/local/mdsplus/include/ncidef.h
 ./usr/local/mdsplus/include/opcbuiltins.h
+./usr/local/mdsplus/include/pthread_port.h
 ./usr/local/mdsplus/include/release.h
 ./usr/local/mdsplus/include/rtevents.h
 ./usr/local/mdsplus/include/servershr.h

--- a/deploy/packaging/redhat/devel.noarch
+++ b/deploy/packaging/redhat/devel.noarch
@@ -63,6 +63,7 @@
 ./usr/local/mdsplus/include/msc_stdint.h
 ./usr/local/mdsplus/include/ncidef.h
 ./usr/local/mdsplus/include/opcbuiltins.h
+./usr/local/mdsplus/include/pthread_port.h
 ./usr/local/mdsplus/include/release.h
 ./usr/local/mdsplus/include/rtevents.h
 ./usr/local/mdsplus/include/servershr.h

--- a/mdsobjects/python/tests/Makefile.in
+++ b/mdsobjects/python/tests/Makefile.in
@@ -687,9 +687,10 @@ TESTS = \
 
 # if VALGRIND_TESTS is defined this list is executed with valgrind
 VALGRIND_TESTS = \
-                 dataUnitTest.py \
-                 treeUnitTest.py \
-                 segmentsUnitTest.py
+        dataUnitTest.py \
+        segmentsUnitTest.py \
+        treeUnitTest.py \
+        threadsUnitTest.py
 
 
 # DISABLE PYTHON LEAK DETECTION: This suppression file shall be removed when

--- a/tdishr/TdiCompile.c
+++ b/tdishr/TdiCompile.c
@@ -53,7 +53,8 @@ int Tdi1Compile(int opcode __attribute__ ((unused)), int narg, struct descriptor
   EMPTYXD(tmp);
   struct descriptor *text_ptr;
   LockMdsShrMutex(&yacc_mutex, &yacc_mutex_initialized);
-  if (TdiThreadStatic()->compiler_recursing == 1) {
+  GET_TDITHREADSTATIC_P;
+  if (TdiThreadStatic_p->compiler_recursing == 1) {
     fprintf(stderr, "Error: Recursive calls to TDI Compile is not supported");
     return TdiRECURSIVE;
   }
@@ -63,11 +64,11 @@ int Tdi1Compile(int opcode __attribute__ ((unused)), int narg, struct descriptor
     status = TdiINVDTYDSC;
   if STATUS_OK {
     if (text_ptr->length > 0) {
-      if (TdiThreadStatic()->compiler_recursing == 1) {
+      if (TdiThreadStatic_p->compiler_recursing == 1) {
 	fprintf(stderr, "Error: Recursive calls to TDI Compile is not supported\n");
 	return TdiRECURSIVE;
       }
-      TdiThreadStatic()->compiler_recursing = 1;
+      TdiThreadStatic_p->compiler_recursing = 1;
       if (!TdiRefZone.l_zone)
 	status = LibCreateVmZone(&TdiRefZone.l_zone);
       /****************************************
@@ -76,7 +77,7 @@ int Tdi1Compile(int opcode __attribute__ ((unused)), int narg, struct descriptor
       TdiRefZone.l_status = TdiBOMB;
       lock_buffer_key();
       if (TdiRefZone.a_begin)
-        free(TdiRefZone.a_begin);
+          free(TdiRefZone.a_begin);
       TdiRefZone.a_begin = TdiRefZone.a_cur =
 	  memcpy(malloc(text_ptr->length), text_ptr->pointer, text_ptr->length);
       TdiRefZone.a_end = TdiRefZone.a_cur + text_ptr->length;
@@ -102,7 +103,7 @@ int Tdi1Compile(int opcode __attribute__ ((unused)), int narg, struct descriptor
 	  status = MdsCopyDxXd((struct descriptor *)TdiRefZone.a_result, out_ptr);
       }
       LibResetVmZone(&TdiRefZone.l_zone);
-      TdiThreadStatic()->compiler_recursing = 0;
+      TdiThreadStatic_p->compiler_recursing = 0;
     }
   }
   MdsFree1Dx(&tmp, NULL);

--- a/tdishr/TdiCull.c
+++ b/tdishr/TdiCull.c
@@ -15,7 +15,7 @@
 #include "tdirefcat.h"
 #include "tdirefstandard.h"
 #include "tdinelements.h"
-#include "tdithreadsafe.h"
+#include "tdirefzone.h"
 #include <tdishr_messages.h>
 #include <mdsshr_messages.h>
 #include <mdsshr.h>

--- a/tdishr/TdiLex.c
+++ b/tdishr/TdiLex.c
@@ -166,7 +166,7 @@ STATIC_ROUTINE int TdiLexComment(int len __attribute__ ((unused)),
 {
   char c, c1;
   int count = 1;
-
+  GET_TDITHREADSTATIC_P;
   while (count) {
     if ((c = input()) == '/') {
       if ((c1 = input()) == '*')
@@ -225,6 +225,7 @@ STATIC_ROUTINE int TdiLexFloat(int str_len, unsigned char *str, struct marker *m
 {
   struct descriptor_s str_dsc = { 0, DTYPE_T, CLASS_S, 0 };
   int bad, idx, status, tst, type;
+  GET_TDITHREADSTATIC_P;
   STATIC_CONSTANT struct {
     unsigned short length;
     unsigned char dtype;
@@ -306,7 +307,7 @@ STATIC_ROUTINE int TdiLexIdent(int len, unsigned char *str, struct marker *mark_
 {
   int j, token;
   unsigned char *str_l;
-
+  GET_TDITHREADSTATIC_P;
 /*
         upcase(str,len);
 */
@@ -395,6 +396,7 @@ STATIC_ROUTINE int TdiLexIdent(int len, unsigned char *str, struct marker *mark_
 
 STATIC_ROUTINE int TdiLexInteger(int str_len, unsigned char *str, struct marker *mark_ptr)
 {
+  GET_TDITHREADSTATIC_P;
   STATIC_ROUTINE struct {
     unsigned short length;
     unsigned char udtype, sdtype;
@@ -613,6 +615,7 @@ STATIC_ROUTINE int TdiLexInteger(int str_len, unsigned char *str, struct marker 
 */
 int TdiLexPath(int len, unsigned char *str, struct marker *mark_ptr)
 {
+  GET_TDITHREADSTATIC_P;
   int nid, token = LEX_VALUE;
   unsigned char *str_l;
   str_l = (unsigned char *)strncpy((char *)malloc(len + 1), (char *)str, len);
@@ -649,6 +652,7 @@ int TdiLexPath(int len, unsigned char *str, struct marker *mark_ptr)
 */
 STATIC_ROUTINE int TdiLexPoint(int len, unsigned char *str, struct marker *mark_ptr)
 {
+  GET_TDITHREADSTATIC_P;
   int lenx = len - 2;
   while (str[lenx + 1] == '.' || str[lenx + 1] == ':')
     --lenx;
@@ -665,6 +669,7 @@ STATIC_ROUTINE int TdiLexPoint(int len, unsigned char *str, struct marker *mark_
 */
 STATIC_ROUTINE int TdiLexBinEq(int token)
 {
+  GET_TDITHREADSTATIC_P;
   char cx;
 
   while ((cx = input()) == ' ' || cx == '\t') ;
@@ -678,6 +683,7 @@ STATIC_ROUTINE int TdiLexPunct(int len __attribute__ ((unused)),
 			       unsigned char *str,
 			       struct marker *mark_ptr)
 {
+  GET_TDITHREADSTATIC_P;
   char c0 = str[0], c1 = input();
 
   mark_ptr->rptr = 0;
@@ -834,6 +840,7 @@ int TdiLexQuote(int len __attribute__ ((unused)),
 		unsigned char *str,
 		struct marker *mark_ptr)
 {
+  GET_TDITHREADSTATIC_P;
   char c, c1, *cptr = TdiRefZone.a_cur;
   int cur = 0, limit;
 
@@ -927,6 +934,7 @@ int TdiLexQuote(int len __attribute__ ((unused)),
 #define YYNEWLINE 10
 int yylex()
 {
+  GET_TDITHREADSTATIC_P;
   int nstr;
   while ((nstr = yylook()) >= 0)
   switch (nstr) {
@@ -1494,6 +1502,7 @@ extern "C" {
 #endif				/* YY_NOPROTO */
 int yylook()
 {
+  GET_TDITHREADSTATIC_P;
   register struct yysvf *yystate, **lsp;
   register struct yywork *yyt;
   struct yysvf *yyz;
@@ -1687,6 +1696,7 @@ int yyback(int *p, int m)
 	/* the following are only used in the lex library */
 int yyinput()
 {
+  GET_TDITHREADSTATIC_P;
   return (input());
 }
 
@@ -1697,5 +1707,6 @@ void yyoutput()
 
 void yyunput(int c __attribute__ ((unused)))
 {
+  GET_TDITHREADSTATIC_P;
   unput(c);
 }

--- a/tdishr/TdiMakeFunctionTable.c
+++ b/tdishr/TdiMakeFunctionTable.c
@@ -33,7 +33,6 @@
 #define DTYPE_YY                DTYPE_HC
 
 #include "tdirefzone.h"
-
 #include "tdiyacc.h"
 YYSTYPE YYLVAL = { {0} };
 

--- a/tdishr/TdiYacc.c
+++ b/tdishr/TdiYacc.c
@@ -86,8 +86,6 @@ extern unsigned short
     OpcPostInc,
     OpcPreInc, OpcStatement, OpcSubscript, OpcUnaryMinus, OpcUnaryPlus, OpcUsing, OpcVector;
 
-struct TdiZoneStruct TdiRefZone = { 0 };
-
 extern int TdiYacc_RESOLVE();
 extern int TdiLex();
 extern int TdiYacc_IMMEDIATE();
@@ -774,6 +772,7 @@ __YYSCLASS char *yyreds[] = {
         yylval = newvalue;\
         goto yynewstate;\
 }
+//"
 #define YYRECOVERING()  (!!yyerrflag)
 #ifndef YYDEBUG
 #define YYDEBUG  1		/* make debugging available */
@@ -831,6 +830,7 @@ int yychar;			/* current input token number */
 */
 int yyparse()
 {
+  GET_TDITHREADSTATIC_P;
   register YYSTYPE *yypvt;	/* top of value stack for $vars */
 
   /*
@@ -1811,6 +1811,7 @@ int yyparse()
 
 STATIC_ROUTINE int allocate_stacks()
 {
+  GET_THREADSTATIC_P;
   /* allocate the yys and yyv stacks */
   yys = (int *)malloc(yymaxdepth * sizeof(int));
   yyv = (YYSTYPE *) malloc(yymaxdepth * sizeof(YYSTYPE));

--- a/tdishr/TdiYacc.c
+++ b/tdishr/TdiYacc.c
@@ -3,11 +3,6 @@
 #ifdef __VMS
 #pragma module TdiYacc TdiYacc
 #endif
-
-#ifdef WIN32
-//#pragma warning (disable : 4244 4102 )	/* int to short conversions and unreferenced label */
-#endif
-
 /*      TdiYacc.Y
         YACC converts this to TdiYacc.C to compile TDI statements.
         Each YACC-LEX symbol has a returned token and a yylval value.
@@ -53,19 +48,6 @@
 #include <tdishr_messages.h>
 #include <mds_stdarg.h>
 
-#ifdef ERROR
-#undef ERROR
-#endif
-#ifdef TEXT
-#undef TEXT
-#endif
-#ifdef CONST
-#undef CONST
-#endif
-#ifdef IN
-#undef IN
-#endif
-
 extern unsigned short
  OpcAbort,
     OpcAdd,
@@ -110,67 +92,8 @@ extern int TdiLexPath();
 
 STATIC_THREADSAFE struct marker _EMPTY_MARKER = { 0 };
 
-//#line 111 "TdiYacc.y"
-typedef union {
-  struct marker mark;
-} YYSTYPE;
-#ifdef __cplusplus
-#include <stdio.h>
-#include <yacc.h>
-#endif				/* __cplusplus */
-#define ERROR 257
-#define IDENT 258
-#define POINT 259
-#define TEXT 260
-#define VALUE 261
-#define BREAK 262
-#define CASE 263
-#define COND 264
-#define DEFAULT 265
-#define DO 266
-#define ELSE 267
-#define ELSEW 268
-#define FOR 269
-#define GOTO 270
-#define IF 271
-#define LABEL 272
-#define RETURN 273
-#define SIZEOF 274
-#define SWITCH 275
-#define USING 276
-#define WHERE 277
-#define WHILE 278
-#define ARG 279
-#define CAST 280
-#define CONST 281
-#define INC 282
-#define ADD 283
-#define CONCAT 284
-#define IAND 285
-#define IN 286
-#define IOR 287
-#define IXOR 288
-#define LEQV 289
-#define POWER 290
-#define PROMO 291
-#define RANGE 292
-#define SHIFT 293
-#define BINEQ 294
-#define LAND 295
-#define LEQ 296
-#define LGE 297
-#define LOR 298
-#define MUL 299
-#define UNARY 300
-#define LANDS 301
-#define LEQS 302
-#define LGES 303
-#define LORS 304
-#define MULS 305
-#define UNARYS 306
-#define FUN 307
-#define MODIF 308
-#define VBL 309
+#include "tdiyacc.h"
+
 #define yyclearin yychar = -1
 #define yyerrok yyerrflag = 0
 extern int yychar;

--- a/tdishr/TdiYaccSubs.c
+++ b/tdishr/TdiYaccSubs.c
@@ -37,6 +37,7 @@ int TdiYacc_RESOLVE();
 int TdiYacc_ARG(struct marker *mark_ptr)
 {
   INIT_STATUS;
+  GET_TDITHREADSTATIC_P;
   struct descriptor *ptr;
   struct descriptor_xd junk = EMPTY_XD;
   unsigned int len = mark_ptr->rptr->length;
@@ -77,6 +78,7 @@ int TdiYacc_BUILD(int ndesc,
 		  struct marker *arg1,
 		  struct marker *arg2, struct marker *arg3, struct marker *arg4)
 {
+  GET_TDITHREADSTATIC_P;
   struct descriptor_function *tmp;
   int dsc_size = sizeof(struct descriptor_function) + sizeof(struct descriptor *) * (ndesc - 1);
   unsigned int vm_size = dsc_size + sizeof(unsigned short);
@@ -133,6 +135,7 @@ int TdiYacc_BUILD(int ndesc,
 */
 int TdiYacc_IMMEDIATE(struct descriptor_xd **dsc_ptr_ptr)
 {
+  GET_TDITHREADSTATIC_P;
   struct descriptor_xd xd = EMPTY_XD, junk = EMPTY_XD, *ptr = *dsc_ptr_ptr;
   int status;
 
@@ -185,6 +188,7 @@ int TdiYacc_IMMEDIATE(struct descriptor_xd **dsc_ptr_ptr)
 
 int TdiYacc_RESOLVE(struct descriptor_function **out_ptr_ptr)
 {
+  GET_TDITHREADSTATIC_P;
   struct descriptor_function *out_ptr = *out_ptr_ptr;
   struct TdiFunctionStruct *this_ptr;
   int j, ndesc, opcode;

--- a/tdishr/tdirefzone.h
+++ b/tdishr/tdirefzone.h
@@ -1,3 +1,5 @@
+#ifndef TDIREFZONE_H
+#define TDIREFZONE_H
 /*	tdirefzone.h
 	References to zone used by Tdi1BUILD_FUNCTION, TdiYacc, and TdiLex_... .
 
@@ -16,9 +18,10 @@ struct TdiZoneStruct {
   struct descriptor **a_list;	/*first argument        */
   int l_rel_path;		/*keep relative paths   */
 };
-extern struct TdiZoneStruct TdiRefZone;
 
 #include <libroutines.h>
+#include "tdithreadsafe.h"
+#define TdiRefZone (TdiThreadStatic_p->TdiRefZone)
 
 struct marker {
   struct descriptor_r *rptr;
@@ -40,18 +43,18 @@ struct marker {
 #define yylex()		TdiLex()
 #define yyerror(s)	TdiRefZone.l_ok = yyval.mark.w_ok; return MDSplusERROR
 
-#define MAKE_S(dtype_in,bytes,out)\
-	{int dsc_size = sizeof(struct descriptor_s);\
-	unsigned int vm_size = dsc_size + (bytes);\
+#define MAKE_S(dtype_in,bytes,out)					\
+	{int dsc_size = sizeof(struct descriptor_s);			\
+	unsigned int vm_size = dsc_size + (bytes);			\
 	LibGetVm(&vm_size,(void *)&(out),(void *)&TdiRefZone.l_zone);	\
-	((struct descriptor *)(out))->length = bytes;		\
-	((struct descriptor *)(out))->dtype = dtype_in;		\
+	((struct descriptor *)(out))->length = bytes;			\
+	((struct descriptor *)(out))->dtype = dtype_in;			\
 	((struct descriptor *)(out))->class = CLASS_S;			\
 	((struct descriptor *)(out))->pointer = (char *)(out) + dsc_size;}
 
-#define MAKE_XD(dtype_in,bytes,out)\
-	{int dsc_size = sizeof(struct descriptor_xd);\
-	unsigned int vm_size = dsc_size + (bytes);\
+#define MAKE_XD(dtype_in,bytes,out)					\
+	{int dsc_size = sizeof(struct descriptor_xd);			\
+	unsigned int vm_size = dsc_size + (bytes);			\
 	LibGetVm(&vm_size,(void *)&(out),(void *)&TdiRefZone.l_zone);	\
 	((struct descriptor_xd *)(out))->l_length = bytes;		\
 	((struct descriptor_xd *)(out))->length = 0;			\
@@ -59,12 +62,12 @@ struct marker {
 	((struct descriptor_xd *)(out))->class = CLASS_XD;		\
 	((struct descriptor_xd *)(out))->pointer = (struct descriptor *)((char *)(out) + dsc_size);}
 
-#define MAKE_R(ndesc,dtype_in,bytes,out)\
-	{int dsc_size = sizeof($RECORD(ndesc));\
-	unsigned int vm_size = dsc_size + (bytes);\
+#define MAKE_R(ndesc,dtype_in,bytes,out)				\
+	{int dsc_size = sizeof($RECORD(ndesc));				\
+	unsigned int vm_size = dsc_size + (bytes);			\
 	LibGetVm(&vm_size,(void *)&(out),(void *)&TdiRefZone.l_zone);	\
-	((struct descriptor *)(out))->length = bytes;		\
-	((struct descriptor *)(out))->dtype = dtype_in;		\
+	((struct descriptor *)(out))->length = bytes;			\
+	((struct descriptor *)(out))->dtype = dtype_in;			\
 	((struct descriptor *)(out))->class = CLASS_R;			\
 	((struct descriptor *)(out))->pointer = (char *)(out) + dsc_size;}
 
@@ -72,3 +75,4 @@ struct marker {
 	Give an extra semicolon. Must be able to unput.
 	Caution: side effect--unput changes c pointer.
 	**********************************************/
+#endif

--- a/tdishr/tdithreadsafe.h
+++ b/tdishr/tdithreadsafe.h
@@ -1,3 +1,8 @@
+#ifndef TDIREFZONE_H
+#include "tdirefzone.h"
+#else
+#ifndef TDITHREADSAFE_H
+#define TDITHREADSAFE_H
 #include <mdsdescrip.h>
 #include <pthread_port.h>
 
@@ -17,8 +22,14 @@ typedef struct _thread_static {
   int compiler_recursing;
   struct descriptor *TdiRANGE_PTRS[3];
   struct descriptor_xd *TdiSELF_PTR;
+  struct TdiZoneStruct TdiRefZone;
 } ThreadStatic;
 
 extern ThreadStatic *TdiThreadStatic();
 extern void LockTdiMutex(pthread_mutex_t *, int *);
 extern void UnlockTdiMutex(pthread_mutex_t *);
+
+#define GET_TDITHREADSTATIC_P ThreadStatic *TdiThreadStatic_p = TdiThreadStatic()
+
+#endif
+#endif

--- a/tdishr/tdiyacc.h
+++ b/tdishr/tdiyacc.h
@@ -1,4 +1,15 @@
-
+#ifdef ERROR
+#undef ERROR
+#endif
+#ifdef TEXT
+#undef TEXT
+#endif
+#ifdef CONST
+#undef CONST
+#endif
+#ifdef IN
+#undef IN
+#endif
 typedef union {
   struct marker mark;
 } YYSTYPE;


### PR DESCRIPTION
* replaced TdiRefZone with a thread specific copy from TdiThreadStatic
* added GET_TDITHREADSTATIC_P makro to init TdiThreadStatic_p no need to call TdiThreadStatic() more than once
* added TdiRefZone makro to keep most of the code as is
* added GET_TDITHREADSTATIC_P to the head oth methods that need TdiRefZone
* free TdiRefZone.a_begin if set and TdiIntrinsic its last done: recursive == 0
* entangled tdithreadsafe.h tdirefzone.h properly so one can include either or or both