### PR TITLE
Fix: Fix mdsip connect to remove bind to eth0

### DIFF
--- a/mdstcpip/ioroutinestcp.h
+++ b/mdstcpip/ioroutinestcp.h
@@ -181,9 +181,6 @@ static int io_connect(int conid, char *protocol __attribute__ ((unused)), char *
         fcntl(sock, F_SETFL, 0);
 #endif
     } else {
-#if !defined(_WIN32) && defined(SO_BINDTODEVICE)
-      err = setsockopt(sock, SOL_SOCKET, SO_BINDTODEVICE, "eth0", strlen("eth0"));
-#endif
       err = connect(sock, (struct sockaddr *)&sin, sizeof(sin));
     }
     if (err == -1) {


### PR DESCRIPTION
At some point a bind to eth0 was added to the TCP plugin to mdsip
and this breaks mdsconnect on any system that does not use eth0
to connect to the remote system.