### PR TITLE
Build: Fix email address used to send bad commit message title

### DIFF
--- a/deploy/commit_type_check.sh
+++ b/deploy/commit_type_check.sh
@@ -9,7 +9,7 @@
 # email to be sent to the person who created a commit with an invalid title.
 #
 
-git log $1..HEAD --no-merges --decorate=short --pretty=format:"%<(80,trunc)%s%n%ce" |
+git log $1..HEAD --no-merges --decorate=short --pretty=format:"%<(80,trunc)%s%n%ae" |
 awk -v EMAILMSG="$2" -F: '{ IGNORECASE=1
                TITLE=$0
                switch ($1) {


### PR DESCRIPTION
The commit message title (first line) is used to determine the type of version
increment to use. This title syntax is checked and an email is sent to the author of the commit if the commit message does not follow our standard format. This fix is to use the email of the author of the commit not the account running the build job.