### PR TITLE
Fix: repair bug in routine used to map cts setting files

### DIFF
--- a/camshr/map_data_file.c
+++ b/camshr/map_data_file.c
@@ -139,6 +139,7 @@ int map_data_file(int dbType)
       *FileIsMapped = FALSE;
       goto MapData_Exit;
     }
+    break;
 
   default:
     return 0;


### PR DESCRIPTION
In removing one of the compiler warnings about potential undefined behavior
a needed break statement in a case clause was omitted. The change fixed the
undefined behavior by making it always fail which was not the intent!