### PR TITLE
Fix: Opaque attempt to get dim for opaque segments

### DIFF
--- a/treeshr/TreeSegments.c
+++ b/treeshr/TreeSegments.c
@@ -968,7 +968,9 @@ static int ReadSegment(TREE_INFO * tinfo, int nid, SEGMENT_HEADER * shead,
         MdsCopyDxXd((struct descriptor *)&dim2, dim);
         free(dim_ptr);
       } else {
-        TreeGetDsc(tinfo, nid, sinfo->dimension_offset, sinfo->dimension_length, dim);
+	if (sinfo->dimension_length != -1) {
+          TreeGetDsc(tinfo, nid, sinfo->dimension_offset, sinfo->dimension_length, dim);
+	}
       }
       if (!compressed_segment) {
         MdsCopyDxXd((struct descriptor *)&ans, segment);


### PR DESCRIPTION
When storing opaque segments (list of jpegs etc) no dimension
information is stored for each entry. The ReadSegment code was
trying to obtain a dimension which resulted in a malloc(-1) call.
This fix prevents attempting to read the dimension if their is none.