### PR TITLE
Feature: Reduce library exports to improve image activation performance

### DIFF
--- a/configure
+++ b/configure
@@ -6672,6 +6672,7 @@ _ACEOF
 
 { $as_echo "$as_me:${as_lineno-$LINENO}: result: **********VISIBILITY*********$CFLAG_VISIBILITY*******************" >&5
 $as_echo "**********VISIBILITY*********$CFLAG_VISIBILITY*******************" >&6; }
+CFLAGS="$CFLAGS $CFLAG_VISIBILITY"
 #if test -n "$CFLAG_VISIBILITY" && test "$is_w32" != yes; then
 #	CFLAGS="$CFLAGS $CFLAG_VISIBILITY"
 #fi

--- a/configure.ac
+++ b/configure.ac
@@ -79,6 +79,7 @@ AC_CHECK_TOOL([WINDRES], [windres], [:])
 AC_MSG_RESULT([before VISIBILITY])
 gl_VISIBILITY
 AC_MSG_RESULT([**********VISIBILITY*********$CFLAG_VISIBILITY*******************])
+CFLAGS="$CFLAGS $CFLAG_VISIBILITY"
 #if test -n "$CFLAG_VISIBILITY" && test "$is_w32" != yes; then
 #	CFLAGS="$CFLAGS $CFLAG_VISIBILITY"
 #fi

--- a/include/mdsshr.h
+++ b/include/mdsshr.h
@@ -86,6 +86,7 @@ extern int MdsGet1DxS(const unsigned short *len, const unsigned char *dtype,
 			       struct descriptor_xd *out);
 extern char *MdsGetMsg(int sts);
 extern void MdsGetMsgDsc(int status, struct descriptor *out);
+extern int MdsGetStdMsg(int status, const char **fac_out, const char **msgnam_out, const char **text_out);
 extern int MdsFree1Dx(struct descriptor_xd *dsc, void **zone);
 extern int MdsMsg(int sts, const char *fmt, ...);
 extern int MDSQueueEvent(const char *event, int *eventid);

--- a/javatraverser2/Makefile.in
+++ b/javatraverser2/Makefile.in
@@ -467,7 +467,7 @@ top_builddir = @top_builddir@
 top_srcdir = @top_srcdir@
 uiddir = @uiddir@
 EXTRA_DIST = 
-CLEANFILES = $(java_DATA)  \
+CLEANFILES = $(java_DATA) \
 	$(addprefix $(JAVAROOT)/,$(TRAV_CLS)) \
 	$(addprefix $(JAVAROOT)/,$(TOOLS_CLS)) \
 	$(addprefix $(JAVAROOT)/,$(MDS_CLS))

--- a/mdsdcl/mdsdclThreadSafe.c
+++ b/mdsdcl/mdsdclThreadSafe.c
@@ -43,13 +43,13 @@ ThreadStatic *mdsdclGetThreadStatic(){
   return (ThreadStatic *)p;
 }
 
-void mdsdclSetPrompt(const char *prompt){
+EXPORT void mdsdclSetPrompt(const char *prompt){
   GET_THREADSTATIC_P;
   if (PROMPT) free(PROMPT);
   PROMPT = strdup(prompt);
 }
 
-char *mdsdclGetPrompt(){
+EXPORT char *mdsdclGetPrompt(){
   char *ans;
   GET_THREADSTATIC_P;
   if (!PROMPT)

--- a/mdsmisc/bwfilter.c
+++ b/mdsmisc/bwfilter.c
@@ -13,7 +13,7 @@ EXPORT int bwfilter(float *w_cut_in, int *order_in, int *num, float *in, float *
   int M, N;
   int p, q, order = *order_in;
   double num_coeff, den_coeff, c[max_order + 1], d[max_order + 1];
-  double coeff[2][max_order + 1];
+  double coeff[2][max_order + 1] = {{0},{0}};
   double w_cut = (double)*w_cut_in, omega_cut;
   int upto, i, j, k;
   int in_idx = 0, out_idx;

--- a/mdsobjects/labview/lv.c
+++ b/mdsobjects/labview/lv.c
@@ -9,6 +9,7 @@
  *
  *   Josh Stillerman 10/19/12
  */
+#include <config.h>
 #include <stdint.h>
 #include  <platdefines.h>
 #include <extcode.h>
@@ -33,7 +34,7 @@ void (*LVMoveBlock) () = 0;
 UHandle(*LVDSNewHandle) () = 0;
 MgErr(*LVNumericArrayResize) () = 0;
 
-extern void MoveBlock(const void *src, void *dest, size_t siz)
+EXPORT extern void MoveBlock(const void *src, void *dest, size_t siz)
 {
   if (!LVMoveBlock)
     Initialize();
@@ -41,7 +42,7 @@ extern void MoveBlock(const void *src, void *dest, size_t siz)
     LVMoveBlock(src, dest, siz);
 }
 
-extern UHandle DSNewHandle(size_t siz)
+EXPORT extern UHandle DSNewHandle(size_t siz)
 {
   if (!LVDSNewHandle)
     Initialize();
@@ -51,7 +52,7 @@ extern UHandle DSNewHandle(size_t siz)
     return (UHandle) - 1;
 }
 
-MgErr NumericArrayResizeCACCA(int32 a, int32 b, UHandle * h, size_t siz)
+EXPORT MgErr NumericArrayResizeCACCA(int32 a, int32 b, UHandle * h, size_t siz)
 {
   printf("CIAO SONO NUMERIC ARRAY RESIZE CACCA\n");
   printf("\n\n\n\n");
@@ -63,7 +64,7 @@ MgErr NumericArrayResizeCACCA(int32 a, int32 b, UHandle * h, size_t siz)
     return -1;
 }
 
-MgErr NumericArrayResize(int32 a, int32 b, UHandle * h, size_t siz)
+EXPORT MgErr NumericArrayResize(int32 a, int32 b, UHandle * h, size_t siz)
 {
   printf("CIAO SONO NUMERIC ARRAY RESIZE\n");
   printf("\n\n\n\n");

--- a/mdsobjects/python/mdsExceptions.py
+++ b/mdsobjects/python/mdsExceptions.py
@@ -1,3 +1,4 @@
+
 ########################################################
 # This module was generated using mdsshr/gen_device.py
 # To add new status messages modify one of the
@@ -1541,7 +1542,7 @@ class _PyException(MDSplusException):
 
 class PyUNHANDLED_EXCEPTION(_PyException):
   status=662480186
-  message="Python device raised and exception, see log files for more details"
+  message="Python device raised an exception, see log files for more details"
   msgnam="UNHANDLED_EXCEPTION"
 
 MDSplusException.statusDict[662480184] = PyUNHANDLED_EXCEPTION

--- a/mdsshr/MdsGetStdMsg.c
+++ b/mdsshr/MdsGetStdMsg.c
@@ -1,3 +1,5 @@
+#include <config.h>
+
 static const char *FAC_DEV = "DEV";
 static const char *FAC_RETICON = "RETICON";
 static const char *FAC_J221 = "J221";
@@ -40,7 +42,7 @@ static const char *FAC_CAM = "CAM";
 static const char *FAC_TCL = "TCL";
 
 
-int MdsGetStdMsg(int status, const char **fac_out, const char **msgnam_out, const char **text_out) {
+EXPORT int MdsGetStdMsg(int status, const char **fac_out, const char **msgnam_out, const char **text_out) {
     int sts;
     switch (status & (-8)) {
 
@@ -1746,7 +1748,7 @@ int MdsGetStdMsg(int status, const char **fac_out, const char **msgnam_out, cons
 
 /* PyUNHANDLED_EXCEPTION */
       case 0x277ca538:
-        {static const char *text="Python device raised and exception, see log files for more details";
+        {static const char *text="Python device raised an exception, see log files for more details";
         static const char *msgnam="UNHANDLED_EXCEPTION";
         *fac_out = FAC_PY;
         *msgnam_out = msgnam;

--- a/mdsshr/UdpEventSettings.c
+++ b/mdsshr/UdpEventSettings.c
@@ -25,7 +25,7 @@ static const char *environ_var[NUM_SETTINGS] = {"mdsevent_loop", "mdsevent_ttl",
 static const char *xml_setting[NUM_SETTINGS] = {"IP_MULTICAST_LOOP", "IP_MULTICAST_TTL", "IP_MULTICAST_IF", "PORT", "ADDRESS"};
 static const char *fname = "eventsConfig.xml";
 
-int UdpEventGetLoop(unsigned char *loop) {
+EXPORT int UdpEventGetLoop(unsigned char *loop) {
   int status = 0;
   if (settings[LOOP]) {
     if (strcmp("0", settings[LOOP]) == 0) {
@@ -157,7 +157,7 @@ static const char *getProperty(xmlDocPtr doc, const char *settings, const char *
   return ans;
 }
 
-void InitializeEventSettings()
+EXPORT void InitializeEventSettings()
 {
   int i, missing=0;
   xmlInitParser();

--- a/mdsshr/gen_messages.py
+++ b/mdsshr/gen_messages.py
@@ -161,12 +161,12 @@ for filename,filepath in xmllist.items():
 
 f_getmsg=open('%s/mdsshr/MdsGetStdMsg.c'%sourcedir,'w')
 exceptionDict=[]
-
+f_getmsg.write("#include <config.h>\n\n");
 for facu in faclist:
     f_getmsg.write("static const char *FAC_%s = \"%s\";\n" % (facu,facu))
 f_getmsg.write("""
 
-int MdsGetStdMsg(int status, const char **fac_out, const char **msgnam_out, const char **text_out) {
+EXPORT int MdsGetStdMsg(int status, const char **fac_out, const char **msgnam_out, const char **text_out) {
     int sts;
     switch (status & (-8)) {
 """)

--- a/tdishr/TdiExtPython.c
+++ b/tdishr/TdiExtPython.c
@@ -31,7 +31,6 @@ static pthread_mutex_t libpython_mutex = PTHREAD_MUTEX_INITIALIZER;
 typedef void* PyThreadState;
 static PyThreadState *(*PyGILState_Ensure)() = NULL;
 static void (*PyGILState_Release)(PyThreadState *) = NULL;
-extern int MdsGetStdMsg();
 
 typedef void* PyObject;
 typedef ssize_t Py_ssize_t;
@@ -360,7 +359,7 @@ int TdiExtPython(struct descriptor *modname_d,
               if STATUS_NOT_OK {
                 char *fac_out=NULL, *msgnam_out=NULL, *text_out=NULL;
                 const char *f = "WSEIF???";
-                MdsGetStdMsg(status,&fac_out,&msgnam_out,&text_out);
+                MdsGetStdMsg(status,(const char **)&fac_out,(const char **)&msgnam_out,(const char **)&text_out);
                 printf("%%%s-%c-%s: %s\n",fac_out,f[status&7],msgnam_out,text_out);
                }
             } else {

--- a/tdishr/TdiIntrinsic.c
+++ b/tdishr/TdiIntrinsic.c
@@ -195,7 +195,7 @@ STATIC_ROUTINE int interlude(int (*f1) (), int opcode, int narg,
   return status;
 }
 
-int TdiIntrinsic(int opcode, int narg, struct descriptor *list[], struct descriptor_xd *out_ptr)
+EXPORT int TdiIntrinsic(int opcode, int narg, struct descriptor *list[], struct descriptor_xd *out_ptr)
 {
   INIT_STATUS, stat1 = MDSplusSUCCESS;
   struct TdiFunctionStruct *fun_ptr = (struct TdiFunctionStruct *)&TdiRefFunction[opcode];

--- a/tdishr/tdishrp.h
+++ b/tdishr/tdishrp.h
@@ -19,8 +19,6 @@ int TdiGetRecord(int nid, struct descriptor_xd *out);
 int TdiGetShape(int narg, struct descriptor_xd dat[1], unsigned short length, unsigned char dtype,
 		int *cmode_ptr, struct descriptor_xd *out_ptr);
 int TdiHash(int len, char *pstring);
-int _TdiIntrinsic(void *dbid, int opcode, int narg, struct descriptor *list[],
-		  struct descriptor_xd *out_ptr);
 int TdiMasterData(int nsig, struct descriptor_xd sig[1], struct descriptor_xd uni[1],
 		  int *cmode_ptr, struct descriptor_xd *out_ptr);
 int Tdi3Multiply(struct descriptor *in1, struct descriptor *in2, struct descriptor *out);


### PR DESCRIPTION
The MDSplus libraries contain numerous routines which are only used locally in that library. Currently all entry points are being exported by default and a large percentage of these symbols are not used externally and can be removed from the export list. This PR will only export symbols that are needed by other libraries, executables or those referenced by languages such as idl, python, java, matlab or tdi. Reducing the number of exports in the libraries should make program startup and dynamic lookup of routines much more efficient.