### PR TITLE
Fix: ensure TreeOpenEdit uses a null pointer for ctx if no ctx argume…

### DIFF
--- a/mdsobjects/python/_treeshr.py
+++ b/mdsobjects/python/_treeshr.py
@@ -260,7 +260,9 @@ def TreeOpenNew(tree,shot):
         raise _Exceptions.statusToException(status)
     return ctx
 
-def TreeOpenEdit(tree,shot,ctx=_C.c_void_p(0)):
+def TreeOpenEdit(tree,shot,ctx=None):
+    if ctx is None:
+      ctx=_C.c_void_p(0)
     status = __TreeOpenEdit(_C.byref(ctx),_ver.tobytes(tree),shot)
     if not (status & 1):
         raise _Exceptions.statusToException(status)


### PR DESCRIPTION
…nt supplied

The existing code passed the default context by reference to TreeOpenEdit which
ended up changing the actual default from a pointer to null to the ctx set by the
TreeOpenEdit call so the next time the python method was called it did not behave as
expected and passed a pointer to memory that had been freed. This fixes this problem.