### PR TITLE
FIX: Arrays of zero length strings cause problems in various languages.

### DIFF
--- a/javamds/mdsobjects.c
+++ b/javamds/mdsobjects.c
@@ -60,8 +60,7 @@ static jintArray getDimensions(JNIEnv * env, void *dsc)
 {
   ARRAY_COEFF(char *, 256) * arrD = dsc;
   jintArray jdims;
-  int dim = arrD->arsize / arrD->length;
-
+  int dim = (arrD->length > 0) ? arrD->arsize / arrD->length : 0;
   jdims = (*env)->NewIntArray(env, arrD->dimct);
   if (arrD->dimct == 1)
     (*env)->SetIntArrayRegion(env, jdims, 0, 1, (const jint *)&dim);
@@ -283,7 +282,7 @@ static jobject DescripToObject(JNIEnv * env, struct descriptor *desc,
       array_d = (struct descriptor_a *)desc;
 
     args[1].l = getDimensions(env, array_d);
-    length = array_d->arsize / array_d->length;
+    length = (array_d->length != 0) ? array_d->arsize / array_d->length : 0;
     switch (array_d->dtype) {
     case DTYPE_MISSING:
       return NULL;

--- a/mdsobjects/python/_descriptor.py
+++ b/mdsobjects/python/_descriptor.py
@@ -465,7 +465,7 @@ class descriptor(_C.Structure):
                         descr.arsize=descr.arsize*dim
                         shape.append(dim)
             else:
-                shape=[int(descr.arsize/descr.length),]
+                shape=[descr.arsize/descr.length if descr.length != 0 else 0,]
             if self.dtype == _dtypes.DTYPE_T:
                 return _array.StringArray(_N.ndarray(shape=shape,dtype=_N.dtype(('S',descr.length)),buffer=_ver.buffer(_C.cast(self.pointer,_C.POINTER(_C.c_byte*descr.arsize)).contents)))
 #                return StringArray(_N.chararray(shape,itemsize=descr.length,buffer=buffer(_C.cast(self.pointer,_C.POINTER(_C.c_char*descr.arsize)).contents.value)))

--- a/tcl/tcl_show_data.c
+++ b/tcl/tcl_show_data.c
@@ -313,7 +313,7 @@ static int CvtAdscT(struct descriptor_a *in_dsc_ptr, int depth, char **output)
       strcat(out_str, bchars);
     }
   } else {
-    sprintf(bchars, "%d", in_dsc_ptr->arsize / in_dsc_ptr->length);
+    sprintf(bchars, "%d", in_dsc_ptr->arsize / ((in_dsc_ptr->length)?in_dsc_ptr->length:1));
     out_str = realloc(out_str, strlen(out_str) + strlen(bchars) + 10);
     strcat(out_str, bchars);
   }


### PR DESCRIPTION
When encountering arrays of zero length strings various languages either
cause divide by zero errors or seg fault.

There are 2 cases:
1 - the array is bounded (IDL is the only way you can create one of these)
2 - the array is unbounded
These changes make the code return empty data when encountering these objects.