### PR TITLE
Feature: Add command line recall to tditest

### DIFF
--- a/mdsobjects/python/tests/dclUnitTest.py
+++ b/mdsobjects/python/tests/dclUnitTest.py
@@ -119,7 +119,7 @@ class dclTests(TestCase):
             if port==0:
                 if fix0: port = default_port
                 else: return None,0
-            return 'LOCALHOST:%d'%(port,),port
+            return 'localhost:%d'%(port,),port
         def start_mdsip(server,port,logname,env=None):
             if port>0:
                 from subprocess import Popen,STDOUT

--- a/tditest/Makefile.in
+++ b/tditest/Makefile.in
@@ -16,5 +16,5 @@ clean :
 	@ $(RM) @MAKEBINDIR@tditest$(EXE)
 
 @MAKEBINDIR@tditest$(EXE) : $(SOURCES)
-	$(LINK.c) $(OUTPUT_OPTION) $^ -L@MAKESHLIBDIR@ -lTdiShr -lTreeShr -lMdsShr $(LIBS) $(LIBSOCKET)
+	$(LINK.c) $(OUTPUT_OPTION) $^ -L@MAKESHLIBDIR@ -lTdiShr -lTreeShr -lMdsShr $(LIBS) $(LIBSOCKET) @LIBREADLINE@
 

--- a/tditest/tditest.c
+++ b/tditest/tditest.c
@@ -1,32 +1,75 @@
 #include <string.h>
 #include <stdio.h>
+#include <stdlib.h>
+#include <readline/readline.h>
+#include <readline/history.h>
 #include <mdsdescrip.h>
 #include <mds_stdarg.h>
 #define MAXEXPR 16384
 #include <tdishr.h>
 
+static char *history_file=NULL;
+
 static void tdiputs(char *line);
+
+static char *getExpression(FILE *f_in, char *command) {
+  char line_in[MAXEXPR] = {0};
+  char *ans;
+  if ( f_in == NULL ) {
+    ans = readline("");
+  } else {
+    ans = fgets(line_in, MAXEXPR-1, f_in);
+    if (ans) {
+      if (ans[strlen(ans)-1]=='\n')
+	ans[strlen(ans)-1]='\0';
+      ans=strdup(ans);
+    }	
+  }
+  if (ans && strlen(ans) > 0 && ans[strlen(ans)-1] == '\\' ) {
+    ans[strlen(ans)-1]='\0';
+    ans = getExpression(f_in, ans);
+  }
+  if (command) {
+    char *newcmd=strcpy(malloc(strlen(command)+strlen(ans)+1),command);
+    strcat(newcmd,ans);
+    free(command);
+    free(ans);
+    ans = newcmd;
+  }
+  return ans;
+}
+  
 int main(int argc, char **argv)
 {
-  FILE *in = stdin;
+  FILE *f_in = NULL;
   int status;
-/*
-  static char expr[MAXEXPR] = "WRITE(_OUTPUT_UNIT,`DECOMPILE(`";
-*/
-  static char expr[MAXEXPR] = "";
-  static struct descriptor expr_dsc = { 0, DTYPE_T, CLASS_S, (char *)expr };
+  static struct descriptor expr_dsc = { 0, DTYPE_T, CLASS_S, 0};
   static EMPTYXD(ans);
   static EMPTYXD(output_unit);
   static DESCRIPTOR(out_unit_stdout, "PUBLIC _OUTPUT_UNIT=*");
   static DESCRIPTOR(out_unit_other, "PUBLIC _OUTPUT_UNIT=FOPEN($,'w')");
   static DESCRIPTOR(reset_output_unit, "PUBLIC _OUTPUT_UNIT=$");
-  int prefixlen = strlen(expr);
-  char line_in[MAXEXPR];
+  char *command=NULL;
   if (argc > 1) {
-    in = fopen(argv[1], "r");
-    if (in == (FILE *) 0) {
+    f_in = fopen(argv[1], "r");
+    if (f_in == (FILE *) 0) {
       printf("Error opening input file /%s/\n", argv[1]);
       return 0;
+    }
+  }
+  else {
+#ifdef _WIN32
+    char *home = getenv("USERPROFILE");
+    char *sep = "\\";
+#else
+    char *home = getenv("HOME");
+    char *sep = "/";
+#endif
+    if (home) {
+      char *history = ".tditest";
+      history_file = malloc(strlen(history) + strlen(home) + strlen(history) + 1);
+      sprintf(history_file, "%s%s%s", home, sep, history);
+      read_history(history_file);
     }
   }
   if (argc > 2) {
@@ -36,32 +79,38 @@ int main(int argc, char **argv)
     TdiExecute((struct descriptor *)&out_unit_other, &out_d, &output_unit MDS_END_ARG);
   } else
     TdiExecute((struct descriptor *)&out_unit_stdout, &output_unit MDS_END_ARG);
-  while (fgets(line_in, MAXEXPR-1, in) != NULL) {
-    int comment = line_in[0] == '!';
-    size_t len = strlen(line_in);
+  while ((command=getExpression(f_in,NULL)) != NULL &&
+	 strcasecmp(command,"exit") != 0 &&
+	 strcasecmp(command,"quit") != 0) {
+    int comment = command[0] == '!';
     if (!comment) {
       TdiExecute((struct descriptor *)&reset_output_unit, &output_unit, &ans MDS_END_ARG);
-      tdiputs(line_in);
-    }
-    if ( len>1 ) while ( line_in[len - 2] == '\\' ){
-      fgets(&line_in[len - 2], MAXEXPR - len + 2, in);
-      if (!comment)
-	tdiputs(&line_in[len - 2]);
-      len = strlen(line_in);
+      if (f_in) tdiputs(command);
     }
     if (!comment) {
       static DESCRIPTOR(error_out, "_MSG=DEBUG(0),DEBUG(4),WRITE($,_MSG)");
       static DESCRIPTOR(clear_errors, "WRITE($,DECOMPILE($)),DEBUG(4)");
-      expr[prefixlen] = 0;
-      strcat(expr, line_in);
-      strcat(line_in, " = ");
-      expr_dsc.length = strlen(expr);
+      expr_dsc.length = strlen(command);
+      expr_dsc.pointer = command;
       status = TdiExecute((struct descriptor *)&expr_dsc, &ans MDS_END_ARG);
-      if (status & 1)
+      if (status & 1) {
+	add_history(command);
 	TdiExecute((struct descriptor *)&clear_errors, &output_unit, &ans, &ans MDS_END_ARG);
+      }
       else
 	TdiExecute((struct descriptor *)&error_out, &output_unit, &ans MDS_END_ARG);
     }
+    if (command) {
+      free(command);
+      command=NULL;
+    }
+  }
+  if (command) {
+    free(command);
+  }
+  if (history_file) {
+    write_history(history_file);
+    free(history_file);
   }
   return 1;
 }


### PR DESCRIPTION
This change adds command line recall to the tditest utility.
If tditest is executed without any arguments it will save expressions
it receives and successfully evaluates in a history file. The command
line recall supports readline keystroke macros for doing things like
searching for a command in the history etc. Also  the echo of the comm
ands entered from stdin are no longer echoed.