### PR TITLE
FIX: Strings G than 32 K bytes can not be put over thin connections

### DIFF
--- a/mdstcpip/SendArg.c
+++ b/mdstcpip/SendArg.c
@@ -4,7 +4,7 @@
 
 
 
-int SendArg(int id, unsigned char idx, char dtype, unsigned char nargs, short length, char ndims,
+int SendArg(int id, unsigned char idx, char dtype, unsigned char nargs, unsigned short length, char ndims,
 	    int *dims, char *bytes)
 {
   int status;

--- a/mdstcpip/mdsip_connections.h
+++ b/mdstcpip/mdsip_connections.h
@@ -633,7 +633,7 @@ EXPORT int ReuseCheck(char *hostin, char *unique, size_t buflen);
 /// succesfully sent or false otherwise.
 ///
 EXPORT int SendArg(int id, unsigned char idx, char dtype, unsigned char nargs,
-                   short length, char ndims, int *dims, char *bytes);
+                   unsigned short length, char ndims, int *dims, char *bytes);
 
 ////////////////////////////////////////////////////////////////////////////////
 ///


### PR DESCRIPTION
The length argument to SendArg in mdstcpip was types as short instead of
as unsigned short.  This caused a negative number to arrive at this call
when called from python Connection object when the argument was > 32K bytes.

Change the declaration to 'unsigned short'