### PR TITLE
Fix: The CAENV1740__add.fun was removed but package contents not updated

### DIFF
--- a/deploy/packaging/debian/rfxdevices.noarch
+++ b/deploy/packaging/debian/rfxdevices.noarch
@@ -58,7 +58,6 @@
 ./usr/local/mdsplus/tdi/RfxDevices/CAENV1731__store.fun
 ./usr/local/mdsplus/tdi/RfxDevices/CAENV1731__trigger.fun
 ./usr/local/mdsplus/tdi/RfxDevices/CAENV1740.py
-./usr/local/mdsplus/tdi/RfxDevices/CAENV1740__add.fun
 ./usr/local/mdsplus/tdi/RfxDevices/CAENVME_FIFOBLTReadCycle.fun
 ./usr/local/mdsplus/tdi/RfxDevices/CAENVME_FIFOBLTWriteCycle.fun
 ./usr/local/mdsplus/tdi/RfxDevices/CAENVME_Init.fun

--- a/deploy/packaging/redhat/rfxdevices.noarch
+++ b/deploy/packaging/redhat/rfxdevices.noarch
@@ -59,7 +59,6 @@
 ./usr/local/mdsplus/tdi/RfxDevices/CAENV1731__store.fun
 ./usr/local/mdsplus/tdi/RfxDevices/CAENV1731__trigger.fun
 ./usr/local/mdsplus/tdi/RfxDevices/CAENV1740.py
-./usr/local/mdsplus/tdi/RfxDevices/CAENV1740__add.fun
 ./usr/local/mdsplus/tdi/RfxDevices/CAENVME_FIFOBLTReadCycle.fun
 ./usr/local/mdsplus/tdi/RfxDevices/CAENVME_FIFOBLTWriteCycle.fun
 ./usr/local/mdsplus/tdi/RfxDevices/CAENVME_Init.fun


### PR DESCRIPTION
The RFXdevices/CAENV1740__add.fun was removed since the device support
was changed to python but the change was not added to the expected contents
files.