### PR TITLE
Build: Use tmpdir for windows testing winebottle

### DIFF
--- a/deploy/platform/windows/windows_docker_build.sh
+++ b/deploy/platform/windows/windows_docker_build.sh
@@ -8,10 +8,13 @@
 # publish:
 # /publish/$branch/MDSplus-*.exe
 #
-test64="64 x86_64-w64-mingw32 bin_x86_64 bin_x86_64"
-test32="32 i686-w64-mingw32   bin_x86    bin_x86"
+winebottle64=$(mktemp --tmpdir -d winebottle64.XXXXXXXX)
+test64="64 x86_64-w64-mingw32 bin_x86_64 bin_x86_64 --with-winebottle=$winebottle64"
+winebottle32=$(mktemp --tmpdir -d winebottle32.XXXXXXXX)
+test32="32 i686-w64-mingw32   bin_x86    bin_x86 --with-winebottle=$winebottle32"
 export JNI_INCLUDE_DIR=/source/3rd-party-apis/windows-jdk
 export JNI_MD_INCLUDE_DIR=/source/3rd-party-apis/windows-jdk/win32
+
 buildrelease() {
     abort=0
     ### Clean up workspace


### PR DESCRIPTION
When tests are performed on the Windows platform a winebottle
was being created in the current directory for tests to be performed
using wine (windows emulation on linux). This winebottle has symlinks
to the root filesystem and this causes problems when doing builds
using jenkins. The jenkins build searches for various types of files
in the workspace directory tree and if the winebottle is in the
workspace directory these symlinks cause an infinite recursion. This
PR will cause docker builds for windows to create the winebottle in
a subdirectory of /tmp to avoid this recusion problem.