### PR TITLE
Build: Add java build to alpine armhf os

### DIFF
--- a/deploy/platform/alpine/alpine_docker_build.sh
+++ b/deploy/platform/alpine/alpine_docker_build.sh
@@ -17,7 +17,7 @@ gethost() {
 }
 
 getjava() {
-    if [ "$ARCH" = "armhf" ]; then echo "--disable-java"; fi
+    if [ "$ARCH" = "armhfxxxxx" ]; then echo "--disable-java"; fi
 }
 
 if [ -z "$host" ]


### PR DESCRIPTION
With new jars_dir build option the java packages should be available for armhf