### PR TITLE
Fix: Remove reference to libraw1394 in links where it is not needed.

### DIFF
--- a/configure
+++ b/configure
@@ -8306,6 +8306,7 @@ fi
 #
 
 
+raw_old_libs="$LIBS" #### needed because of nested call to MDS_SEARCH_LIBS
 
   old_LIBS="$LIBS"
   { $as_echo "$as_me:${as_lineno-$LINENO}: checking for library containing raw1394_get_libversion" >&5
@@ -8487,6 +8488,7 @@ fi
 
   LIBS="$old_LIBS"
 
+LIBS="$raw_old_libs"
 
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking for library containing gethostbyname" >&5
 $as_echo_n "checking for library containing gethostbyname... " >&6; }

--- a/configure.ac
+++ b/configure.ac
@@ -608,11 +608,13 @@ AS_VAR_SET_IF([TARGET_ARCH],[CFLAGS="$CFLAGS $TARGET_ARCH"])
 
 dnl see if we have libdc1394 libraries and what version
 
+raw_old_libs="$LIBS" #### needed because of nested call to MDS_SEARCH_LIBS
 MDS_SEARCH_LIBS([raw1394_get_libversion],[raw1394],
 [
   MDS_SEARCH_LIBS([dc1394_new],[dc1394],[DC1394_SUPPORT2="${MAKESHLIBDIR}libdc1394_support2$SHARETYPE"])
   MDS_SEARCH_LIBS([dc1394_get_camera_info],[dc1394],[DC1394_SUPPORT="${MAKESHLIBDIR}libdc1394_support$SHARETYPE"])
 ])
+LIBS="$raw_old_libs"
 
 AC_SEARCH_LIBS([gethostbyname], [nsl socket],
                [AS_VAR_IF([ac_cv_search_gethostbyname], ["none required"], [], [LIBSOCKET=$ac_cv_search_gethostbyname])],


### PR DESCRIPTION
The check for libraw1394 did nested calls to the MDS_SEARCH_LIBS function
in configure and this caused -lraw1394 to be added to the LIBS environment
variable adding it to all links. This change fixes this problem.