### PR TITLE
Zck py connection

### DIFF
--- a/mdsobjects/python/connection.py
+++ b/mdsobjects/python/connection.py
@@ -238,6 +238,9 @@ class Connection(object):
                 self.__sendArg__(arg,i+1,num)
             return self.__getAnswer__(timeout)
 
+    def getObject(self,exp,*args,**kwargs):
+        return self.get('serializeout(`(%s;))'%exp,*args,**kwargs).deserialize()
+
     def setDefault(self,path):
         """Change the current default tree location on the remote server
         @param path: Tree node path to be the new default location.

--- a/mdsobjects/python/tests/dclUnitTest.py
+++ b/mdsobjects/python/tests/dclUnitTest.py
@@ -28,7 +28,7 @@ import os,sys
 from re import match
 from threading import RLock
 
-from MDSplus import Tree,Device,Connection,GetMany
+from MDSplus import Tree,Device,Connection,GetMany,Range
 from MDSplus import getenv,setenv,dcl,ccl,tcl,cts
 from MDSplus import mdsExceptions as Exc
 
@@ -190,6 +190,13 @@ class Tests(TestCase):
                 """ mdsconnect """
                 c = Connection(server)
                 self.assertEqual(c.get('1').tolist(),1)
+                self.assertEqual(c.getObject('1:3:1').__class__,Range)
+                if not sys.platform.startswith('win'): # Windows does not support timeout yet
+                    try: #  currently the connection needs to be closed after a timeout
+                        Connection(server).get("wait(1)",timeout=100)
+                        self.fail("Connection.get(wait(1)) should have timed out.")
+                    except Exc.MDSplusException as e:
+                        self.assertEqual(e.__class__,Exc.TdiTIMEOUT)
                 g = GetMany(c);
                 g.append('a','1')
                 g.append('b','$',2)

--- a/mdstcpip/GetAnswerInfo.c
+++ b/mdstcpip/GetAnswerInfo.c
@@ -68,7 +68,7 @@ int GetAnswerInfoTO(int id, char *dtype, short *length, char *ndims, int *dims, 
       free(m);
       *mout = 0;
     }
-    return MDSplusERROR;
+    return status;
   }
   if (m->h.ndims) {
     *numbytes = m->h.length;

--- a/mdstcpip/GetMdsMsg.c
+++ b/mdstcpip/GetMdsMsg.c
@@ -30,6 +30,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "zlib/zlib.h"
 #include "mdsip_connections.h"
 #include <pthread_port.h>
+#include <tdishr_messages.h>
 
 static int GetBytesTO(int id, void *buffer, size_t bytes_to_recv, int to_msec){
   char *bptr = (char *)buffer;
@@ -42,7 +43,9 @@ static int GetBytesTO(int id, void *buffer, size_t bytes_to_recv, int to_msec){
         bytes_recv = io->recv_to(id, bptr, bytes_to_recv, to_msec);
       else
         bytes_recv = io->recv(id, bptr, bytes_to_recv);
-      if (bytes_recv <= 0) {
+      if (bytes_recv == 0)
+	return TdiTIMEOUT;
+      if (bytes_recv < 0) {
 	if (errno != EINTR)
 	  return MDSplusERROR;
 	tries++;


### PR DESCRIPTION
* adds getObject to Connection which allows the easy transfer of complex data objects e.g. signals
* adds separation of TimeOut vs other Exceptions during GetAnswerInfo
TODO: after a timeout the server still tries to send result and interferes with subsequent calls. Server either needs to be notified to cancel operation or the connection needs to be terminated. currently it is the responsibility of the user to do so when used in python. The only internal use is during DoLogin which terminates the connection on failure.