### PR TITLE
FIX: GetManyExecute

### DIFF
--- a/mdsobjects/cpp/mdsdata.c
+++ b/mdsobjects/cpp/mdsdata.c
@@ -802,7 +802,7 @@ void convertToIEEEFloat(int dtype, int length, void *ptr)
 }
 
 ///////////////mdsip support for Connection class///////////
-struct descriptor_xd *GetManyExecute(char *serializedIn)
+struct descriptor_xd EXPORT *GetManyExecute(char *serializedIn)
 {
   static EMPTYXD(xd);
   struct descriptor_xd *serResult;


### PR DESCRIPTION
Routime GetManyExecute of MdsObjectsCppShr must be globally visible because it is accessed from the Java MdsObjects interface, i.e. from library JavaMds.