### PR TITLE
Build: User real source directory inside docker images

### DIFF
--- a/deploy/packaging/windows/mdsplus.nsi
+++ b/deploy/packaging/windows/mdsplus.nsi
@@ -78,8 +78,8 @@ Section
 SetOutPath "$INSTDIR"
 SetShellVarContext all
 File "/oname=ChangeLog.rtf" ChangeLog
-File /source/mdsplus.ico
-File /source/MDSplus-License.rtf
+File ${srcdir}/mdsplus.ico
+File ${srcdir}/MDSplus-License.rtf
 writeUninstaller "$INSTDIR\uninstall.exe"
 WriteRegStr HKLM "${ENVREG}" MDS_PATH "$INSTDIR\tdi"
 WriteRegStr HKLM "${ENVREG}" MDSPLUS_DIR "$INSTDIR"
@@ -165,7 +165,7 @@ WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\MDSplus" "
 WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\MDSplus" "DisplayIcon" "INSTDIR\mdsplus.ico"
 WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\MDSplus" "Publisher" "MDSplus Collaboratory"
 WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\MDSplus" "HelpLink" "${HELPURL}"
-WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\MDSplus" "InstallSource" "http://www.mdsplus.org/dist/SOURCES/mdsplus${FLAVOR}-${MAJOR}.${MINOR}-${RELEASE}.tgz"
+WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\MDSplus" "InstallSource" "http://www.mdsplus.org/dist${SRCDIR}S/mdsplus${FLAVOR}-${MAJOR}.${MINOR}-${RELEASE}.tgz"
 WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\MDSplus" "URLUpdateInfo" "${UPDATEURL}"
 WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\MDSplus" "URLInfoAbout" "${ABOUTURL}"
 WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\MDSplus" "DisplayVersion" "${MAJOR}.${MINOR}.${RELEASE}"
@@ -219,7 +219,7 @@ SectionEnd
 
 Section "PYTHON"
 SetOutPath "$INSTDIR\mdsobjects"
-File /r /x MDSplus /source/mdsobjects/python
+File /r /x MDSplus ${srcdir}/mdsobjects/python
 SetOutPath "$INSTDIR\mdsobjects\python"
 File /workspace/releasebld/64/mdsobjects/python/_version.py
 SetOutPath "$INSTDIR\mdsobjects\python"

--- a/deploy/platform/alpine/alpine_build_apks.py
+++ b/deploy/platform/alpine/alpine_build_apks.py
@@ -25,6 +25,8 @@
 #
 import subprocess,os,sys,xml.etree.ElementTree as ET,fnmatch,tempfile,shutil
 
+srcdir=os.path.realpath(os.path.dirname(os.path.realpath(__file__))+'/../../..')
+      
 def getPackageFiles(buildroot,includes,excludes):
     files=list()
     for f in includes:
@@ -104,7 +106,7 @@ def buildApks():
     else:
         info['BNAME']="-%s" % info['BRANCH']
     info['rflavor']=info['BNAME']
-    tree=ET.parse('/source/deploy/packaging/linux.xml')
+    tree=ET.parse(srcdir+'/deploy/packaging/linux.xml')
     root=tree.getroot()
     apks=list()
     pkg_exclusions=('repo','gsi','gsi_bin','idl','idl_bin',

--- a/deploy/platform/alpine/alpine_docker_build.sh
+++ b/deploy/platform/alpine/alpine_docker_build.sh
@@ -7,6 +7,7 @@
 testx86_64="64 x86_64-linux bin lib"
 testx86="32 i686-linux   bin lib --with-gsi=/usr:gcc32"
 testarmhf="arm armv6-alpine-linux-muslgnueabihf bin lib"
+srcdir=$(realpath $(dirname ${0})/../..)
 
 gethost() {
     case $1 in
@@ -60,7 +61,7 @@ buildrelease() {
     RELEASE_VERSION=${RELEASE_VERSION} \
     ARCH=${ARCH} \
     DISTNAME=${DISTNAME} \
-    HOME=/ /source/deploy/platform/alpine/alpine_build_apks.py
+    HOME=/ ${srcdir}/deploy/platform/alpine/alpine_build_apks.py
   fi
 }
 

--- a/deploy/platform/alpine/alpine_docker_build.sh
+++ b/deploy/platform/alpine/alpine_docker_build.sh
@@ -7,7 +7,7 @@
 testx86_64="64 x86_64-linux bin lib"
 testx86="32 i686-linux   bin lib --with-gsi=/usr:gcc32"
 testarmhf="arm armv6-alpine-linux-muslgnueabihf bin lib"
-srcdir=$(realpath $(dirname ${0})/../..)
+srcdir=$(readlink -e $(dirname ${0})/../..)
 
 gethost() {
     case $1 in

--- a/deploy/platform/alpine/alpine_docker_build.sh
+++ b/deploy/platform/alpine/alpine_docker_build.sh
@@ -7,7 +7,7 @@
 testx86_64="64 x86_64-linux bin lib"
 testx86="32 i686-linux   bin lib --with-gsi=/usr:gcc32"
 testarmhf="arm armv6-alpine-linux-muslgnueabihf bin lib"
-srcdir=$(readlink -e $(dirname ${0})/../..)
+srcdir=$(readlink -f $(dirname ${0})/../..)
 
 gethost() {
     case $1 in

--- a/deploy/platform/debian/debian_build_debs.py
+++ b/deploy/platform/debian/debian_build_debs.py
@@ -25,6 +25,8 @@
 #
 import subprocess,os,sys,xml.etree.ElementTree as ET,fnmatch,tempfile,shutil
 
+srcdir=os.path.realpath(os.path.dirname(os.path.realpath(__file__))+'/../../..')
+
 def getPackageFiles(buildroot,includes,excludes):
     files=list()
     for f in includes:
@@ -103,7 +105,7 @@ def buildDebs():
     info['release']=int(version[2])
     info['BNAME']=os.environ['BNAME']
     info['rflavor']=info['BNAME']
-    tree=ET.parse('/source/deploy/packaging/linux.xml')
+    tree=ET.parse(srcdir+'/deploy/packaging/linux.xml')
     root=tree.getroot()
     debs=list()
     for package in root.getiterator('package'):

--- a/deploy/platform/debian/debian_docker_build.sh
+++ b/deploy/platform/debian/debian_docker_build.sh
@@ -12,6 +12,8 @@
 # /publish/$branch/DEBS/$arch/*.deb
 #
 
+srcdir=$(realpath $(dirname ${0})/../..)
+
 # configure based on ARCH
 case "${ARCH}" in
   "amd64")
@@ -83,7 +85,7 @@ buildrelease() {
 	     ARCH=${ARCH} \
 	     DISTNAME=${DISTNAME} \
 	     PLATFORM=${PLATFORM} \
-	     /source/deploy/platform/debian/debian_build_debs.py
+	     ${srcdir}/deploy/platform/debian/debian_build_debs.py
     baddeb=0
     for deb in $(find /release/${BRANCH}/DEBS/${ARCH} -name "*\.deb")
     do
@@ -94,13 +96,13 @@ buildrelease() {
 	fi
         if [[ x${pkg} == x*_bin ]]
         then
-          checkfile=/source/deploy/packaging/${PLATFORM}/$pkg.$ARCH
+          checkfile=${srcdir}/deploy/packaging/${PLATFORM}/$pkg.$ARCH
         else
-          checkfile=/source/deploy/packaging/${PLATFORM}/$pkg.noarch
+          checkfile=${srcdir}/deploy/packaging/${PLATFORM}/$pkg.noarch
         fi
 	if [ "$UPDATEPKG" = "yes" ]
 	then
-	    mkdir -p /source/deploy/packaging/${PLATFORM}
+	    mkdir -p ${srcdir}/deploy/packaging/${PLATFORM}
 	    makelist $deb > ${checkfile}
 	else
 	    set +e

--- a/deploy/platform/debian/debian_docker_build.sh
+++ b/deploy/platform/debian/debian_docker_build.sh
@@ -12,7 +12,7 @@
 # /publish/$branch/DEBS/$arch/*.deb
 #
 
-srcdir=$(realpath $(dirname ${0})/../..)
+srcdir=$(readlink -e $(dirname ${0})/../..)
 
 # configure based on ARCH
 case "${ARCH}" in

--- a/deploy/platform/platform_build.sh
+++ b/deploy/platform/platform_build.sh
@@ -46,6 +46,7 @@ spacedelim() {
     echo $ans
 }
 rundocker(){
+    srcdir=$(realpath ${SRCDIR})
     images=(${DOCKERIMAGE})
     ARCH="$(spacedelim ${ARCH})"
     arches=(${ARCH})
@@ -55,7 +56,7 @@ rundocker(){
     if [ -z "$INTERACTIVE" ]
     then
         stdio="-a stdout -a stderr"
-        program="/source/deploy/platform/platform_docker_build.sh"
+        program="${srcdir}/deploy/platform/platform_docker_build.sh"
     else
         stdio="-i"
         program="/bin/bash"
@@ -67,8 +68,8 @@ rundocker(){
         echo "Building installers for ${arch} using ${image}"
         if [ ! -z "$INTERACTIVE" ]
         then
-            echo "run /source/deploy/platform/platform_docker_build.sh"
-            echo "or  NOMAKE=1 /source/deploy/platform/platform_docker_build.sh"
+            echo "run ${srcdir}/deploy/platform/platform_docker_build.sh"
+            echo "or  NOMAKE=1 ${srcdir}/deploy/platform/platform_docker_build.sh"
         fi
         #
         # If there are both 32-bit and 64-bit packages for the platform
@@ -109,7 +110,7 @@ rundocker(){
            -e "mdsevent_port=$EVENT_PORT" \
            -e "HOME=/workspace" \
            -e "JARS_DIR=$jars_dir" \
-           -v $(realpath ${SRCDIR}):/source \
+           -v ${srcdir}:${srcdir} \
            -v ${WORKSPACE}:/workspace \
            $port_forwarding \
            $(volume "${JARS_DIR}" /jars_dir) \

--- a/deploy/platform/platform_docker_build.sh
+++ b/deploy/platform/platform_docker_build.sh
@@ -7,9 +7,10 @@
 # Build script from within a docker image
 #
 export HOME=/tmp/home
+srcdir=$(realpath $(dirname ${0})/../..)
 mkdir -p $HOME
 tio(){
-    :&& /source/deploy/platform/timeout.sh "$@";
+    :&& ${srcdir}/deploy/platform/timeout.sh "$@";
     return $?;
 }
 getenv() {
@@ -35,11 +36,11 @@ testarch(){
 config() {
     if [ -z "$JARS_DIR" ]
     then
-	JAVA_OPTS="--with-java_target=6 --with-java_bootclasspath=/source/rt.jar"
+	JAVA_OPTS="--with-java_target=6 --with-java_bootclasspath=${srcdir}/rt.jar"
     else
 	JAVA_OPTS="--with-jars=${JARS_DIR}"
     fi
-    :&& /source/configure \
+    :&& ${srcdir}/configure \
         --prefix=${MDSPLUS_DIR} \
         --exec_prefix=${MDSPLUS_DIR} \
         --host=$2 \
@@ -55,7 +56,7 @@ config_test(){
     export WINEPATH="Z:${MDSPLUS_DIR}/$3"
     rm -Rf $(dirname "${MDSPLUS_DIR}");
     mkdir -p ${MDSPLUS_DIR};
-    cp -rf /source/xml ${MDSPLUS_DIR}/xml;
+    cp -rf ${srcdir}/xml ${MDSPLUS_DIR}/xml;
     MDS_PATH=${MDSPLUS_DIR}/tdi;
     pushd ${MDSPLUS_DIR}/..;
     config $@ --enable-debug --enable-werror;
@@ -145,7 +146,7 @@ make_jars() {
   rm -Rf /workspace/jars
   mkdir -p /workspace/jars
   pushd /workspace/jars
-  /source/configure --enable-java_only --with-java_target=6 --with-java_bootclasspath=/source/rt.jar
+  ${srcdir}/configure --enable-java_only --with-java_target=6 --with-java_bootclasspath=${srcdir}/rt.jar
   if [ -z "$NOMAKE" ]; then
     $MAKE
   fi
@@ -200,9 +201,9 @@ export PYTHONDONTWRITEBYTECODE=no
 export PyLib=$(ldd $(which python) | grep libpython | awk '{print $3}')
 main(){
     MAKE=${MAKE:="env LANG=en_US.UTF-8 make"}
-    if [ -r /source/deploy/os/${OS}.env ]
+    if [ -r ${srcdir}/deploy/os/${OS}.env ]
     then
-        source /source/deploy/os/${OS}.env
+        source ${srcdir}/deploy/os/${OS}.env
     fi
     if [ "$TEST" = "yes" ]
     then
@@ -230,7 +231,7 @@ main(){
         publish
     fi
 }
-source /source/deploy/platform/${PLATFORM}/${PLATFORM}_docker_build.sh
+source ${srcdir}/deploy/platform/${PLATFORM}/${PLATFORM}_docker_build.sh
 if [ ! -z "$0" ] && [ ${0:0:1} != "-" ] && [ "$( basename $0 )" = "platform_docker_build.sh" ]
 then
     env

--- a/deploy/platform/platform_docker_build.sh
+++ b/deploy/platform/platform_docker_build.sh
@@ -7,7 +7,7 @@
 # Build script from within a docker image
 #
 export HOME=/tmp/home
-srcdir=$(readlink -e $(dirname ${0})/../..)
+srcdir=$(readlink -f $(dirname ${0})/../..)
 mkdir -p $HOME
 tio(){
     :&& ${srcdir}/deploy/platform/timeout.sh "$@";

--- a/deploy/platform/platform_docker_build.sh
+++ b/deploy/platform/platform_docker_build.sh
@@ -7,7 +7,7 @@
 # Build script from within a docker image
 #
 export HOME=/tmp/home
-srcdir=$(realpath $(dirname ${0})/../..)
+srcdir=$(readlink -e $(dirname ${0})/../..)
 mkdir -p $HOME
 tio(){
     :&& ${srcdir}/deploy/platform/timeout.sh "$@";

--- a/deploy/platform/redhat/redhat_build_rpms.py
+++ b/deploy/platform/redhat/redhat_build_rpms.py
@@ -25,6 +25,8 @@
 #
 import subprocess,os,sys,pexpect,xml.etree.ElementTree as ET,fnmatch,tempfile
 
+srcdir=os.path.realpath(os.path.dirname(os.path.realpath(__file__))+'/../../..')
+
 def externalPackage(info, root, package):
     ans = None
     for extpackages in root.getiterator('external_packages'):
@@ -78,7 +80,7 @@ def buildRpms():
     info['buildroot']=os.environ['BUILDROOT']
     info['bname']=os.environ['BNAME']
     info['platform']=os.environ['PLATFORM']
-    tree=ET.parse('/source/deploy/packaging/linux.xml')
+    tree=ET.parse(srcdir+'/deploy/packaging/linux.xml')
     root=tree.getroot()
     rpmspec=root.find('rpm').find('spec_start').text
     s=rpmspec.split('\n')

--- a/deploy/platform/redhat/redhat_docker_build.sh
+++ b/deploy/platform/redhat/redhat_docker_build.sh
@@ -13,7 +13,7 @@
 # /publish/$branch/cache/$arch/*.rpm-*
 #
 
-srcdir=$(realpath $(dirname ${0})/../..)
+srcdir=$(readlink -e $(dirname ${0})/../..)
 
 test64="64 x86_64-linux bin64 lib64 --with-gsi=/usr:gcc64"
 test32="32 i686-linux   bin32 lib32 --with-gsi=/usr:gcc32"

--- a/deploy/platform/redhat/redhat_docker_build.sh
+++ b/deploy/platform/redhat/redhat_docker_build.sh
@@ -12,6 +12,9 @@
 # /publish/$branch/RPMS/$arch/*.rpm
 # /publish/$branch/cache/$arch/*.rpm-*
 #
+
+srcdir=$(realpath $(dirname ${0})/../..)
+
 test64="64 x86_64-linux bin64 lib64 --with-gsi=/usr:gcc64"
 test32="32 i686-linux   bin32 lib32 --with-gsi=/usr:gcc32"
 makelist(){
@@ -57,7 +60,7 @@ buildrelease(){
     ###
     mkdir -p ${BUILDROOT}/etc/yum.repos.d;
     mkdir -p ${BUILDROOT}/etc/pki/rpm-gpg/;
-    cp /source/deploy/platform/redhat/RPM-GPG-KEY-MDSplus ${BUILDROOT}/etc/pki/rpm-gpg/;
+    cp ${srcdir}/deploy/platform/redhat/RPM-GPG-KEY-MDSplus ${BUILDROOT}/etc/pki/rpm-gpg/;
     if [ -d /sign_keys/.gnupg ]
     then
         GPGCHECK="1"
@@ -86,7 +89,7 @@ EOF
           DISTNAME=${DISTNAME} \
           BUILDROOT=${BUILDROOT} \
           PLATFORM=${PLATFORM} \
-          /source/deploy/platform/${PLATFORM}/${PLATFORM}_build_rpms.py;
+          ${srcdir}/deploy/platform/${PLATFORM}/${PLATFORM}_build_rpms.py;
     createrepo -q /release/${BRANCH}/RPMS
     badrpm=0
     for rpm in $(find /release/${BRANCH}/RPMS -name '*\.rpm')
@@ -101,10 +104,10 @@ EOF
             continue
         fi
         pkg=${pkg}.$(echo $(basename $rpm) | cut -f5 -d- | cut -f3 -d.)
-        checkfile=/source/deploy/packaging/${PLATFORM}/$pkg
+        checkfile=${srcdir}/deploy/packaging/${PLATFORM}/$pkg
         if [ "$UPDATEPKG" = "yes" ]
         then
-            mkdir -p /source/deploy/packaging/${PLATFORM}/
+            mkdir -p ${srcdir}/deploy/packaging/${PLATFORM}/
             makelist $rpm > ${checkfile}
         else
             echo "Checking contents of $(basename $rpm)"

--- a/deploy/platform/windows/windows_docker_build.sh
+++ b/deploy/platform/windows/windows_docker_build.sh
@@ -12,8 +12,12 @@ winebottle64=$(mktemp --tmpdir -d winebottle64.XXXXXXXX)
 test64="64 x86_64-w64-mingw32 bin_x86_64 bin_x86_64 --with-winebottle=$winebottle64"
 winebottle32=$(mktemp --tmpdir -d winebottle32.XXXXXXXX)
 test32="32 i686-w64-mingw32   bin_x86    bin_x86 --with-winebottle=$winebottle32"
-export JNI_INCLUDE_DIR=/source/3rd-party-apis/windows-jdk
-export JNI_MD_INCLUDE_DIR=/source/3rd-party-apis/windows-jdk/win32
+
+srcdir=$(realpath $(dirname ${0})/../..)
+
+export JNI_INCLUDE_DIR=${srcdir}/3rd-party-apis/windows-jdk
+export JNI_MD_INCLUDE_DIR=${srcdir}/3rd-party-apis/windows-jdk/win32
+
 
 buildrelease() {
     abort=0
@@ -62,10 +66,10 @@ buildrelease() {
         trap windows_cleanup EXIT
         topsrcdir=${WINREMBLD}/${tmpdir}
         cd ${tmpdir}
-        rsync -am --include="*/" --include="*.h*" --include="*.def" --exclude="*" /source/ ./
+        rsync -am --include="*/" --include="*.h*" --include="*.def" --exclude="*" ${srcdir}/ ./
         rsync -am /workspace/releasebld/64/include/config.h ./include/
-        rsync -a /source/mdsobjects/cpp /source/mdsobjects/MdsObjects* /source/mdsobjects/VS-* ./mdsobjects/
-        rsync -a /source/deploy/platform/windows/winbld.bat ./deploy/
+        rsync -a ${srcdir}/mdsobjects/cpp ${srcdir}/mdsobjects/MdsObjects* ${srcdir}/mdsobjects/VS-* ./mdsobjects/
+        rsync -a ${srcdir}/deploy/platform/windows/winbld.bat ./deploy/
         rsync -a ${MDSPLUS_DIR}/bin_* ./
         curl http://${WINHOST}:8080${topsrcdir}/deploy/winbld.bat
         # see if files are there
@@ -77,7 +81,7 @@ buildrelease() {
     fi
     pushd $MDSPLUS_DIR
     makensis -DMAJOR=${major} -DMINOR=${minor} -DRELEASE=${release} -DFLAVOR=${bname} -NOCD \
-         -DOUTDIR=/release/${BRANCH} ${vs} /source/deploy/packaging/${PLATFORM}/mdsplus.nsi
+         -DOUTDIR=/release/${BRANCH} -Dsrcdir=${srcdir} ${vs} ${srcdir}/deploy/packaging/${PLATFORM}/mdsplus.nsi
     popd
     if [ -d /sign_keys ]
     then

--- a/deploy/platform/windows/windows_docker_build.sh
+++ b/deploy/platform/windows/windows_docker_build.sh
@@ -13,7 +13,7 @@ test64="64 x86_64-w64-mingw32 bin_x86_64 bin_x86_64 --with-winebottle=$winebottl
 winebottle32=$(mktemp --tmpdir -d winebottle32.XXXXXXXX)
 test32="32 i686-w64-mingw32   bin_x86    bin_x86 --with-winebottle=$winebottle32"
 
-srcdir=$(realpath $(dirname ${0})/../..)
+srcdir=$(readlink -e $(dirname ${0})/../..)
 
 export JNI_INCLUDE_DIR=${srcdir}/3rd-party-apis/windows-jdk
 export JNI_MD_INCLUDE_DIR=${srcdir}/3rd-party-apis/windows-jdk/win32

--- a/testing/winpython
+++ b/testing/winpython
@@ -2,6 +2,7 @@
 test=$(basename $4)
 test=${test:0:-11}
 echo $test
+srcdir=$(readlink -f $(dirname ${0})/..)
 if [ "$test" == "dcl" ]; then
   if [ -z $ACTION_SERVER ]
   then
@@ -9,7 +10,7 @@ if [ "$test" == "dcl" ]; then
     then
       ACTION_PORT=8800
     fi
-    cmd="wine mdsip -s -p ${ACTION_PORT} -h $(winepath -w /source/mdsobjects/python/tests/mdsip.hosts)"
+    cmd="wine mdsip -s -p ${ACTION_PORT} -h $(winepath -w ${srcdir}/mdsobjects/python/tests/mdsip.hosts)"
     echo "$cmd";$cmd  &>server_0.log &
     export ACTION_SERVER=localhost:${ACTION_PORT}
   fi
@@ -19,7 +20,7 @@ if [ "$test" == "dcl" ]; then
     then
       MONITOR_PORT=4400
     fi
-    cmd="wine mdsip -s -p ${MONITOR_PORT} -h $(winepath -w /source/mdsobjects/python/tests/mdsip.hosts)"
+    cmd="wine mdsip -s -p ${MONITOR_PORT} -h $(winepath -w ${srcdir}/mdsobjects/python/tests/mdsip.hosts)"
     echo "$cmd";$cmd &>monitor_0.log &
     export ACTION_MONITOR=localhost:${MONITOR_PORT}
   fi


### PR DESCRIPTION
The original docker build scripts used /source for the source volume.
Various development tools can be used better if the docker builds use
the same source directory spec as that outside of docker. For example
if the source lives in /home/twf/mdsplus-alpha and that same directory
is used as the internal volume inside the docker container instead of
mapping it to /source, all debug information etc will contain the correct
source file location if used outside of docker.