### PR TITLE
Fix: use default recv if recv_to is not available

### DIFF
--- a/mdstcpip/GetMdsMsg.c
+++ b/mdstcpip/GetMdsMsg.c
@@ -38,7 +38,10 @@ static int GetBytesTO(int id, void *buffer, size_t bytes_to_recv, int to_msec){
     int tries = 0;
     while (bytes_to_recv > 0 && (tries < 10)) {
       ssize_t bytes_recv;
-      bytes_recv = io->recv_to(id, bptr, bytes_to_recv, to_msec);
+      if (io->recv_to && to_msec>=0) // don't use timeout if not available or requested
+        bytes_recv = io->recv_to(id, bptr, bytes_to_recv, to_msec);
+      else
+        bytes_recv = io->recv(id, bptr, bytes_to_recv);
       if (bytes_recv <= 0) {
 	if (errno != EINTR)
 	  return MDSplusERROR;

--- a/mdstcpip/IoRoutinesTunnel.c
+++ b/mdstcpip/IoRoutinesTunnel.c
@@ -43,7 +43,11 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 static ssize_t tunnel_send(int id, const void *buffer, size_t buflen, int nowait);
 static ssize_t tunnel_recv(int id, void *buffer, size_t len);
+#ifdef _WIN32
+#define tunnel_recv_to NULL
+#else
 static ssize_t tunnel_recv_to(int id, void *buffer, size_t len, int to_msec);
+#endif
 static int tunnel_disconnect(int id);
 static int tunnel_connect(int id, char *protocol, char *host);
 static int tunnel_listen(int argc, char **argv);
@@ -122,24 +126,23 @@ static ssize_t tunnel_recv(int id, void *buffer, size_t buflen){
 #endif
 }
 
+#ifndef _WIN32
 static ssize_t tunnel_recv_to(int id, void *buffer, size_t buflen, int to_msec){
   struct TUNNEL_PIPES *p = getTunnelPipes(id);
   if (!p) return -1;
-#ifdef _WIN32
-  ssize_t num = 0;
-  return ReadFile(p->stdout_pipe, buffer, buflen, (DWORD *)&num, NULL) ? num : -1;
-#else
-  struct timeval timeout;
-  timeout.tv_sec = (to_msec/1000);
-  timeout.tv_usec = to_msec % 1000;
-  fd_set set;
-  FD_ZERO(&set); /* clear the set */
-  FD_SET(p->stdout_pipe, &set); /* add our file descriptor to the set */
-  int rv = select(p->stdout_pipe + 1, &set, NULL, NULL, &timeout);
-  if (rv>0) return read(p->stdout_pipe, buffer, buflen);
-  return rv;
-#endif
+  if (to_msec>=0) { // don't tiime out if to_msec < 0
+    struct timeval timeout;
+    timeout.tv_sec = (to_msec/1000);
+    timeout.tv_usec = to_msec % 1000;
+    fd_set set;
+    FD_ZERO(&set); /* clear the set */
+    FD_SET(p->stdout_pipe, &set); /* add our file descriptor to the set */
+    int rv = select(p->stdout_pipe + 1, &set, NULL, NULL, &timeout);
+    if (rv<=0) return rv;
+  }
+  return read(p->stdout_pipe, buffer, buflen);
 }
+#endif
 
 #ifndef _WIN32
 static void ChildSignalHandler(int num __attribute__ ((unused)))

--- a/mdstcpip/ioroutines.h
+++ b/mdstcpip/ioroutines.h
@@ -57,16 +57,21 @@
 #define LOAD_INITIALIZESOCKETS
 #include <pthread_port.h>
 static ssize_t io_send(int conid, const void *buffer, size_t buflen, int nowait);
+#ifdef _WIN32
+static ssize_t io_recv(int conid, void *buffer, size_t len);
+#define io_recv_to NULL
+#else
 static ssize_t io_recv_to(int conid, void *buffer, size_t len, int to_msec);
+inline static ssize_t io_recv(int conid, void *buffer, size_t len){
+  return io_recv_to(conid,buffer,len,-1);
+}
+#endif
 static int io_disconnect(int conid);
 static int io_flush(int conid);
 static int io_listen(int argc, char **argv);
 static int io_authorize(int conid, char *username);
 static int io_connect(int conid, char *protocol, char *host);
 static int io_reuseCheck(char *host, char *unique, size_t buflen);
-inline static ssize_t io_recv(int conid, void *buffer, size_t len){
-  return io_recv_to(conid,buffer,len,-1);
-}
 static IoRoutines io_routines = {
   io_connect, io_send, io_recv, io_flush, io_listen, io_authorize, io_reuseCheck, io_disconnect, io_recv_to
 };


### PR DESCRIPTION
silly did not take other protocols into account

this should also add timeout for the tunnel but it is currently not used. maybe it can be used via python Connection. i will see if this can be included in tests somewhere
