### PR TITLE
Fix: Logic to decide if environment variable / event vs tcpip backwards

### DIFF
--- a/servershr/ServerSendMonitor.c
+++ b/servershr/ServerSendMonitor.c
@@ -17,7 +17,7 @@ int ServerSendMonitor(char *monitor, char *tree, int shot, int phase,
   now[strlen(now) - 1] = 0;
   const char*        event_str = "event:";
   const unsigned int event_len = strlen(event_str);
-  if (initialized) {
+  if (!initialized) {
     initialized = B_TRUE;
     char *mon_env = getenv(monitor);
     if (!mon_env)


### PR DESCRIPTION
The code sets initialized to FALSE and it is only set to true in a block
that said if (initialized)  which would never get executed.

Changed so that the check is for !initialized.