### PR TITLE
Build: Add --promote_to=<branch> option on trigger script

### DIFF
--- a/deploy/promote.sh
+++ b/deploy/promote.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+#
+# Promote a branch (i.e. stable) to the current head of another branch (i.e. alpha)
+#
+# Format: promote.sh git-source-dir 
+BRANCH=$1
+PROMOTE_TO=$2
+set -v
+set -e
+git checkout ${PROMOTE_TO}
+git pull
+git checkout ${BRANCH}
+git rebase -q -s ours ${PROMOTE_TO}
+set +e
+git pull -q -s recursive -X theirs 2>/dev/null
+set -e
+git status | grep "modified:" | awk '{system("git checkout '${PROMOTE_TO}' -- "$2)}'
+git status | grep "deleted by us:" | awk '{system("git rm "$4)}'
+git commit -m "Feature: Promote ${BRANCH} to ${PROMOTE_TO}"
+git push


### PR DESCRIPTION
This should enable us to add an option promote option on release builds
such as the jenkins stable release build job to optionally perform a promotion
of stable to the alpha head and creating a stable release with the same version
and content as the current alpha branch.