### PR TITLE
Zck fix mdsip timeout

### DIFF
--- a/javamds/mdsobjects.c
+++ b/javamds/mdsobjects.c
@@ -62,7 +62,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #endif
 
 extern int GetAnswerInfoTS(int sock, char *dtype, short *length, char *ndims, int *dims,
-			   int *numbytes, void * *dptr, void **m, int timeout);
+			   int *numbytes, void * *dptr, void **m);
 
 static void printDecompiled(struct descriptor *dsc)
 {
@@ -3177,7 +3177,7 @@ JNIEXPORT jobject JNICALL Java_MDSplus_Connection_get
   }
 
   free((char *)dscs);
-  status = GetAnswerInfoTS(sockId, &dtype, &length, &nDims, dims, &numBytes, &ptr, &mem, 0);
+  status = GetAnswerInfoTS(sockId, &dtype, &length, &nDims, dims, &numBytes, &ptr, &mem);
   if STATUS_NOT_OK {
     exc = (*env)->FindClass(env, "MDSplus/MdsException");
     (*env)->ThrowNew(env, exc, MdsGetMsg(status));
@@ -3351,7 +3351,7 @@ JNIEXPORT void JNICALL Java_MDSplus_Connection_put
     }
   }
   free((char *)dscs);
-  status = GetAnswerInfoTS(sockId, &dtype, &length, &nDims, dims, &numBytes, &ptr, &mem, 0);
+  status = GetAnswerInfoTS(sockId, &dtype, &length, &nDims, dims, &numBytes, &ptr, &mem);
   if STATUS_NOT_OK {
     exc = (*env)->FindClass(env, "MDSplus/MdsException");
     (*env)->ThrowNew(env, exc, MdsGetMsg(status));

--- a/mdsobjects/cpp/mdsipobjects.cpp
+++ b/mdsobjects/cpp/mdsipobjects.cpp
@@ -50,7 +50,7 @@ extern "C"  void *putManyObj(char *serializedIn);
 extern "C" void *compileFromExprWithArgs(char *expr, int nArgs, void *args, void *tree);
 extern "C" int  SendArg(int sock, unsigned char idx, char dtype, unsigned char nargs, short length, char ndims,
 int *dims, char *bytes);
-extern "C" int GetAnswerInfoTS(int sock, char *dtype, short *length, char *ndims, int *dims, int *numbytes, void * *dptr, void **m, int timeout);
+extern "C" int GetAnswerInfoTS(int sock, char *dtype, short *length, char *ndims, int *dims, int *numbytes, void * *dptr, void **m);
 extern "C" int MdsOpen(int sock, char *tree, int shot);
 extern "C" int MdsSetDefault(int sock, char *node);
 extern "C" int MdsClose(int sock);
@@ -338,8 +338,8 @@ Data *Connection::get(const char *expr, Data **args, int nArgs)
 			throw MdsException(status);
 		}
 	}
-    //	unlockGlobal();	
-    status = GetAnswerInfoTS(sockId, &dtype, &length, &nDims, retDims, &numBytes, &ptr, &mem, 0);
+    //	unlockGlobal();
+    status = GetAnswerInfoTS(sockId, &dtype, &length, &nDims, retDims, &numBytes, &ptr, &mem);
 	unlockLocal();
 	if(!(status & 1))
 		throw MdsException(status);
@@ -470,7 +470,7 @@ void Connection::put(const char *inPath, char *expr, Data **args, int nArgs)
 
 	int retDims[MAX_DIMS];
 	int numBytes;
-    status = GetAnswerInfoTS(sockId, &dtype, &length, &nDims, retDims, &numBytes, &ptr, &mem, 0);
+    status = GetAnswerInfoTS(sockId, &dtype, &length, &nDims, retDims, &numBytes, &ptr, &mem);
 	unlockLocal();
     if ((status & 1) && dtype == DTYPE_LONG_IP && nDims == 0 && numBytes == sizeof(int))
     	status = *(reinterpret_cast<int *>(ptr));

--- a/mdstcpip/ConnectToMds.c
+++ b/mdstcpip/ConnectToMds.c
@@ -96,7 +96,7 @@ static int DoLogin(int id)
   status = SendMdsMsg(id, m, 0);
   free(m);
   if STATUS_OK {
-    m = GetMdsMsgTO(id, &status, 10.f);
+    m = GetMdsMsgTO(id, &status, 10000);
     if (m == 0 || STATUS_NOT_OK) {
       printf("Error in connect\n");
       return MDSplusERROR;

--- a/mdstcpip/GetAnswerInfo.c
+++ b/mdstcpip/GetAnswerInfo.c
@@ -31,14 +31,13 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ////////////////////////////////////////////////////////////////////////////////
 
 __attribute__((deprecated))
-int GetAnswerInfo(int id, char *dtype, short *length, char *ndims, int *dims, int *numbytes,
-		  void **dptr, int timeout_sec){
+int GetAnswerInfo(int id, char *dtype, short *length, char *ndims, int *dims, int *numbytes, void **dptr){
   static void *m = 0;
   if (m) {
     free(m);
     m=NULL;
   }
-  return GetAnswerInfoTS(id, dtype, length, ndims, dims, numbytes, dptr, &m, timeout_sec);
+  return GetAnswerInfoTS(id, dtype, length, ndims, dims, numbytes, dptr, &m);
 }
 
 
@@ -46,14 +45,19 @@ int GetAnswerInfo(int id, char *dtype, short *length, char *ndims, int *dims, in
 //  GetAnswerInfoTS  ///////////////////////////////////////////////////////////
 ////////////////////////////////////////////////////////////////////////////////
 
-int GetAnswerInfoTS(int id, char *dtype, short *length, char *ndims, int *dims, int *numbytes,
-		    void **dptr, void **mout, int timeout_sec){
+inline int GetAnswerInfoTS(int id, char *dtype, short *length, char *ndims, int *dims, int *numbytes, void **dptr, void **mout){
+  return GetAnswerInfoTO(id, dtype, length, ndims, dims, numbytes, dptr, mout, -1);
+}
+
+
+int GetAnswerInfoTO(int id, char *dtype, short *length, char *ndims, int *dims, int *numbytes,
+		    void **dptr, void **mout, int timeout_msec){
   INIT_STATUS;
   int i;
   Message *m;
   *mout = 0;
   *numbytes = 0;
-  m = GetMdsMsgTO(id, &status,timeout_sec);
+  m = GetMdsMsgTO(id, &status, timeout_msec);
   if STATUS_NOT_OK {
     *dtype = 0;
     *length = 0;

--- a/mdstcpip/GetMdsMsg.c
+++ b/mdstcpip/GetMdsMsg.c
@@ -31,14 +31,14 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "mdsip_connections.h"
 #include <pthread_port.h>
 
-static int GetBytes(int id, void *buffer, size_t bytes_to_recv){
+static int GetBytesTO(int id, void *buffer, size_t bytes_to_recv, int to_msec){
   char *bptr = (char *)buffer;
   IoRoutines *io = GetConnectionIo(id);
   if (io) {
     int tries = 0;
     while (bytes_to_recv > 0 && (tries < 10)) {
       ssize_t bytes_recv;
-      bytes_recv = io->recv(id, bptr, bytes_to_recv);
+      bytes_recv = io->recv_to(id, bptr, bytes_to_recv, to_msec);
       if (bytes_recv <= 0) {
 	if (errno != EINTR)
 	  return MDSplusERROR;
@@ -59,25 +59,20 @@ static int GetBytes(int id, void *buffer, size_t bytes_to_recv){
   return MDSplusERROR;
 }
 
+static int GetBytes(int id, void* buffer, size_t bytes_to_recv){
+  return GetBytesTO(id, buffer, bytes_to_recv, -1);
+}
 
 ////////////////////////////////////////////////////////////////////////////////
 //  GetMdsMsg  /////////////////////////////////////////////////////////////////
 ////////////////////////////////////////////////////////////////////////////////
 
-static void resettimeout(void* id){
-  IoRoutines *ior = GetConnectionIo(*(int*)id);
-  if (ior && ior->settimeout) ior->settimeout(*(int*)id,0,0);
-}
-
-Message *GetMdsMsgTO(int id, int *status, int sec){
+Message *GetMdsMsgTO(int id, int *status, int to_msec){
   MsgHdr header;
   Message *msg = 0;
   int msglen = 0;
   //MdsSetClientAddr(0);
-  IoRoutines *ior = GetConnectionIo(id);
-  if (ior && ior->settimeout) ior->settimeout(id,sec,0);
-  pthread_cleanup_push(resettimeout,(void*)&id);
-  *status = GetBytes(id, (void *)&header, sizeof(MsgHdr));
+  *status = GetBytesTO(id, (void *)&header, sizeof(MsgHdr), to_msec);
   if IS_OK(*status) {
     if (Endian(header.client_type) != Endian(ClientType()))
       FlipHeader(&header);
@@ -122,12 +117,11 @@ Message *GetMdsMsgTO(int id, int *status, int sec){
     if (IS_OK(*status) && (Endian(header.client_type) != Endian(ClientType())))
       FlipData(msg);
   }
-  pthread_cleanup_pop(1);
   return msg;
 }
 
 Message *GetMdsMsg(int id, int *status){
-  return GetMdsMsgTO(id, status, -1.f);
+  return GetMdsMsgTO(id, status, -1);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/mdstcpip/MdsPut.c
+++ b/mdstcpip/MdsPut.c
@@ -101,7 +101,7 @@ int MdsPut(int id, char *node, char *expression, ...)
     int numbytes;
     void *dptr;
     void *mem = 0;
-    status = GetAnswerInfoTS(id, &dtype, &len, &ndims, dims, &numbytes, &dptr, &mem, 0);
+    status = GetAnswerInfoTS(id, &dtype, &len, &ndims, dims, &numbytes, &dptr, &mem);
     if (status & 1 && dtype == DTYPE_LONG && ndims == 0 && numbytes == sizeof(int))
       memcpy(&status, dptr, numbytes);
     if (mem)

--- a/mdstcpip/MdsValue.c
+++ b/mdstcpip/MdsValue.c
@@ -75,8 +75,7 @@ int MdsValue(int id, char *expression, ...)
     void *dptr;
     void *mem = 0;
     status =
-	GetAnswerInfoTS(id, &ans_arg->dtype, &len, &ans_arg->ndims, ans_arg->dims, &numbytes, &dptr,
-			&mem, 0);
+	GetAnswerInfoTS(id, &ans_arg->dtype, &len, &ans_arg->ndims, ans_arg->dims, &numbytes, &dptr, &mem);
     ans_arg->length = len;
     if (numbytes) {
       if (ans_arg->dtype == DTYPE_CSTRING) {

--- a/mdstcpip/ioroutines.h
+++ b/mdstcpip/ioroutines.h
@@ -57,16 +57,18 @@
 #define LOAD_INITIALIZESOCKETS
 #include <pthread_port.h>
 static ssize_t io_send(int conid, const void *buffer, size_t buflen, int nowait);
-static ssize_t io_recv(int conid, void *buffer, size_t len);
+static ssize_t io_recv_to(int conid, void *buffer, size_t len, int to_msec);
 static int io_disconnect(int conid);
 static int io_flush(int conid);
 static int io_listen(int argc, char **argv);
 static int io_authorize(int conid, char *username);
 static int io_connect(int conid, char *protocol, char *host);
 static int io_reuseCheck(char *host, char *unique, size_t buflen);
-static int io_settimeout(int conid, int sec, int usec);
+inline static ssize_t io_recv(int conid, void *buffer, size_t len){
+  return io_recv_to(conid,buffer,len,-1);
+}
 static IoRoutines io_routines = {
-  io_connect, io_send, io_recv, io_flush, io_listen, io_authorize, io_reuseCheck, io_disconnect, io_settimeout
+  io_connect, io_send, io_recv, io_flush, io_listen, io_authorize, io_reuseCheck, io_disconnect, io_recv_to
 };
 
 static int GetHostAndPort(char *hostin, struct sockaddr_in *sin);

--- a/mdstcpip/ioroutinesV6.h
+++ b/mdstcpip/ioroutinesV6.h
@@ -59,16 +59,18 @@ inet_ntop(AF_INET6, &sin.sin6_addr, iphost, INET6_ADDRSTRLEN)
 #define LOAD_INITIALIZESOCKETS
 #include <pthread_port.h>
 static ssize_t io_send(int conid, const void *buffer, size_t buflen, int nowait);
-static ssize_t io_recv(int conid, void *buffer, size_t len);
 static int io_disconnect(int conid);
 static int io_flush(int conid);
 static int io_listen(int argc, char **argv);
 static int io_authorize(int conid, char *username);
 static int io_connect(int conid, char *protocol, char *host);
 static int io_reuseCheck(char *host, char *unique, size_t buflen);
-static int io_settimeout(int conid, int sec, int usec);
+static ssize_t io_recv_to(int conid, void *buffer, size_t len, int to_msec);
+inline static ssize_t io_recv(int conid, void *buffer, size_t len){
+  return io_recv_to(conid, buffer,len, -1);
+}
 static IoRoutines io_routines = {
-  io_connect, io_send, io_recv, io_flush, io_listen, io_authorize, io_reuseCheck, io_disconnect, io_settimeout
+  io_connect, io_send, io_recv, io_flush, io_listen, io_authorize, io_reuseCheck, io_disconnect, io_recv_to
 };
 
 static int GetHostAndPort(char *hostin, struct sockaddr_in6 *sin);

--- a/mdstcpip/ioroutinestcp.h
+++ b/mdstcpip/ioroutinestcp.h
@@ -299,16 +299,3 @@ static int io_listen(int argc, char **argv){
     runServerMode(&options[1]);
   return C_ERROR;
 }
-
-static int io_settimeout(int conid, int sec, int usec) {
-  SOCKET sock = getSocket(conid);
-  if (sock != INVALID_SOCKET) {
-    if (sec>0 || (sec==0 && usec >0)){
-      struct timeval tv = {sec, usec};
-      return setsockopt(sock, SOL_SOCKET, SO_RCVTIMEO, (const char*)&tv,sizeof(struct timeval));
-    }
-    // disable timeout
-    return setsockopt(sock, SOL_SOCKET, SO_RCVTIMEO, NULL, 0);
-  }
-  return C_ERROR;
-}

--- a/mdstcpip/ioroutinesudt.h
+++ b/mdstcpip/ioroutinesudt.h
@@ -182,7 +182,3 @@ static int io_listen(int argc, char **argv){
     runServerMode(&options[1]);
   return C_ERROR;
 }
-
-static int io_settimeout(int id __attribute__ ((unused)), int sec __attribute__ ((unused)), int usec __attribute__ ((unused))){
-  return C_ERROR;
-}

--- a/mdstcpip/mdsip_connections.h
+++ b/mdstcpip/mdsip_connections.h
@@ -135,6 +135,7 @@ typedef struct _mds_message {
 /// | authorize  | authorize client with username    |
 /// | reuseCheck |                                   |
 /// | disconnect | clear connection instance         |
+/// | recv_to    | receive buffer from cocnection with time out |
 ///
 typedef struct _io_routines {
   int (*connect)(int conid, char *protocol, char *connectString);
@@ -145,7 +146,7 @@ typedef struct _io_routines {
   int (*authorize)(int conid, char *username);
   int (*reuseCheck)(char *connectString, char *uniqueString, size_t buflen);
   int (*disconnect)(int conid);
-  int (*settimeout)(int conid, int sec, int usec);
+  ssize_t (*recv_to)(int conid, void *buffer, size_t len, int to_msec);
 } IoRoutines;
 
 #define EVENTASTREQUEST "---EVENTAST---REQUEST---"
@@ -339,7 +340,7 @@ EXPORT void FreeMessage(void *message);
 /// \return the function returns the status held by the answered descriptor.
 ///
 EXPORT int GetAnswerInfo(int id, char *dtype, short *length, char *ndims,
-                         int *dims, int *numbytes, void **dptr, int timeout);
+                         int *dims, int *numbytes, void **dptr);
 
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -361,6 +362,8 @@ EXPORT int GetAnswerInfo(int id, char *dtype, short *length, char *ndims,
 /// \return the function returns the status held by the answered descriptor
 ///
 EXPORT int GetAnswerInfoTS(int id, char *dtype, short *length, char *ndims,
+                           int *dims, int *numbytes, void **dptr, void **m);
+EXPORT int GetAnswerInfoTO(int id, char *dtype, short *length, char *ndims,
                            int *dims, int *numbytes, void **dptr, void **m, int timeout);
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/mdstcpip/testing/mdscp.c
+++ b/mdstcpip/testing/mdscp.c
@@ -123,7 +123,7 @@ static int doOpen(int streams, char *name, int options, int mode, struct mdsfile
       int sts;
       if (((sts =
 	    GetAnswerInfoTS(mfile->socket, &dtype, &length, &ndims, dims, &numbytes, &dptr,
-			    &msg, 0)) & 1) && (length == sizeof(mfile->fd))) {
+			    &msg)) & 1) && (length == sizeof(mfile->fd))) {
 	memcpy(&mfile->fd, dptr, sizeof(mfile->fd));
 	status = 0;
       } else {

--- a/php/mdsplus.c
+++ b/php/mdsplus.c
@@ -39,7 +39,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
   | Author:                                                              |
   +----------------------------------------------------------------------+
 
-  $Id$ 
+  $Id$
 */
 
 #ifdef HAVE_CONFIG_H
@@ -476,7 +476,7 @@ PHP_FUNCTION(mdsplus_value)
       void *dptr;
       void *mem = 0;
       status =
-		  GetAnswerInfoTS(socket, &ans.dtype, &len, &ans.ndims, &ans.dims, &numbytes, &dptr, &mem, 0);
+		  GetAnswerInfoTS(socket, &ans.dtype, &len, &ans.ndims, &ans.dims, &numbytes, &dptr, &mem);
       ans.length = len;
       if (numbytes) {
 	if (ans.dtype == DTYPE_CSTRING) {
@@ -663,7 +663,7 @@ PHP_FUNCTION(mdsplus_put)
       void *dptr;
       void *mem = 0;
       status =
-		  GetAnswerInfoTS(socket, &ans.dtype, &len, &ans.ndims, &ans.dims, &numbytes, &dptr, &mem, 0);
+		  GetAnswerInfoTS(socket, &ans.dtype, &len, &ans.ndims, &ans.dims, &numbytes, &dptr, &mem);
       ans.length = len;
       if (numbytes) {
 	if (ans.dtype == DTYPE_CSTRING) {

--- a/servershr/ServerSendMessage.c
+++ b/servershr/ServerSendMessage.c
@@ -258,7 +258,7 @@ int ServerSendMessage(int *msgid, char *server, int op, int *retstatus, pthread_
       CleanupJob(status, jobid);
       return status;
   }
-  status = GetAnswerInfoTS(conid, &dtype, &len, &ndims, dims, &numbytes, (void **)&dptr, &mem, 0);
+  status = GetAnswerInfoTS(conid, &dtype, &len, &ndims, dims, &numbytes, (void **)&dptr, &mem);
   if (op==SrvStop) {
     if STATUS_NOT_OK {
       status = MDSplusSUCCESS;

--- a/tdic/TdiShrExt.c
+++ b/tdic/TdiShrExt.c
@@ -386,7 +386,7 @@ EXPORT struct descriptor_xd *rMdsValue(struct descriptor *expression, ...)
   va_end(incrmtr);
 /* Get the reply ================================================== */
   if (status & 1) {
-    status = GetAnswerInfoTS(sock, &dtype, &len, &ndims, dims, &numbytes, &dptr, &mem, 0);
+    status = GetAnswerInfoTS(sock, &dtype, &len, &ndims, dims, &numbytes, &dptr, &mem);
 #ifdef DEBUG
     printf("Reply status[%d],dtype[%d],len[%d],ndims[%d],numbytes[%d],ans[%d]\n", status, dtype,
 	   len, ndims, numbytes, *(int *)dptr);


### PR DESCRIPTION
* Added recv_to which uses poll instead of the io_settimeout implementation.
* Attempt to fix the issue addressed in #1047 by adding GetAnswerInfoTO instead of replacing GetAnswerInfoTS to avoid conflicts. therefore reverts some changes in #1047