### PR TITLE
Fix: threadsafe dclDocs

### DIFF
--- a/conf/gcc-lsan.supp
+++ b/conf/gcc-lsan.supp
@@ -4,6 +4,7 @@ leak:MdsShrGetThreadStatic
 leak:mdsdclGetThreadStatic
 leak:mdsdclSetPrompt
 leak:mdsdclSetDefFile
+leak:mdsdclAllocDocDef
 leak:TreeGetThreadStatic
 leak:TdiGetThreadStatic
 leak:TRACE

--- a/mdsdcl/cmdExecute.c
+++ b/mdsdcl/cmdExecute.c
@@ -17,10 +17,10 @@
 #include "dcl_p.h"
 #include "mdsdclthreadsafe.h"
 
-static dclDocListPtr dclDocs = 0;
 
 dclDocListPtr mdsdcl_getdocs(){
-  return dclDocs;
+  GET_THREADSTATIC_P;
+  return DCLDOCS;
 }
 
 /*! Free the memory associated with a parameter definition structure.
@@ -54,8 +54,7 @@ void freeParameter(dclParameterPtr * p_in){
  \param q [in,out] The address of a pointer to a dclQualifier struct
 */
 
-static void freeQualifier(dclQualifierPtr * q_in)
-{
+static void freeQualifier(dclQualifierPtr * q_in){
   if (q_in) {
     dclQualifierPtr q = *q_in;
     if (q) {
@@ -83,8 +82,7 @@ static void freeQualifier(dclQualifierPtr * q_in)
  \param cmdDef [in] A pointer to a dclCommand structure.
 */
 
-void freeCommandParamsAndQuals(dclCommandPtr cmdDef)
-{
+void freeCommandParamsAndQuals(dclCommandPtr cmdDef){
   if (cmdDef) {
     int i;
     if (cmdDef->parameter_count > 0) {
@@ -108,8 +106,7 @@ void freeCommandParamsAndQuals(dclCommandPtr cmdDef)
  \param cmd [in,out] The address of a pointer to a dclCommand structure
 */
 
-static void freeCommand(dclCommandPtr * cmd_in)
-{
+static void freeCommand(dclCommandPtr * cmd_in){
   if (cmd_in) {
     dclCommandPtr cmd = *cmd_in;
     if (cmd) {
@@ -142,8 +139,7 @@ static void freeCommand(dclCommandPtr * cmd_in)
 
 */
 
-static void findVerbInfo(xmlNodePtr node, dclCommandPtr cmd)
-{
+static void findVerbInfo(xmlNodePtr node, dclCommandPtr cmd){
 
   /* If the parent node is a verb */
 
@@ -1005,6 +1001,14 @@ static void mdsdclSetupCommands(xmlDocPtr doc)
   }
 }
 
+
+
+/* Static shared list of parsed docs */
+static dclDocListPtr SdclDocs = NULL;
+STATIC_THREADSAFE pthread_mutex_t SdclDocs_lock   = PTHREAD_MUTEX_INITIALIZER;
+#define   LOCK_SDCLDOCS pthread_mutex_lock  (&SdclDocs_lock);
+#define UNLOCK_SDCLDOCS pthread_mutex_unlock(&SdclDocs_lock);
+
 /*! Add a command table by parsing an xml command definition file.
     The file is located in a directory specified by an environment
     variable "MDSXML" or the current directory if that environment
@@ -1014,7 +1018,6 @@ static void mdsdclSetupCommands(xmlDocPtr doc)
   \param error [out] An error message if trouble finding and/or parsing
                      the xml command definition file.
 */
-
 EXPORT int mdsdclAddCommands(const char *name_in, char **error)
 {
   size_t i;
@@ -1044,24 +1047,35 @@ EXPORT int mdsdclAddCommands(const char *name_in, char **error)
   strcat(commands, "_commands");
   free(name);
 
-  /* See if that command table has already been loaded. If it has, pop that table
+  /* See if that command table has already been loaded in the private list. If it has, pop that table
      to the top of the stack and return */
-
-  for (doc_l = dclDocs, doc_p = 0; doc_l; doc_p = doc_l, doc_l = doc_l->next) {
+  GET_THREADSTATIC_P;
+  for (doc_l = DCLDOCS, doc_p = 0; doc_l; doc_p = doc_l, doc_l = doc_l->next) {
     if (strcmp(doc_l->name, commands) == 0) {
       if (doc_p) {
 	doc_p->next = doc_l->next;
-	doc_l->next = dclDocs;
-	dclDocs = doc_l;
+	doc_l->next = DCLDOCS;
+	DCLDOCS = doc_l;
       }
       free(commands);
-      mdsdclSetupCommands(dclDocs->doc);
+      mdsdclSetupCommands(DCLDOCS->doc);
+      return 0;
+    }
+  }
+  /* See if that command table has already been loaded in the static list. If it has, add that table
+     to the top of the private stack and return */
+  LOCK_SDCLDOCS;
+  for (doc_l = SdclDocs; doc_l ; doc_l = doc_l->next) {
+    if (strcmp(doc_l->name, commands) == 0) {
+      UNLOCK_SDCLDOCS; // no need to hold it as tail is immutable
+      mdsdclAllocDocDef(doc_l);
+      free(commands);
+      mdsdclSetupCommands(DCLDOCS->doc);
       return 0;
     }
   }
 
   /* Initialize the xml parser */
-
   xmlInitParser();
 
   /* Look for command definitions in $MDSPLUS_DIR/xml/ */
@@ -1086,21 +1100,23 @@ EXPORT int mdsdclAddCommands(const char *name_in, char **error)
   /* If cannot find the file or parse it, set the error string */
 
   if (doc == 0) {
+    UNLOCK_SDCLDOCS;
     char *errstr = malloc(strlen(filename) + 50);
     sprintf(errstr, " Error: unable to parse %s\n", filename);
     *error = errstr;
     status = -1;
   } else {
-
-    /* else stick the parsed xml document at the top of the command stack */
-
+    /* else stick the parsed xml document at the top of the command stack
+    doc_p for the private entry and doc_l for the static one*/
     doc_l = malloc(sizeof(dclDocList));
     doc_l->name = commands;
     doc_l->doc = doc;
-    doc_l->next = dclDocs;
-    dclDocs = doc_l;
+    doc_l->next = SdclDocs;
+    SdclDocs = doc_l;
+    UNLOCK_SDCLDOCS;
+    mdsdclAllocDocDef(doc_l);
     status = 0;
-    mdsdclSetupCommands(dclDocs->doc);
+    mdsdclSetupCommands(DCLDOCS->doc);
   }
   free(filename);
   return status;
@@ -1157,7 +1173,8 @@ int cmdExecute(dclCommandPtr cmd, char **prompt_out, char **error_out,
   char *output = 0;
   dclDocListPtr doc_l;
   cmd->image=0;
-  if (dclDocs == NULL)
+  GET_THREADSTATIC_P;
+  if (!DCLDOCS)
     mdsdclAddCommands("mdsdcl_commands", &error);
   if (mdsdclVerify() && strlen(cmd->command_line) > 0) {
     char *prompt = mdsdclGetPrompt();
@@ -1173,7 +1190,7 @@ int cmdExecute(dclCommandPtr cmd, char **prompt_out, char **error_out,
     }
     free(prompt);
   }
-  for (doc_l = dclDocs; doc_l != NULL &&
+  for (doc_l = DCLDOCS; doc_l != NULL &&
        invalid_command(status) && (status != MdsdclPROMPT_MORE); doc_l = doc_l->next) {
     dclCommandPtr cmdDef = memset(malloc(sizeof(dclCommand)), 0, sizeof(dclCommand));
     cmdDef->verb = strdup(cmd->verb);

--- a/mdsdcl/mdsdclThreadSafe.c
+++ b/mdsdcl/mdsdclThreadSafe.c
@@ -6,42 +6,38 @@
 #include <stdlib.h>
 #include <string.h>
 /* Key for the thread-specific buffer */
-STATIC_THREADSAFE int is_init = B_FALSE;
 STATIC_THREADSAFE pthread_key_t buffer_key;
 /* Once-only initialisation of the key */
-STATIC_THREADSAFE pthread_rwlock_t buffer_lock   = PTHREAD_RWLOCK_INITIALIZER;
-#define WRLOCK_BUFFER pthread_rwlock_wrlock(&buffer_lock);
-#define RDLOCK_BUFFER pthread_rwlock_rdlock(&buffer_lock);
-#define UNLOCK_BUFFER pthread_rwlock_unlock(&buffer_lock);
+STATIC_THREADSAFE pthread_once_t buffer_key_once = PTHREAD_ONCE_INIT;
 
 /* Free the thread-specific buffer */
 STATIC_ROUTINE void buffer_destroy(void *buf){
-  if (buf) {
-    ThreadStatic *ThreadStatic_p = (ThreadStatic *)buf;
-    if (ThreadStatic_p) {
-      if (PROMPT) free(PROMPT);
-      if (DEF_FILE) free(DEF_FILE);
+  ThreadStatic *ThreadStatic_p = (ThreadStatic *)buf;
+  if (ThreadStatic_p) {
+    if (PROMPT) free(PROMPT);
+    if (DEF_FILE) free(DEF_FILE);
+    dclDocListPtr next,dcl = DCLDOCS;
+    for (;dcl;) {
+      next = dcl->next;
+      free(dcl);
+      dcl=next;
     }
-    free(buf);
   }
+  free(buf);
 }
+STATIC_ROUTINE void buffer_key_alloc(){
+  pthread_key_create(&buffer_key, buffer_destroy);
+}
+
 /* Return the thread-specific buffer */
 ThreadStatic *mdsdclGetThreadStatic(){
-  ThreadStatic *p;
-  RDLOCK_BUFFER;
-  if (!is_init) {
-    UNLOCK_BUFFER;
-    WRLOCK_BUFFER;
-    pthread_key_create(&buffer_key, buffer_destroy);
-    is_init = B_TRUE;
+  pthread_once(&buffer_key_once, buffer_key_alloc);
+  void* p = pthread_getspecific(buffer_key);
+  if (!p) {
+    p = calloc(1, sizeof(ThreadStatic));
+    pthread_setspecific(buffer_key, p);
   }
-  p = (ThreadStatic *) pthread_getspecific(buffer_key);
-  if (p == NULL) {
-    p = (ThreadStatic *) memset(calloc(1, sizeof(ThreadStatic)), 0, sizeof(ThreadStatic));
-    pthread_setspecific(buffer_key, (void *)p);
-  }
-  UNLOCK_BUFFER;
-  return p;
+  return (ThreadStatic *)p;
 }
 
 void mdsdclSetPrompt(const char *prompt){
@@ -66,6 +62,15 @@ void mdsdclSetDefFile(const char *deffile){
     DEF_FILE = strdup(deffile + 1);
   else
     DEF_FILE = strdup(deffile);
+}
+
+void mdsdclAllocDocDef(dclDocListPtr doc_l){
+  GET_THREADSTATIC_P;
+  dclDocListPtr doc_p = malloc(sizeof(dclDocList));
+  doc_p->name = doc_l->name;
+  doc_p->doc  = doc_l->doc;
+  doc_p->next = DCLDOCS;
+  DCLDOCS = doc_p;
 }
 
 #ifdef PTHREAD_RECURSIVE_MUTEX_INITIALIZER

--- a/mdsdcl/mdsdclthreadsafe.h
+++ b/mdsdcl/mdsdclthreadsafe.h
@@ -3,16 +3,19 @@
 typedef struct _ThreadStatic {
 char *prompt;
 char *def_file;
+dclDocListPtr dclDocs;
 } ThreadStatic;
 
 #define GET_THREADSTATIC_P ThreadStatic *ThreadStatic_p = mdsdclGetThreadStatic()
 #define PROMPT   (ThreadStatic_p->prompt)
 #define DEF_FILE (ThreadStatic_p->def_file)
+#define DCLDOCS  (ThreadStatic_p->dclDocs)
 
 
 extern ThreadStatic *mdsdclGetThreadStatic();
 extern void mdsdclSetPrompt(const char *prompt);
 extern char *mdsdclGetPrompt();
 extern void mdsdclSetDefFile(const char *deffile);
+extern void mdsdclAllocDocDef(dclDocListPtr doc_l);
 extern void dclLock();
 extern void dclUnlock();


### PR DESCRIPTION
use a shared static list to hold the parsed doc or read in xmls
use a thread private list to hold the current order with pointers to the static entries