### PR TITLE
Zck python ctx

### DIFF
--- a/mdsobjects/python/tests/dclUnitTest.py
+++ b/mdsobjects/python/tests/dclUnitTest.py
@@ -17,7 +17,7 @@ class dclTests(TestCase):
     @property
     def shot(self):
         return self.index*dclTests.shotinc+1
-    def _doTCLTest(self,expr,out=None,err=None,re=False):
+    def _doTCLTest(self,expr,out=None,err=None,re=False,tcl=tcl):
         def checkre(pattern,string):
             if pattern is None:
                 self.assertEqual(string is None,True)
@@ -166,6 +166,7 @@ class dclTests(TestCase):
                 self._doTCLTest('show server %s'%server,out=show_server,re=True)
                 testDispatchCommand(server,'set verify')
                 testDispatchCommand(server,'type test')
+                self._doTCLTest('set tree pytree/shot=%d'%shot)
                 self._doTCLTest('dispatch/build%s'%monitor_opt)
                 self._doTCLTest('dispatch/phase%s INIT'%monitor_opt)
                 sleep(1)

--- a/mdsobjects/python/tests/treeUnitTest.py
+++ b/mdsobjects/python/tests/treeUnitTest.py
@@ -2,7 +2,7 @@ from unittest import TestCase,TestSuite
 import os
 from threading import Lock
 
-from MDSplus import Tree,TreeNode,Data,makeArray,Signal,Range,DateToQuad,Device,Int32Array
+from MDSplus import Tree,TreeNode,Data,makeArray,Signal,Range,DateToQuad,Device,Int32Array,tree,tcl
 from MDSplus import getenv,setenv
 
 class treeTests(TestCase):
@@ -45,6 +45,41 @@ class treeTests(TestCase):
         cls.envx[name] = value
         setenv(name,value)
 
+    @classmethod
+    def tearDownClass(cls):
+        import gc,shutil
+        gc.collect()
+        with cls.lock:
+            cls.instances -= 1
+            if not cls.instances>0:
+                shutil.rmtree(cls.tmpdir)
+
+    def treeCtx(self):
+        def check(n):
+            self.assertEqual((tree._TreeCtx.gettctx().ctx,n),tree._TreeCtx.ctxs.items()[0])
+        self.assertEqual(tree._TreeCtx.ctxs,{})  # neither tcl nor tdi has been called yet
+        tcl('edit pytree/shot=%d/new'%self.shot);check(1)
+        Data.execute('$EXPT'); check(1)
+        t = Tree();            check(2)
+        Data.execute('tcl("dir", _out)'); check(2)
+        del(t);                check(1)
+        Data.execute('_out');check(1)
+        t = Tree('pytree',self.shot+1,'NEW');
+        self.assertEqual(tree._TreeCtx.ctxs[tree._TreeCtx.gettctx().ctx],1)
+        self.assertEqual(tree._TreeCtx.ctxs[t.ctx.value],1)
+        Data.execute('tcl("close")');
+        self.assertEqual(tree._TreeCtx.ctxs[tree._TreeCtx.gettctx().ctx],1)
+        self.assertEqual(tree._TreeCtx.ctxs[t.ctx.value],1)
+        self.assertEqual(str(t),'Tree("PYTREE",%d,"Edit")'%(self.shot+1,))
+        self.assertEqual(str(Data.execute('tcl("show db", _out);_out')),"\n")
+        del(t)
+        check(1)  # tcl/tdi context remains until end of session
+        t = Tree('pytree',self.shot+1,'NEW');
+        self.assertEqual(tree._TreeCtx.ctxs[tree._TreeCtx.gettctx().ctx],1)
+        self.assertEqual(tree._TreeCtx.ctxs[t.ctx.value],1)
+        del(t)
+        check(1)
+
     def buildTrees(self):
         with Tree('pytree',self.shot,'new') as pytree:
             if pytree.shot != self.shot:
@@ -80,7 +115,7 @@ class treeTests(TestCase):
             node.compress_on_put=True
             node.record=Signal(Range(2.,2000.,2.),None,Range(1.,1000.))
             ip=pytreesub_top.addNode('ip','signal')
-            rec=Data.compile("Build_Signal(Build_With_Units(\\MAG_ROGOWSKI.SIGNALS:ROG_FG + 2100. * \\BTOR, 'ampere'), *, DIM_OF(\\BTOR))")
+            rec=pytreesub.tdiCompile("Build_Signal(Build_With_Units(\\MAG_ROGOWSKI.SIGNALS:ROG_FG + 2100. * \\BTOR, 'ampere'), *, DIM_OF(\\BTOR))")
             ip.record=rec
             ip.tag='MAG_PLASMA_CURRENT'
             ip.tag='MAGNETICS_PLASMA_CURRENT'
@@ -91,15 +126,6 @@ class treeTests(TestCase):
                 node=pytreesub_top.addNode('child%02d' % (i,),'structure')
                 node.addDevice('dt200_%02d' % (i,),'dt200').on=False
             pytreesub.write()
-
-    @classmethod
-    def tearDownClass(cls):
-        import gc,shutil
-        gc.collect()
-        with cls.lock:
-            cls.instances -= 1
-            if not cls.instances>0:
-                shutil.rmtree(cls.tmpdir)
 
     def openTrees(self):
         pytree = Tree('pytree',self.shot)
@@ -293,7 +319,7 @@ class treeTests(TestCase):
             self.__getattribute__(test)()
     @staticmethod
     def getTests():
-        return ['buildTrees','openTrees','getNode','setDefault','nodeLinkage','nciInfo','getData','segments','getCompression']
+        return ['treeCtx',]#'buildTrees','openTrees','getNode','setDefault','nodeLinkage','nciInfo','getData','segments','getCompression']
     @classmethod
     def getTestCases(cls):
         return map(cls,cls.getTests())

--- a/mdsobjects/python/tree.py
+++ b/mdsobjects/python/tree.py
@@ -16,6 +16,7 @@ _data=_mimport('mdsdata')
 _scalar=_mimport('mdsscalar')
 _treenode=_mimport('treenode')
 _tdishr=_mimport('_tdishr')
+_mdsdcl=_mimport('mdsdcl')
 
 class _ThreadData(_threading.local):
     def __init__(self):
@@ -674,6 +675,9 @@ class Tree(object):
         finally:
             Tree.unlock()
 
+    def tcl(self,*args,**kwargs):
+        kwargs['ctx'] = self.ctx
+        return _mdsdcl.tcl(*args,**kwargs)
     def tdiCompile(self,*args,**kwargs):
         """Compile a TDI expression. Format: tdiCompile('expression-string',(arg1,...))"""
         kwargs['ctx'] = self.ctx
@@ -698,3 +702,4 @@ class Tree(object):
         """Return primitive data type. Format: tdiData(value)"""
         kwargs['ctx'] = self.ctx
         return _tdishr.TdiData(*args,**kwargs)
+

--- a/mdsobjects/python/treenode.py
+++ b/mdsobjects/python/treenode.py
@@ -14,6 +14,7 @@ _Exceptions=_mimport('mdsExceptions')
 _scalar=_mimport('mdsscalar')
 _tree=_mimport('tree')
 _treeshr=_mimport('_treeshr')
+_tdishr=_mimport('_tdishr')
 _mdsdcl=_mimport('mdsdcl')
 _ver=_mimport('version')
 
@@ -227,7 +228,7 @@ class TreeNode(_data.Data):
             try:
                 self.restoreContext()
                 try:
-                    ans = _data.Data.execute('getnci($,$)',self,name)
+                    ans = _tdishr.TdiExecute('getnci($,$)',(self,name),ctx=self.tree.ctx)
                     if isinstance(ans,_scalar.Uint8):
                         if name not in ('class','dtype'):
                             ans = bool(ans)

--- a/tdishr/TdiExtFunction.c
+++ b/tdishr/TdiExtFunction.c
@@ -79,7 +79,7 @@ int Tdi1ExtFunction(int opcode __attribute__ ((unused)),
 {
   INIT_STATUS;
   struct descriptor_d image = EMPTY_D, entry = EMPTY_D;
-  struct descriptor_xd tmp[253];
+  struct descriptor_xd tmp[253];tmp[0]=EMPTY_XD;
   struct descriptor_d file = { 0, DTYPE_T, CLASS_D, 0 };
   FREED_ON_EXIT(&image);
   FREED_ON_EXIT(&entry);


### PR DESCRIPTION
restores the tdi/tcl context properly
hierarchy:
1. ctx argument (e.g. to work on specific Tree() object)
2. local tree context _TreeCtx.gettctx() (e.g. to handle trees using the static tdi and dcl methods)
3. current database =switchDbid() (e.g. when called as pyfun from external program)
4. use empty db and init it as local if required (opened=True)