### PR TITLE
Zck setTimeContext does return double even if the original dim was an expression generating Q types

### DIFF
--- a/xtreeshr/XTreeDefaultResample.c
+++ b/xtreeshr/XTreeDefaultResample.c
@@ -432,7 +432,7 @@ static void resample(int64_t start, int64_t end, int64_t delta, int64_t * inTime
 
 //The default resample handles int64 timebases
 //return 0 if the conversion is  not possible
-static int64_t *convertTimebaseToInt64(struct descriptor_signal *inSignalD, int *outSamples)
+static int64_t *convertTimebaseToInt64(struct descriptor_signal *inSignalD, int *outSamples, int *isFloat)
 {
   struct descriptor_a *currDim;
   double *doublePtr;
@@ -464,7 +464,7 @@ static int64_t *convertTimebaseToInt64(struct descriptor_signal *inSignalD, int 
       MdsFree1Dx(&currXd, 0);
       return outPtr;
     }
-
+    *isFloat = 1;
     status = TdiFloat(&currXd, &currXd MDS_END_ARG);
   }
   currDim = (struct descriptor_a *)currXd.pointer;
@@ -604,10 +604,8 @@ static int XTreeDefaultResampleMode(struct descriptor_signal *inSignalD, struct 
   }
 
 //This version handles only 64 bit time format
-  if (inSignalD->dimensions[0]->dtype != DTYPE_Q && inSignalD->dimensions[0]->dtype != DTYPE_QU)
-    isFloat = 1;
 
-  timebase64 = convertTimebaseToInt64(inSignalD, &numTimebaseSamples);
+  timebase64 = convertTimebaseToInt64(inSignalD, &numTimebaseSamples, &isFloat);
   if (!timebase64)
     return 0;			//Cannot convert timebase to 64 bit int
 
@@ -705,7 +703,7 @@ static int XTreeDefaultResampleMode(struct descriptor_signal *inSignalD, struct 
   else {
     outDimArray.length = 8;
     outDimArray.arsize = 8 * outSamples;
-    outDimArray.dtype = DTYPE_QU;
+    outDimArray.dtype = DTYPE_Q;
     outDimArray.pointer = (char *)outDim;
   }
 

--- a/xtreeshr/XTreeDefaultResample.c
+++ b/xtreeshr/XTreeDefaultResample.c
@@ -191,7 +191,7 @@ static void resample(int64_t start, int64_t end, int64_t delta, int64_t * inTime
 								nextData = ((int *)(&data[timebaseIdx * itemSize]))[i];
 								currData = prevData + (nextData - prevData) * (refTime - timebase[timebaseIdx - 1])
 								/ (timebase[timebaseIdx] - timebase[timebaseIdx - 1]);
-								((unsigned int *)(&outData[outSamples * itemSize]))[i] = currData;
+								((int *)(&outData[outSamples * itemSize]))[i] = currData;
 							}
 							break;
 						case DTYPE_QU:
@@ -316,7 +316,7 @@ static void resample(int64_t start, int64_t end, int64_t delta, int64_t * inTime
 							break;
 						case DTYPE_L:
 							for (i = 0; i < numDataItems; i++) {
-								unsigned int currData, minData, maxData;
+								int currData, minData, maxData;
 								minData = maxData = ((int *)(&data[(prevTimebaseIdx) * itemSize]))[i];
 								for(j = prevTimebaseIdx + 1; j < timebaseIdx; j++)
 								{
@@ -332,18 +332,18 @@ static void resample(int64_t start, int64_t end, int64_t delta, int64_t * inTime
 							break;
 						case DTYPE_QU:
 							for (i = 0; i < numDataItems; i++) {
-								int64_t currData, minData, maxData;
-								minData = maxData = ((int64_t *)(&data[(prevTimebaseIdx) * itemSize]))[i];
+								uint64_t currData, minData, maxData;
+								minData = maxData = ((uint64_t *)(&data[(prevTimebaseIdx) * itemSize]))[i];
 								for(j = prevTimebaseIdx + 1; j < timebaseIdx; j++)
 								{
-									currData = ((int64_t *)(&data[j * itemSize]))[i];
+									currData = ((uint64_t *)(&data[j * itemSize]))[i];
 									if(currData > maxData)
 										maxData = currData;
 									if(currData < minData)
 										minData = currData;
 								}
-								((int64_t *)(&outData[2*outSamples * itemSize]))[i] = minData;
-								((int64_t *)(&outData[(2*outSamples+1) * itemSize]))[i] = maxData;
+								((uint64_t *)(&outData[2*outSamples * itemSize]))[i] = minData;
+								((uint64_t *)(&outData[(2*outSamples+1) * itemSize]))[i] = maxData;
 							}
 							break;
 						case DTYPE_Q:


### PR DESCRIPTION
* resolved inconsistent data conversions (uint <-> int) in XTreeDefaultResample
* if dim is an expression (e.g. "-10Q : 10Q : 1Q") the original code would not identify the datatype as int64 but default to float instead.