### PR TITLE
Build: Fix macos compiler warnings

### DIFF
--- a/configure
+++ b/configure
@@ -635,6 +635,7 @@ USE_TM_GMTOFF
 USE_PIPED_MESSAGING
 uiddir
 XM_LIBS
+THREAD
 TDIC
 TAR_EXCLUDE
 TARGET_ARCH
@@ -840,7 +841,6 @@ READLINE_LDFLAGS
 READLINE_CPPFLAGS
 LIBSOCKET
 MAKEETCDIR
-THREAD
 VS_FALSE
 VS_TRUE
 MINGW_FALSE
@@ -8020,7 +8020,6 @@ FOR_LDFLAGS=""
 SHARETYPE=".so"
 
 THREAD="-pthread"
-
 MITDEVICESIO_TARGETS=""
 case "$host" in
 *mingw*)
@@ -8162,8 +8161,9 @@ case "$host" in
        HUP_TO_XINETD="/etc/rc.d/init.d/xinetd restart";
        HUP_TO_INETD="kill -HUP \`/sbin/pidof inetd\`";;
 *apple-darwin*) echo "Configuring for MacOS X";
+       THREAD=""
        MACOSX="macosx"
-       CFLAGS="$CFLAGS -arch x86_64 -arch i386 -dynamic";
+       CFLAGS="$CFLAGS -arch x86_64 -arch i386 -dynamic -Wno-error=unused-command-line-argument -Wno-missing-field-initializers -Wno-parentheses-equality";
        FCFLAGS="$FCFLAGS -fno-range-check"
        FORLD="gfortran"
        FOR_LDFLAGS="-shared"
@@ -17132,6 +17132,7 @@ fi
 if test "x$mandir" = x"\${datarootdir}/man"; then :
   mandir="${datarootdir}/man"
 fi
+
 
 
 

--- a/configure.ac
+++ b/configure.ac
@@ -378,7 +378,6 @@ FOR_LDFLAGS=""
 SHARETYPE=".so"
 
 THREAD="-pthread"
-AC_SUBST([THREAD])
 MITDEVICESIO_TARGETS=""
 case "$host" in
 *mingw*)
@@ -520,8 +519,9 @@ case "$host" in
        HUP_TO_XINETD="/etc/rc.d/init.d/xinetd restart";
        HUP_TO_INETD="kill -HUP \`/sbin/pidof inetd\`";;
 *apple-darwin*) echo "Configuring for MacOS X";
+       THREAD=""
        MACOSX="macosx"
-       CFLAGS="$CFLAGS -arch x86_64 -arch i386 -dynamic";
+       CFLAGS="$CFLAGS -arch x86_64 -arch i386 -dynamic -Wno-error=unused-command-line-argument -Wno-missing-field-initializers -Wno-parentheses-equality";
        FCFLAGS="$FCFLAGS -fno-range-check"
        FORLD="gfortran"
        FOR_LDFLAGS="-shared"
@@ -1274,6 +1274,7 @@ AC_SUBST(SYBASE_LIB)
 AC_SUBST([TARGET_ARCH])
 AC_SUBST(TAR_EXCLUDE)
 AC_SUBST(TDIC)
+AC_SUBST([THREAD])
 AC_SUBST(UIL)
 AC_SUBST(XM_LIBS)
 AC_SUBST(uiddir)

--- a/deploy/platform/macosx/macosx_build.sh
+++ b/deploy/platform/macosx/macosx_build.sh
@@ -35,7 +35,7 @@ fi
 MAKE=${MAKE:="env LANG=en_US.UTF-8 make"}
 if [ -z "$JARS_DIR" ]
 then
-    JAVA_OPTS="--with-java_target=6 --with-java_bootclasspath=/source/rt.jar"
+    JAVA_OPTS="--with-java_target=6 --with-java_bootclasspath=${SRCDIR}/rt.jar"
 else
     JAVA_OPTS="--with-jars=${JARS_DIR}"
 fi

--- a/idlmdswidgets/cw_wveditv5.c
+++ b/idlmdswidgets/cw_wveditv5.c
@@ -11,7 +11,6 @@
 #include <X11/Xatom.h>
 #include <X11/cursorfont.h>
 #include <Xm/Text.h>
-#include <malloc.h>
 #include "export.h"
 
 enum callback_id { CB_UNKNOWN, CB_AUTOSCALE, CB_CROSSHAIRS, CB_LIMITS, CB_MOVE, CB_STRETCH,

--- a/include/mdsobjects.h
+++ b/include/mdsobjects.h
@@ -40,7 +40,9 @@
 #  define NOEXCEPT noexcept
 # else
 #  define NOEXCEPT throw()
-#  define nullptr NULL
+#  ifndef nullptr
+#    define nullptr NULL
+#  endif
 # endif
 
 ///@}

--- a/include/mdsplus/ConditionVar.hpp
+++ b/include/mdsplus/ConditionVar.hpp
@@ -18,11 +18,12 @@
 #include <pthread.h>
 #endif
 
-#ifdef MDS_MAC
+#ifdef MDS_MACxxx
 #include <mach/clock.h>
 #include <mach/mach.h>
-
+#ifndef CLOCK_REALTIME
 #define CLOCK_REALTIME 0
+#endif
 static void clock_gettime(int dummyClock __attribute__ ((unused)), timespec * ts) {
 	clock_serv_t cclock;
 	mach_timespec_t mts;

--- a/javamds/mdsobjects.c
+++ b/javamds/mdsobjects.c
@@ -2691,7 +2691,7 @@ JNIEXPORT jint JNICALL Java_MDSplus_TreeNode_addDevice
     (JNIEnv * env, jclass cls __attribute__ ((unused)), jint nid, jint ctx1, jint ctx2, jstring jname, jstring jtype) {
   const char *name;
   const char *type;
-  int status, newNid, defNid = -1;
+  int status, newNid=-1, defNid = -1;
   void *ctx = getCtx(ctx1, ctx2);
 
   name = (*env)->GetStringUTFChars(env, jname, 0);

--- a/mdsdcl/mdsdcl.c
+++ b/mdsdcl/mdsdcl.c
@@ -182,7 +182,7 @@ int main(int argc, char const *argv[])
 	  hist = remove_history(where_history());
 	  if (hist) {
 	    if (hist->line)
-	      free(hist->line);
+	      free((void *)hist->line);
 	    free(hist);
 	  }
 

--- a/mdsdcl/mdsdcl_commands.c
+++ b/mdsdcl/mdsdcl_commands.c
@@ -2,6 +2,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <ctype.h>
 #include <mdsdcl_messages.h>
 #include <sys/time.h>
 #ifdef HAVE_SYS_RESOURCE_H
@@ -204,7 +205,7 @@ EXPORT int mdsdcl_set_verify(void *ctx, char **error __attribute__ ((unused)), c
 	 ****************************************************************/
 EXPORT int mdsdcl_define_symbol(void *ctx, char **error, char **output __attribute__ ((unused)))
 {
-  char *name, *value;
+  char *name=NULL, *value=NULL;
   int status = cli_get_value(ctx, "SYMBOL", &name);
   if STATUS_NOT_OK {
     *error = malloc(100);

--- a/mdsdcl/mdsdcl_show_version.c.in
+++ b/mdsdcl/mdsdcl_show_version.c.in
@@ -2,7 +2,6 @@
 #include <config.h>
 #include <string.h>
 #include <stdio.h>
-#include <malloc.h>
 
 EXPORT int mdsdcl_show_version(void *ctx __attribute__ ((unused)), char **error __attribute__ ((unused)), char **output)
 {

--- a/servershr/ServerSendMessage.c
+++ b/servershr/ServerSendMessage.c
@@ -308,7 +308,7 @@ static void DoBeforeAst(int jobid)
 {
   Job *j;
   void *astparam = NULL;
-  void (*before_ast) ();
+  void (*before_ast) () = NULL;
   LOCK_JOBS;
   for (j = Jobs; j && (j->jobid != jobid); j = j->next) ;
   if (j) {

--- a/tdishr/TdiApd.c
+++ b/tdishr/TdiApd.c
@@ -55,8 +55,8 @@ int UnwrapComma(int narg, struct descriptor *list[], int *nout_p, struct descrip
   return status;
 }
 
-int Tdi1Apd(char dtype, int narg, struct descriptor *list[], struct descriptor_xd *out_ptr){
-  struct descriptor_a arr = { sizeof(void*), dtype, CLASS_APD, (void*)0, 0, 0, {0}, 1, 0};
+int Tdi1Apd(int dtype, int narg, struct descriptor *list[], struct descriptor_xd *out_ptr){
+  struct descriptor_a arr = { sizeof(void*), (unsigned char)(dtype & 0xff), CLASS_APD, (void*)0, 0, 0, {0}, 1, 0};
   if (narg==0) return MdsCopyDxXd((struct descriptor*)&arr, out_ptr);
   struct descriptor **alist, **olist;
   int osize, asize, alen;


### PR DESCRIPTION
The clang compiler on macosx is finding more compiler warnings.
Some need fixing while others just need to be suppressed.