### PR TITLE
Fix:  windows mdsip-client-ssh.bat script invoke the user's bashrc on the host

### DIFF
--- a/mdstcpip/mdsip-client-ssh
+++ b/mdstcpip/mdsip-client-ssh
@@ -1,2 +1,2 @@
 #!/bin/sh
-exec ssh $1 "/bin/sh -c '. /etc/profile; $2'"
+exec ssh $1 "/bin/sh -l -c $2"

--- a/mdstcpip/mdsip-client-ssh.bat
+++ b/mdstcpip/mdsip-client-ssh.bat
@@ -5,5 +5,5 @@ if %errorlevel% == 9009 goto use_plink
 :use_plink
   plink --help >nul 2>&1
   if %errorlevel% == 9009 goto done
-    plink -agent -batch %1 %2
+    plink -agent -batch %1 "/bin/sh -c '. /etc/profile; %2'"
 :done

--- a/mdstcpip/mdsip-client-ssh.bat
+++ b/mdstcpip/mdsip-client-ssh.bat
@@ -5,5 +5,5 @@ if %errorlevel% == 9009 goto use_plink
 :use_plink
   plink --help >nul 2>&1
   if %errorlevel% == 9009 goto done
-    plink -agent -batch %1 "/bin/sh -c '. /etc/profile; %2'"
+    plink -agent -batch %1 "/bin/sh -l -c  %2"
 :done


### PR DESCRIPTION

The provided windows mdsip-client-ssh.bat script that uses putty provided plink command
to invoke mdsip-server-ssh on the host computer, was not setting up the user's environment.

For systems where the MDSplus commands and scripts are not available before login, this is
required.