### PR TITLE
Zck python ctx DO_NOT_MERGE_YET

### DIFF
--- a/deploy/commit_type_check.sh
+++ b/deploy/commit_type_check.sh
@@ -4,7 +4,7 @@
 #
 # The original commit is passed in as an argument ("origin" for pull requests and
 # the last release tag for release builds.
-# 
+#
 # The second argument to this script should be the filespec of the contents of an
 # email to be sent to the person who created a commit with an invalid title.
 #
@@ -24,16 +24,16 @@ awk -v EMAILMSG="$2" -F: '{ IGNORECASE=1
                    VERSION="PATCH"
                  }
                  OK="1"
-                 break 
+                 break
                case "Tests":
 	       case "Revert \"Tests":
-               case "Docs": 
+               case "Docs":
 	       case "Revert \"Docs":
                case "Build":
 	       case "Revert \"Build":
                  if ( VERSION == "" ) {
                    VERSION="SAME"
-                 }                 
+                 }
                  OK="1"
                  break
                default:

--- a/mdsobjects/python/apd.py
+++ b/mdsobjects/python/apd.py
@@ -1,4 +1,4 @@
-# 
+#
 # Copyright (c) 2017, Massachusetts Institute of Technology All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -79,7 +79,7 @@ class Apd(_array.Array):
     def tree(self,tree):
         for desc in self.descs:
             if isinstance(desc,_data.Data):
-                desc.tree=tree
+                desc._setTree(tree)
 
     @classmethod
     def fromDescriptor(cls,d):

--- a/mdsobjects/python/apd.py
+++ b/mdsobjects/python/apd.py
@@ -86,7 +86,7 @@ class Apd(_array.Array):
         num   = int(d.arsize/d.length)
         dptrs = _C.cast(d.pointer,_C.POINTER(_C.c_void_p*num)).contents
         descs = [_descriptor.pointerToObject(dptr,d.tree) for dptr in dptrs]
-        return cls(descs)._setCtx(d.ctx)
+        return cls(descs)._setTree(d.tree)
 
 
     def __hasBadTreeReferences__(self,tree):
@@ -122,7 +122,7 @@ class Apd(_array.Array):
         @rtype: Data|tuple
         """
         try:
-            return self.descs[idx]._setCtx(self.ctx)
+            return self.descs[idx]._setTree(self.tree)
         except:
             return
 
@@ -145,7 +145,7 @@ class Apd(_array.Array):
         """Return the descriptor indexed by idx. (indexes start at 0).
         @rtype: Data
         """
-        return self[idx]._setCtx(self.ctx)
+        return self[idx]._setTree(self.tree)
 
     def setDescs(self,descs):
         """Set the descriptors of the Apd.

--- a/mdsobjects/python/compound.py
+++ b/mdsobjects/python/compound.py
@@ -77,8 +77,7 @@ class Compound(_dat.Data):
     def tree(self,tree):
         for arg in self._args:
             if isinstance(arg,_dat.Data):
-                try: arg._setTree(tree)
-                except: print(arg)
+                arg._setTree(tree)
 
     def __hasBadTreeReferences__(self,tree):
         for arg in self._args:

--- a/mdsobjects/python/compound.py
+++ b/mdsobjects/python/compound.py
@@ -54,10 +54,6 @@ class Compound(_dat.Data):
             if k in self.fields:
                 self.setDescAt(self._fields[k],v)
 
-    def _setCtx(self,ctx):
-        self.ctx = ctx
-        return self
-
     def _str_bad_ref(self):
         return '%s(%s)'%(self.__class__.__name__,','.join([str(d) for d in self.getDescs()]))
 

--- a/mdsobjects/python/compound.py
+++ b/mdsobjects/python/compound.py
@@ -1,4 +1,4 @@
-# 
+#
 # Copyright (c) 2017, Massachusetts Institute of Technology All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -77,7 +77,8 @@ class Compound(_dat.Data):
     def tree(self,tree):
         for arg in self._args:
             if isinstance(arg,_dat.Data):
-                arg.tree=tree
+                try: arg._setTree(tree)
+                except: print(arg)
 
     def __hasBadTreeReferences__(self,tree):
         for arg in self._args:
@@ -241,8 +242,7 @@ class Compound(_dat.Data):
             else:
                 opcptr=_C.cast(d.pointer,_C.POINTER(_C.c_uint32))
             ans.opcode = opcptr.contents.value
-        ans.tree=d.tree
-        return ans
+        return ans._setTree(d.tree)
 
 class Action(Compound):
     """

--- a/mdsobjects/python/descriptor.py
+++ b/mdsobjects/python/descriptor.py
@@ -48,7 +48,6 @@ def pointerToObject(pointer,tree=None):
 
 class Descriptor(object):
     tree=None
-    ctx=None
     dclass_id = 0
     class _structure_class(_C.Structure):
         _fields_=[("length",_C.c_ushort),
@@ -60,14 +59,10 @@ class Descriptor(object):
     @property
     def value(self):
         if self.dclass:
-            d=self.desc_class(self._structure,self.__dict__)._setCtx(self.ctx)
-            try:
-                d.tree=self.tree
-            except:
-                pass
-            return d.value
-    def _setCtx(self,ctx):
-        self.ctx=ctx
+            return self.desc_class(self._structure,self.__dict__)._setTree(self.tree).value
+    def _setTree(self,tree):
+        _tre = _mimport('tree')
+        if isinstance(tree,_tre.Tree): self.tree=tree
         return self
 
     @property
@@ -141,7 +136,7 @@ class Descriptor_s(Descriptor):
     @property
     def value(self):
         if self.dtype:
-            return dtypeToClass[self.dtype].fromDescriptor(self)._setCtx(self.ctx)
+            return dtypeToClass[self.dtype].fromDescriptor(self)._setTree(self.tree)
 
 class Descriptor_d(Descriptor_s):
     dclass_id = 2
@@ -161,12 +156,7 @@ class Descriptor_xs(Descriptor_s):
     @property
     def value(self):
         if self.l_length and self.pointer:
-            d = Descriptor(self.pointer,self.__dict__)._setCtx(self.ctx)
-            try:
-                d.tree = self.tree
-            except:
-                pass
-            return d.value
+            return Descriptor(self.pointer,self.__dict__)._setTree(self.tree).value
 
 class Descriptor_xd(Descriptor_xs):
     dclass_id = 192
@@ -207,7 +197,7 @@ class Descriptor_a(Descriptor):
     @property
     def value(self):
         if self.dtype:
-            return dtypeToArrayClass[self.dtype].fromDescriptor(self)._setCtx(self.ctx)
+            return dtypeToArrayClass[self.dtype].fromDescriptor(self)._setTree(self.tree)
     @property
     def binscale(self):
         return bool(self.aflags & 8)
@@ -260,7 +250,7 @@ class Descriptor_ca(Descriptor_a):
     def value(self):
         xd = Descriptor_xd()
         _exc.checkStatus(_MdsShr.MdsDecompress(self.ptr,xd.ptr))
-        return xd._setCtx(self.ctx).value
+        return xd._setTree(self.tree).value
 
 class Descriptor_apd(Descriptor_a):
     dclass_id = 196

--- a/mdsobjects/python/descriptor.py
+++ b/mdsobjects/python/descriptor.py
@@ -1,4 +1,4 @@
-# 
+#
 # Copyright (c) 2017, Massachusetts Institute of Technology All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -42,9 +42,7 @@ _MdsShr=_ver.load_library('MdsShr')
 
 def pointerToObject(pointer,tree=None):
     if not pointer: return None
-    d=Descriptor(pointer)
-    d.tree=tree
-    return d.value
+    return Descriptor(pointer)._setTree(tree).value
 
 class Descriptor(object):
     tree=None

--- a/mdsobjects/python/mdsarray.py
+++ b/mdsobjects/python/mdsarray.py
@@ -41,10 +41,6 @@ _cmd=_mimport('compound')
 class Array(_dat.Data):
     ctype = None
     __MAX_DIM = 8
-    @property
-    def tree(self):      return None
-    @tree.setter
-    def tree(self,tree): pass
     @property  # used by numpy.array
     def __array_interface__(self):
         data = self.value

--- a/mdsobjects/python/mdsarray.py
+++ b/mdsobjects/python/mdsarray.py
@@ -41,6 +41,10 @@ _cmd=_mimport('compound')
 class Array(_dat.Data):
     ctype = None
     __MAX_DIM = 8
+    @property
+    def tree(self):      return None
+    @tree.setter
+    def tree(self,tree): pass
     @property  # used by numpy.array
     def __array_interface__(self):
         data = self.value
@@ -52,8 +56,6 @@ class Array(_dat.Data):
             'data':data,
             'version':3,
         }
-
-    def _setCtx(self,*args,**kwargs): return self
 
     def __new__(cls,*value):
         """Convert a python object to a MDSobject Data array

--- a/mdsobjects/python/mdsarray.py
+++ b/mdsobjects/python/mdsarray.py
@@ -1,4 +1,4 @@
-# 
+#
 # Copyright (c) 2017, Massachusetts Institute of Technology All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -41,6 +41,7 @@ _cmd=_mimport('compound')
 class Array(_dat.Data):
     ctype = None
     __MAX_DIM = 8
+    def _setTree(self,*a,**kw): return self;
     @property  # used by numpy.array
     def __array_interface__(self):
         data = self.value

--- a/mdsobjects/python/mdsdata.py
+++ b/mdsobjects/python/mdsdata.py
@@ -461,8 +461,8 @@ class Data(object):
         @rtype: Bool
         """
         return bool(
-            _MdsShr.MdsCompareXd(self.byref,
-                                 Data(value).byref))
+            _MdsShr.MdsCompareXd(self.ref,
+                                 Data.byref(value)))
     @property
     def descriptor(self):  # keep ref of descriptor with instance
         self.__descriptor = self._descriptor

--- a/mdsobjects/python/mdsdata.py
+++ b/mdsobjects/python/mdsdata.py
@@ -69,22 +69,19 @@ def _TdiShrFun(function,errormessage,expression,*args,**kwargs):
             tree=arg.tree
             if tree is not None:
                 break
-    xd = _dsc.Descriptor_xd()
     if tree is None:
         for arg in dargs:
             if arg.tree is None: continue
             tree = arg.tree
             if isinstance(arg,_tre.TreeNode): break
+    xd = _dsc.Descriptor_xd()   
     rargs = list(map(Data.byref,dargs))+[xd.byref,_C.c_void_p(-1)]
     _tre._TreeCtx.pushTree(tree)
     try:
         _exc.checkStatus(function(*rargs))
     finally:
         _tre._TreeCtx.popTree()
-    ans = xd._setTree(tree).value
-    if tree is not None:
-        ans.tree = tree
-    return ans
+    return xd._setTree(tree).value
 
 def TdiCompile(expression,*args,**kwargs):
     """Compile a TDI expression. Format: TdiCompile('expression-string')"""

--- a/mdsobjects/python/mdsdata.py
+++ b/mdsobjects/python/mdsdata.py
@@ -69,6 +69,7 @@ def _TdiShrFun(function,errormessage,expression,*args,**kwargs):
             tree=arg.tree
             if tree is not None:
                 break
+    xd = _dsc.Descriptor_xd()
     if tree is not None:
         ctx = tree.ctx
         xd.tree=tree

--- a/mdsobjects/python/mdsdcl.py
+++ b/mdsobjects/python/mdsdcl.py
@@ -40,7 +40,7 @@ _mdsdcl=_ver.load_library('Mdsdcl')
 _mdsdcl_do_command_dsc=_mdsdcl.mdsdcl_do_command_dsc
 _mdsdcl_do_command_dsc.argtypes=[_C.c_char_p, _dsc.Descriptor_xd.PTR, _dsc.Descriptor_xd.PTR]
 
-def dcl(command,return_out=False,return_error=False,raise_exception=False,ctx=None,setcommand='mdsdcl'):
+def dcl(command,return_out=False,return_error=False,raise_exception=False,tree=None,setcommand='mdsdcl'):
     """Execute a dcl command
     @param command: command expression to execute
     @type command: str
@@ -65,11 +65,11 @@ def dcl(command,return_out=False,return_error=False,raise_exception=False,ctx=No
     else:
         out_p=_dsc.Descriptor_xd.null
     _exc.checkStatus(_mdsdcl_do_command_dsc(_ver.tobytes('set command %s'%(setcommand,)), error_p, out_p))
-    _tre._TreeCtx.pushCtx(ctx)
+    _tre._TreeCtx.pushTree(tree)
     try:
         status = _mdsdcl_do_command_dsc(_ver.tobytes(command), error_p, out_p)
     finally:
-        _tre._TreeCtx.popCtx()
+        _tre._TreeCtx.popTree()
     if raise_exception: _exc.checkStatus(status)
     if return_out and return_error:
         return (xd_output.value,xd_error.value)

--- a/mdsobjects/python/mdsdcl.py
+++ b/mdsobjects/python/mdsdcl.py
@@ -1,4 +1,4 @@
-# 
+#
 # Copyright (c) 2017, Massachusetts Institute of Technology All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/mdsobjects/python/mdsscalar.py
+++ b/mdsobjects/python/mdsscalar.py
@@ -40,10 +40,6 @@ _exc=_mimport('mdsExceptions')
 
 class Scalar(_dat.Data):
     _value = None
-    @property
-    def tree(self):      return None
-    @tree.setter
-    def tree(self,tree): pass
 
     def _setCtx(self,*args,**kwargs): return self
 

--- a/mdsobjects/python/mdsscalar.py
+++ b/mdsobjects/python/mdsscalar.py
@@ -40,6 +40,10 @@ _exc=_mimport('mdsExceptions')
 
 class Scalar(_dat.Data):
     _value = None
+    @property
+    def tree(self):      return None
+    @tree.setter
+    def tree(self,tree): pass
 
     def _setCtx(self,*args,**kwargs): return self
 

--- a/mdsobjects/python/mdsscalar.py
+++ b/mdsobjects/python/mdsscalar.py
@@ -1,4 +1,4 @@
-# 
+#
 # Copyright (c) 2017, Massachusetts Institute of Technology All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -40,8 +40,7 @@ _exc=_mimport('mdsExceptions')
 
 class Scalar(_dat.Data):
     _value = None
-
-    def _setCtx(self,*args,**kwargs): return self
+    def _setTree(self,*a,**kw): return self;
 
     def __new__(cls,*value):
         if cls is not Scalar or len(value)==0:

--- a/mdsobjects/python/tests/dataUnitTest.py
+++ b/mdsobjects/python/tests/dataUnitTest.py
@@ -130,6 +130,10 @@ class Tests(TestCase):
             test('_a<_b',       a< b,   res.pop())
             test('_a<=_b',      a<=b,   res.pop())
 
+    def testData(self):
+        self.assertEqual(m.Data(2).compare(2),True)
+        self.assertEqual(m.Data(2).compare(1),False)
+
     def testScalars(self):
         def doTest(suffix,cl,scl,ucl,**kw):
             """ test scalar """
@@ -359,7 +363,7 @@ class Tests(TestCase):
             self.__getattribute__(test)()
     @staticmethod
     def getTests():
-        return ['testScalars','testArrays','vmsSupport','tdiFunctions','decompile','tdiPythonInterface']
+        return ['testData','testScalars','testArrays','vmsSupport','tdiFunctions','decompile','tdiPythonInterface']
     @classmethod
     def getTestCases(cls):
         return map(cls,cls.getTests())

--- a/mdsobjects/python/tests/dclUnitTest.py
+++ b/mdsobjects/python/tests/dclUnitTest.py
@@ -104,7 +104,13 @@ class Tests(TestCase):
             if not cls.instances>0:
                 shutil.rmtree(cls.tmpdir)
 
+    @classmethod
+    def tearDown(cls):
+        import gc
+        gc.collect()
+
     def dclInterface(self):
+      def test():
         Tree('pytree',-1,'ReadOnly').createPulse(self.shot)
         self.assertEqual(dcl('help set verify',1,1,0)[1],None)
         self.assertEqual(tcl('help set tree',1,1,0)[1],None)
@@ -138,8 +144,15 @@ class Tests(TestCase):
         self._doExceptionTest('close',Exc.TreeNOT_OPEN)
         self._doExceptionTest('dispatch/command/server=xXxXxXx type test',Exc.ServerPATH_DOWN)
         self._doExceptionTest('dispatch/command/server type test',Exc.MdsdclIVVERB)
+      test()
+
+      import MDSplus,gc;gc.collect()
+      refs = 0 if sys.platform.startswith('win') else 1
+      self.assertEqual([o for o in gc.get_objects() if isinstance(o,MDSplus.Tree)][refs:],[])
+
 
     def dispatcher(self):
+      def test():
         from time import sleep
         hosts = '%s/mdsip.hosts'%self.root
         def testDispatchCommand(mdsip,command,stdout=None,stderr=None):
@@ -241,6 +254,9 @@ class Tests(TestCase):
             self._doTCLTest('close/all')
         pytree = Tree('pytree',shot,'ReadOnly')
         self.assertTrue(pytree.TESTDEVICE.INIT1_DONE.record <= pytree.TESTDEVICE.INIT2_DONE.record)
+      test()
+      import MDSplus,gc;gc.collect()
+      self.assertEqual([o for o in gc.get_objects() if isinstance(o,MDSplus.Tree)],[])
 
     def runTest(self):
         for test in self.getTests():
@@ -249,7 +265,7 @@ class Tests(TestCase):
     def getTests():
         lst = ['dclInterface']
         if Tests.inThread: return lst
-        return lst + ['dispatcher']
+        return ['dispatcher'] + lst
     @classmethod
     def getTestCases(cls):
         return map(cls,cls.getTests())

--- a/mdsobjects/python/tests/devicesUnitTest.py
+++ b/mdsobjects/python/tests/devicesUnitTest.py
@@ -48,6 +48,7 @@ class Tests(TestCase):
             cls._instances -= 1
             if not cls._instances>0:
                 shutil.rmtree(cls._tmpdir)
+
     def DevicesTests(self,devices):
         with Tree('devtree',-1,'new') as t:
             for name in sorted(devices.__dict__.keys()):

--- a/mdsobjects/python/tests/segmentsUnitTest.py
+++ b/mdsobjects/python/tests/segmentsUnitTest.py
@@ -55,7 +55,8 @@ class Tests(TestCase):
             if not cls.instances>0:
                 shutil.rmtree(cls.tmpdir)
 
-    def arrayDimensionOrder(self):
+    def ArrayDimensionOrder(self):
+      def test():
         from MDSplus import Tree,Float32,Float32Array,Int16Array
         from numpy import int16,zeros
         from random import randint
@@ -85,8 +86,12 @@ class Tests(TestCase):
         self.assertEqual(shape[0],retShape[0])
         self.assertEqual(shape[1],retShape[1])
         self.assertEqual(shape[2],retShape[2])
+      test()
+      import MDSplus,gc;gc.collect()
+      self.assertEqual([o for o in gc.get_objects() if isinstance(o,MDSplus.Tree)],[])
 
-    def writeSegments(self):
+    def WriteSegments(self):
+      def test():
         from MDSplus import Tree,Int32Array,Opaque
         from numpy import array,zeros,int32
         with Tree('seg_tree',self.shot,'NEW') as ptree:
@@ -198,10 +203,15 @@ class Tests(TestCase):
         self.assertEqual(len(node.record),3)
         lens=(54851,706564,77013)
         for i in range(3):
-          seg = node.getSegment(i)
-          self.assertEqual(len(seg.value.data.data()),lens[i])
+            seg = node.getSegment(i)
+            self.assertEqual(len(seg.value.data.data()),lens[i])
+      test()
+      import MDSplus,gc;gc.collect()
+      self.assertEqual([o for o in gc.get_objects() if isinstance(o,MDSplus.Tree)],[])
+        
 
     def TimeContext(self):
+      def test():
         from MDSplus import Tree,Int64,Int64Array,Int32Array
         with Tree('seg_tree',self.shot,'NEW') as ptree:
             node = ptree.addNode('S')
@@ -219,9 +229,17 @@ class Tests(TestCase):
         self.assertEqual(node.record.data().tolist(),[3,5]+[6])  # delta is applied per segment
         node.tree.setTimeContext()
         self.assertEqual(node.record.data().tolist(),list(range(-9,9)))
+      test()
+      import MDSplus,gc;gc.collect()
+      self.assertEqual([o for o in gc.get_objects() if isinstance(o,MDSplus.Tree)],[])
 
-    def compressSegments(self):
+    def CompressSegments(self):
+      def test():
         from MDSplus import Tree,DateToQuad,Range
+        import gc
+        for a in gc.garbage:
+            if isinstance(a,Tree):
+                print(a)
         with Tree('seg_tree',self.shot,'NEW') as ptree:
             ptree.addNode('S').compress_on_put = False
             ptree.write()
@@ -234,13 +252,16 @@ class Tests(TestCase):
         ptree1 = Tree('seg_tree',self.shot+1)
         ptree1.compressDatafile()
         self.assertEqual((node.record==ptree1.S.record).all(),True)
+      test()
+      import MDSplus,gc;gc.collect()
+      self.assertEqual([o for o in gc.get_objects() if isinstance(o,MDSplus.Tree)],[])
 
     def runTest(self):
         for test in self.getTests():
             self.__getattribute__(test)()
     @staticmethod
     def getTests():
-        return ['arrayDimensionOrder','writeSegments','compressSegments','TimeContext']
+        return ['ArrayDimensionOrder','WriteSegments','TimeContext','CompressSegments']
     @classmethod
     def getTestCases(cls):
         return map(cls,cls.getTests())

--- a/mdsobjects/python/tests/treeUnitTest.py
+++ b/mdsobjects/python/tests/treeUnitTest.py
@@ -274,7 +274,8 @@ class Tests(TestCase):
         pydev = pytree.TESTDEVICE
         part = pydev.conglomerate_nids[1]
         self.assertEqual(part.PART_NAME(),':ACTIONSERVER')
-        self.assertEqual(part.original_part_name,str(Data.execute('GETNCI($,"ORIGINAL_PART_NAME")',part)))
+        self.assertEqual(part.original_part_name,':ACTIONSERVER')
+        self.assertEqual(str(Data.execute('GETNCI($,"ORIGINAL_PART_NAME")',part)),':ACTIONSERVER')
         self.assertEqual(pydev.__class__,Device.PyDevice('TestDevice'))
         devs = pytree.getNodeWild('\\PYTREESUB::TOP.***','DEVICE')
         part = devs[0].conglomerate_nids[3]

--- a/mdsobjects/python/tests/treeUnitTest.py
+++ b/mdsobjects/python/tests/treeUnitTest.py
@@ -78,10 +78,10 @@ class Tests(TestCase):
                 shutil.rmtree(cls.tmpdir)
 
     def treeCtx(self):
-        from gc import collect
+        from gc import collect,get_objects
         from time import sleep
         def check(n):
-            self.assertEqual(n,tree._TreeCtx.ctxs.items()[0][1])
+            self.assertEqual(n,len(tree._TreeCtx.ctxs.items()[0][1]))
         self.assertEqual(tree._TreeCtx.ctxs,{})  # neither tcl nor tdi has been called yet
         tcl('edit pytree/shot=%d/new'%self.shot);check(1)
         Data.execute('$EXPT'); check(1)
@@ -90,21 +90,23 @@ class Tests(TestCase):
         del(t);collect(2);sleep(.1);check(1)
         Data.execute('_out');check(1)
         t = Tree('pytree',self.shot+1,'NEW');
-        self.assertEqual(tree._TreeCtx.ctxs[tree._TreeCtx.local.tctx.ctx],1)
-        self.assertEqual(tree._TreeCtx.ctxs[t.ctx.value],1)
+        self.assertEqual(len(tree._TreeCtx.ctxs[tree._TreeCtx.local.tctx.ctx]),1)
+        self.assertEqual(len(tree._TreeCtx.ctxs[t.ctx.value]),1)
         Data.execute('tcl("close")');
-        self.assertEqual(tree._TreeCtx.ctxs[tree._TreeCtx.local.tctx.ctx],1)
-        self.assertEqual(tree._TreeCtx.ctxs[t.ctx.value],1)
+        self.assertEqual(len(tree._TreeCtx.ctxs[tree._TreeCtx.local.tctx.ctx]),1)
+        self.assertEqual(len(tree._TreeCtx.ctxs[t.ctx.value]),1)
         self.assertEqual(str(t),'Tree("PYTREE",%d,"Edit")'%(self.shot+1,))
         self.assertEqual(str(Data.execute('tcl("show db", _out);_out')),"\n")
         del(t);collect(2);sleep(.01);check(1)
         # tcl/tdi context remains until end of session
         t = Tree('pytree',self.shot+1,'NEW');
-        self.assertEqual(tree._TreeCtx.ctxs[tree._TreeCtx.local.tctx.ctx],1)
-        self.assertEqual(tree._TreeCtx.ctxs[t.ctx.value],1)
+        self.assertEqual(len(tree._TreeCtx.ctxs[tree._TreeCtx.local.tctx.ctx]),1)
+        self.assertEqual(len(tree._TreeCtx.ctxs[t.ctx.value]),1)
         del(t);collect(2);sleep(.01);check(1)
+        self.assertEqual([o for o in get_objects() if isinstance(o,Tree)],[])
 
     def buildTrees(self):
+      def test():
         with Tree('pytree',self.shot,'new') as pytree:
             if pytree.shot != self.shot:
                 raise Exception("Shot number changed! tree.shot=%d, thread.shot=%d" % (pytree.shot, self.shot))
@@ -150,8 +152,12 @@ class Tests(TestCase):
                 node=pytreesub_top.addNode('child%02d' % (i,),'structure')
                 node.addDevice('dt200_%02d' % (i,),'dt200').on=False
             pytreesub.write()
+      test()
+      import MDSplus,gc;gc.collect()
+      self.assertEqual([o for o in gc.get_objects() if isinstance(o,MDSplus.Tree)],[])
 
     def openTrees(self):
+      def test():
         pytree = Tree('pytree',self.shot)
         self.assertEqual(str(pytree),'Tree("PYTREE",%d,"Normal")'%(self.shot,))
         pytree.createPulse(self.shot+1)
@@ -159,8 +165,12 @@ class Tests(TestCase):
             Tree.setCurrent('pytree',self.shot+1)
             pytree2=Tree('pytree',0)
             self.assertEqual(str(pytree2),'Tree("PYTREE",%d,"Normal")'%(self.shot+1,))
+      test()
+      import MDSplus,gc;gc.collect()
+      self.assertEqual([o for o in gc.get_objects() if isinstance(o,MDSplus.Tree)],[])
 
     def getNode(self):
+      def test():
         pytree=Tree('pytree',self.shot,'ReadOnly')
         ip = pytree.getNode('\\ip')
         self.assertEqual(str(ip),'\\PYTREESUB::IP')
@@ -169,15 +179,23 @@ class Tests(TestCase):
         self.assertEqual(ip.nid,pytree.__PYTREESUB__IP.nid)
         self.assertEqual(pytree.TESTDEVICE.__class__,Device.PyDevice('TESTDEVICE'))
         self.assertEqual(pytree.CYGNET4K.__class__,Device.PyDevice('CYGNET4K'))
+      test()
+      import MDSplus,gc;gc.collect()
+      self.assertEqual([o for o in gc.get_objects() if isinstance(o,MDSplus.Tree)],[])
 
     def setDefault(self):
+      def test():
         pytree = Tree('pytree',self.shot,'ReadOnly')
         pytree2= Tree('pytree',self.shot,'ReadOnly')
         pytree.setDefault(pytree._IP)
         self.assertEqual(str(pytree.getDefault()),'\\PYTREESUB::IP')
         self.assertEqual(str(pytree2.getDefault()),'\\PYTREE::TOP')
+      test()
+      import MDSplus,gc;gc.collect()
+      self.assertEqual([o for o in gc.get_objects() if isinstance(o,MDSplus.Tree)],[])
 
     def nodeLinkage(self):
+      def test():
         from numpy import array,int32
         pytree = Tree('pytree',self.shot,'ReadOnly')
         top=TreeNode(0,pytree)
@@ -234,8 +252,12 @@ class Tests(TestCase):
         self.assertEqual(ip.node_name,ip.getNodeName())
         self.assertEqual(ip.path,"\\PYTREESUB::IP")
         self.assertEqual(ip.path,ip.getPath())
+      test()
+      import MDSplus,gc;gc.collect()
+      self.assertEqual([o for o in gc.get_objects() if isinstance(o,MDSplus.Tree)],[])
 
     def nciInfo(self):
+      def test():
         pytree = Tree('pytree',self.shot,'ReadOnly')
         ip=pytree.getNode('\\ip')
         self.assertEqual(ip.getUsage(),'SIGNAL')
@@ -291,8 +313,12 @@ class Tests(TestCase):
         self.assertEqual((ip.tags==makeArray(['IP','MAGNETICS_IP','MAG_IP','MAGNETICS_PLASMA_CURRENT','MAG_PLASMA_CURRENT'])).all(),True)
         self.assertEqual((ip.tags==ip.getTags()).all(),True)
         self.assertEqual(ip.time_inserted,ip.getTimeInserted())
+      test()
+      import MDSplus,gc;gc.collect()
+      self.assertEqual([o for o in gc.get_objects() if isinstance(o,MDSplus.Tree)],[])
 
     def getData(self):
+      def test():
         pytree = Tree('pytree',self.shot,'ReadOnly')
         ip=pytree.getNode('\\ip')
         pytree.setDefault(ip)
@@ -302,14 +328,21 @@ class Tests(TestCase):
         self.assertEqual(ip.versions,ip.containsVersions())
         self.assertEqual(ip.getNumSegments(),0)
         self.assertEqual(ip.getSegment(0),None)
+      test()
+      import MDSplus,gc;gc.collect()
+      self.assertEqual([o for o in gc.get_objects() if isinstance(o,MDSplus.Tree)],[])
 
     def getCompression(self):
+      def test():
         pytree = Tree('pytree',self.shot)
         testing = Tree('testing', -1)
         for node in testing.getNodeWild(".compression:*"):
             pytree.SIG_CMPRS.record=node.record
             self.assertTrue((pytree.SIG_CMPRS.record == node.record).all(),
                              msg="Error writing compressed signal%s"%node)
+      test()
+      import MDSplus,gc;gc.collect()
+      self.assertEqual([o for o in gc.get_objects() if isinstance(o,MDSplus.Tree)],[])
 
     def runTest(self):
         for test in self.getTests():

--- a/mdsobjects/python/tests/treeUnitTest.py
+++ b/mdsobjects/python/tests/treeUnitTest.py
@@ -81,26 +81,26 @@ class Tests(TestCase):
         from gc import collect
         from time import sleep
         def check(n):
-            self.assertEqual((tree._TreeCtx.gettctx().ctx,n),tree._TreeCtx.ctxs.items()[0])
+            self.assertEqual(n,tree._TreeCtx.ctxs.items()[0][1])
         self.assertEqual(tree._TreeCtx.ctxs,{})  # neither tcl nor tdi has been called yet
         tcl('edit pytree/shot=%d/new'%self.shot);check(1)
         Data.execute('$EXPT'); check(1)
         t = Tree();            check(2)
-        Data.execute('tcl("dir", _out)'); check(2)
+        Data.execute('tcl("dir", _out)');check(2)
         del(t);collect(2);sleep(.1);check(1)
         Data.execute('_out');check(1)
         t = Tree('pytree',self.shot+1,'NEW');
-        self.assertEqual(tree._TreeCtx.ctxs[tree._TreeCtx.gettctx().ctx],1)
+        self.assertEqual(tree._TreeCtx.ctxs[tree._TreeCtx.local.tctx.ctx],1)
         self.assertEqual(tree._TreeCtx.ctxs[t.ctx.value],1)
         Data.execute('tcl("close")');
-        self.assertEqual(tree._TreeCtx.ctxs[tree._TreeCtx.gettctx().ctx],1)
+        self.assertEqual(tree._TreeCtx.ctxs[tree._TreeCtx.local.tctx.ctx],1)
         self.assertEqual(tree._TreeCtx.ctxs[t.ctx.value],1)
         self.assertEqual(str(t),'Tree("PYTREE",%d,"Edit")'%(self.shot+1,))
         self.assertEqual(str(Data.execute('tcl("show db", _out);_out')),"\n")
         del(t);collect(2);sleep(.01);check(1)
         # tcl/tdi context remains until end of session
         t = Tree('pytree',self.shot+1,'NEW');
-        self.assertEqual(tree._TreeCtx.ctxs[tree._TreeCtx.gettctx().ctx],1)
+        self.assertEqual(tree._TreeCtx.ctxs[tree._TreeCtx.local.tctx.ctx],1)
         self.assertEqual(tree._TreeCtx.ctxs[t.ctx.value],1)
         del(t);collect(2);sleep(.01);check(1)
 

--- a/mdsobjects/python/tree.py
+++ b/mdsobjects/python/tree.py
@@ -1000,7 +1000,7 @@ class Tree(object):
         kwargs['tree'] = self.tree
         return _dat.TdiData(arg,**kwargs)
 
-class TreeNode(_scr.Int32): # HINT: TreeNode begin
+class TreeNode(_dat.Data): # HINT: TreeNode begin  (maybe subclass of _scr.Int32 some day)
     """Class to represent an MDSplus node reference (nid).
     @ivar nid: node index of this node.
     @type nid: int
@@ -1241,7 +1241,6 @@ class TreeNode(_scr.Int32): # HINT: TreeNode begin
             self._nid=None
         else:
             self._nid=_C.c_int32(int(value))
-
     nid_reference=nciProp("nid_reference","node data contains nid references")
 
     node_name=name=nciProp("node_name","node name")

--- a/mdsobjects/python/tree.py
+++ b/mdsobjects/python/tree.py
@@ -1026,7 +1026,7 @@ class TreeNode(_dat.Data): # HINT: TreeNode begin
         node = super(TreeNode,cls).__new__(cls)
         head = nid._head if isinstance(nid,TreeNode) else head
         if not isinstance(head,(Device,)) and type(node) is TreeNode:
-            TreeNode.__init__(node,nid,tree,head)
+            TreeNode.__init__(node,nid,tree,head,*a,**kw)
             try:
                 if str(node.usage) == "DEVICE":
                     return node.record.getDevice(node,head=0)

--- a/treeshr/treeshrp.h
+++ b/treeshr/treeshrp.h
@@ -154,17 +154,17 @@ typedef struct named_attributes_index {
                            (outp)[6] = ((char *)&in)[1]; (outp)[7] = ((char *)&in)[0]
 #else
 
-static inline int64_t swapquad(void *buf) {
+static inline int64_t swapquad(const void *buf) {
   int64_t ans;
   memcpy(&ans,buf,sizeof(ans));
   return ans;
 }
-static inline int32_t swapint(void *buf) {
+static inline int32_t swapint(const void *buf) {
   int32_t ans;
   memcpy(&ans,buf,sizeof(ans));
   return ans;
 }
-static inline int16_t swapshort(void *buf) {
+static inline int16_t swapshort(const void *buf) {
   int16_t ans;
   memcpy(&ans,buf,sizeof(ans));
   return ans;
@@ -732,7 +732,7 @@ extern void _TreeDeleteNodesDiscard(void *dbid);
 extern int TreeGetDatafile(TREE_INFO * info_ptr, unsigned char *rfa, int *buffer_size, char *record,
 			   int *retsize, int *nodenum, unsigned char flags);
 extern int TreeEstablishRundownEvent(TREE_INFO * info);
-extern int TreeGetDsc(TREE_INFO * info, int nid, int64_t offset, int length,
+extern int TreeGetDsc(TREE_INFO * info, const int nid, const int64_t offset, const int length,
 		      struct descriptor_xd *dsc);
 extern int TreeGetExtendedAttributes(TREE_INFO * info_ptr, int64_t offset,
 				     EXTENDED_ATTRIBUTES * att);


### PR DESCRIPTION
not deprecation warning yet.
e.g.:
Instead of 
Data.execute(expression_with_node_refs)
one should use
tree_instance.tdi(expression_with_node_refs)