### PR TITLE
Fix: Build new release even with bad commit message

### DIFF
--- a/deploy/commit_type_check.sh
+++ b/deploy/commit_type_check.sh
@@ -20,7 +20,7 @@ awk -v EMAILMSG="$2" -F: '{ IGNORECASE=1
                  break
                case "Fix":
 	       case "Revert \"Fix":
-                 if ( VERSION == "SAME" ) {
+                 if ( VERSION == "" ) {
                    VERSION="PATCH"
                  }
                  OK="1"
@@ -46,9 +46,10 @@ awk -v EMAILMSG="$2" -F: '{ IGNORECASE=1
                }
             }
             END {
-              if ( VERSION == "" ) VERSION="SAME";
-              if ( FAIL == "TRUE" && VERSION == "SAME" ) {
+              if ( FAIL == "TRUE" && VERSION == "" ) {
                 print("BADCOMMIT")
+              } else if ( VERSION == "" ) {
+                print("SAME")
               } else {
                 print(VERSION)
               }


### PR DESCRIPTION
A bad commit message was preventing a release build even if there
were additional proper commit messages indicating the type of version
increase. This fix should enable a release build if there are any proper
commit messages indicating a new releas should be created.