### PR TITLE
Build: Allow gdb use inside docker builds

### DIFF
--- a/deploy/platform/platform_build.sh
+++ b/deploy/platform/platform_build.sh
@@ -84,7 +84,7 @@ rundocker(){
         else port_forwarding="-p ${FORWARD_PORT}:${FORWARD_PORT}"
              echo $port_forwarding
         fi
-        docker run -t $stdio --cidfile=${WORKSPACE}/${OS}_docker-cid \
+        docker run --cap-add=SYS_PTRACE -t $stdio --cidfile=${WORKSPACE}/${OS}_docker-cid \
            -u $(id -u):$(id -g) \
            -h $DISTNAME \
            -e "ARCH=${arch}" \


### PR DESCRIPTION
When a build hangs it may be useful to run gdb on the process inside
the docker container to determine the cause of the hang. The SYS_PTRACE
capability must be enabled before you can use gdb inside the container.
To gdb the process you need to use "docker exec" to run gdb in the container.