### PR TITLE
Build: Move winebottle to /tmp directory to prevent directory recursi…

### DIFF
--- a/deploy/platform/windows/windows_docker_build.sh
+++ b/deploy/platform/windows/windows_docker_build.sh
@@ -8,8 +8,8 @@
 # publish:
 # /publish/$branch/MDSplus-*.exe
 #
-test64="64 x86_64-w64-mingw32 bin_x86_64 bin_x86_64"
-test32="32 i686-w64-mingw32   bin_x86    bin_x86"
+test64="64 x86_64-w64-mingw32 bin_x86_64 bin_x86_64 --with-winebottle=/tmp/winebottle-64"
+test32="32 i686-w64-mingw32   bin_x86    bin_x86 --with-winebottle=/tmp/winebottle-32"
 export JNI_INCLUDE_DIR=/source/3rd-party-apis/windows-jdk
 export JNI_MD_INCLUDE_DIR=/source/3rd-party-apis/windows-jdk/win32
 buildrelease() {


### PR DESCRIPTION
…on in jenkins

Jenkins searches the workspace for build artifacts and the wine directory causes
recursion since it has a hard symlink to the system root directory. This will move
the winebottles to the /tmp directory instead of being created in the jenkins workspace.