### PR TITLE
Fix: Add EXPORT for mdsdcl_spawn

### DIFF
--- a/mdsdcl/mdsdcl_commands.c
+++ b/mdsdcl/mdsdcl_commands.c
@@ -291,7 +291,7 @@ extern int LibSpawn();
 	/**************************************************************
 	 * mdsdcl_spawn:
 	 **************************************************************/
-int mdsdcl_spawn(void *ctx, char **error, char **output __attribute__ ((unused)))
+EXPORT int mdsdcl_spawn(void *ctx, char **error, char **output __attribute__ ((unused)))
 {
   int notifyFlag;
   int waitFlag;


### PR DESCRIPTION
This export was missing preventing spawn and submit from working.