### PR TITLE
Zck treedomethod nid num

### DIFF
--- a/mdsobjects/python/tests/__init__.py
+++ b/mdsobjects/python/tests/__init__.py
@@ -11,7 +11,7 @@ def _mimportSuite(name, level=1):
     except:
         return __import__(name, globals()).suite
 
-from unittest import TestCase,TestSuite,TextTestRunner
+from unittest import TestSuite,TextTestRunner
 import os,sys
 import gc;gc.set_debug(gc.DEBUG_UNCOLLECTABLE)
 
@@ -30,37 +30,6 @@ segmentsSuite=   _mimportSuite('segmentsUnitTest')
 treeSuite=       _mimportSuite('treeUnitTest')
 threadsSuite=    _mimportSuite('threadsUnitTest')
 
-class cleanup(TestCase):
-    dir=None
-
-    def cleanup(self):
-        if cleanup.dir is not None:
-            dir=cleanup.dir
-            for i in os.walk(dir,False):
-                for f in i[2]:
-                    try:
-                      os.remove(i[0]+os.sep+f)
-                    except Exception:
-                      import sys
-                      e=sys.exc_info()[1]
-                      print( e)
-                for d in i[1]:
-                    try:
-                      os.rmdir(i[0]+os.sep+d)
-                    except Exception:
-                      import sys
-                      e=sys.exc_info()[1]
-                      print( e)
-            try:
-              os.rmdir(dir)
-            except Exception:
-              import sys
-              e=sys.exc_info()[1]
-              print( e)
-        return
-    def runTest(self):
-        self.cleanup()
-
 def test_all(*arg):
     if getenv('waitdbg') is not None:
       print("Hit return after gdb is connected\n")
@@ -73,8 +42,7 @@ def test_all(*arg):
     tests.append(exceptionSuite())
     tests.append(segmentsSuite())
     tests.append(treeSuite())
-    if os.getenv('TEST_THREADS') is not None:
-        tests.append(threadsSuite())
+    tests.append(threadsSuite())
     return TestSuite(tests)
 
 def run():

--- a/treeshr/TreeDoMethod.c
+++ b/treeshr/TreeDoMethod.c
@@ -101,7 +101,7 @@ int _TreeDoMethod(void *dbid, struct descriptor *nid_dsc, struct descriptor *met
   {0, NciEND_OF_LIST, 0, 0}
   };
   void (*addr) ();
-  static int (*TdiExecute) () = 0;
+  static int (*TdiExecute) () = NULL;
   STATIC_CONSTANT DESCRIPTOR(close, "$)");
   STATIC_CONSTANT DESCRIPTOR(arg, "$,");
   STATIC_CONSTANT DESCRIPTOR(tdishr, "TdiShr");
@@ -114,13 +114,15 @@ int _TreeDoMethod(void *dbid, struct descriptor *nid_dsc, struct descriptor *met
   void *arglist[256];
   count(nargs);
   arglist[0] = arglist_nargs(nargs);
-  if (nid_dsc->dtype != DTYPE_NID || (!nid_dsc->pointer))
+  if (!nid_dsc->pointer
+   || (nid_dsc->dtype!=DTYPE_NID
+    && nid_dsc->dtype!=DTYPE_L
+    && nid_dsc->dtype!=DTYPE_LU))
     return TreeNOMETHOD;
   head_nid = 0;
   status = _TreeGetNci(dbid, *(int *)nid_dsc->pointer, itmlst);
-  if (!(status & 1))
+  if STATUS_NOT_OK
     return status;
-
   if (conglomerate_elt || (data_type == DTYPE_CONGLOM)) {
     int i;
     arglist[1] = nid_dsc;
@@ -135,22 +137,24 @@ int _TreeDoMethod(void *dbid, struct descriptor *nid_dsc, struct descriptor *met
     conglom_ptr = (struct descriptor_conglom *)xd.pointer;
     if (conglom_ptr->dtype != DTYPE_CONGLOM)
       return TreeNOT_CONGLOM;
-    if (conglom_ptr->image && conglom_ptr->image->length == strlen("__python__")
-	&& strncmp(conglom_ptr->image->pointer, "__python__", strlen("__python__")) == 0) {
+    if (conglom_ptr->image
+     && conglom_ptr->image->length == strlen("__python__")
+     && strncmp(conglom_ptr->image->pointer, "__python__", strlen("__python__")) == 0) {
       void *dbid = *TreeCtx();
       /**** Try python class ***/
       struct descriptor_d exp = { 0, DTYPE_T, CLASS_D, 0 };
       STATIC_CONSTANT DESCRIPTOR(open, "PyDoMethod(");
       StrCopyDx((struct descriptor *)&exp, (struct descriptor *)&open);
-      if (nargs == 4 && method_ptr->length == strlen("DW_SETUP")
-	  && strncmp(method_ptr->pointer, "DW_SETUP", strlen("DW_SETUP")) == 0) {
+      if (nargs == 4
+       && method_ptr->length == strlen("DW_SETUP")
+       && strncmp(method_ptr->pointer, "DW_SETUP", strlen("DW_SETUP")) == 0) {
 	arglist[3] = arglist[4];
 	nargs--;
       }
       for (i = 1; i < nargs - 1; i++)
 	StrAppend(&exp, (struct descriptor *)&arg);
       StrAppend(&exp, (struct descriptor *)&close);
-      if (TdiExecute == 0)
+      if (!TdiExecute)
 	status = LibFindImageSymbol(&tdishr, &tdiexecute, &TdiExecute);
       if STATUS_OK {
 	for (i = nargs; i > 0; i--)
@@ -165,8 +169,7 @@ int _TreeDoMethod(void *dbid, struct descriptor *nid_dsc, struct descriptor *met
       *TreeCtx() = dbid;
       return status;
     }
-    StrConcat((struct descriptor *)&method, conglom_ptr->model, (struct descriptor *)&underunder,
-	      method_ptr MDS_END_ARG);
+    StrConcat((struct descriptor *)&method, conglom_ptr->model, (struct descriptor *)&underunder, method_ptr MDS_END_ARG);
     for (i = 0; i < method.length; i++)
       method.pointer[i] = tolower(method.pointer[i]);
     if (conglom_ptr->image && conglom_ptr->image->dtype == DTYPE_T)


### PR DESCRIPTION
* allows to manually call TreeDoMethod using the nid number instead of the nid (would have been evaluated otherwise)
* Fixes DeadLock in ServerDispatchPhase if no action to do
* use #define DEBUG to print debug messages