### PR TITLE
Gm fix javatraverser2 and mdsobjects cpp

### DIFF
--- a/javatraverser2/Makefile.am
+++ b/javatraverser2/Makefile.am
@@ -1,5 +1,5 @@
 EXTRA_DIST = 
-CLEANFILES = $(java_DATA) JTMANIFEST.mf \
+CLEANFILES = $(java_DATA) \
 	$(addprefix $(JAVAROOT)/,$(TRAV_CLS)) \
 	$(addprefix $(JAVAROOT)/,$(TOOLS_CLS)) \
 	$(addprefix $(JAVAROOT)/,$(MDS_CLS))

--- a/javatraverser2/Makefile.in
+++ b/javatraverser2/Makefile.in
@@ -467,7 +467,7 @@ top_builddir = @top_builddir@
 top_srcdir = @top_srcdir@
 uiddir = @uiddir@
 EXTRA_DIST = 
-CLEANFILES = $(java_DATA) JTMANIFEST.mf \
+CLEANFILES = $(java_DATA)  \
 	$(addprefix $(JAVAROOT)/,$(TRAV_CLS)) \
 	$(addprefix $(JAVAROOT)/,$(TOOLS_CLS)) \
 	$(addprefix $(JAVAROOT)/,$(MDS_CLS))

--- a/mdsobjects/cpp/mdstreeobjects.cpp
+++ b/mdsobjects/cpp/mdstreeobjects.cpp
@@ -1232,7 +1232,10 @@ TreeNode *TreeNode::getNode(char const * relPath)
 	if(status & 1) status = _TreeFindNode(tree->getCtx(), relPath, &newNid);
 	if(status & 1) status = _TreeSetDefaultNid(tree->getCtx(), defNid);
 	if(!(status & 1))
+	{
+		status = _TreeSetDefaultNid(tree->getCtx(), defNid);
 		throw MdsException(status);
+	}
 	return new TreeNode(newNid, tree);
 }
 


### PR DESCRIPTION
1) Solves the issue encountered whan building javatraverser2 after clean
2) Solves the incorrect default setting when TreeNode::getNode() raises an exception (i.e. node not found)