### PR TITLE
Fix: MdsValue termination argument must be Null pointer

### DIFF
--- a/camshr/RemCamMulti.c
+++ b/camshr/RemCamMulti.c
@@ -55,7 +55,7 @@ static void getiosb(int serverid, short *iosb)
 {
   int status;
   struct descrip ans_d = { 0, 0, {0}, 0, 0 };
-  status = MdsValue(serverid, "_iosb", &ans_d, 0);
+  status = MdsValue(serverid, "_iosb", &ans_d, NULL);
   if (status & 1 && ans_d.dtype == DTYPE_USHORT && ans_d.ndims == 1 && ans_d.dims[0] == 4) {
     memcpy(RemCamLastIosb, ans_d.ptr, 8);
     if (iosb)
@@ -69,7 +69,7 @@ static void getdata(int serverid, void *data)
 {
   int status;
   struct descrip ans_d = { 0, 0, {0}, 0, 0 };
-  status = MdsValue(serverid, "_data", &ans_d, 0);
+  status = MdsValue(serverid, "_data", &ans_d, NULL);
   if (status & 1 && (ans_d.dtype == DTYPE_USHORT || ans_d.dtype == DTYPE_LONG) && ans_d.ptr)
     memcpy(data, ans_d.ptr, ((ans_d.dtype == DTYPE_USHORT) ? 2 : 4) * ans_d.dims[0]);
   if (ans_d.ptr)
@@ -93,9 +93,9 @@ static int DoCamMulti(char *routine, char *name, int a, int f, int count, void *
       data_d.dtype = mem < 24 ? DTYPE_SHORT : DTYPE_LONG;
       data_d.dims[0] = count;
       data_d.ptr = data;
-      status = MdsValue(serverid, cmd, &data_d, &ans_d, 0);
+      status = MdsValue(serverid, cmd, &data_d, &ans_d, NULL);
     } else {
-      status = MdsValue(serverid, cmd, &ans_d, 0);
+      status = MdsValue(serverid, cmd, &ans_d, NULL);
     }
     if (status & 1 && ans_d.dtype == DTYPE_LONG && ans_d.ptr) {
       memcpy(&status, ans_d.ptr, 4);
@@ -117,7 +117,7 @@ int RemCamSetMAXBUF(char *name, int new)
     struct descrip ans_d = { 0, 0, {0}, 0, 0};
     char cmd[512];
     sprintf(cmd, "CamSetMAXBUF('%s',%d)", name, new);
-    status = MdsValue(serverid, cmd, &ans_d, 0);
+    status = MdsValue(serverid, cmd, &ans_d, NULL);
     if (status & 1 && ans_d.dtype == DTYPE_LONG && ans_d.ptr) {
       memcpy(&status, ans_d.ptr, 4);
       free(ans_d.ptr);
@@ -136,7 +136,7 @@ int RemCamGetMAXBUF(char *name)
     struct descrip ans_d = { 0, 0, {0}, 0, 0 };
     char cmd[512];
     sprintf(cmd, "CamGetMAXBUF('%s')", name);
-    status = MdsValue(serverid, cmd, &ans_d, 0);
+    status = MdsValue(serverid, cmd, &ans_d, NULL);
     if (status & 1 && ans_d.dtype == DTYPE_LONG && ans_d.ptr) {
       memcpy(&status, ans_d.ptr, 4);
       free(ans_d.ptr);

--- a/camshr/RemCamSingle.c
+++ b/camshr/RemCamSingle.c
@@ -44,7 +44,7 @@ static void getiosb(int serverid, short *iosb)
 {
   int status;
   struct descrip ans_d = { 0, 0, {0}, 0, 0};
-  status = MdsValue(serverid, "_iosb", &ans_d, 0);
+  status = MdsValue(serverid, "_iosb", &ans_d, NULL);
   if (status & 1 && ans_d.dtype == DTYPE_USHORT && ans_d.ndims == 1 && ans_d.dims[0] == 4) {
     memcpy(RemCamLastIosb, ans_d.ptr, 8);
     if (iosb)
@@ -58,7 +58,7 @@ static void getdata(int serverid, void *data)
 {
   int status;
   struct descrip ans_d = { 0, 0, {0}, 0, 0};
-  status = MdsValue(serverid, "_data", &ans_d, 0);
+  status = MdsValue(serverid, "_data", &ans_d, NULL);
   if (status & 1 && (ans_d.dtype == DTYPE_USHORT || ans_d.dtype == DTYPE_LONG) && ans_d.ptr)
     memcpy(data, ans_d.ptr, (ans_d.dtype == DTYPE_USHORT) ? 2 : 4);
   if (ans_d.ptr)
@@ -81,9 +81,9 @@ static int CamSingle(char *routine, char *name, int a, int f, void *data, int me
     if (writeData) {
       data_d.dtype = mem < 24 ? DTYPE_SHORT : DTYPE_LONG;
       data_d.ptr = data;
-      status = MdsValue(serverid, cmd, &data_d, &ans_d, 0);
+      status = MdsValue(serverid, cmd, &data_d, &ans_d, NULL);
     } else {
-      status = MdsValue(serverid, cmd, &ans_d, 0);
+      status = MdsValue(serverid, cmd, &ans_d, NULL);
     }
     if (status & 1 && ans_d.dtype == DTYPE_LONG && ans_d.ptr) {
       memcpy(&status, ans_d.ptr, 4);

--- a/dwscope/evaluate.c
+++ b/dwscope/evaluate.c
@@ -700,13 +700,13 @@ Boolean EvaluateData(Boolean brief, int row, int col, int idx, Boolean * event,
   int status;
   long sock = Connect();
   ival = row;
-  status = MdsValue(sock, "_ROW=$", &id, &ans, 0);
+  status = MdsValue(sock, "_ROW=$", &id, &ans, NULL);
   FreeDescrip(ans)
       ival = col;
-  status = MdsValue(sock, "_COLUMN=$", &id, &ans, 0);
+  status = MdsValue(sock, "_COLUMN=$", &id, &ans, NULL);
   FreeDescrip(ans)
       ival = idx;
-  status = MdsValue(sock, "_INDEX=$", &id, &ans, 0);
+  status = MdsValue(sock, "_INDEX=$", &id, &ans, NULL);
   FreeDescrip(ans)
       if (strlen(database)) {
     if (strlen(shot)) {
@@ -715,7 +715,7 @@ Boolean EvaluateData(Boolean brief, int row, int col, int idx, Boolean * event,
       if (!
 	  (MdsValue
 	   (sock, "long(execute($))", MakeDescrip(&tmp, DTYPE_CSTRING, 0, NULL, shot), &ans,
-	    0) & 1))
+	    NULL) & 1))
 	return Error(brief, "Error evaluating shot number", error, ans.ptr, &ans);
       shotnum = *(int *)ans.ptr;
       if (event) {
@@ -734,29 +734,29 @@ Boolean EvaluateData(Boolean brief, int row, int col, int idx, Boolean * event,
       return Error(1, "Error opening database", error, NULL, NULL);
   }
   if (strlen(default_node)) {
-    MdsValue(sock, "TreeShr->TreeSetDefaultNid(val(0))", &ans, 0);
+    MdsValue(sock, "TreeShr->TreeSetDefaultNid(val(0))", &ans, NULL);
     FreeDescrip(ans);
     if (!(MdsSetDefault(sock, default_node) & 1))
       return Error(1, "Default node not found", error, NULL, NULL);
   } else {
-    MdsValue(sock, "TreeShr->TreeSetDefaultNid(val(0))", &ans, 0);
+    MdsValue(sock, "TreeShr->TreeSetDefaultNid(val(0))", &ans, NULL);
     FreeDescrip(ans);
   }
   if (strlen(y)) {
     Descrip(yans, 0, NULL);
     String yexp = XtMalloc(strlen(y) + 100);
     sprintf(yexp, "_y$$dwscope = (%s),f_float(data(_y$$dwscope))", y);
-    if (MdsValue(sock, yexp, &yans, 0) & 1) {
+    if (MdsValue(sock, yexp, &yans, NULL) & 1) {
       int count = Nelements(&yans);
       if (count >= 1) {
 	Descrip(xans, 0, NULL);
 	if (strlen(x)) {
 	  String xexp = XtMalloc(strlen(x) + 100);
 	  sprintf(xexp, "f_float(data(%s))", x);
-	  status = MdsValue(sock, xexp, &xans, 0);
+	  status = MdsValue(sock, xexp, &xans, NULL);
 	  XtFree(xexp);
 	} else
-	  status = MdsValue(sock, "f_float(data(dim_of(_y$$dwscope)))", &xans, 0);
+	  status = MdsValue(sock, "f_float(data(dim_of(_y$$dwscope)))", &xans, NULL);
 	if (status & 1) {
 	  int xcount = Nelements(&xans);
 	  if (xcount < count)
@@ -799,7 +799,7 @@ Boolean EvaluateText(String text, String error_prefix, String * text_ret, String
     Descrip(tmp, 0, NULL);
     if (MdsValue
 	(sock, "trim(adjustl(execute($)))", MakeDescrip(&tmp, DTYPE_CSTRING, 0, NULL, text), &ans,
-	 0) & 1) {
+	 NULL) & 1) {
       *text_ret = XtNewString(ans.ptr);
       FreeDescrip(ans);
     } else {

--- a/mdstcpip/MdsSetCompression.c
+++ b/mdstcpip/MdsSetCompression.c
@@ -20,7 +20,7 @@ int MdsSetCompression(int id, int level)
     char expression[128];
     struct descrip ans = {0};
     sprintf(expression, "MdsSetCompression(%d)", level);
-    MdsValue(id, expression, &ans, 0);
+    MdsValue(id, expression, &ans, NULL);
     if (ans.ptr != 0)
       free(ans.ptr);
   }

--- a/mdstcpip/testing/mdsiptest.c
+++ b/mdstcpip/testing/mdsiptest.c
@@ -16,7 +16,7 @@ int main(int argc, char **argv)
   if (sock != -1) {
     printf("status from MdsOpen = %d\n", MdsOpen(sock, "main", -1));
     ans.ptr = 0;
-    if (MdsValue(sock, "f_float(member)", &ans, 0) & 1) {
+    if (MdsValue(sock, "f_float(member)", &ans, NULL) & 1) {
       printf("%g\n", *(float *)ans.ptr);
       val = *(float *)ans.ptr;
       val = val + (float)1.;
@@ -27,10 +27,10 @@ int main(int argc, char **argv)
       ans.ptr = 0;
     }
     vald.ptr = (void *)&val;
-    status = MdsPut(sock, "member", "$", &vald, 0);
+    status = MdsPut(sock, "member", "$", &vald, NULL);
     if (!(status & 1))
       printf("Error during put %d\n", status);
-    if (MdsValue(sock, "42.0", &ans, 0) & 1)
+    if (MdsValue(sock, "42.0", &ans, NULL) & 1)
       printf("%g\n", *(float *)ans.ptr);
     else
       printf("%s\n", (char *)ans.ptr);

--- a/php/mdsplus.c
+++ b/php/mdsplus.c
@@ -112,7 +112,7 @@ static char *mdsplus_translate_status(int socket, int status)
   struct descrip ans;
   int tmpstat;
   sprintf(expression, "getmsg(%d)", status);
-  tmpstat = MdsValue(socket, expression, &ans, 0);
+  tmpstat = MdsValue(socket, expression, &ans, NULL);
   if (tmpstat & 1 && ans.ptr)
     return (char *)ans.ptr;
   else {
@@ -409,7 +409,7 @@ PHP_FUNCTION(mdsplus_value)
   expression_len = (int)zexpression_len;
   mdsplus_replace_error(0, 1);
   if (num_args == 2)
-    status = MdsValue(socket, expression, &ans, 0);
+    status = MdsValue(socket, expression, &ans, NULL);
   else {
     int dims[7] = { 0, 0, 0, 0, 0, 0, 0 };
     if (zend_get_parameters_array_ex(num_args, args) != SUCCESS)
@@ -589,7 +589,7 @@ PHP_FUNCTION(mdsplus_put)
   expression_len = (int)zexpression_len;
   mdsplus_replace_error(0, 1);
   if (num_args == 3)
-    status = MdsPut(socket, node, expression, &ans, 0);
+    status = MdsPut(socket, node, expression, &ans, NULL);
   else {
     int dims[7] = { 0, 0, 0, 0, 0, 0, 0 };
     char putexp[512];

--- a/treeshr/RemoteAccess.c
+++ b/treeshr/RemoteAccess.c
@@ -301,7 +301,7 @@ STATIC_ROUTINE int MdsValue0(int socket, char *exp, struct descrip *ans)
       return status;
   }
   LockMdsShrMutex(&IOMutex, &IOMutex_initialized);
-  status = (*MdsValue) (socket, exp, ans, 0);
+  status = (*MdsValue) (socket, exp, ans, NULL);
   UnlockMdsShrMutex(&IOMutex);
   return status;
 }
@@ -315,7 +315,7 @@ STATIC_ROUTINE int MdsValue1(int socket, char *exp, struct descrip *arg1, struct
       return status;
   }
   LockMdsShrMutex(&IOMutex, &IOMutex_initialized);
-  status = (*MdsValue) (socket, exp, arg1, ans, 0);
+  status = (*MdsValue) (socket, exp, arg1, ans, NULL);
   UnlockMdsShrMutex(&IOMutex);
   return status;
 }


### PR DESCRIPTION
MdsValue was called in several places with a terminating 32-bit integer 0
instead of a NULL pointer causing unpredictable behavior.