### PR TITLE
FIX: add library to jScope and jTraverser - fixes mac SIP problem

### DIFF
--- a/javascope/jScope.template
+++ b/javascope/jScope.template
@@ -19,4 +19,4 @@ LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$MDSPLUS_DIR/${lib} \
 SHLIB_PATH=$SHLIB_PATH:$MDSPLUS_DIR/${lib} \
 DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH:$MDSPLUS_DIR/${lib} \
 CLASSPATH=$HOME:$MDSPLUS_DIR/java/classes/jScope.jar:$MDSPLUS_DIR/java/classes \
-$java -Xmx512M jScope $1 $2 $3 $4 $5 $6 $7
+$java -Xmx512M -Djava.library.path=$MDSPLUS_DIR/${lib}  jScope $1 $2 $3 $4 $5 $6 $7

--- a/javatraverser/jTraverser.template
+++ b/javatraverser/jTraverser.template
@@ -19,4 +19,4 @@ LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$MDSPLUS_DIR/${lib} \
 SHLIB_PATH=$SHLIB_PATH:$MDSPLUS_DIR/${lib} \
 DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH:$MDSPLUS_DIR/${lib} \
 CLASSPATH=$MDSPLUS_DIR/java/classes/jTraverser.jar:$MDSPLUS_DIR/java/classes/jScope.jar:$MDSPLUS_DIR/java/classes/jDevices.jar \
-$java -Xss5M jTraverser $1 $2 $3 $4 $5 $6 $7
+$java -Xss5M -Djava.library.path=$MDSPLUS_DIR/${lib} jTraverser $1 $2 $3 $4 $5 $6 $7


### PR DESCRIPTION
Novimir Pablant found that adding -Djava.library.path=$MDSPLUS_DIR/${lib}
to the jTraverser command allowed him to fire it up even with macintosh
SIP (System Integrity Protection) enabled.

tested on linux, works there also.