### PR TITLE
FIX - show server command after a stop server command crashes 

### DIFF
--- a/servershr/ServerSendMessage.c
+++ b/servershr/ServerSendMessage.c
@@ -230,8 +230,11 @@ int ServerSendMessage(int *msgid, char *server, int op, int *retstatus, pthread_
       return status;
   }
   status = GetAnswerInfoTS(conid, &dtype, &len, &ndims, dims, &numbytes, (void **)&dptr, &mem);
-  if STATUS_NOT_OK
+  if STATUS_NOT_OK {
     perror("Error: no response from server");
+      CleanupJob(status, jobid);
+      return status;
+  }
   if (mem)
     free(mem);
   return status;


### PR DESCRIPTION
doing a double free

After sending a stop server command, the 'read answer info' call returns an
error, which is fine, since the server does not answer, however the error
case was only doing perror, and then falling through to the free of any
allocated memory.  Since the 'job' never completes, the job is still in the
que.  When the next 'show server' command comes along free(malloc) chokes
because it is trying to free memory that is not allocated.