### PR TITLE
Build: Fix install cleanup of .class files

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -156,9 +156,9 @@ $(install_DIRS):
 .PHONY: install
 install: ##@build build and install active modules to prefix directory
 install: $(install_DIRS)
-	- find $(prefix)/java -name '*.class' -delete #### No need to include class files
 	$(MKDIR_P) $(prefix)/local/tdi
 	$(MKDIR_P) $(prefix)/java
+	- find $(prefix)/java -name '*.class' -delete #### No need to include class files
 	tar -C ${top_srcdir} \
 		--exclude='.gitignore' \
 		--exclude='*.pyc' \


### PR DESCRIPTION
The top level install removes .class files from the install root since only
the jar files are needed. If java build is disabled the install cleanup failed
because the java directory does not exits. This moves the cleanup until after
a java directory is created.