### PR TITLE
Fix: Repair a bug in the mdsip timeout handling

### DIFF
--- a/mdstcpip/ioroutinestcp.h
+++ b/mdstcpip/ioroutinestcp.h
@@ -303,8 +303,9 @@ static int io_listen(int argc, char **argv){
 static int io_settimeout(int conid, int sec, int usec) {
   SOCKET sock = getSocket(conid);
   if (sock != INVALID_SOCKET) {
-      struct timeval tv = {sec, usec};
-      return setsockopt(sock, SOL_SOCKET, SO_RCVTIMEO, (const char*)&tv,sizeof(struct timeval));
+    //      struct timeval tv = {sec, usec};
+    //  return setsockopt(sock, SOL_SOCKET, SO_RCVTIMEO, (const char*)&tv,sizeof(struct timeval));
+    return 0;
   }
   return C_ERROR;
 }

--- a/mdstcpip/ioroutinestcp.h
+++ b/mdstcpip/ioroutinestcp.h
@@ -300,7 +300,7 @@ static int io_listen(int argc, char **argv){
   return C_ERROR;
 }
 
-static int io_settimeout(int conid, int sec, int usec) {
+static int io_settimeout(int conid, int sec __attribute__ ((unused)), int usec __attribute__ ((unused))) {
   SOCKET sock = getSocket(conid);
   if (sock != INVALID_SOCKET) {
     //      struct timeval tv = {sec, usec};

--- a/mdstcpip/ioroutinestcp.h
+++ b/mdstcpip/ioroutinestcp.h
@@ -303,12 +303,8 @@ static int io_listen(int argc, char **argv){
 static int io_settimeout(int conid, int sec, int usec) {
   SOCKET sock = getSocket(conid);
   if (sock != INVALID_SOCKET) {
-    if (sec>0 || (sec==0 && usec >0)){
       struct timeval tv = {sec, usec};
       return setsockopt(sock, SOL_SOCKET, SO_RCVTIMEO, (const char*)&tv,sizeof(struct timeval));
-    }
-    // disable timeout
-    return setsockopt(sock, SOL_SOCKET, SO_RCVTIMEO, NULL, 0);
   }
   return C_ERROR;
 }


### PR DESCRIPTION
The existing code called setsockopt with a 0 for the option
value when attempting to clear the socket timeout but that does
not work and setsockopt returns -1 and EINVAL for error so the
timeout does not get cleared. To clear the timeout you have to
send a timeout value (sec=0,usec=0) for the option value instead.