### PR TITLE
Fix: This commit fixes a problem with python handling of with_error d…

### DIFF
--- a/mdsobjects/python/compound.py
+++ b/mdsobjects/python/compound.py
@@ -485,7 +485,7 @@ class WithError(Compound):
     """Specifies error information for any kind of data.
     """
     fields=('data','error')
-    dtype_id=211
+    dtype_id=213
 _dsc.addDtypeToClass(WithError)
 
 class Parameter(Compound):


### PR DESCRIPTION
…ata.

A typo in the compound.py python module specified the wrong data type
number for the WithError class. This prevented access of data stored
with an error value from python. This should fix this problem.