### PR TITLE
Fix: repair a problem detected by valgrind in TreeRenameNode

### DIFF
--- a/treeshr/TreeRenameNode.c
+++ b/treeshr/TreeRenameNode.c
@@ -211,7 +211,7 @@ static int FixParentState(PINO_DATABASE * dblist, NODE * parent_ptr, NODE * chil
   int retlen;
   unsigned int child_flags;
   NCI_ITM child_itm_list[] =
-      { {sizeof(unsigned int), NciGET_FLAGS, (unsigned char *)&child_flags, &retlen},
+      { {sizeof(unsigned int), NciGET_FLAGS, &child_flags, &retlen},
 	{0, NciEND_OF_LIST, 0, 0}
   };
   node_to_nid(dblist, parent_ptr, (&parent_nid));


### PR DESCRIPTION
Remove a cast from a pointer to an unsigned int into a pointer to
an unsigned char.