### PR TITLE
Fix: Better handling of text arrays of zero length srings

### DIFF
--- a/mdsobjects/python/mdsarray.py
+++ b/mdsobjects/python/mdsarray.py
@@ -217,7 +217,15 @@ class Array(_dat.Data):
         else:
             shape=[int(d.arsize/d.length),]
         if d.dtype == StringArray.dtype_id:
-            return StringArray(getNumpy(_N.dtype(('S',d.length)),_C.c_byte,d.arsize))
+            if d.length == 0:
+                strarr=''
+                for dim in shape:
+                    if dim > 0:
+                        strarr=[strarr]*dim
+                ans = StringArray(_N.array(strarr))
+            else:
+                ans = StringArray(getNumpy(_N.dtype(('S',d.length)),_C.c_byte,d.arsize))
+            return ans
         if d.dtype == _tre.TreeNode.dtype_id:
             d.dtype=Int32Array.dtype_id
             nids=getNumpy(_N.int32,_C.c_int32,int(d.arsize/d.length))
@@ -364,7 +372,8 @@ class StringArray(Array):
         elif not value.flags.writeable:
             value = value.copy()
         for i in _ver.xrange(len(value.flat)):
-            value.flat[i]=value.flat[i].ljust(value.itemsize)
+            vlen=len(value.flat[i])
+            value.flat[i]=value.flat[i].ljust(vlen)
         self._value = value
     @property
     def value(self):

--- a/tdishr/TdiVector.c
+++ b/tdishr/TdiVector.c
@@ -166,6 +166,11 @@ int Tdi1Vector(int opcode, int narg, struct descriptor *list[], struct descripto
       status = TdiConvert((*pdat)[j].pointer, &arr MDS_END_ARG);
       arr.pointer += arr.arsize;
     }
+    if (arr.length == 0 && arr.dtype == DTYPE_T && arr.dimct == 1) {
+      arr.aflags.coeff = 1;
+      arr.m[0] = narg;
+      status = MdsCopyDxXd((struct descriptor *)&arr, out_ptr);
+    }
   }
 
 	/*************************

--- a/tdishr/tdinelements.h
+++ b/tdishr/tdinelements.h
@@ -10,7 +10,19 @@
 	else {\
 		switch (dsc_ptr->class) {\
 		default : count = 0; status = TdiINVCLADSC; break;\
-		case CLASS_A : count = ((int)dsc_ptr->length > 0) ? (int)((struct descriptor_a *)dsc_ptr)->arsize / (int)dsc_ptr->length : 0; break;\
+		case CLASS_A : {				  \
+		  array_coeff *aptr = (array_coeff *)dsc_ptr; \
+		  count = 0; \
+		  if (aptr->length != 0) { \
+		    count = aptr->arsize / aptr->length; \
+	          } else if ( aptr->dtype == DTYPE_T && aptr->aflags.coeff == 1 ) { \
+		    int i; \
+		    for (i=0;i<aptr->dimct;i++) { \
+		      if (count == 0) count=aptr->m[i]; else count=count*aptr->m[i]; \
+		    }\
+		  }\
+		  break;\
+ 	        }\
 		case CLASS_S : case CLASS_D : count = 1; break;\
 		} \
 	}


### PR DESCRIPTION
When an array of strings is created using, for example, ['',''],
an array descriptor is created with length=0 and arsize=0 but with aflags.coeff set and
dimct and m[0:dimct-1] filled in. This enables the determination of number of elements and
shape without using length and arsize. Many tdishr function still rely on length and arsize
so not all functions will work on these empty string arrays yet. Since the code prior to this
commit didn't work with empty string arrays this commit shouldn't break anything that was
working in ealier versions.