### PR TITLE
Fix: Clear write once attribute when writing segments into an empty node

### DIFF
--- a/treeshr/TreeSegments.c
+++ b/treeshr/TreeSegments.c
@@ -325,11 +325,11 @@ if (STATUS_OK && (shot_open && (local_nci->flags & NciM_NO_WRITE_SHOT))) \
   RETURN(UNLOCK_NCI,TreeNOWRITESHOT); \
 if (STATUS_OK && (!shot_open && (local_nci->flags & NciM_NO_WRITE_MODEL))) \
   RETURN(UNLOCK_NCI,TreeNOWRITEMODEL); \
- if (STATUS_OK && (local_nci->flags & NciM_WRITE_ONCE) && local_nci->length==0) \
-   local_nci->flags &= ~NciM_WRITE_ONCE; \
-if (STATUS_OK && (local_nci->flags & NciM_WRITE_ONCE) && local_nci->length) \
-    RETURN(UNLOCK_NCI,TreeNOOVERWRITE);
-
+if (STATUS_OK && (local_nci->flags & NciM_WRITE_ONCE)) { \
+  if (local_nci->length) \
+    RETURN(UNLOCK_NCI,TreeNOOVERWRITE); \
+  local_nci->flags &= ~NciM_WRITE_ONCE; \
+}
 
 #define OPEN_DATAFILE_WRITE1() status = OpenDatafileWrite1(status,tinfo,&stv)
 inline static int OpenDatafileWrite1(int status,TREE_INFO *tinfo, int *stv_ptr){

--- a/treeshr/TreeSegments.c
+++ b/treeshr/TreeSegments.c
@@ -325,6 +325,8 @@ if (STATUS_OK && (shot_open && (local_nci->flags & NciM_NO_WRITE_SHOT))) \
   RETURN(UNLOCK_NCI,TreeNOWRITESHOT); \
 if (STATUS_OK && (!shot_open && (local_nci->flags & NciM_NO_WRITE_MODEL))) \
   RETURN(UNLOCK_NCI,TreeNOWRITEMODEL); \
+ if (STATUS_OK && (local_nci->flags & NciM_WRITE_ONCE) && local_nci->length==0) \
+   local_nci->flags &= ~NciM_WRITE_ONCE; \
 if (STATUS_OK && (local_nci->flags & NciM_WRITE_ONCE) && local_nci->length) \
     RETURN(UNLOCK_NCI,TreeNOOVERWRITE);
 

--- a/treeshr/TreeSegments.c
+++ b/treeshr/TreeSegments.c
@@ -328,7 +328,7 @@ if (STATUS_OK && (!shot_open && (local_nci->flags & NciM_NO_WRITE_MODEL))) \
 if (STATUS_OK && (local_nci->flags & NciM_WRITE_ONCE)) { \
   if (local_nci->length) {\
     RETURN(UNLOCK_NCI,TreeNOOVERWRITE); \
-  }
+  } \
   local_nci->flags &= ~NciM_WRITE_ONCE; \
 }
 

--- a/treeshr/TreeSegments.c
+++ b/treeshr/TreeSegments.c
@@ -326,8 +326,9 @@ if (STATUS_OK && (shot_open && (local_nci->flags & NciM_NO_WRITE_SHOT))) \
 if (STATUS_OK && (!shot_open && (local_nci->flags & NciM_NO_WRITE_MODEL))) \
   RETURN(UNLOCK_NCI,TreeNOWRITEMODEL); \
 if (STATUS_OK && (local_nci->flags & NciM_WRITE_ONCE)) { \
-  if (local_nci->length) \
+  if (local_nci->length) {\
     RETURN(UNLOCK_NCI,TreeNOOVERWRITE); \
+  }
   local_nci->flags &= ~NciM_WRITE_ONCE; \
 }
 


### PR DESCRIPTION
The write_once attribute when used with segments is only meaningful when
set after the completion of intended storage of all segments. If a node
has the write_once attribute set before storage begins it will only permit
one segment write to the node which will break many existing devices.

This fix will clear the write_once attribute on a node if the node contains
no data when the first segment is written.