### PR TITLE
Build: Add --test_timeunit to trigger options

### DIFF
--- a/deploy/trigger.sh
+++ b/deploy/trigger.sh
@@ -14,7 +14,7 @@ NAME
                  build jobs used to test pull requests and generate new MDSplus releases.
 
 SYNOPSIS
-    ./trigger.sh [--test[=skip]] [--testrelease] [--valgrind=skip] [--sanitize=skip] [--test_format=tap|log]
+    ./trigger.sh [--test[=skip]] [--test_timeunit=factor] [--testrelease] [--valgrind=skip] [--sanitize=skip] [--test_format=tap|log]
                  [--release] [--releasedir=directory]
                  [--publish] [--publishdir=directory]
                  [--keys=dir] [--dockerpull] [--color]
@@ -51,6 +51,9 @@ OPTIONS
        cross-compiled platforms cannot be tested so the os.opt file will
        contain a --test=skip which supercedes a --test option on the
        command line.
+
+    --test_timeunit=factor
+       Multiply timeout limits by factor to extend or shorten timeout limits
 
     --testrelease
        Use for pull request tests so kits will be built and checked but
@@ -155,6 +158,9 @@ parsecmd() {
 		;;
 	    --test=skip)
 		opts="${opts} ${i}"
+		;;
+	    --test_timeunit=*)
+		opts="${opts} --test_timeunit=${i#*=}"
 		;;
 	    --test_format=*)
 		opts="${opts} ${i}"


### PR DESCRIPTION
--test_timeunit was added to build options. This enables the use of
--test_timeunit when triggering builds.