### PR TITLE
Feature: Add username, date, and connection info to mdsip-ssh.log

### DIFF
--- a/mdstcpip/mdsip-server-ssh
+++ b/mdstcpip/mdsip-server-ssh
@@ -1,2 +1,5 @@
 #!/bin/sh
+date >> ~/mdsip-ssh.log
+echo "----------> Connected `date` SSH mdsip connection from `whoami` on $SSH_CLIENT" >> ~/mdsip-ssh.log
 exec mdsip -P ssh 2>> ~/mdsip-ssh.log
+echo "----------< Disconnected `date` >> ~/mdsip-ssh.log


### PR DESCRIPTION
When a user connects to a server using the ssh protocol, the server
runs mdsip-ssh-server and directs stderr to ~/mdsip-ssh.log.

This change adds information about the connection to the file. There
does not appear to be a sample server script for windows, only a client
script, so this only applies to linux like platforms.

Incomming ssh connections to windows servers have not been tested or
implemented.