### PR TITLE
Fix: Use find tag instead of find node wild in create pulse for perfo…

### DIFF
--- a/treeshr/TreeCreatePulseFile.c
+++ b/treeshr/TreeCreatePulseFile.c
@@ -81,11 +81,13 @@ int _TreeCreatePulseFile(void *dbid, int shotid, int numnids_in, int *nids_in)
   if (numnids_in == 0) {
     void *ctx = 0;
     nids[0] = 0;
-    for (num = 1;
+    for (num = 0; num < 256 && _TreeFindTagWild(dbid, "TOP", &nids[num], &ctx); num++);
+    /* for (num = 1;
 	 num < 256
 	 && (_TreeFindNodeWild(dbid, "***", &nids[num], &ctx, (1 << TreeUSAGE_SUBTREE)) & 1);
 	 num++) ;
     TreeFindNodeEnd(&ctx);
+    */
   } else {
     num = 0;
     for (i = 0; i < numnids_in; i++) {


### PR DESCRIPTION
…rmance

For some reason that I cannot recall or find I had changed TreeCreatePule to
use a wildcard call to TreeFindNodeWild to identify all the subtree nodes but under
certain conditions this can be very inefficient. (The TreeFindNodeWild code probably
needs revisited to improve performance!) This change reverts the code back to use
TreeFindTag using TOP to find subtrees.