### PR TITLE
FIX: resource leak during throw

### DIFF
--- a/javascope/jScope/ASCIIDataProvider.java
+++ b/javascope/jScope/ASCIIDataProvider.java
@@ -126,9 +126,9 @@ class ASCIIDataProvider implements DataProvider
                     y = resizeBuffer(y, count );                  
                 }
             }
+            bufR.close();
             if( x == null || y == null )
                 throw(new Exception("No data in file or file syntax error"));
-            bufR.close();
         }
         
         private boolean setPropValues(String in, Properties prop)


### PR DESCRIPTION
bufR is only closed if there is no exception. Move close() before the exception check so that it is always closed even in the case of a throw. This removes a warning highlighting the resource leak.