### PR TITLE
Build: Add --test_timeunit option to modify test timeouts

### DIFF
--- a/deploy/build.sh
+++ b/deploy/build.sh
@@ -104,6 +104,13 @@ OPTIONS
        the results in a standard tap format which only gives pass or fail
        information.
 
+    --test_timeunit=float-point-number
+       Multiplier to apply to tests timeouts. If this option is used the
+       timeout time for a test will be set to this value times the normal
+       timeout for the test. For example, --test_timeunit=2.5 would
+       allow the tests to run 2.5 as long as the normally do before being
+       stopped with a timeout error. 
+
    --eventport=number
        Select a port number to use for udp event tests. If running
        multiple docker containers concurrently doing tests you should
@@ -274,6 +281,9 @@ parsecmd() {
 		;;
 	    --test_format=*)
 		TEST_FORMAT="${i#*=}"
+		;;
+	    --test_timeunit=*)
+		TEST_TIMEUNIT="${i#*=}"
 		;;
 	    --eventport=*)
 		EVENT_PORT="${i#*=}"
@@ -616,6 +626,7 @@ fi
 OS=${OS} \
   TEST=${TEST} \
   TEST_FORMAT=${TEST_FORMAT} \
+  TEST_TIMEUNIT=${TEST_TIMEUNIT} \
   EVENT_PORT=${EVENT_PORT} \
   MAKE_JARS=${MAKE_JARS} \
   RELEASE=${RELEASE} \

--- a/deploy/platform/platform_build.sh
+++ b/deploy/platform/platform_build.sh
@@ -102,6 +102,7 @@ rundocker(){
            -e "SANITIZE" \
            -e "TEST" \
            -e "TESTFORMAT" \
+	   -e "TEST_TIMEUNIT" \
            -e "UPDATEPKG" \
            -e "VALGRIND_TOOLS" \
 	   -e "MAKE_JARS" \


### PR DESCRIPTION
The --test_timeunit option for the build.sh script can be used to adjust
the normal timeout duration used for tests. This option specifies a floating point
multiplier for the normal timeout. For example: --test_timeunit=.5 would reduce
the timeout on tests to half their normal time.