### PR TITLE
Build: Exclude valgrind tracing of certain programs

### DIFF
--- a/mdsobjects/python/tests/Makefile.am
+++ b/mdsobjects/python/tests/Makefile.am
@@ -43,10 +43,7 @@ VALGRIND_SUPPRESSIONS_FILES_PY = \
 # Skipping child programs that are launched inside python classes
 #
 VALGRIND_FLAGS = \
-                 --trace-children-skip=*/ld \
-                 --trace-children-skip=*/collect2 \
-                 --trace-children-skip=*/ldconfig \
-                 --trace-children-skip=*/sh
+                 --trace-children-skip=*/ld,*/collect2,*/ldconfig,*/sh
                  
 
 # Files produced by tests that must be purged

--- a/mdsobjects/python/tests/Makefile.in
+++ b/mdsobjects/python/tests/Makefile.in
@@ -569,10 +569,7 @@ VALGRIND = @VALGRIND@
 # Skipping child programs that are launched inside python classes
 #
 VALGRIND_FLAGS = \
-                 --trace-children-skip=*/ld \
-                 --trace-children-skip=*/collect2 \
-                 --trace-children-skip=*/ldconfig \
-                 --trace-children-skip=*/sh
+                 --trace-children-skip=*/ld,*/collect2,*/ldconfig,*/sh
 
 VALGRIND_HAVE_TOOL_drd = @VALGRIND_HAVE_TOOL_drd@
 VALGRIND_HAVE_TOOL_exp_sgcheck = @VALGRIND_HAVE_TOOL_exp_sgcheck@


### PR DESCRIPTION
Combine --trace-children-skip options in a single option for valgrind.