### PR TITLE
Fix: Older matlab 2011 fix for MDSplus interface

### DIFF
--- a/matlab/mdsvalue.m
+++ b/matlab/mdsvalue.m
@@ -17,7 +17,7 @@ function [ result, status ] = mdsvalue( expression, varargin)
       extra=1;
     end
     n = size(varargin,2);
-    args = javaArray('MDSplus.Data',n+extra);
+    args = javaArray('MDSplus.Data',max(1,n+extra));
     for k = 1: n
       argin=varargin(k);
       try


### PR DESCRIPTION
A problem was discovered when using the matlab interface with
matlab version 2011. This fixes the problem.