### PR TITLE
Fix: Restore MDSplus python exception superclasses

### DIFF
--- a/mdsobjects/python/mdsExceptions.py
+++ b/mdsobjects/python/mdsExceptions.py
@@ -33,6 +33,7 @@
 ########################################################
 
 class MDSplusException(Exception):
+  fac="MDSplus"
   statusDict={}
   severities=["W", "S", "E", "I", "F", "?", "?", "?"]
   def __new__(cls,*argv):
@@ -2465,10 +2466,6 @@ class StrSTRTOOLON(StrException):
   msgnam="STRTOOLON"
 
 MDSplusException.statusDict[2392176] = StrSTRTOOLON
-
-
-class MDSplusException(MDSplusException):
-  fac="MDSplus"
 
 
 class MDSplusWARNING(MDSplusException):

--- a/mdsobjects/python/mdsExceptions.py
+++ b/mdsobjects/python/mdsExceptions.py
@@ -89,11 +89,11 @@ def checkStatus(status,ignore=tuple()):
 
 
 
-class _DevException(MDSplusException):
+class DevException(MDSplusException):
   fac="Dev"
 
 
-class DevBAD_ENDIDX(_DevException):
+class DevBAD_ENDIDX(DevException):
   status=662470666
   message="unable to read end index for channel"
   msgnam="BAD_ENDIDX"
@@ -101,7 +101,7 @@ class DevBAD_ENDIDX(_DevException):
 MDSplusException.statusDict[662470664] = DevBAD_ENDIDX
 
 
-class DevBAD_FILTER(_DevException):
+class DevBAD_FILTER(DevException):
   status=662470674
   message="illegal filter selected"
   msgnam="BAD_FILTER"
@@ -109,7 +109,7 @@ class DevBAD_FILTER(_DevException):
 MDSplusException.statusDict[662470672] = DevBAD_FILTER
 
 
-class DevBAD_FREQ(_DevException):
+class DevBAD_FREQ(DevException):
   status=662470682
   message="illegal digitization frequency selected"
   msgnam="BAD_FREQ"
@@ -117,7 +117,7 @@ class DevBAD_FREQ(_DevException):
 MDSplusException.statusDict[662470680] = DevBAD_FREQ
 
 
-class DevBAD_GAIN(_DevException):
+class DevBAD_GAIN(DevException):
   status=662470690
   message="illegal gain selected"
   msgnam="BAD_GAIN"
@@ -125,7 +125,7 @@ class DevBAD_GAIN(_DevException):
 MDSplusException.statusDict[662470688] = DevBAD_GAIN
 
 
-class DevBAD_HEADER(_DevException):
+class DevBAD_HEADER(DevException):
   status=662470698
   message="unable to read header selection"
   msgnam="BAD_HEADER"
@@ -133,7 +133,7 @@ class DevBAD_HEADER(_DevException):
 MDSplusException.statusDict[662470696] = DevBAD_HEADER
 
 
-class DevBAD_HEADER_IDX(_DevException):
+class DevBAD_HEADER_IDX(DevException):
   status=662470706
   message="unknown header configuration index"
   msgnam="BAD_HEADER_IDX"
@@ -141,7 +141,7 @@ class DevBAD_HEADER_IDX(_DevException):
 MDSplusException.statusDict[662470704] = DevBAD_HEADER_IDX
 
 
-class DevBAD_MEMORIES(_DevException):
+class DevBAD_MEMORIES(DevException):
   status=662470714
   message="unable to read number of memory modules"
   msgnam="BAD_MEMORIES"
@@ -149,7 +149,7 @@ class DevBAD_MEMORIES(_DevException):
 MDSplusException.statusDict[662470712] = DevBAD_MEMORIES
 
 
-class DevBAD_MODE(_DevException):
+class DevBAD_MODE(DevException):
   status=662470722
   message="illegal mode selected"
   msgnam="BAD_MODE"
@@ -157,7 +157,7 @@ class DevBAD_MODE(_DevException):
 MDSplusException.statusDict[662470720] = DevBAD_MODE
 
 
-class DevBAD_NAME(_DevException):
+class DevBAD_NAME(DevException):
   status=662470730
   message="unable to read module name"
   msgnam="BAD_NAME"
@@ -165,7 +165,7 @@ class DevBAD_NAME(_DevException):
 MDSplusException.statusDict[662470728] = DevBAD_NAME
 
 
-class DevBAD_OFFSET(_DevException):
+class DevBAD_OFFSET(DevException):
   status=662470738
   message="illegal offset selected"
   msgnam="BAD_OFFSET"
@@ -173,7 +173,7 @@ class DevBAD_OFFSET(_DevException):
 MDSplusException.statusDict[662470736] = DevBAD_OFFSET
 
 
-class DevBAD_STARTIDX(_DevException):
+class DevBAD_STARTIDX(DevException):
   status=662470746
   message="unable to read start index for channel"
   msgnam="BAD_STARTIDX"
@@ -181,7 +181,7 @@ class DevBAD_STARTIDX(_DevException):
 MDSplusException.statusDict[662470744] = DevBAD_STARTIDX
 
 
-class DevNOT_TRIGGERED(_DevException):
+class DevNOT_TRIGGERED(DevException):
   status=662470754
   message="device was not triggered,  check wires and triggering device"
   msgnam="NOT_TRIGGERED"
@@ -189,7 +189,7 @@ class DevNOT_TRIGGERED(_DevException):
 MDSplusException.statusDict[662470752] = DevNOT_TRIGGERED
 
 
-class DevFREQ_TO_HIGH(_DevException):
+class DevFREQ_TO_HIGH(DevException):
   status=662470762
   message="the frequency is set to high for the requested number of channels"
   msgnam="FREQ_TO_HIGH"
@@ -197,7 +197,7 @@ class DevFREQ_TO_HIGH(_DevException):
 MDSplusException.statusDict[662470760] = DevFREQ_TO_HIGH
 
 
-class DevINVALID_NOC(_DevException):
+class DevINVALID_NOC(DevException):
   status=662470770
   message="the NOC (number of channels) requested is greater than the physical number of channels"
   msgnam="INVALID_NOC"
@@ -205,7 +205,7 @@ class DevINVALID_NOC(_DevException):
 MDSplusException.statusDict[662470768] = DevINVALID_NOC
 
 
-class DevRANGE_MISMATCH(_DevException):
+class DevRANGE_MISMATCH(DevException):
   status=662470778
   message="the range specified on the menu doesn't match the range setting on the device"
   msgnam="RANGE_MISMATCH"
@@ -213,7 +213,7 @@ class DevRANGE_MISMATCH(_DevException):
 MDSplusException.statusDict[662470776] = DevRANGE_MISMATCH
 
 
-class DevCAMACERR(_DevException):
+class DevCAMACERR(DevException):
   status=662470786
   message="Error doing CAMAC IO"
   msgnam="CAMACERR"
@@ -221,7 +221,7 @@ class DevCAMACERR(_DevException):
 MDSplusException.statusDict[662470784] = DevCAMACERR
 
 
-class DevBAD_VERBS(_DevException):
+class DevBAD_VERBS(DevException):
   status=662470794
   message="Error reading interpreter list (:VERBS)"
   msgnam="BAD_VERBS"
@@ -229,7 +229,7 @@ class DevBAD_VERBS(_DevException):
 MDSplusException.statusDict[662470792] = DevBAD_VERBS
 
 
-class DevBAD_COMMANDS(_DevException):
+class DevBAD_COMMANDS(DevException):
   status=662470802
   message="Error reading command list"
   msgnam="BAD_COMMANDS"
@@ -237,7 +237,7 @@ class DevBAD_COMMANDS(_DevException):
 MDSplusException.statusDict[662470800] = DevBAD_COMMANDS
 
 
-class DevCAM_ADNR(_DevException):
+class DevCAM_ADNR(DevException):
   status=662470810
   message="CAMAC: Address not recognized (2160)"
   msgnam="CAM_ADNR"
@@ -245,7 +245,7 @@ class DevCAM_ADNR(_DevException):
 MDSplusException.statusDict[662470808] = DevCAM_ADNR
 
 
-class DevCAM_ERR(_DevException):
+class DevCAM_ERR(DevException):
   status=662470818
   message="CAMAC: Error reported by crate controler"
   msgnam="CAM_ERR"
@@ -253,7 +253,7 @@ class DevCAM_ERR(_DevException):
 MDSplusException.statusDict[662470816] = DevCAM_ERR
 
 
-class DevCAM_LOSYNC(_DevException):
+class DevCAM_LOSYNC(DevException):
   status=662470826
   message="CAMAC: Lost Syncronization error"
   msgnam="CAM_LOSYNC"
@@ -261,7 +261,7 @@ class DevCAM_LOSYNC(_DevException):
 MDSplusException.statusDict[662470824] = DevCAM_LOSYNC
 
 
-class DevCAM_LPE(_DevException):
+class DevCAM_LPE(DevException):
   status=662470834
   message="CAMAC: Longitudinal Parity error"
   msgnam="CAM_LPE"
@@ -269,7 +269,7 @@ class DevCAM_LPE(_DevException):
 MDSplusException.statusDict[662470832] = DevCAM_LPE
 
 
-class DevCAM_TMO(_DevException):
+class DevCAM_TMO(DevException):
   status=662470842
   message="CAMAC: Highway time out error"
   msgnam="CAM_TMO"
@@ -277,7 +277,7 @@ class DevCAM_TMO(_DevException):
 MDSplusException.statusDict[662470840] = DevCAM_TMO
 
 
-class DevCAM_TPE(_DevException):
+class DevCAM_TPE(DevException):
   status=662470850
   message="CAMAC: Transverse Parity error"
   msgnam="CAM_TPE"
@@ -285,7 +285,7 @@ class DevCAM_TPE(_DevException):
 MDSplusException.statusDict[662470848] = DevCAM_TPE
 
 
-class DevCAM_STE(_DevException):
+class DevCAM_STE(DevException):
   status=662470858
   message="CAMAC: Serial Transmission error"
   msgnam="CAM_STE"
@@ -293,7 +293,7 @@ class DevCAM_STE(_DevException):
 MDSplusException.statusDict[662470856] = DevCAM_STE
 
 
-class DevCAM_DERR(_DevException):
+class DevCAM_DERR(DevException):
   status=662470866
   message="CAMAC: Delayed error from SCC"
   msgnam="CAM_DERR"
@@ -301,7 +301,7 @@ class DevCAM_DERR(_DevException):
 MDSplusException.statusDict[662470864] = DevCAM_DERR
 
 
-class DevCAM_SQ(_DevException):
+class DevCAM_SQ(DevException):
   status=662470874
   message="CAMAC: I/O completion with Q = 1"
   msgnam="CAM_SQ"
@@ -309,7 +309,7 @@ class DevCAM_SQ(_DevException):
 MDSplusException.statusDict[662470872] = DevCAM_SQ
 
 
-class DevCAM_NOSQ(_DevException):
+class DevCAM_NOSQ(DevException):
   status=662470882
   message="CAMAC: I/O completion with Q = 0"
   msgnam="CAM_NOSQ"
@@ -317,7 +317,7 @@ class DevCAM_NOSQ(_DevException):
 MDSplusException.statusDict[662470880] = DevCAM_NOSQ
 
 
-class DevCAM_SX(_DevException):
+class DevCAM_SX(DevException):
   status=662470890
   message="CAMAC: I/O completion with X = 1"
   msgnam="CAM_SX"
@@ -325,7 +325,7 @@ class DevCAM_SX(_DevException):
 MDSplusException.statusDict[662470888] = DevCAM_SX
 
 
-class DevCAM_NOSX(_DevException):
+class DevCAM_NOSX(DevException):
   status=662470898
   message="CAMAC: I/O completion with X = 0"
   msgnam="CAM_NOSX"
@@ -333,7 +333,7 @@ class DevCAM_NOSX(_DevException):
 MDSplusException.statusDict[662470896] = DevCAM_NOSX
 
 
-class DevINV_SETUP(_DevException):
+class DevINV_SETUP(DevException):
   status=662470906
   message="device was not properly set up"
   msgnam="INV_SETUP"
@@ -341,7 +341,7 @@ class DevINV_SETUP(_DevException):
 MDSplusException.statusDict[662470904] = DevINV_SETUP
 
 
-class DevPYDEVICE_NOT_FOUND(_DevException):
+class DevPYDEVICE_NOT_FOUND(DevException):
   status=662470914
   message="Python device class not found."
   msgnam="PYDEVICE_NOT_FOUND"
@@ -349,7 +349,7 @@ class DevPYDEVICE_NOT_FOUND(_DevException):
 MDSplusException.statusDict[662470912] = DevPYDEVICE_NOT_FOUND
 
 
-class DevPY_INTERFACE_LIBRARY_NOT_FOUND(_DevException):
+class DevPY_INTERFACE_LIBRARY_NOT_FOUND(DevException):
   status=662470922
   message="The needed device hardware interface library could not be loaded."
   msgnam="PY_INTERFACE_LIBRARY_NOT_FOUND"
@@ -357,7 +357,7 @@ class DevPY_INTERFACE_LIBRARY_NOT_FOUND(_DevException):
 MDSplusException.statusDict[662470920] = DevPY_INTERFACE_LIBRARY_NOT_FOUND
 
 
-class DevIO_STUCK(_DevException):
+class DevIO_STUCK(DevException):
   status=662470930
   message="I/O to Device is stuck. Check network connection and board status."
   msgnam="IO_STUCK"
@@ -365,7 +365,7 @@ class DevIO_STUCK(_DevException):
 MDSplusException.statusDict[662470928] = DevIO_STUCK
 
 
-class DevUNKOWN_STATE(_DevException):
+class DevUNKOWN_STATE(DevException):
   status=662470938
   message="Device returned unrecognized state string"
   msgnam="UNKOWN_STATE"
@@ -373,7 +373,7 @@ class DevUNKOWN_STATE(_DevException):
 MDSplusException.statusDict[662470936] = DevUNKOWN_STATE
 
 
-class DevWRONG_TREE(_DevException):
+class DevWRONG_TREE(DevException):
   status=662470946
   message="Attempt to digitizerinto different tree than it was armed with"
   msgnam="WRONG_TREE"
@@ -381,7 +381,7 @@ class DevWRONG_TREE(_DevException):
 MDSplusException.statusDict[662470944] = DevWRONG_TREE
 
 
-class DevWRONG_PATH(_DevException):
+class DevWRONG_PATH(DevException):
   status=662470954
   message="Attempt to store digitizer into different path than it was armed with"
   msgnam="WRONG_PATH"
@@ -389,7 +389,7 @@ class DevWRONG_PATH(_DevException):
 MDSplusException.statusDict[662470952] = DevWRONG_PATH
 
 
-class DevWRONG_SHOT(_DevException):
+class DevWRONG_SHOT(DevException):
   status=662470962
   message="Attempt to store digitizer into different shot than it was armed with"
   msgnam="WRONG_SHOT"
@@ -397,7 +397,7 @@ class DevWRONG_SHOT(_DevException):
 MDSplusException.statusDict[662470960] = DevWRONG_SHOT
 
 
-class DevOFFLINE(_DevException):
+class DevOFFLINE(DevException):
   status=662470970
   message="Device is not on line.  Check network connection"
   msgnam="OFFLINE"
@@ -405,7 +405,7 @@ class DevOFFLINE(_DevException):
 MDSplusException.statusDict[662470968] = DevOFFLINE
 
 
-class DevTRIGGERED_NOT_STORED(_DevException):
+class DevTRIGGERED_NOT_STORED(DevException):
   status=662470978
   message="Device was triggered but not stored."
   msgnam="TRIGGERED_NOT_STORED"
@@ -413,7 +413,7 @@ class DevTRIGGERED_NOT_STORED(_DevException):
 MDSplusException.statusDict[662470976] = DevTRIGGERED_NOT_STORED
 
 
-class DevNO_NAME_SPECIFIED(_DevException):
+class DevNO_NAME_SPECIFIED(DevException):
   status=662470986
   message="Device name must be specifed - pleas fill it in."
   msgnam="NO_NAME_SPECIFIED"
@@ -421,7 +421,7 @@ class DevNO_NAME_SPECIFIED(_DevException):
 MDSplusException.statusDict[662470984] = DevNO_NAME_SPECIFIED
 
 
-class DevBAD_ACTIVE_CHAN(_DevException):
+class DevBAD_ACTIVE_CHAN(DevException):
   status=662470994
   message="Active channels either not available or invalid"
   msgnam="BAD_ACTIVE_CHAN"
@@ -429,7 +429,7 @@ class DevBAD_ACTIVE_CHAN(_DevException):
 MDSplusException.statusDict[662470992] = DevBAD_ACTIVE_CHAN
 
 
-class DevBAD_TRIG_SRC(_DevException):
+class DevBAD_TRIG_SRC(DevException):
   status=662471002
   message="Trigger source either not available or invalid"
   msgnam="BAD_TRIG_SRC"
@@ -437,7 +437,7 @@ class DevBAD_TRIG_SRC(_DevException):
 MDSplusException.statusDict[662471000] = DevBAD_TRIG_SRC
 
 
-class DevBAD_CLOCK_SRC(_DevException):
+class DevBAD_CLOCK_SRC(DevException):
   status=662471010
   message="Clock source either not available or invalid"
   msgnam="BAD_CLOCK_SRC"
@@ -445,7 +445,7 @@ class DevBAD_CLOCK_SRC(_DevException):
 MDSplusException.statusDict[662471008] = DevBAD_CLOCK_SRC
 
 
-class DevBAD_PRE_TRIG(_DevException):
+class DevBAD_PRE_TRIG(DevException):
   status=662471018
   message="Pre trigger samples either not available or invalid"
   msgnam="BAD_PRE_TRIG"
@@ -453,7 +453,7 @@ class DevBAD_PRE_TRIG(_DevException):
 MDSplusException.statusDict[662471016] = DevBAD_PRE_TRIG
 
 
-class DevBAD_POST_TRIG(_DevException):
+class DevBAD_POST_TRIG(DevException):
   status=662471026
   message="Clock source either not available or invalid"
   msgnam="BAD_POST_TRIG"
@@ -461,7 +461,7 @@ class DevBAD_POST_TRIG(_DevException):
 MDSplusException.statusDict[662471024] = DevBAD_POST_TRIG
 
 
-class DevBAD_CLOCK_FREQ(_DevException):
+class DevBAD_CLOCK_FREQ(DevException):
   status=662471034
   message="Clock frequency either not available or invalid"
   msgnam="BAD_CLOCK_FREQ"
@@ -469,7 +469,7 @@ class DevBAD_CLOCK_FREQ(_DevException):
 MDSplusException.statusDict[662471032] = DevBAD_CLOCK_FREQ
 
 
-class DevTRIGGER_FAILED(_DevException):
+class DevTRIGGER_FAILED(DevException):
   status=662471042
   message="Device trigger method failed"
   msgnam="TRIGGER_FAILED"
@@ -477,7 +477,7 @@ class DevTRIGGER_FAILED(_DevException):
 MDSplusException.statusDict[662471040] = DevTRIGGER_FAILED
 
 
-class DevERROR_READING_CHANNEL(_DevException):
+class DevERROR_READING_CHANNEL(DevException):
   status=662471050
   message="Error reading data for channel from device"
   msgnam="ERROR_READING_CHANNEL"
@@ -485,7 +485,7 @@ class DevERROR_READING_CHANNEL(_DevException):
 MDSplusException.statusDict[662471048] = DevERROR_READING_CHANNEL
 
 
-class DevERROR_DOING_INIT(_DevException):
+class DevERROR_DOING_INIT(DevException):
   status=662471058
   message="Error sending ARM command to device"
   msgnam="ERROR_DOING_INIT"
@@ -493,11 +493,11 @@ class DevERROR_DOING_INIT(_DevException):
 MDSplusException.statusDict[662471056] = DevERROR_DOING_INIT
 
 
-class _ReticonException(MDSplusException):
+class ReticonException(MDSplusException):
   fac="Reticon"
 
 
-class ReticonNORMAL(_ReticonException):
+class ReticonNORMAL(ReticonException):
   status=662471065
   message="successful completion"
   msgnam="NORMAL"
@@ -505,7 +505,7 @@ class ReticonNORMAL(_ReticonException):
 MDSplusException.statusDict[662471064] = ReticonNORMAL
 
 
-class ReticonBAD_FRAMES(_ReticonException):
+class ReticonBAD_FRAMES(ReticonException):
   status=662471074
   message="frame count must be less than or equal to 2048"
   msgnam="BAD_FRAMES"
@@ -513,7 +513,7 @@ class ReticonBAD_FRAMES(_ReticonException):
 MDSplusException.statusDict[662471072] = ReticonBAD_FRAMES
 
 
-class ReticonBAD_FRAME_SELECT(_ReticonException):
+class ReticonBAD_FRAME_SELECT(ReticonException):
   status=662471082
   message="frame interval must be 1,2,4,8,16,32 or 64"
   msgnam="BAD_FRAME_SELECT"
@@ -521,7 +521,7 @@ class ReticonBAD_FRAME_SELECT(_ReticonException):
 MDSplusException.statusDict[662471080] = ReticonBAD_FRAME_SELECT
 
 
-class ReticonBAD_NUM_STATES(_ReticonException):
+class ReticonBAD_NUM_STATES(ReticonException):
   status=662471090
   message="number of states must be between 1 and 4"
   msgnam="BAD_NUM_STATES"
@@ -529,7 +529,7 @@ class ReticonBAD_NUM_STATES(_ReticonException):
 MDSplusException.statusDict[662471088] = ReticonBAD_NUM_STATES
 
 
-class ReticonBAD_PERIOD(_ReticonException):
+class ReticonBAD_PERIOD(ReticonException):
   status=662471098
   message="period must be .5,1,2,4,8,16,32,64,128,256,512,1024,2048,4096 or 8192 msec"
   msgnam="BAD_PERIOD"
@@ -537,7 +537,7 @@ class ReticonBAD_PERIOD(_ReticonException):
 MDSplusException.statusDict[662471096] = ReticonBAD_PERIOD
 
 
-class ReticonBAD_PIXEL_SELECT(_ReticonException):
+class ReticonBAD_PIXEL_SELECT(ReticonException):
   status=662471106
   message="pixel selection must be an array of 256 boolean values"
   msgnam="BAD_PIXEL_SELECT"
@@ -545,7 +545,7 @@ class ReticonBAD_PIXEL_SELECT(_ReticonException):
 MDSplusException.statusDict[662471104] = ReticonBAD_PIXEL_SELECT
 
 
-class ReticonDATA_CORRUPTED(_ReticonException):
+class ReticonDATA_CORRUPTED(ReticonException):
   status=662471114
   message="data in memory is corrupted or framing error detected, no data stored"
   msgnam="DATA_CORRUPTED"
@@ -553,7 +553,7 @@ class ReticonDATA_CORRUPTED(_ReticonException):
 MDSplusException.statusDict[662471112] = ReticonDATA_CORRUPTED
 
 
-class ReticonTOO_MANY_FRAMES(_ReticonException):
+class ReticonTOO_MANY_FRAMES(ReticonException):
   status=662471122
   message="over 8192 frame start indicators in data read from memory"
   msgnam="TOO_MANY_FRAMES"
@@ -561,11 +561,11 @@ class ReticonTOO_MANY_FRAMES(_ReticonException):
 MDSplusException.statusDict[662471120] = ReticonTOO_MANY_FRAMES
 
 
-class _J221Exception(MDSplusException):
+class J221Exception(MDSplusException):
   fac="J221"
 
 
-class J221NORMAL(_J221Exception):
+class J221NORMAL(J221Exception):
   status=662471465
   message="successful completion"
   msgnam="NORMAL"
@@ -573,7 +573,7 @@ class J221NORMAL(_J221Exception):
 MDSplusException.statusDict[662471464] = J221NORMAL
 
 
-class J221INVALID_DATA(_J221Exception):
+class J221INVALID_DATA(J221Exception):
   status=662471476
   message="ignoring invalid data in channel !SL"
   msgnam="INVALID_DATA"
@@ -581,7 +581,7 @@ class J221INVALID_DATA(_J221Exception):
 MDSplusException.statusDict[662471472] = J221INVALID_DATA
 
 
-class J221NO_DATA(_J221Exception):
+class J221NO_DATA(J221Exception):
   status=662471482
   message="no valid data was found for any channel"
   msgnam="NO_DATA"
@@ -589,11 +589,11 @@ class J221NO_DATA(_J221Exception):
 MDSplusException.statusDict[662471480] = J221NO_DATA
 
 
-class _TimingException(MDSplusException):
+class TimingException(MDSplusException):
   fac="Timing"
 
 
-class TimingINVCLKFRQ(_TimingException):
+class TimingINVCLKFRQ(TimingException):
   status=662471866
   message="Invalid clock frequency"
   msgnam="INVCLKFRQ"
@@ -601,7 +601,7 @@ class TimingINVCLKFRQ(_TimingException):
 MDSplusException.statusDict[662471864] = TimingINVCLKFRQ
 
 
-class TimingINVDELDUR(_TimingException):
+class TimingINVDELDUR(TimingException):
   status=662471874
   message="Invalid pulse delay or duration, must be less than 655 seconds"
   msgnam="INVDELDUR"
@@ -609,7 +609,7 @@ class TimingINVDELDUR(_TimingException):
 MDSplusException.statusDict[662471872] = TimingINVDELDUR
 
 
-class TimingINVOUTCTR(_TimingException):
+class TimingINVOUTCTR(TimingException):
   status=662471882
   message="Invalid output mode selected"
   msgnam="INVOUTCTR"
@@ -617,7 +617,7 @@ class TimingINVOUTCTR(_TimingException):
 MDSplusException.statusDict[662471880] = TimingINVOUTCTR
 
 
-class TimingINVPSEUDODEV(_TimingException):
+class TimingINVPSEUDODEV(TimingException):
   status=662471890
   message="Invalid pseudo device attached to this decoder channel"
   msgnam="INVPSEUDODEV"
@@ -625,7 +625,7 @@ class TimingINVPSEUDODEV(_TimingException):
 MDSplusException.statusDict[662471888] = TimingINVPSEUDODEV
 
 
-class TimingINVTRGMOD(_TimingException):
+class TimingINVTRGMOD(TimingException):
   status=662471898
   message="Invalid trigger mode selected"
   msgnam="INVTRGMOD"
@@ -633,7 +633,7 @@ class TimingINVTRGMOD(_TimingException):
 MDSplusException.statusDict[662471896] = TimingINVTRGMOD
 
 
-class TimingNOPSEUDODEV(_TimingException):
+class TimingNOPSEUDODEV(TimingException):
   status=662471907
   message="No Pseudo device attached to this channel ... disabling"
   msgnam="NOPSEUDODEV"
@@ -641,7 +641,7 @@ class TimingNOPSEUDODEV(_TimingException):
 MDSplusException.statusDict[662471904] = TimingNOPSEUDODEV
 
 
-class TimingTOO_MANY_EVENTS(_TimingException):
+class TimingTOO_MANY_EVENTS(TimingException):
   status=662471914
   message="More than 16 events used by this decoder"
   msgnam="TOO_MANY_EVENTS"
@@ -649,11 +649,11 @@ class TimingTOO_MANY_EVENTS(_TimingException):
 MDSplusException.statusDict[662471912] = TimingTOO_MANY_EVENTS
 
 
-class _B2408Exception(MDSplusException):
+class B2408Exception(MDSplusException):
   fac="B2408"
 
 
-class B2408NORMAL(_B2408Exception):
+class B2408NORMAL(B2408Exception):
   status=662472265
   message="successful completion"
   msgnam="NORMAL"
@@ -661,7 +661,7 @@ class B2408NORMAL(_B2408Exception):
 MDSplusException.statusDict[662472264] = B2408NORMAL
 
 
-class B2408OVERFLOW(_B2408Exception):
+class B2408OVERFLOW(B2408Exception):
   status=662472275
   message="Triggers received after overflow"
   msgnam="OVERFLOW"
@@ -669,7 +669,7 @@ class B2408OVERFLOW(_B2408Exception):
 MDSplusException.statusDict[662472272] = B2408OVERFLOW
 
 
-class B2408TRIG_LIM(_B2408Exception):
+class B2408TRIG_LIM(B2408Exception):
   status=662472284
   message="Trigger limit possibly exceeded"
   msgnam="TRIG_LIM"
@@ -677,11 +677,11 @@ class B2408TRIG_LIM(_B2408Exception):
 MDSplusException.statusDict[662472280] = B2408TRIG_LIM
 
 
-class _FeraException(MDSplusException):
+class FeraException(MDSplusException):
   fac="Fera"
 
 
-class FeraNORMAL(_FeraException):
+class FeraNORMAL(FeraException):
   status=662472665
   message="successful completion"
   msgnam="NORMAL"
@@ -689,7 +689,7 @@ class FeraNORMAL(_FeraException):
 MDSplusException.statusDict[662472664] = FeraNORMAL
 
 
-class FeraDIGNOTSTRARRAY(_FeraException):
+class FeraDIGNOTSTRARRAY(FeraException):
   status=662472674
   message="The digitizer names must be an array of strings"
   msgnam="DIGNOTSTRARRAY"
@@ -697,7 +697,7 @@ class FeraDIGNOTSTRARRAY(_FeraException):
 MDSplusException.statusDict[662472672] = FeraDIGNOTSTRARRAY
 
 
-class FeraNODIG(_FeraException):
+class FeraNODIG(FeraException):
   status=662472682
   message="The digitizer names must be specified"
   msgnam="NODIG"
@@ -705,7 +705,7 @@ class FeraNODIG(_FeraException):
 MDSplusException.statusDict[662472680] = FeraNODIG
 
 
-class FeraMEMNOTSTRARRAY(_FeraException):
+class FeraMEMNOTSTRARRAY(FeraException):
   status=662472690
   message="The memory names must be an array of strings"
   msgnam="MEMNOTSTRARRAY"
@@ -713,7 +713,7 @@ class FeraMEMNOTSTRARRAY(_FeraException):
 MDSplusException.statusDict[662472688] = FeraMEMNOTSTRARRAY
 
 
-class FeraNOMEM(_FeraException):
+class FeraNOMEM(FeraException):
   status=662472698
   message="The memory names must be specified"
   msgnam="NOMEM"
@@ -721,7 +721,7 @@ class FeraNOMEM(_FeraException):
 MDSplusException.statusDict[662472696] = FeraNOMEM
 
 
-class FeraPHASE_LOST(_FeraException):
+class FeraPHASE_LOST(FeraException):
   status=662472706
   message="Data phase lost No FERA data stored"
   msgnam="PHASE_LOST"
@@ -729,7 +729,7 @@ class FeraPHASE_LOST(_FeraException):
 MDSplusException.statusDict[662472704] = FeraPHASE_LOST
 
 
-class FeraCONFUSED(_FeraException):
+class FeraCONFUSED(FeraException):
   status=662472716
   message="Fera Data inconsitant.  Data for this point zered."
   msgnam="CONFUSED"
@@ -737,7 +737,7 @@ class FeraCONFUSED(_FeraException):
 MDSplusException.statusDict[662472712] = FeraCONFUSED
 
 
-class FeraOVER_RUN(_FeraException):
+class FeraOVER_RUN(FeraException):
   status=662472724
   message="Possible FERA memory overrun, too many triggers."
   msgnam="OVER_RUN"
@@ -745,7 +745,7 @@ class FeraOVER_RUN(_FeraException):
 MDSplusException.statusDict[662472720] = FeraOVER_RUN
 
 
-class FeraOVERFLOW(_FeraException):
+class FeraOVERFLOW(FeraException):
   status=662472731
   message="Possible FERA data saturated.  Data point zeroed"
   msgnam="OVERFLOW"
@@ -753,11 +753,11 @@ class FeraOVERFLOW(_FeraException):
 MDSplusException.statusDict[662472728] = FeraOVERFLOW
 
 
-class _Hm650Exception(MDSplusException):
+class Hm650Exception(MDSplusException):
   fac="Hm650"
 
 
-class Hm650NORMAL(_Hm650Exception):
+class Hm650NORMAL(Hm650Exception):
   status=662473065
   message="successful completion"
   msgnam="NORMAL"
@@ -765,7 +765,7 @@ class Hm650NORMAL(_Hm650Exception):
 MDSplusException.statusDict[662473064] = Hm650NORMAL
 
 
-class Hm650DLYCHNG(_Hm650Exception):
+class Hm650DLYCHNG(Hm650Exception):
   status=662473076
   message="HM650 requested delay can not be processed by hardware."
   msgnam="DLYCHNG"
@@ -773,11 +773,11 @@ class Hm650DLYCHNG(_Hm650Exception):
 MDSplusException.statusDict[662473072] = Hm650DLYCHNG
 
 
-class _Hv4032Exception(MDSplusException):
+class Hv4032Exception(MDSplusException):
   fac="Hv4032"
 
 
-class Hv4032NORMAL(_Hv4032Exception):
+class Hv4032NORMAL(Hv4032Exception):
   status=662473465
   message="successful completion"
   msgnam="NORMAL"
@@ -785,7 +785,7 @@ class Hv4032NORMAL(_Hv4032Exception):
 MDSplusException.statusDict[662473464] = Hv4032NORMAL
 
 
-class Hv4032WRONG_POD_TYPE(_Hv4032Exception):
+class Hv4032WRONG_POD_TYPE(Hv4032Exception):
   status=662473474
   message="HV40321A n and p can only be used with the HV4032 device"
   msgnam="WRONG_POD_TYPE"
@@ -793,11 +793,11 @@ class Hv4032WRONG_POD_TYPE(_Hv4032Exception):
 MDSplusException.statusDict[662473472] = Hv4032WRONG_POD_TYPE
 
 
-class _Hv1440Exception(MDSplusException):
+class Hv1440Exception(MDSplusException):
   fac="Hv1440"
 
 
-class Hv1440NORMAL(_Hv1440Exception):
+class Hv1440NORMAL(Hv1440Exception):
   status=662473865
   message="successful completion"
   msgnam="NORMAL"
@@ -805,7 +805,7 @@ class Hv1440NORMAL(_Hv1440Exception):
 MDSplusException.statusDict[662473864] = Hv1440NORMAL
 
 
-class Hv1440WRONG_POD_TYPE(_Hv1440Exception):
+class Hv1440WRONG_POD_TYPE(Hv1440Exception):
   status=662473874
   message="HV1443 can only be used with the HV1440 device"
   msgnam="WRONG_POD_TYPE"
@@ -813,7 +813,7 @@ class Hv1440WRONG_POD_TYPE(_Hv1440Exception):
 MDSplusException.statusDict[662473872] = Hv1440WRONG_POD_TYPE
 
 
-class Hv1440BAD_FRAME(_Hv1440Exception):
+class Hv1440BAD_FRAME(Hv1440Exception):
   status=662473882
   message="HV1440 could not read the frame"
   msgnam="BAD_FRAME"
@@ -821,7 +821,7 @@ class Hv1440BAD_FRAME(_Hv1440Exception):
 MDSplusException.statusDict[662473880] = Hv1440BAD_FRAME
 
 
-class Hv1440BAD_RANGE(_Hv1440Exception):
+class Hv1440BAD_RANGE(Hv1440Exception):
   status=662473890
   message="HV1440 could not read the range"
   msgnam="BAD_RANGE"
@@ -829,7 +829,7 @@ class Hv1440BAD_RANGE(_Hv1440Exception):
 MDSplusException.statusDict[662473888] = Hv1440BAD_RANGE
 
 
-class Hv1440OUTRNG(_Hv1440Exception):
+class Hv1440OUTRNG(Hv1440Exception):
   status=662473898
   message="HV1440 out of range"
   msgnam="OUTRNG"
@@ -837,7 +837,7 @@ class Hv1440OUTRNG(_Hv1440Exception):
 MDSplusException.statusDict[662473896] = Hv1440OUTRNG
 
 
-class Hv1440STUCK(_Hv1440Exception):
+class Hv1440STUCK(Hv1440Exception):
   status=662473906
   message="HV1440 not responding with Q"
   msgnam="STUCK"
@@ -845,11 +845,11 @@ class Hv1440STUCK(_Hv1440Exception):
 MDSplusException.statusDict[662473904] = Hv1440STUCK
 
 
-class _JoergerException(MDSplusException):
+class JoergerException(MDSplusException):
   fac="Joerger"
 
 
-class JoergerBAD_PRE_TRIGGER(_JoergerException):
+class JoergerBAD_PRE_TRIGGER(JoergerException):
   status=662474266
   message="bad pretrigger specified, specify a value of 0,1,2,3,4,5,6 or 7"
   msgnam="BAD_PRE_TRIGGER"
@@ -857,7 +857,7 @@ class JoergerBAD_PRE_TRIGGER(_JoergerException):
 MDSplusException.statusDict[662474264] = JoergerBAD_PRE_TRIGGER
 
 
-class JoergerBAD_ACT_MEMORY(_JoergerException):
+class JoergerBAD_ACT_MEMORY(JoergerException):
   status=662474274
   message="bad active memory specified, specify a value of 1,2,3,4,5,6,7 or 8"
   msgnam="BAD_ACT_MEMORY"
@@ -865,7 +865,7 @@ class JoergerBAD_ACT_MEMORY(_JoergerException):
 MDSplusException.statusDict[662474272] = JoergerBAD_ACT_MEMORY
 
 
-class JoergerBAD_GAIN(_JoergerException):
+class JoergerBAD_GAIN(JoergerException):
   status=662474282
   message="bad gain specified, specify a value of 1,2,4 or 8"
   msgnam="BAD_GAIN"
@@ -873,11 +873,11 @@ class JoergerBAD_GAIN(_JoergerException):
 MDSplusException.statusDict[662474280] = JoergerBAD_GAIN
 
 
-class _U_of_mException(MDSplusException):
+class U_of_mException(MDSplusException):
   fac="U_of_m"
 
 
-class U_of_mBAD_WAVE_LENGTH(_U_of_mException):
+class U_of_mBAD_WAVE_LENGTH(U_of_mException):
   status=662474666
   message="bad wave length specified, specify value between 0 and 13000"
   msgnam="BAD_WAVE_LENGTH"
@@ -885,7 +885,7 @@ class U_of_mBAD_WAVE_LENGTH(_U_of_mException):
 MDSplusException.statusDict[662474664] = U_of_mBAD_WAVE_LENGTH
 
 
-class U_of_mBAD_SLIT_WIDTH(_U_of_mException):
+class U_of_mBAD_SLIT_WIDTH(U_of_mException):
   status=662474674
   message="bad slit width specified, specify value between 0 and 500"
   msgnam="BAD_SLIT_WIDTH"
@@ -893,7 +893,7 @@ class U_of_mBAD_SLIT_WIDTH(_U_of_mException):
 MDSplusException.statusDict[662474672] = U_of_mBAD_SLIT_WIDTH
 
 
-class U_of_mBAD_NUM_SPECTRA(_U_of_mException):
+class U_of_mBAD_NUM_SPECTRA(U_of_mException):
   status=662474682
   message="bad number of spectra specified, specify value between 1 and 100"
   msgnam="BAD_NUM_SPECTRA"
@@ -901,7 +901,7 @@ class U_of_mBAD_NUM_SPECTRA(_U_of_mException):
 MDSplusException.statusDict[662474680] = U_of_mBAD_NUM_SPECTRA
 
 
-class U_of_mBAD_GRATING(_U_of_mException):
+class U_of_mBAD_GRATING(U_of_mException):
   status=662474690
   message="bad grating type specified, specify value between 1 and 5"
   msgnam="BAD_GRATING"
@@ -909,7 +909,7 @@ class U_of_mBAD_GRATING(_U_of_mException):
 MDSplusException.statusDict[662474688] = U_of_mBAD_GRATING
 
 
-class U_of_mBAD_EXPOSURE(_U_of_mException):
+class U_of_mBAD_EXPOSURE(U_of_mException):
   status=662474698
   message="bad exposure time specified, specify value between 30 and 3000"
   msgnam="BAD_EXPOSURE"
@@ -917,7 +917,7 @@ class U_of_mBAD_EXPOSURE(_U_of_mException):
 MDSplusException.statusDict[662474696] = U_of_mBAD_EXPOSURE
 
 
-class U_of_mBAD_FILTER(_U_of_mException):
+class U_of_mBAD_FILTER(U_of_mException):
   status=662474706
   message="bad neutral density filter specified, specify value between 0 and 5"
   msgnam="BAD_FILTER"
@@ -925,7 +925,7 @@ class U_of_mBAD_FILTER(_U_of_mException):
 MDSplusException.statusDict[662474704] = U_of_mBAD_FILTER
 
 
-class U_of_mGO_FILE_ERROR(_U_of_mException):
+class U_of_mGO_FILE_ERROR(U_of_mException):
   status=662474714
   message="error creating new go file"
   msgnam="GO_FILE_ERROR"
@@ -933,7 +933,7 @@ class U_of_mGO_FILE_ERROR(_U_of_mException):
 MDSplusException.statusDict[662474712] = U_of_mGO_FILE_ERROR
 
 
-class U_of_mDATA_FILE_ERROR(_U_of_mException):
+class U_of_mDATA_FILE_ERROR(U_of_mException):
   status=662474722
   message="error opening datafile"
   msgnam="DATA_FILE_ERROR"
@@ -941,11 +941,11 @@ class U_of_mDATA_FILE_ERROR(_U_of_mException):
 MDSplusException.statusDict[662474720] = U_of_mDATA_FILE_ERROR
 
 
-class _IdlException(MDSplusException):
+class IdlException(MDSplusException):
   fac="Idl"
 
 
-class IdlNORMAL(_IdlException):
+class IdlNORMAL(IdlException):
   status=662475065
   message="successful completion"
   msgnam="NORMAL"
@@ -953,7 +953,7 @@ class IdlNORMAL(_IdlException):
 MDSplusException.statusDict[662475064] = IdlNORMAL
 
 
-class IdlERROR(_IdlException):
+class IdlERROR(IdlException):
   status=662475074
   message="IDL returned a non zero error code"
   msgnam="ERROR"
@@ -961,11 +961,11 @@ class IdlERROR(_IdlException):
 MDSplusException.statusDict[662475072] = IdlERROR
 
 
-class _B5910aException(MDSplusException):
+class B5910aException(MDSplusException):
   fac="B5910a"
 
 
-class B5910aBAD_CHAN(_B5910aException):
+class B5910aBAD_CHAN(B5910aException):
   status=662475466
   message="error evaluating data for channel !SL"
   msgnam="BAD_CHAN"
@@ -973,7 +973,7 @@ class B5910aBAD_CHAN(_B5910aException):
 MDSplusException.statusDict[662475464] = B5910aBAD_CHAN
 
 
-class B5910aBAD_CLOCK(_B5910aException):
+class B5910aBAD_CLOCK(B5910aException):
   status=662475474
   message="invalid internal clock range specified"
   msgnam="BAD_CLOCK"
@@ -981,7 +981,7 @@ class B5910aBAD_CLOCK(_B5910aException):
 MDSplusException.statusDict[662475472] = B5910aBAD_CLOCK
 
 
-class B5910aBAD_ITERATIONS(_B5910aException):
+class B5910aBAD_ITERATIONS(B5910aException):
   status=662475482
   message="invalid number of iterations specified"
   msgnam="BAD_ITERATIONS"
@@ -989,7 +989,7 @@ class B5910aBAD_ITERATIONS(_B5910aException):
 MDSplusException.statusDict[662475480] = B5910aBAD_ITERATIONS
 
 
-class B5910aBAD_NOC(_B5910aException):
+class B5910aBAD_NOC(B5910aException):
   status=662475490
   message="invalid number of active channels specified"
   msgnam="BAD_NOC"
@@ -997,7 +997,7 @@ class B5910aBAD_NOC(_B5910aException):
 MDSplusException.statusDict[662475488] = B5910aBAD_NOC
 
 
-class B5910aBAD_SAMPS(_B5910aException):
+class B5910aBAD_SAMPS(B5910aException):
   status=662475498
   message="number of samples specificed invalid"
   msgnam="BAD_SAMPS"
@@ -1005,11 +1005,11 @@ class B5910aBAD_SAMPS(_B5910aException):
 MDSplusException.statusDict[662475496] = B5910aBAD_SAMPS
 
 
-class _J412Exception(MDSplusException):
+class J412Exception(MDSplusException):
   fac="J412"
 
 
-class J412NOT_SORTED(_J412Exception):
+class J412NOT_SORTED(J412Exception):
   status=662475866
   message="times specified for J412 module were not sorted"
   msgnam="NOT_SORTED"
@@ -1017,7 +1017,7 @@ class J412NOT_SORTED(_J412Exception):
 MDSplusException.statusDict[662475864] = J412NOT_SORTED
 
 
-class J412NO_DATA(_J412Exception):
+class J412NO_DATA(J412Exception):
   status=662475874
   message="there were no times specifed for J412 module"
   msgnam="NO_DATA"
@@ -1025,7 +1025,7 @@ class J412NO_DATA(_J412Exception):
 MDSplusException.statusDict[662475872] = J412NO_DATA
 
 
-class J412BADCYCLES(_J412Exception):
+class J412BADCYCLES(J412Exception):
   status=662475882
   message="The number of cycles must be 1 .. 255"
   msgnam="BADCYCLES"
@@ -1033,11 +1033,11 @@ class J412BADCYCLES(_J412Exception):
 MDSplusException.statusDict[662475880] = J412BADCYCLES
 
 
-class _Tr16Exception(MDSplusException):
+class Tr16Exception(MDSplusException):
   fac="Tr16"
 
 
-class Tr16NORMAL(_Tr16Exception):
+class Tr16NORMAL(Tr16Exception):
   status=662476265
   message="successful completion"
   msgnam="NORMAL"
@@ -1045,7 +1045,7 @@ class Tr16NORMAL(_Tr16Exception):
 MDSplusException.statusDict[662476264] = Tr16NORMAL
 
 
-class Tr16BAD_MEMSIZE(_Tr16Exception):
+class Tr16BAD_MEMSIZE(Tr16Exception):
   status=662476274
   message="Memory size must be in 128K, 256K, 512k, 1024K"
   msgnam="BAD_MEMSIZE"
@@ -1053,7 +1053,7 @@ class Tr16BAD_MEMSIZE(_Tr16Exception):
 MDSplusException.statusDict[662476272] = Tr16BAD_MEMSIZE
 
 
-class Tr16BAD_ACTIVEMEM(_Tr16Exception):
+class Tr16BAD_ACTIVEMEM(Tr16Exception):
   status=662476282
   message="Active Mem must be power of 2 8K to 1024K"
   msgnam="BAD_ACTIVEMEM"
@@ -1061,7 +1061,7 @@ class Tr16BAD_ACTIVEMEM(_Tr16Exception):
 MDSplusException.statusDict[662476280] = Tr16BAD_ACTIVEMEM
 
 
-class Tr16BAD_ACTIVECHAN(_Tr16Exception):
+class Tr16BAD_ACTIVECHAN(Tr16Exception):
   status=662476290
   message="Active channels must be in 1,2,4,8,16"
   msgnam="BAD_ACTIVECHAN"
@@ -1069,7 +1069,7 @@ class Tr16BAD_ACTIVECHAN(_Tr16Exception):
 MDSplusException.statusDict[662476288] = Tr16BAD_ACTIVECHAN
 
 
-class Tr16BAD_PTS(_Tr16Exception):
+class Tr16BAD_PTS(Tr16Exception):
   status=662476298
   message="PTS must be power of 2 32 to 1024K"
   msgnam="BAD_PTS"
@@ -1077,7 +1077,7 @@ class Tr16BAD_PTS(_Tr16Exception):
 MDSplusException.statusDict[662476296] = Tr16BAD_PTS
 
 
-class Tr16BAD_FREQUENCY(_Tr16Exception):
+class Tr16BAD_FREQUENCY(Tr16Exception):
   status=662476306
   message="Invalid clock frequency"
   msgnam="BAD_FREQUENCY"
@@ -1085,7 +1085,7 @@ class Tr16BAD_FREQUENCY(_Tr16Exception):
 MDSplusException.statusDict[662476304] = Tr16BAD_FREQUENCY
 
 
-class Tr16BAD_MASTER(_Tr16Exception):
+class Tr16BAD_MASTER(Tr16Exception):
   status=662476314
   message="Master must be 0 or 1"
   msgnam="BAD_MASTER"
@@ -1093,7 +1093,7 @@ class Tr16BAD_MASTER(_Tr16Exception):
 MDSplusException.statusDict[662476312] = Tr16BAD_MASTER
 
 
-class Tr16BAD_GAIN(_Tr16Exception):
+class Tr16BAD_GAIN(Tr16Exception):
   status=662476322
   message="Gain must be 1, 2, 4, or 8"
   msgnam="BAD_GAIN"
@@ -1101,11 +1101,11 @@ class Tr16BAD_GAIN(_Tr16Exception):
 MDSplusException.statusDict[662476320] = Tr16BAD_GAIN
 
 
-class _A14Exception(MDSplusException):
+class A14Exception(MDSplusException):
   fac="A14"
 
 
-class A14NORMAL(_A14Exception):
+class A14NORMAL(A14Exception):
   status=662476665
   message="successful completion"
   msgnam="NORMAL"
@@ -1113,7 +1113,7 @@ class A14NORMAL(_A14Exception):
 MDSplusException.statusDict[662476664] = A14NORMAL
 
 
-class A14BAD_CLK_DIVIDE(_A14Exception):
+class A14BAD_CLK_DIVIDE(A14Exception):
   status=662476674
   message="Clock divide must be one of 1,2,4,10,20,40, or 100"
   msgnam="BAD_CLK_DIVIDE"
@@ -1121,7 +1121,7 @@ class A14BAD_CLK_DIVIDE(_A14Exception):
 MDSplusException.statusDict[662476672] = A14BAD_CLK_DIVIDE
 
 
-class A14BAD_MODE(_A14Exception):
+class A14BAD_MODE(A14Exception):
   status=662476682
   message="Mode must be in the range of 0 to 4"
   msgnam="BAD_MODE"
@@ -1129,7 +1129,7 @@ class A14BAD_MODE(_A14Exception):
 MDSplusException.statusDict[662476680] = A14BAD_MODE
 
 
-class A14BAD_CLK_POLARITY(_A14Exception):
+class A14BAD_CLK_POLARITY(A14Exception):
   status=662476690
   message="Clock polarity must be either 0 (rising) or 1 (falling)"
   msgnam="BAD_CLK_POLARITY"
@@ -1137,7 +1137,7 @@ class A14BAD_CLK_POLARITY(_A14Exception):
 MDSplusException.statusDict[662476688] = A14BAD_CLK_POLARITY
 
 
-class A14BAD_STR_POLARITY(_A14Exception):
+class A14BAD_STR_POLARITY(A14Exception):
   status=662476698
   message="Start polarity must be either 0 (rising) or 1 (falling)"
   msgnam="BAD_STR_POLARITY"
@@ -1145,7 +1145,7 @@ class A14BAD_STR_POLARITY(_A14Exception):
 MDSplusException.statusDict[662476696] = A14BAD_STR_POLARITY
 
 
-class A14BAD_STP_POLARITY(_A14Exception):
+class A14BAD_STP_POLARITY(A14Exception):
   status=662476706
   message="Stop polarity must be either 0 (rising) or 1 (falling)"
   msgnam="BAD_STP_POLARITY"
@@ -1153,7 +1153,7 @@ class A14BAD_STP_POLARITY(_A14Exception):
 MDSplusException.statusDict[662476704] = A14BAD_STP_POLARITY
 
 
-class A14BAD_GATED(_A14Exception):
+class A14BAD_GATED(A14Exception):
   status=662476714
   message="Gated clock must be either 0 (not gated) or 1 (gated)"
   msgnam="BAD_GATED"
@@ -1161,11 +1161,11 @@ class A14BAD_GATED(_A14Exception):
 MDSplusException.statusDict[662476712] = A14BAD_GATED
 
 
-class _L6810Exception(MDSplusException):
+class L6810Exception(MDSplusException):
   fac="L6810"
 
 
-class L6810NORMAL(_L6810Exception):
+class L6810NORMAL(L6810Exception):
   status=662477065
   message="successful completion"
   msgnam="NORMAL"
@@ -1173,7 +1173,7 @@ class L6810NORMAL(_L6810Exception):
 MDSplusException.statusDict[662477064] = L6810NORMAL
 
 
-class L6810BAD_ACTIVECHAN(_L6810Exception):
+class L6810BAD_ACTIVECHAN(L6810Exception):
   status=662477074
   message="Active chans must be 1, 2, or 4"
   msgnam="BAD_ACTIVECHAN"
@@ -1181,7 +1181,7 @@ class L6810BAD_ACTIVECHAN(_L6810Exception):
 MDSplusException.statusDict[662477072] = L6810BAD_ACTIVECHAN
 
 
-class L6810BAD_ACTIVEMEM(_L6810Exception):
+class L6810BAD_ACTIVEMEM(L6810Exception):
   status=662477082
   message="Active memory must be power of 2 LE 8192"
   msgnam="BAD_ACTIVEMEM"
@@ -1189,7 +1189,7 @@ class L6810BAD_ACTIVEMEM(_L6810Exception):
 MDSplusException.statusDict[662477080] = L6810BAD_ACTIVEMEM
 
 
-class L6810BAD_FREQUENCY(_L6810Exception):
+class L6810BAD_FREQUENCY(L6810Exception):
   status=662477090
   message="Frequency must be in [0, .02, .05, .1, .2, .5, 1, 2, 5, 10, 20, 50, 100,  200, 500, 1000, 2000, 5000]"
   msgnam="BAD_FREQUENCY"
@@ -1197,7 +1197,7 @@ class L6810BAD_FREQUENCY(_L6810Exception):
 MDSplusException.statusDict[662477088] = L6810BAD_FREQUENCY
 
 
-class L6810BAD_FULL_SCALE(_L6810Exception):
+class L6810BAD_FULL_SCALE(L6810Exception):
   status=662477098
   message="Full Scale must be in [.4096, 1.024, 2.048, 4.096, 10.24, 25.6, 51.2, 102.4]"
   msgnam="BAD_FULL_SCALE"
@@ -1205,7 +1205,7 @@ class L6810BAD_FULL_SCALE(_L6810Exception):
 MDSplusException.statusDict[662477096] = L6810BAD_FULL_SCALE
 
 
-class L6810BAD_MEMORIES(_L6810Exception):
+class L6810BAD_MEMORIES(L6810Exception):
   status=662477106
   message="Memories must 1 .. 16"
   msgnam="BAD_MEMORIES"
@@ -1213,7 +1213,7 @@ class L6810BAD_MEMORIES(_L6810Exception):
 MDSplusException.statusDict[662477104] = L6810BAD_MEMORIES
 
 
-class L6810BAD_COUPLING(_L6810Exception):
+class L6810BAD_COUPLING(L6810Exception):
   status=662477114
   message="Channel source / coupling must be one of 0 .. 7"
   msgnam="BAD_COUPLING"
@@ -1221,7 +1221,7 @@ class L6810BAD_COUPLING(_L6810Exception):
 MDSplusException.statusDict[662477112] = L6810BAD_COUPLING
 
 
-class L6810BAD_OFFSET(_L6810Exception):
+class L6810BAD_OFFSET(L6810Exception):
   status=662477122
   message="Offset must be between 0 and 255"
   msgnam="BAD_OFFSET"
@@ -1229,7 +1229,7 @@ class L6810BAD_OFFSET(_L6810Exception):
 MDSplusException.statusDict[662477120] = L6810BAD_OFFSET
 
 
-class L6810BAD_SEGMENTS(_L6810Exception):
+class L6810BAD_SEGMENTS(L6810Exception):
   status=662477130
   message="Number of segments must be 1 .. 1024"
   msgnam="BAD_SEGMENTS"
@@ -1237,7 +1237,7 @@ class L6810BAD_SEGMENTS(_L6810Exception):
 MDSplusException.statusDict[662477128] = L6810BAD_SEGMENTS
 
 
-class L6810BAD_TRIG_DELAY(_L6810Exception):
+class L6810BAD_TRIG_DELAY(L6810Exception):
   status=662477138
   message="Trigger delay must be between -8 and 247 in units of 8ths of segment size"
   msgnam="BAD_TRIG_DELAY"
@@ -1245,11 +1245,11 @@ class L6810BAD_TRIG_DELAY(_L6810Exception):
 MDSplusException.statusDict[662477136] = L6810BAD_TRIG_DELAY
 
 
-class _J_dacException(MDSplusException):
+class J_dacException(MDSplusException):
   fac="J_dac"
 
 
-class J_dacOUTRNG(_J_dacException):
+class J_dacOUTRNG(J_dacException):
   status=662477466
   message="Joerger DAC Channels out of range.  Bad chans code !XW"
   msgnam="OUTRNG"
@@ -1257,11 +1257,11 @@ class J_dacOUTRNG(_J_dacException):
 MDSplusException.statusDict[662477464] = J_dacOUTRNG
 
 
-class _IncaaException(MDSplusException):
+class IncaaException(MDSplusException):
   fac="Incaa"
 
 
-class IncaaBAD_ACTIVE_CHANS(_IncaaException):
+class IncaaBAD_ACTIVE_CHANS(IncaaException):
   status=662477866
   message="bad active channels selection"
   msgnam="BAD_ACTIVE_CHANS"
@@ -1269,7 +1269,7 @@ class IncaaBAD_ACTIVE_CHANS(_IncaaException):
 MDSplusException.statusDict[662477864] = IncaaBAD_ACTIVE_CHANS
 
 
-class IncaaBAD_MASTER(_IncaaException):
+class IncaaBAD_MASTER(IncaaException):
   status=662477874
   message="bad master selection, must be 0 or 1"
   msgnam="BAD_MASTER"
@@ -1277,7 +1277,7 @@ class IncaaBAD_MASTER(_IncaaException):
 MDSplusException.statusDict[662477872] = IncaaBAD_MASTER
 
 
-class IncaaBAD_EXT_1MHZ(_IncaaException):
+class IncaaBAD_EXT_1MHZ(IncaaException):
   status=662477882
   message="bad ext 1mhz selection, must be 0 or 1"
   msgnam="BAD_EXT_1MHZ"
@@ -1285,7 +1285,7 @@ class IncaaBAD_EXT_1MHZ(_IncaaException):
 MDSplusException.statusDict[662477880] = IncaaBAD_EXT_1MHZ
 
 
-class IncaaBAD_PTSC(_IncaaException):
+class IncaaBAD_PTSC(IncaaException):
   status=662477890
   message="bad PTSC setting"
   msgnam="BAD_PTSC"
@@ -1293,11 +1293,11 @@ class IncaaBAD_PTSC(_IncaaException):
 MDSplusException.statusDict[662477888] = IncaaBAD_PTSC
 
 
-class _L8212Exception(MDSplusException):
+class L8212Exception(MDSplusException):
   fac="L8212"
 
 
-class L8212BAD_HEADER(_L8212Exception):
+class L8212BAD_HEADER(L8212Exception):
   status=662478266
   message="Invalid header jumper information (e.g. 49414944432)"
   msgnam="BAD_HEADER"
@@ -1305,7 +1305,7 @@ class L8212BAD_HEADER(_L8212Exception):
 MDSplusException.statusDict[662478264] = L8212BAD_HEADER
 
 
-class L8212BAD_MEMORIES(_L8212Exception):
+class L8212BAD_MEMORIES(L8212Exception):
   status=662478274
   message="Invalid number of memories, must be 1 .. 16"
   msgnam="BAD_MEMORIES"
@@ -1313,7 +1313,7 @@ class L8212BAD_MEMORIES(_L8212Exception):
 MDSplusException.statusDict[662478272] = L8212BAD_MEMORIES
 
 
-class L8212BAD_NOC(_L8212Exception):
+class L8212BAD_NOC(L8212Exception):
   status=662478282
   message="Invalid number of active channels"
   msgnam="BAD_NOC"
@@ -1321,7 +1321,7 @@ class L8212BAD_NOC(_L8212Exception):
 MDSplusException.statusDict[662478280] = L8212BAD_NOC
 
 
-class L8212BAD_OFFSET(_L8212Exception):
+class L8212BAD_OFFSET(L8212Exception):
   status=662478290
   message="Invalid offset must be one of (0, -2048, -4096)"
   msgnam="BAD_OFFSET"
@@ -1329,7 +1329,7 @@ class L8212BAD_OFFSET(_L8212Exception):
 MDSplusException.statusDict[662478288] = L8212BAD_OFFSET
 
 
-class L8212BAD_PTS(_L8212Exception):
+class L8212BAD_PTS(L8212Exception):
   status=662478298
   message="Invalid pts code, must be 0 .. 7"
   msgnam="BAD_PTS"
@@ -1337,7 +1337,7 @@ class L8212BAD_PTS(_L8212Exception):
 MDSplusException.statusDict[662478296] = L8212BAD_PTS
 
 
-class L8212FREQ_TO_HIGH(_L8212Exception):
+class L8212FREQ_TO_HIGH(L8212Exception):
   status=662478306
   message="Frequency to high for selected number of channels"
   msgnam="FREQ_TO_HIGH"
@@ -1345,7 +1345,7 @@ class L8212FREQ_TO_HIGH(_L8212Exception):
 MDSplusException.statusDict[662478304] = L8212FREQ_TO_HIGH
 
 
-class L8212INVALID_NOC(_L8212Exception):
+class L8212INVALID_NOC(L8212Exception):
   status=662478314
   message="Invalid number of active channels"
   msgnam="INVALID_NOC"
@@ -1353,11 +1353,11 @@ class L8212INVALID_NOC(_L8212Exception):
 MDSplusException.statusDict[662478312] = L8212INVALID_NOC
 
 
-class _MpbException(MDSplusException):
+class MpbException(MDSplusException):
   fac="Mpb"
 
 
-class MpbBADTIME(_MpbException):
+class MpbBADTIME(MpbException):
   status=662478666
   message="Could not read time"
   msgnam="BADTIME"
@@ -1365,7 +1365,7 @@ class MpbBADTIME(_MpbException):
 MDSplusException.statusDict[662478664] = MpbBADTIME
 
 
-class MpbBADFREQ(_MpbException):
+class MpbBADFREQ(MpbException):
   status=662478674
   message="Could not read frequency"
   msgnam="BADFREQ"
@@ -1373,11 +1373,11 @@ class MpbBADFREQ(_MpbException):
 MDSplusException.statusDict[662478672] = MpbBADFREQ
 
 
-class _L8828Exception(MDSplusException):
+class L8828Exception(MDSplusException):
   fac="L8828"
 
 
-class L8828BAD_OFFSET(_L8828Exception):
+class L8828BAD_OFFSET(L8828Exception):
   status=662479066
   message="Offset for L8828 must be between 0 and 255"
   msgnam="BAD_OFFSET"
@@ -1385,7 +1385,7 @@ class L8828BAD_OFFSET(_L8828Exception):
 MDSplusException.statusDict[662479064] = L8828BAD_OFFSET
 
 
-class L8828BAD_PRETRIG(_L8828Exception):
+class L8828BAD_PRETRIG(L8828Exception):
   status=662479074
   message="Pre trigger samples for L8828 must be betwwen 0 and 7 eighths"
   msgnam="BAD_PRETRIG"
@@ -1393,7 +1393,7 @@ class L8828BAD_PRETRIG(_L8828Exception):
 MDSplusException.statusDict[662479072] = L8828BAD_PRETRIG
 
 
-class L8828BAD_ACTIVEMEM(_L8828Exception):
+class L8828BAD_ACTIVEMEM(L8828Exception):
   status=662479082
   message="ACTIVEMEM must be beteen 16K and 2M"
   msgnam="BAD_ACTIVEMEM"
@@ -1401,7 +1401,7 @@ class L8828BAD_ACTIVEMEM(_L8828Exception):
 MDSplusException.statusDict[662479080] = L8828BAD_ACTIVEMEM
 
 
-class L8828BAD_CLOCK(_L8828Exception):
+class L8828BAD_CLOCK(L8828Exception):
   status=662479090
   message="Invalid clock frequency specified."
   msgnam="BAD_CLOCK"
@@ -1409,11 +1409,11 @@ class L8828BAD_CLOCK(_L8828Exception):
 MDSplusException.statusDict[662479088] = L8828BAD_CLOCK
 
 
-class _L8818Exception(MDSplusException):
+class L8818Exception(MDSplusException):
   fac="L8818"
 
 
-class L8818BAD_OFFSET(_L8818Exception):
+class L8818BAD_OFFSET(L8818Exception):
   status=662479466
   message="Offset for L8828 must be between 0 and 255"
   msgnam="BAD_OFFSET"
@@ -1421,7 +1421,7 @@ class L8818BAD_OFFSET(_L8818Exception):
 MDSplusException.statusDict[662479464] = L8818BAD_OFFSET
 
 
-class L8818BAD_PRETRIG(_L8818Exception):
+class L8818BAD_PRETRIG(L8818Exception):
   status=662479474
   message="Pre trigger samples for L8828 must be betwwen 0 and 7 eighths"
   msgnam="BAD_PRETRIG"
@@ -1429,7 +1429,7 @@ class L8818BAD_PRETRIG(_L8818Exception):
 MDSplusException.statusDict[662479472] = L8818BAD_PRETRIG
 
 
-class L8818BAD_ACTIVEMEM(_L8818Exception):
+class L8818BAD_ACTIVEMEM(L8818Exception):
   status=662479482
   message="ACTIVEMEM must be beteen 16K and 2M"
   msgnam="BAD_ACTIVEMEM"
@@ -1437,7 +1437,7 @@ class L8818BAD_ACTIVEMEM(_L8818Exception):
 MDSplusException.statusDict[662479480] = L8818BAD_ACTIVEMEM
 
 
-class L8818BAD_CLOCK(_L8818Exception):
+class L8818BAD_CLOCK(L8818Exception):
   status=662479490
   message="Invalid clock frequency specified."
   msgnam="BAD_CLOCK"
@@ -1445,11 +1445,11 @@ class L8818BAD_CLOCK(_L8818Exception):
 MDSplusException.statusDict[662479488] = L8818BAD_CLOCK
 
 
-class _J_tr612Exception(MDSplusException):
+class J_tr612Exception(MDSplusException):
   fac="J_tr612"
 
 
-class J_tr612BAD_ACTMEM(_J_tr612Exception):
+class J_tr612BAD_ACTMEM(J_tr612Exception):
   status=662479546
   message="ACTMEM value out of range, must be 0-7 where 0=1/8th and 7 = all"
   msgnam="BAD_ACTMEM"
@@ -1457,7 +1457,7 @@ class J_tr612BAD_ACTMEM(_J_tr612Exception):
 MDSplusException.statusDict[662479544] = J_tr612BAD_ACTMEM
 
 
-class J_tr612BAD_PRETRIG(_J_tr612Exception):
+class J_tr612BAD_PRETRIG(J_tr612Exception):
   status=662479554
   message="PRETRIG value out of range, must be 0-7 where 0 = none and 7 = 7/8 pretrigger samples"
   msgnam="BAD_PRETRIG"
@@ -1465,7 +1465,7 @@ class J_tr612BAD_PRETRIG(_J_tr612Exception):
 MDSplusException.statusDict[662479552] = J_tr612BAD_PRETRIG
 
 
-class J_tr612BAD_MODE(_J_tr612Exception):
+class J_tr612BAD_MODE(J_tr612Exception):
   status=662479562
   message="MODE value out of range, must be 0 (for normal) or 1 (for burst mode)"
   msgnam="BAD_MODE"
@@ -1473,7 +1473,7 @@ class J_tr612BAD_MODE(_J_tr612Exception):
 MDSplusException.statusDict[662479560] = J_tr612BAD_MODE
 
 
-class J_tr612BAD_FREQUENCY(_J_tr612Exception):
+class J_tr612BAD_FREQUENCY(J_tr612Exception):
   status=662479570
   message="FREQUENCY value out of range, must be 0-4 where 0=3MHz,1=2MHz,2=1MHz,3=100KHz,4=external"
   msgnam="BAD_FREQUENCY"
@@ -1481,11 +1481,11 @@ class J_tr612BAD_FREQUENCY(_J_tr612Exception):
 MDSplusException.statusDict[662479568] = J_tr612BAD_FREQUENCY
 
 
-class _L8206Exception(MDSplusException):
+class L8206Exception(MDSplusException):
   fac="L8206"
 
 
-class L8206NODATA(_L8206Exception):
+class L8206NODATA(L8206Exception):
   status=662479868
   message="no data has been written to memory"
   msgnam="NODATA"
@@ -1493,11 +1493,11 @@ class L8206NODATA(_L8206Exception):
 MDSplusException.statusDict[662479864] = L8206NODATA
 
 
-class _H912Exception(MDSplusException):
+class H912Exception(MDSplusException):
   fac="H912"
 
 
-class H912BAD_CLOCK(_H912Exception):
+class H912BAD_CLOCK(H912Exception):
   status=662479946
   message="Bad value specified in INT_CLOCK node, use Setup device to correct"
   msgnam="BAD_CLOCK"
@@ -1505,7 +1505,7 @@ class H912BAD_CLOCK(_H912Exception):
 MDSplusException.statusDict[662479944] = H912BAD_CLOCK
 
 
-class H912BAD_BLOCKS(_H912Exception):
+class H912BAD_BLOCKS(H912Exception):
   status=662479954
   message="Bad value specified in BLOCKS node, use Setup device to correct"
   msgnam="BAD_BLOCKS"
@@ -1513,7 +1513,7 @@ class H912BAD_BLOCKS(_H912Exception):
 MDSplusException.statusDict[662479952] = H912BAD_BLOCKS
 
 
-class H912BAD_PTS(_H912Exception):
+class H912BAD_PTS(H912Exception):
   status=662479962
   message="Bad value specfiied in PTS node, must be an integer value between 1 and 131071"
   msgnam="BAD_PTS"
@@ -1521,11 +1521,11 @@ class H912BAD_PTS(_H912Exception):
 MDSplusException.statusDict[662479960] = H912BAD_PTS
 
 
-class _H908Exception(MDSplusException):
+class H908Exception(MDSplusException):
   fac="H908"
 
 
-class H908BAD_CLOCK(_H908Exception):
+class H908BAD_CLOCK(H908Exception):
   status=662480026
   message="Bad value specified in INT_CLOCK node, use Setup device to correct"
   msgnam="BAD_CLOCK"
@@ -1533,7 +1533,7 @@ class H908BAD_CLOCK(_H908Exception):
 MDSplusException.statusDict[662480024] = H908BAD_CLOCK
 
 
-class H908BAD_ACTIVE_CHANS(_H908Exception):
+class H908BAD_ACTIVE_CHANS(H908Exception):
   status=662480034
   message="Bad value specified in ACTIVE_CHANS node, use Setup device to correct"
   msgnam="BAD_ACTIVE_CHANS"
@@ -1541,7 +1541,7 @@ class H908BAD_ACTIVE_CHANS(_H908Exception):
 MDSplusException.statusDict[662480032] = H908BAD_ACTIVE_CHANS
 
 
-class H908BAD_PTS(_H908Exception):
+class H908BAD_PTS(H908Exception):
   status=662480042
   message="Bad value specfiied in PTS node, must be an integer value between 1 and 131071"
   msgnam="BAD_PTS"
@@ -1549,11 +1549,11 @@ class H908BAD_PTS(_H908Exception):
 MDSplusException.statusDict[662480040] = H908BAD_PTS
 
 
-class _Dsp2904Exception(MDSplusException):
+class Dsp2904Exception(MDSplusException):
   fac="Dsp2904"
 
 
-class Dsp2904CHANNEL_READ_ERROR(_Dsp2904Exception):
+class Dsp2904CHANNEL_READ_ERROR(Dsp2904Exception):
   status=662480106
   message="Error reading channel"
   msgnam="CHANNEL_READ_ERROR"
@@ -1561,11 +1561,11 @@ class Dsp2904CHANNEL_READ_ERROR(_Dsp2904Exception):
 MDSplusException.statusDict[662480104] = Dsp2904CHANNEL_READ_ERROR
 
 
-class _PyException(MDSplusException):
+class PyException(MDSplusException):
   fac="Py"
 
 
-class PyUNHANDLED_EXCEPTION(_PyException):
+class PyUNHANDLED_EXCEPTION(PyException):
   status=662480186
   message="Python device raised an exception, see log files for more details"
   msgnam="UNHANDLED_EXCEPTION"
@@ -1573,11 +1573,11 @@ class PyUNHANDLED_EXCEPTION(_PyException):
 MDSplusException.statusDict[662480184] = PyUNHANDLED_EXCEPTION
 
 
-class _Dt196bException(MDSplusException):
+class Dt196bException(MDSplusException):
   fac="Dt196b"
 
 
-class Dt196bNO_SAMPLES(_Dt196bException):
+class Dt196bNO_SAMPLES(Dt196bException):
   status=662480266
   message="Module did not acquire any samples"
   msgnam="NO_SAMPLES"
@@ -1585,7 +1585,7 @@ class Dt196bNO_SAMPLES(_Dt196bException):
 MDSplusException.statusDict[662480264] = Dt196bNO_SAMPLES
 
 
-class DevCANNOT_LOAD_SETTINGS(_DevException):
+class DevCANNOT_LOAD_SETTINGS(DevException):
   status=662480290
   message="Error loading settings from XML"
   msgnam="CANNOT_LOAD_SETTINGS"
@@ -1593,7 +1593,7 @@ class DevCANNOT_LOAD_SETTINGS(_DevException):
 MDSplusException.statusDict[662480288] = DevCANNOT_LOAD_SETTINGS
 
 
-class DevCANNOT_GET_BOARD_STATE(_DevException):
+class DevCANNOT_GET_BOARD_STATE(DevException):
   status=662480298
   message="Cannot retrieve state of daq board"
   msgnam="CANNOT_GET_BOARD_STATE"
@@ -1601,7 +1601,7 @@ class DevCANNOT_GET_BOARD_STATE(_DevException):
 MDSplusException.statusDict[662480296] = DevCANNOT_GET_BOARD_STATE
 
 
-class DevACQCMD_FAILED(_DevException):
+class DevACQCMD_FAILED(DevException):
   status=662480306
   message="Error executing acqcmd on daq board"
   msgnam="ACQCMD_FAILED"
@@ -1609,7 +1609,7 @@ class DevACQCMD_FAILED(_DevException):
 MDSplusException.statusDict[662480304] = DevACQCMD_FAILED
 
 
-class DevACQ2SH_FAILED(_DevException):
+class DevACQ2SH_FAILED(DevException):
   status=662480314
   message="Error executing acq2sh command on daq board"
   msgnam="ACQ2SH_FAILED"
@@ -1617,7 +1617,7 @@ class DevACQ2SH_FAILED(_DevException):
 MDSplusException.statusDict[662480312] = DevACQ2SH_FAILED
 
 
-class DevBAD_PARAMETER(_DevException):
+class DevBAD_PARAMETER(DevException):
   status=662480322
   message="Invalid parameter specified for device"
   msgnam="BAD_PARAMETER"
@@ -1625,7 +1625,7 @@ class DevBAD_PARAMETER(_DevException):
 MDSplusException.statusDict[662480320] = DevBAD_PARAMETER
 
 
-class DevCOMM_ERROR(_DevException):
+class DevCOMM_ERROR(DevException):
   status=662480330
   message="Error communicating with device"
   msgnam="COMM_ERROR"
@@ -1633,7 +1633,7 @@ class DevCOMM_ERROR(_DevException):
 MDSplusException.statusDict[662480328] = DevCOMM_ERROR
 
 
-class DevCAMERA_NOT_FOUND(_DevException):
+class DevCAMERA_NOT_FOUND(DevException):
   status=662480338
   message="Could not find specified camera on the network"
   msgnam="CAMERA_NOT_FOUND"
@@ -1641,7 +1641,7 @@ class DevCAMERA_NOT_FOUND(_DevException):
 MDSplusException.statusDict[662480336] = DevCAMERA_NOT_FOUND
 
 
-class DevNOT_A_PYDEVICE(_DevException):
+class DevNOT_A_PYDEVICE(DevException):
   status=662480346
   message="Device is not a python device."
   msgnam="NOT_A_PYDEVICE"
@@ -1652,11 +1652,11 @@ MDSplusException.statusDict[662480344] = DevNOT_A_PYDEVICE
 
 
 
-class _TreeException(MDSplusException):
+class TreeException(MDSplusException):
   fac="Tree"
 
 
-class TreeALREADY_OFF(_TreeException):
+class TreeALREADY_OFF(TreeException):
   status=265388075
   message="Node is already OFF"
   msgnam="ALREADY_OFF"
@@ -1664,7 +1664,7 @@ class TreeALREADY_OFF(_TreeException):
 MDSplusException.statusDict[265388072] = TreeALREADY_OFF
 
 
-class TreeALREADY_ON(_TreeException):
+class TreeALREADY_ON(TreeException):
   status=265388083
   message="Node is already ON"
   msgnam="ALREADY_ON"
@@ -1672,7 +1672,7 @@ class TreeALREADY_ON(_TreeException):
 MDSplusException.statusDict[265388080] = TreeALREADY_ON
 
 
-class TreeALREADY_OPEN(_TreeException):
+class TreeALREADY_OPEN(TreeException):
   status=265388091
   message="Tree is already OPEN"
   msgnam="ALREADY_OPEN"
@@ -1680,7 +1680,7 @@ class TreeALREADY_OPEN(_TreeException):
 MDSplusException.statusDict[265388088] = TreeALREADY_OPEN
 
 
-class TreeALREADY_THERE(_TreeException):
+class TreeALREADY_THERE(TreeException):
   status=265388168
   message="Node is already in the tree"
   msgnam="ALREADY_THERE"
@@ -1688,7 +1688,7 @@ class TreeALREADY_THERE(_TreeException):
 MDSplusException.statusDict[265388168] = TreeALREADY_THERE
 
 
-class TreeBADRECORD(_TreeException):
+class TreeBADRECORD(TreeException):
   status=265388218
   message="Data corrupted: cannot read record"
   msgnam="BADRECORD"
@@ -1696,7 +1696,7 @@ class TreeBADRECORD(_TreeException):
 MDSplusException.statusDict[265388216] = TreeBADRECORD
 
 
-class TreeBOTH_OFF(_TreeException):
+class TreeBOTH_OFF(TreeException):
   status=265388184
   message="Both this node and its parent are off"
   msgnam="BOTH_OFF"
@@ -1704,7 +1704,7 @@ class TreeBOTH_OFF(_TreeException):
 MDSplusException.statusDict[265388184] = TreeBOTH_OFF
 
 
-class TreeBUFFEROVF(_TreeException):
+class TreeBUFFEROVF(TreeException):
   status=265388306
   message="Output buffer overflow"
   msgnam="BUFFEROVF"
@@ -1712,7 +1712,7 @@ class TreeBUFFEROVF(_TreeException):
 MDSplusException.statusDict[265388304] = TreeBUFFEROVF
 
 
-class TreeCONGLOMFULL(_TreeException):
+class TreeCONGLOMFULL(TreeException):
   status=265388322
   message="Current conglomerate is full"
   msgnam="CONGLOMFULL"
@@ -1720,7 +1720,7 @@ class TreeCONGLOMFULL(_TreeException):
 MDSplusException.statusDict[265388320] = TreeCONGLOMFULL
 
 
-class TreeCONGLOM_NOT_FULL(_TreeException):
+class TreeCONGLOM_NOT_FULL(TreeException):
   status=265388330
   message="Current conglomerate is not yet full"
   msgnam="CONGLOM_NOT_FULL"
@@ -1728,7 +1728,7 @@ class TreeCONGLOM_NOT_FULL(_TreeException):
 MDSplusException.statusDict[265388328] = TreeCONGLOM_NOT_FULL
 
 
-class TreeCONTINUING(_TreeException):
+class TreeCONTINUING(TreeException):
   status=265390435
   message="Operation continuing: note following error"
   msgnam="CONTINUING"
@@ -1736,7 +1736,7 @@ class TreeCONTINUING(_TreeException):
 MDSplusException.statusDict[265390432] = TreeCONTINUING
 
 
-class TreeDUPTAG(_TreeException):
+class TreeDUPTAG(TreeException):
   status=265388234
   message="Tag name already in use"
   msgnam="DUPTAG"
@@ -1744,7 +1744,7 @@ class TreeDUPTAG(_TreeException):
 MDSplusException.statusDict[265388232] = TreeDUPTAG
 
 
-class TreeEDITTING(_TreeException):
+class TreeEDITTING(TreeException):
   status=265388434
   message="Tree file open for edit: operation not permitted"
   msgnam="EDITTING"
@@ -1752,7 +1752,7 @@ class TreeEDITTING(_TreeException):
 MDSplusException.statusDict[265388432] = TreeEDITTING
 
 
-class TreeILLEGAL_ITEM(_TreeException):
+class TreeILLEGAL_ITEM(TreeException):
   status=265388298
   message="Invalid item code or part number specified"
   msgnam="ILLEGAL_ITEM"
@@ -1760,7 +1760,7 @@ class TreeILLEGAL_ITEM(_TreeException):
 MDSplusException.statusDict[265388296] = TreeILLEGAL_ITEM
 
 
-class TreeILLPAGCNT(_TreeException):
+class TreeILLPAGCNT(TreeException):
   status=265388242
   message="Illegal page count, error mapping tree file"
   msgnam="ILLPAGCNT"
@@ -1768,7 +1768,7 @@ class TreeILLPAGCNT(_TreeException):
 MDSplusException.statusDict[265388240] = TreeILLPAGCNT
 
 
-class TreeINVDFFCLASS(_TreeException):
+class TreeINVDFFCLASS(TreeException):
   status=265388346
   message="Invalid data fmt: only CLASS_S can have data in NCI"
   msgnam="INVDFFCLASS"
@@ -1776,7 +1776,7 @@ class TreeINVDFFCLASS(_TreeException):
 MDSplusException.statusDict[265388344] = TreeINVDFFCLASS
 
 
-class TreeINVDTPUSG(_TreeException):
+class TreeINVDTPUSG(TreeException):
   status=265388426
   message="Attempt to store datatype which conflicts with the designated usage of this node"
   msgnam="INVDTPUSG"
@@ -1784,7 +1784,7 @@ class TreeINVDTPUSG(_TreeException):
 MDSplusException.statusDict[265388424] = TreeINVDTPUSG
 
 
-class TreeINVPATH(_TreeException):
+class TreeINVPATH(TreeException):
   status=265388290
   message="Invalid tree pathname specified"
   msgnam="INVPATH"
@@ -1792,7 +1792,7 @@ class TreeINVPATH(_TreeException):
 MDSplusException.statusDict[265388288] = TreeINVPATH
 
 
-class TreeINVRECTYP(_TreeException):
+class TreeINVRECTYP(TreeException):
   status=265388354
   message="Record type invalid for requested operation"
   msgnam="INVRECTYP"
@@ -1800,7 +1800,7 @@ class TreeINVRECTYP(_TreeException):
 MDSplusException.statusDict[265388352] = TreeINVRECTYP
 
 
-class TreeINVTREE(_TreeException):
+class TreeINVTREE(TreeException):
   status=265388226
   message="Invalid tree identification structure"
   msgnam="INVTREE"
@@ -1808,7 +1808,7 @@ class TreeINVTREE(_TreeException):
 MDSplusException.statusDict[265388224] = TreeINVTREE
 
 
-class TreeMAXOPENEDIT(_TreeException):
+class TreeMAXOPENEDIT(TreeException):
   status=265388250
   message="Too many files open for edit"
   msgnam="MAXOPENEDIT"
@@ -1816,7 +1816,7 @@ class TreeMAXOPENEDIT(_TreeException):
 MDSplusException.statusDict[265388248] = TreeMAXOPENEDIT
 
 
-class TreeNEW(_TreeException):
+class TreeNEW(TreeException):
   status=265388059
   message="New tree created"
   msgnam="NEW"
@@ -1824,7 +1824,7 @@ class TreeNEW(_TreeException):
 MDSplusException.statusDict[265388056] = TreeNEW
 
 
-class TreeNMN(_TreeException):
+class TreeNMN(TreeException):
   status=265388128
   message="No More Nodes"
   msgnam="NMN"
@@ -1832,7 +1832,7 @@ class TreeNMN(_TreeException):
 MDSplusException.statusDict[265388128] = TreeNMN
 
 
-class TreeNMT(_TreeException):
+class TreeNMT(TreeException):
   status=265388136
   message="No More Tags"
   msgnam="NMT"
@@ -1840,7 +1840,7 @@ class TreeNMT(_TreeException):
 MDSplusException.statusDict[265388136] = TreeNMT
 
 
-class TreeNNF(_TreeException):
+class TreeNNF(TreeException):
   status=265388144
   message="Node Not Found"
   msgnam="NNF"
@@ -1848,7 +1848,7 @@ class TreeNNF(_TreeException):
 MDSplusException.statusDict[265388144] = TreeNNF
 
 
-class TreeNODATA(_TreeException):
+class TreeNODATA(TreeException):
   status=265388258
   message="No data available for this node"
   msgnam="NODATA"
@@ -1856,7 +1856,7 @@ class TreeNODATA(_TreeException):
 MDSplusException.statusDict[265388256] = TreeNODATA
 
 
-class TreeNODNAMLEN(_TreeException):
+class TreeNODNAMLEN(TreeException):
   status=265388362
   message="Node name too long (12 chars max)"
   msgnam="NODNAMLEN"
@@ -1864,7 +1864,7 @@ class TreeNODNAMLEN(_TreeException):
 MDSplusException.statusDict[265388360] = TreeNODNAMLEN
 
 
-class TreeNOEDIT(_TreeException):
+class TreeNOEDIT(TreeException):
   status=265388274
   message="Tree file is not open for edit"
   msgnam="NOEDIT"
@@ -1872,7 +1872,7 @@ class TreeNOEDIT(_TreeException):
 MDSplusException.statusDict[265388272] = TreeNOEDIT
 
 
-class TreeNOLOG(_TreeException):
+class TreeNOLOG(TreeException):
   status=265388458
   message="Experiment pathname (xxx_path) not defined"
   msgnam="NOLOG"
@@ -1880,7 +1880,7 @@ class TreeNOLOG(_TreeException):
 MDSplusException.statusDict[265388456] = TreeNOLOG
 
 
-class TreeNOMETHOD(_TreeException):
+class TreeNOMETHOD(TreeException):
   status=265388208
   message="Method not available for this object"
   msgnam="NOMETHOD"
@@ -1888,7 +1888,7 @@ class TreeNOMETHOD(_TreeException):
 MDSplusException.statusDict[265388208] = TreeNOMETHOD
 
 
-class TreeNOOVERWRITE(_TreeException):
+class TreeNOOVERWRITE(TreeException):
   status=265388418
   message="Write-once node: overwrite not permitted"
   msgnam="NOOVERWRITE"
@@ -1896,7 +1896,7 @@ class TreeNOOVERWRITE(_TreeException):
 MDSplusException.statusDict[265388416] = TreeNOOVERWRITE
 
 
-class TreeNORMAL(_TreeException):
+class TreeNORMAL(TreeException):
   status=265388041
   message="Normal successful completion"
   msgnam="NORMAL"
@@ -1904,7 +1904,7 @@ class TreeNORMAL(_TreeException):
 MDSplusException.statusDict[265388040] = TreeNORMAL
 
 
-class TreeNOTALLSUBS(_TreeException):
+class TreeNOTALLSUBS(TreeException):
   status=265388067
   message="Main tree opened but not all subtrees found/or connected"
   msgnam="NOTALLSUBS"
@@ -1912,7 +1912,7 @@ class TreeNOTALLSUBS(_TreeException):
 MDSplusException.statusDict[265388064] = TreeNOTALLSUBS
 
 
-class TreeNOTCHILDLESS(_TreeException):
+class TreeNOTCHILDLESS(TreeException):
   status=265388282
   message="Node must be childless to become subtree reference"
   msgnam="NOTCHILDLESS"
@@ -1920,7 +1920,7 @@ class TreeNOTCHILDLESS(_TreeException):
 MDSplusException.statusDict[265388280] = TreeNOTCHILDLESS
 
 
-class TreeNOT_IN_LIST(_TreeException):
+class TreeNOT_IN_LIST(TreeException):
   status=265388482
   message="Tree being opened was not in the list"
   msgnam="NOT_IN_LIST"
@@ -1928,7 +1928,7 @@ class TreeNOT_IN_LIST(_TreeException):
 MDSplusException.statusDict[265388480] = TreeNOT_IN_LIST
 
 
-class TreeNOTMEMBERLESS(_TreeException):
+class TreeNOTMEMBERLESS(TreeException):
   status=265388402
   message="Subtree reference can not have members"
   msgnam="NOTMEMBERLESS"
@@ -1936,7 +1936,7 @@ class TreeNOTMEMBERLESS(_TreeException):
 MDSplusException.statusDict[265388400] = TreeNOTMEMBERLESS
 
 
-class TreeNOTOPEN(_TreeException):
+class TreeNOTOPEN(TreeException):
   status=265388266
   message="No tree file currently open"
   msgnam="NOTOPEN"
@@ -1944,7 +1944,7 @@ class TreeNOTOPEN(_TreeException):
 MDSplusException.statusDict[265388264] = TreeNOTOPEN
 
 
-class TreeNOTSON(_TreeException):
+class TreeNOTSON(TreeException):
   status=265388410
   message="Subtree reference cannot be a member"
   msgnam="NOTSON"
@@ -1952,7 +1952,7 @@ class TreeNOTSON(_TreeException):
 MDSplusException.statusDict[265388408] = TreeNOTSON
 
 
-class TreeNOT_CONGLOM(_TreeException):
+class TreeNOT_CONGLOM(TreeException):
   status=265388386
   message="Head node of conglomerate does not contain a DTYPE_CONGLOM record"
   msgnam="NOT_CONGLOM"
@@ -1960,7 +1960,7 @@ class TreeNOT_CONGLOM(_TreeException):
 MDSplusException.statusDict[265388384] = TreeNOT_CONGLOM
 
 
-class TreeNOT_OPEN(_TreeException):
+class TreeNOT_OPEN(TreeException):
   status=265388200
   message="Tree not currently open"
   msgnam="NOT_OPEN"
@@ -1968,7 +1968,7 @@ class TreeNOT_OPEN(_TreeException):
 MDSplusException.statusDict[265388200] = TreeNOT_OPEN
 
 
-class TreeNOWRITEMODEL(_TreeException):
+class TreeNOWRITEMODEL(TreeException):
   status=265388442
   message="Data for this node can not be written into the MODEL file"
   msgnam="NOWRITEMODEL"
@@ -1976,7 +1976,7 @@ class TreeNOWRITEMODEL(_TreeException):
 MDSplusException.statusDict[265388440] = TreeNOWRITEMODEL
 
 
-class TreeNOWRITESHOT(_TreeException):
+class TreeNOWRITESHOT(TreeException):
   status=265388450
   message="Data for this node can not be written into the SHOT file"
   msgnam="NOWRITESHOT"
@@ -1984,7 +1984,7 @@ class TreeNOWRITESHOT(_TreeException):
 MDSplusException.statusDict[265388448] = TreeNOWRITESHOT
 
 
-class TreeNO_CONTEXT(_TreeException):
+class TreeNO_CONTEXT(TreeException):
   status=265388099
   message="There is no active search to end"
   msgnam="NO_CONTEXT"
@@ -1992,7 +1992,7 @@ class TreeNO_CONTEXT(_TreeException):
 MDSplusException.statusDict[265388096] = TreeNO_CONTEXT
 
 
-class TreeOFF(_TreeException):
+class TreeOFF(TreeException):
   status=265388192
   message="Node is OFF"
   msgnam="OFF"
@@ -2000,7 +2000,7 @@ class TreeOFF(_TreeException):
 MDSplusException.statusDict[265388192] = TreeOFF
 
 
-class TreeON(_TreeException):
+class TreeON(TreeException):
   status=265388107
   message="Node is ON"
   msgnam="ON"
@@ -2008,7 +2008,7 @@ class TreeON(_TreeException):
 MDSplusException.statusDict[265388104] = TreeON
 
 
-class TreeOPEN(_TreeException):
+class TreeOPEN(TreeException):
   status=265388115
   message="Tree is OPEN (no edit)"
   msgnam="OPEN"
@@ -2016,7 +2016,7 @@ class TreeOPEN(_TreeException):
 MDSplusException.statusDict[265388112] = TreeOPEN
 
 
-class TreeOPEN_EDIT(_TreeException):
+class TreeOPEN_EDIT(TreeException):
   status=265388123
   message="Tree is OPEN for edit"
   msgnam="OPEN_EDIT"
@@ -2024,7 +2024,7 @@ class TreeOPEN_EDIT(_TreeException):
 MDSplusException.statusDict[265388120] = TreeOPEN_EDIT
 
 
-class TreePARENT_OFF(_TreeException):
+class TreePARENT_OFF(TreeException):
   status=265388176
   message="Parent of this node is OFF"
   msgnam="PARENT_OFF"
@@ -2032,7 +2032,7 @@ class TreePARENT_OFF(_TreeException):
 MDSplusException.statusDict[265388176] = TreePARENT_OFF
 
 
-class TreeREADERR(_TreeException):
+class TreeREADERR(TreeException):
   status=265388474
   message="Error reading record for node"
   msgnam="READERR"
@@ -2040,7 +2040,7 @@ class TreeREADERR(_TreeException):
 MDSplusException.statusDict[265388472] = TreeREADERR
 
 
-class TreeREADONLY(_TreeException):
+class TreeREADONLY(TreeException):
   status=265388466
   message="Tree was opened with readonly access"
   msgnam="READONLY"
@@ -2048,7 +2048,7 @@ class TreeREADONLY(_TreeException):
 MDSplusException.statusDict[265388464] = TreeREADONLY
 
 
-class TreeRESOLVED(_TreeException):
+class TreeRESOLVED(TreeException):
   status=265388049
   message="Indirect reference successfully resolved"
   msgnam="RESOLVED"
@@ -2056,7 +2056,7 @@ class TreeRESOLVED(_TreeException):
 MDSplusException.statusDict[265388048] = TreeRESOLVED
 
 
-class TreeSUCCESS(_TreeException):
+class TreeSUCCESS(TreeException):
   status=265389633
   message="Operation successful"
   msgnam="SUCCESS"
@@ -2064,7 +2064,7 @@ class TreeSUCCESS(_TreeException):
 MDSplusException.statusDict[265389632] = TreeSUCCESS
 
 
-class TreeTAGNAMLEN(_TreeException):
+class TreeTAGNAMLEN(TreeException):
   status=265388370
   message="Tagname too long (max 24 chars)"
   msgnam="TAGNAMLEN"
@@ -2072,7 +2072,7 @@ class TreeTAGNAMLEN(_TreeException):
 MDSplusException.statusDict[265388368] = TreeTAGNAMLEN
 
 
-class TreeTNF(_TreeException):
+class TreeTNF(TreeException):
   status=265388152
   message="Tag Not Found"
   msgnam="TNF"
@@ -2080,7 +2080,7 @@ class TreeTNF(_TreeException):
 MDSplusException.statusDict[265388152] = TreeTNF
 
 
-class TreeTREENF(_TreeException):
+class TreeTREENF(TreeException):
   status=265388160
   message="Tree Not Found"
   msgnam="TREENF"
@@ -2088,7 +2088,7 @@ class TreeTREENF(_TreeException):
 MDSplusException.statusDict[265388160] = TreeTREENF
 
 
-class TreeUNRESOLVED(_TreeException):
+class TreeUNRESOLVED(TreeException):
   status=265388338
   message="Not an indirect node reference: No action taken"
   msgnam="UNRESOLVED"
@@ -2096,7 +2096,7 @@ class TreeUNRESOLVED(_TreeException):
 MDSplusException.statusDict[265388336] = TreeUNRESOLVED
 
 
-class TreeUNSPRTCLASS(_TreeException):
+class TreeUNSPRTCLASS(TreeException):
   status=265388314
   message="Unsupported descriptor class"
   msgnam="UNSPRTCLASS"
@@ -2104,7 +2104,7 @@ class TreeUNSPRTCLASS(_TreeException):
 MDSplusException.statusDict[265388312] = TreeUNSPRTCLASS
 
 
-class TreeUNSUPARRDTYPE(_TreeException):
+class TreeUNSUPARRDTYPE(TreeException):
   status=265388394
   message="Complex data types not supported as members of arrays"
   msgnam="UNSUPARRDTYPE"
@@ -2112,7 +2112,7 @@ class TreeUNSUPARRDTYPE(_TreeException):
 MDSplusException.statusDict[265388392] = TreeUNSUPARRDTYPE
 
 
-class TreeWRITEFIRST(_TreeException):
+class TreeWRITEFIRST(TreeException):
   status=265388378
   message="Tree has been modified:  write or quit first"
   msgnam="WRITEFIRST"
@@ -2120,7 +2120,7 @@ class TreeWRITEFIRST(_TreeException):
 MDSplusException.statusDict[265388376] = TreeWRITEFIRST
 
 
-class TreeFAILURE(_TreeException):
+class TreeFAILURE(TreeException):
   status=265392034
   message="Operation NOT successful"
   msgnam="FAILURE"
@@ -2128,7 +2128,7 @@ class TreeFAILURE(_TreeException):
 MDSplusException.statusDict[265392032] = TreeFAILURE
 
 
-class TreeLOCK_FAILURE(_TreeException):
+class TreeLOCK_FAILURE(TreeException):
   status=265392050
   message="Error locking file, perhaps NFSLOCKING not enabled on this system"
   msgnam="LOCK_FAILURE"
@@ -2136,7 +2136,7 @@ class TreeLOCK_FAILURE(_TreeException):
 MDSplusException.statusDict[265392048] = TreeLOCK_FAILURE
 
 
-class TreeFILE_NOT_FOUND(_TreeException):
+class TreeFILE_NOT_FOUND(TreeException):
   status=265392042
   message="File or Directory Not Found"
   msgnam="FILE_NOT_FOUND"
@@ -2144,7 +2144,7 @@ class TreeFILE_NOT_FOUND(_TreeException):
 MDSplusException.statusDict[265392040] = TreeFILE_NOT_FOUND
 
 
-class TreeCANCEL(_TreeException):
+class TreeCANCEL(TreeException):
   status=265391232
   message="User canceled operation"
   msgnam="CANCEL"
@@ -2152,7 +2152,7 @@ class TreeCANCEL(_TreeException):
 MDSplusException.statusDict[265391232] = TreeCANCEL
 
 
-class TreeNOSEGMENTS(_TreeException):
+class TreeNOSEGMENTS(TreeException):
   status=265392058
   message="No segments exist in this node"
   msgnam="NOSEGMENTS"
@@ -2160,7 +2160,7 @@ class TreeNOSEGMENTS(_TreeException):
 MDSplusException.statusDict[265392056] = TreeNOSEGMENTS
 
 
-class TreeINVDTYPE(_TreeException):
+class TreeINVDTYPE(TreeException):
   status=265392066
   message="Invalid datatype for data segment"
   msgnam="INVDTYPE"
@@ -2168,7 +2168,7 @@ class TreeINVDTYPE(_TreeException):
 MDSplusException.statusDict[265392064] = TreeINVDTYPE
 
 
-class TreeINVSHAPE(_TreeException):
+class TreeINVSHAPE(TreeException):
   status=265392074
   message="Invalid shape for this data segment"
   msgnam="INVSHAPE"
@@ -2176,7 +2176,7 @@ class TreeINVSHAPE(_TreeException):
 MDSplusException.statusDict[265392072] = TreeINVSHAPE
 
 
-class TreeINVSHOT(_TreeException):
+class TreeINVSHOT(TreeException):
   status=265392090
   message="Invalid shot number - must be -1 (model), 0 (current), or Positive"
   msgnam="INVSHOT"
@@ -2184,7 +2184,7 @@ class TreeINVSHOT(_TreeException):
 MDSplusException.statusDict[265392088] = TreeINVSHOT
 
 
-class TreeINVTAG(_TreeException):
+class TreeINVTAG(TreeException):
   status=265392106
   message="Invalid tagname - must begin with alpha followed by 0-22 alphanumeric or underscores"
   msgnam="INVTAG"
@@ -2192,7 +2192,7 @@ class TreeINVTAG(_TreeException):
 MDSplusException.statusDict[265392104] = TreeINVTAG
 
 
-class TreeNOPATH(_TreeException):
+class TreeNOPATH(TreeException):
   status=265392114
   message="No 'treename'_path environment variable defined. Cannot locate tree files."
   msgnam="NOPATH"
@@ -2200,7 +2200,7 @@ class TreeNOPATH(_TreeException):
 MDSplusException.statusDict[265392112] = TreeNOPATH
 
 
-class TreeTREEFILEREADERR(_TreeException):
+class TreeTREEFILEREADERR(TreeException):
   status=265392122
   message="Error reading in tree file contents."
   msgnam="TREEFILEREADERR"
@@ -2208,7 +2208,7 @@ class TreeTREEFILEREADERR(_TreeException):
 MDSplusException.statusDict[265392120] = TreeTREEFILEREADERR
 
 
-class TreeMEMERR(_TreeException):
+class TreeMEMERR(TreeException):
   status=265392130
   message="Memory allocation error."
   msgnam="MEMERR"
@@ -2216,7 +2216,7 @@ class TreeMEMERR(_TreeException):
 MDSplusException.statusDict[265392128] = TreeMEMERR
 
 
-class TreeNOCURRENT(_TreeException):
+class TreeNOCURRENT(TreeException):
   status=265392138
   message="No current shot number set for this tree."
   msgnam="NOCURRENT"
@@ -2224,7 +2224,7 @@ class TreeNOCURRENT(_TreeException):
 MDSplusException.statusDict[265392136] = TreeNOCURRENT
 
 
-class TreeFOPENW(_TreeException):
+class TreeFOPENW(TreeException):
   status=265392146
   message="Error opening file for read-write."
   msgnam="FOPENW"
@@ -2232,7 +2232,7 @@ class TreeFOPENW(_TreeException):
 MDSplusException.statusDict[265392144] = TreeFOPENW
 
 
-class TreeFOPENR(_TreeException):
+class TreeFOPENR(TreeException):
   status=265392154
   message="Error opening file read-only."
   msgnam="FOPENR"
@@ -2240,7 +2240,7 @@ class TreeFOPENR(_TreeException):
 MDSplusException.statusDict[265392152] = TreeFOPENR
 
 
-class TreeFCREATE(_TreeException):
+class TreeFCREATE(TreeException):
   status=265392162
   message="Error creating new file."
   msgnam="FCREATE"
@@ -2248,7 +2248,7 @@ class TreeFCREATE(_TreeException):
 MDSplusException.statusDict[265392160] = TreeFCREATE
 
 
-class TreeCONNECTFAIL(_TreeException):
+class TreeCONNECTFAIL(TreeException):
   status=265392170
   message="Error connecting to remote server."
   msgnam="CONNECTFAIL"
@@ -2256,7 +2256,7 @@ class TreeCONNECTFAIL(_TreeException):
 MDSplusException.statusDict[265392168] = TreeCONNECTFAIL
 
 
-class TreeNCIWRITE(_TreeException):
+class TreeNCIWRITE(TreeException):
   status=265392178
   message="Error writing node characterisitics to file."
   msgnam="NCIWRITE"
@@ -2264,7 +2264,7 @@ class TreeNCIWRITE(_TreeException):
 MDSplusException.statusDict[265392176] = TreeNCIWRITE
 
 
-class TreeDELFAIL(_TreeException):
+class TreeDELFAIL(TreeException):
   status=265392186
   message="Error deleting file."
   msgnam="DELFAIL"
@@ -2272,7 +2272,7 @@ class TreeDELFAIL(_TreeException):
 MDSplusException.statusDict[265392184] = TreeDELFAIL
 
 
-class TreeRENFAIL(_TreeException):
+class TreeRENFAIL(TreeException):
   status=265392194
   message="Error renaming file."
   msgnam="RENFAIL"
@@ -2280,7 +2280,7 @@ class TreeRENFAIL(_TreeException):
 MDSplusException.statusDict[265392192] = TreeRENFAIL
 
 
-class TreeEMPTY(_TreeException):
+class TreeEMPTY(TreeException):
   status=265392200
   message="Empty string provided."
   msgnam="EMPTY"
@@ -2288,7 +2288,7 @@ class TreeEMPTY(_TreeException):
 MDSplusException.statusDict[265392200] = TreeEMPTY
 
 
-class TreePARSEERR(_TreeException):
+class TreePARSEERR(TreeException):
   status=265392210
   message="Invalid node search string."
   msgnam="PARSEERR"
@@ -2296,7 +2296,7 @@ class TreePARSEERR(_TreeException):
 MDSplusException.statusDict[265392208] = TreePARSEERR
 
 
-class TreeNCIREAD(_TreeException):
+class TreeNCIREAD(TreeException):
   status=265392218
   message="Error reading node characteristics from file."
   msgnam="NCIREAD"
@@ -2304,7 +2304,7 @@ class TreeNCIREAD(_TreeException):
 MDSplusException.statusDict[265392216] = TreeNCIREAD
 
 
-class TreeNOVERSION(_TreeException):
+class TreeNOVERSION(TreeException):
   status=265392226
   message="No version available."
   msgnam="NOVERSION"
@@ -2312,7 +2312,7 @@ class TreeNOVERSION(_TreeException):
 MDSplusException.statusDict[265392224] = TreeNOVERSION
 
 
-class TreeDFREAD(_TreeException):
+class TreeDFREAD(TreeException):
   status=265392234
   message="Error reading from datafile."
   msgnam="DFREAD"
@@ -2320,7 +2320,7 @@ class TreeDFREAD(_TreeException):
 MDSplusException.statusDict[265392232] = TreeDFREAD
 
 
-class TreeCLOSEERR(_TreeException):
+class TreeCLOSEERR(TreeException):
   status=265392242
   message="Error closing temporary tree file."
   msgnam="CLOSEERR"
@@ -2328,7 +2328,7 @@ class TreeCLOSEERR(_TreeException):
 MDSplusException.statusDict[265392240] = TreeCLOSEERR
 
 
-class TreeMOVEERROR(_TreeException):
+class TreeMOVEERROR(TreeException):
   status=265392250
   message="Error replacing original treefile with new one."
   msgnam="MOVEERROR"
@@ -2336,7 +2336,7 @@ class TreeMOVEERROR(_TreeException):
 MDSplusException.statusDict[265392248] = TreeMOVEERROR
 
 
-class TreeOPENEDITERR(_TreeException):
+class TreeOPENEDITERR(TreeException):
   status=265392258
   message="Error reopening new treefile for write access."
   msgnam="OPENEDITERR"
@@ -2344,7 +2344,7 @@ class TreeOPENEDITERR(_TreeException):
 MDSplusException.statusDict[265392256] = TreeOPENEDITERR
 
 
-class TreeREADONLY_TREE(_TreeException):
+class TreeREADONLY_TREE(TreeException):
   status=265392266
   message="Tree is marked as readonly. No write operations permitted."
   msgnam="READONLY_TREE"
@@ -2352,7 +2352,7 @@ class TreeREADONLY_TREE(_TreeException):
 MDSplusException.statusDict[265392264] = TreeREADONLY_TREE
 
 
-class TreeWRITETREEERR(_TreeException):
+class TreeWRITETREEERR(TreeException):
   status=265392274
   message="Error writing .tree file"
   msgnam="WRITETREEERR"
@@ -2363,11 +2363,11 @@ MDSplusException.statusDict[265392272] = TreeWRITETREEERR
 
 
 
-class _LibException(MDSplusException):
+class LibException(MDSplusException):
   fac="Lib"
 
 
-class LibINSVIRMEM(_LibException):
+class LibINSVIRMEM(LibException):
   status=1409556
   message="Insufficient virtual memory"
   msgnam="INSVIRMEM"
@@ -2375,7 +2375,7 @@ class LibINSVIRMEM(_LibException):
 MDSplusException.statusDict[1409552] = LibINSVIRMEM
 
 
-class LibINVARG(_LibException):
+class LibINVARG(LibException):
   status=1409588
   message="Invalid argument"
   msgnam="INVARG"
@@ -2383,7 +2383,7 @@ class LibINVARG(_LibException):
 MDSplusException.statusDict[1409584] = LibINVARG
 
 
-class LibINVSTRDES(_LibException):
+class LibINVSTRDES(LibException):
   status=1409572
   message="Invalid string descriptor"
   msgnam="INVSTRDES"
@@ -2391,7 +2391,7 @@ class LibINVSTRDES(_LibException):
 MDSplusException.statusDict[1409568] = LibINVSTRDES
 
 
-class LibKEYNOTFOU(_LibException):
+class LibKEYNOTFOU(LibException):
   status=1409788
   message="Key not found"
   msgnam="KEYNOTFOU"
@@ -2399,7 +2399,7 @@ class LibKEYNOTFOU(_LibException):
 MDSplusException.statusDict[1409784] = LibKEYNOTFOU
 
 
-class LibNOTFOU(_LibException):
+class LibNOTFOU(LibException):
   status=1409652
   message="Entity not found"
   msgnam="NOTFOU"
@@ -2407,7 +2407,7 @@ class LibNOTFOU(_LibException):
 MDSplusException.statusDict[1409648] = LibNOTFOU
 
 
-class LibQUEWASEMP(_LibException):
+class LibQUEWASEMP(LibException):
   status=1409772
   message="Queue was empty"
   msgnam="QUEWASEMP"
@@ -2415,7 +2415,7 @@ class LibQUEWASEMP(_LibException):
 MDSplusException.statusDict[1409768] = LibQUEWASEMP
 
 
-class LibSTRTRU(_LibException):
+class LibSTRTRU(LibException):
   status=1409041
   message="String truncated"
   msgnam="STRTRU"
@@ -2423,11 +2423,11 @@ class LibSTRTRU(_LibException):
 MDSplusException.statusDict[1409040] = LibSTRTRU
 
 
-class _StrException(MDSplusException):
+class StrException(MDSplusException):
   fac="Str"
 
 
-class StrMATCH(_StrException):
+class StrMATCH(StrException):
   status=2393113
   message="Strings match"
   msgnam="MATCH"
@@ -2435,7 +2435,7 @@ class StrMATCH(_StrException):
 MDSplusException.statusDict[2393112] = StrMATCH
 
 
-class StrNOMATCH(_StrException):
+class StrNOMATCH(StrException):
   status=2392584
   message="Strings do not match"
   msgnam="NOMATCH"
@@ -2443,7 +2443,7 @@ class StrNOMATCH(_StrException):
 MDSplusException.statusDict[2392584] = StrNOMATCH
 
 
-class StrNOELEM(_StrException):
+class StrNOELEM(StrException):
   status=2392600
   message="Not enough delimited characters"
   msgnam="NOELEM"
@@ -2451,7 +2451,7 @@ class StrNOELEM(_StrException):
 MDSplusException.statusDict[2392600] = StrNOELEM
 
 
-class StrINVDELIM(_StrException):
+class StrINVDELIM(StrException):
   status=2392592
   message="Not enough delimited characters"
   msgnam="INVDELIM"
@@ -2459,7 +2459,7 @@ class StrINVDELIM(_StrException):
 MDSplusException.statusDict[2392592] = StrINVDELIM
 
 
-class StrSTRTOOLON(_StrException):
+class StrSTRTOOLON(StrException):
   status=2392180
   message="String too long"
   msgnam="STRTOOLON"
@@ -2467,11 +2467,11 @@ class StrSTRTOOLON(_StrException):
 MDSplusException.statusDict[2392176] = StrSTRTOOLON
 
 
-class _MDSplusException(MDSplusException):
+class MDSplusException(MDSplusException):
   fac="MDSplus"
 
 
-class MDSplusWARNING(_MDSplusException):
+class MDSplusWARNING(MDSplusException):
   status=65536
   message="Warning"
   msgnam="WARNING"
@@ -2479,7 +2479,7 @@ class MDSplusWARNING(_MDSplusException):
 MDSplusException.statusDict[65536] = MDSplusWARNING
 
 
-class MDSplusSUCCESS(_MDSplusException):
+class MDSplusSUCCESS(MDSplusException):
   status=65545
   message="Success"
   msgnam="SUCCESS"
@@ -2487,7 +2487,7 @@ class MDSplusSUCCESS(_MDSplusException):
 MDSplusException.statusDict[65544] = MDSplusSUCCESS
 
 
-class MDSplusERROR(_MDSplusException):
+class MDSplusERROR(MDSplusException):
   status=65554
   message="Error"
   msgnam="ERROR"
@@ -2495,7 +2495,7 @@ class MDSplusERROR(_MDSplusException):
 MDSplusException.statusDict[65552] = MDSplusERROR
 
 
-class MDSplusFATAL(_MDSplusException):
+class MDSplusFATAL(MDSplusException):
   status=65572
   message="Fatal"
   msgnam="FATAL"
@@ -2503,11 +2503,11 @@ class MDSplusFATAL(_MDSplusException):
 MDSplusException.statusDict[65568] = MDSplusFATAL
 
 
-class _SsException(MDSplusException):
+class SsException(MDSplusException):
   fac="Ss"
 
 
-class SsSUCCESS(_SsException):
+class SsSUCCESS(SsException):
   status=1
   message="Success"
   msgnam="SUCCESS"
@@ -2515,7 +2515,7 @@ class SsSUCCESS(_SsException):
 MDSplusException.statusDict[0] = SsSUCCESS
 
 
-class SsINTOVF(_SsException):
+class SsINTOVF(SsException):
   status=1148
   message="Integer overflow"
   msgnam="INTOVF"
@@ -2523,7 +2523,7 @@ class SsINTOVF(_SsException):
 MDSplusException.statusDict[1144] = SsINTOVF
 
 
-class SsINTERNAL(_SsException):
+class SsINTERNAL(SsException):
   status=-1
   message="This status is meant for internal use only, you should never have seen this message."
   msgnam="INTERNAL"
@@ -2534,11 +2534,11 @@ MDSplusException.statusDict[-8] = SsINTERNAL
 
 
 
-class _TdiException(MDSplusException):
+class TdiException(MDSplusException):
   fac="Tdi"
 
 
-class TdiBREAK(_TdiException):
+class TdiBREAK(TdiException):
   status=265519112
   message="BREAK was not in DO FOR SWITCH or WHILE"
   msgnam="BREAK"
@@ -2546,7 +2546,7 @@ class TdiBREAK(_TdiException):
 MDSplusException.statusDict[265519112] = TdiBREAK
 
 
-class TdiCASE(_TdiException):
+class TdiCASE(TdiException):
   status=265519120
   message="CASE was not in SWITCH statement"
   msgnam="CASE"
@@ -2554,7 +2554,7 @@ class TdiCASE(_TdiException):
 MDSplusException.statusDict[265519120] = TdiCASE
 
 
-class TdiCONTINUE(_TdiException):
+class TdiCONTINUE(TdiException):
   status=265519128
   message="CONTINUE was not in DO FOR or WHILE"
   msgnam="CONTINUE"
@@ -2562,7 +2562,7 @@ class TdiCONTINUE(_TdiException):
 MDSplusException.statusDict[265519128] = TdiCONTINUE
 
 
-class TdiEXTRANEOUS(_TdiException):
+class TdiEXTRANEOUS(TdiException):
   status=265519136
   message="Some characters were unused, bad number maybe"
   msgnam="EXTRANEOUS"
@@ -2570,7 +2570,7 @@ class TdiEXTRANEOUS(_TdiException):
 MDSplusException.statusDict[265519136] = TdiEXTRANEOUS
 
 
-class TdiRETURN(_TdiException):
+class TdiRETURN(TdiException):
   status=265519144
   message="Extraneous RETURN statement, not from a FUN"
   msgnam="RETURN"
@@ -2578,7 +2578,7 @@ class TdiRETURN(_TdiException):
 MDSplusException.statusDict[265519144] = TdiRETURN
 
 
-class TdiABORT(_TdiException):
+class TdiABORT(TdiException):
   status=265519154
   message="Program requested abort"
   msgnam="ABORT"
@@ -2586,7 +2586,7 @@ class TdiABORT(_TdiException):
 MDSplusException.statusDict[265519152] = TdiABORT
 
 
-class TdiBAD_INDEX(_TdiException):
+class TdiBAD_INDEX(TdiException):
   status=265519162
   message="Index or subscript is too small or too big"
   msgnam="BAD_INDEX"
@@ -2594,7 +2594,7 @@ class TdiBAD_INDEX(_TdiException):
 MDSplusException.statusDict[265519160] = TdiBAD_INDEX
 
 
-class TdiBOMB(_TdiException):
+class TdiBOMB(TdiException):
   status=265519170
   message="Bad punctuation, could not compile the text"
   msgnam="BOMB"
@@ -2602,7 +2602,7 @@ class TdiBOMB(_TdiException):
 MDSplusException.statusDict[265519168] = TdiBOMB
 
 
-class TdiEXTRA_ARG(_TdiException):
+class TdiEXTRA_ARG(TdiException):
   status=265519178
   message="Too many arguments for function, watch commas"
   msgnam="EXTRA_ARG"
@@ -2610,7 +2610,7 @@ class TdiEXTRA_ARG(_TdiException):
 MDSplusException.statusDict[265519176] = TdiEXTRA_ARG
 
 
-class TdiGOTO(_TdiException):
+class TdiGOTO(TdiException):
   status=265519186
   message="GOTO target label not found"
   msgnam="GOTO"
@@ -2618,7 +2618,7 @@ class TdiGOTO(_TdiException):
 MDSplusException.statusDict[265519184] = TdiGOTO
 
 
-class TdiINVCLADSC(_TdiException):
+class TdiINVCLADSC(TdiException):
   status=265519194
   message="Storage class not valid, must be scalar or array"
   msgnam="INVCLADSC"
@@ -2626,7 +2626,7 @@ class TdiINVCLADSC(_TdiException):
 MDSplusException.statusDict[265519192] = TdiINVCLADSC
 
 
-class TdiINVCLADTY(_TdiException):
+class TdiINVCLADTY(TdiException):
   status=265519202
   message="Invalid mixture of storage class and data type"
   msgnam="INVCLADTY"
@@ -2634,7 +2634,7 @@ class TdiINVCLADTY(_TdiException):
 MDSplusException.statusDict[265519200] = TdiINVCLADTY
 
 
-class TdiINVDTYDSC(_TdiException):
+class TdiINVDTYDSC(TdiException):
   status=265519210
   message="Storage data type is not valid"
   msgnam="INVDTYDSC"
@@ -2642,7 +2642,7 @@ class TdiINVDTYDSC(_TdiException):
 MDSplusException.statusDict[265519208] = TdiINVDTYDSC
 
 
-class TdiINV_OPC(_TdiException):
+class TdiINV_OPC(TdiException):
   status=265519218
   message="Invalid operator code in a function"
   msgnam="INV_OPC"
@@ -2650,7 +2650,7 @@ class TdiINV_OPC(_TdiException):
 MDSplusException.statusDict[265519216] = TdiINV_OPC
 
 
-class TdiINV_SIZE(_TdiException):
+class TdiINV_SIZE(TdiException):
   status=265519226
   message="Number of elements does not match declaration"
   msgnam="INV_SIZE"
@@ -2658,7 +2658,7 @@ class TdiINV_SIZE(_TdiException):
 MDSplusException.statusDict[265519224] = TdiINV_SIZE
 
 
-class TdiMISMATCH(_TdiException):
+class TdiMISMATCH(TdiException):
   status=265519234
   message="Shape of arguments does not match"
   msgnam="MISMATCH"
@@ -2666,7 +2666,7 @@ class TdiMISMATCH(_TdiException):
 MDSplusException.statusDict[265519232] = TdiMISMATCH
 
 
-class TdiMISS_ARG(_TdiException):
+class TdiMISS_ARG(TdiException):
   status=265519242
   message="Missing argument is required for function"
   msgnam="MISS_ARG"
@@ -2674,7 +2674,7 @@ class TdiMISS_ARG(_TdiException):
 MDSplusException.statusDict[265519240] = TdiMISS_ARG
 
 
-class TdiNDIM_OVER(_TdiException):
+class TdiNDIM_OVER(TdiException):
   status=265519250
   message="Number of dimensions is over the allowed 8"
   msgnam="NDIM_OVER"
@@ -2682,7 +2682,7 @@ class TdiNDIM_OVER(_TdiException):
 MDSplusException.statusDict[265519248] = TdiNDIM_OVER
 
 
-class TdiNO_CMPLX(_TdiException):
+class TdiNO_CMPLX(TdiException):
   status=265519258
   message="There are no complex forms of this function"
   msgnam="NO_CMPLX"
@@ -2690,7 +2690,7 @@ class TdiNO_CMPLX(_TdiException):
 MDSplusException.statusDict[265519256] = TdiNO_CMPLX
 
 
-class TdiNO_OPC(_TdiException):
+class TdiNO_OPC(TdiException):
   status=265519266
   message="No support for this function, today"
   msgnam="NO_OPC"
@@ -2698,7 +2698,7 @@ class TdiNO_OPC(_TdiException):
 MDSplusException.statusDict[265519264] = TdiNO_OPC
 
 
-class TdiNO_OUTPTR(_TdiException):
+class TdiNO_OUTPTR(TdiException):
   status=265519274
   message="An output pointer is required"
   msgnam="NO_OUTPTR"
@@ -2706,7 +2706,7 @@ class TdiNO_OUTPTR(_TdiException):
 MDSplusException.statusDict[265519272] = TdiNO_OUTPTR
 
 
-class TdiNO_SELF_PTR(_TdiException):
+class TdiNO_SELF_PTR(TdiException):
   status=265519282
   message="No $VALUE is defined for signal or validation"
   msgnam="NO_SELF_PTR"
@@ -2714,7 +2714,7 @@ class TdiNO_SELF_PTR(_TdiException):
 MDSplusException.statusDict[265519280] = TdiNO_SELF_PTR
 
 
-class TdiNOT_NUMBER(_TdiException):
+class TdiNOT_NUMBER(TdiException):
   status=265519290
   message="Value is not a scalar number and must be"
   msgnam="NOT_NUMBER"
@@ -2722,7 +2722,7 @@ class TdiNOT_NUMBER(_TdiException):
 MDSplusException.statusDict[265519288] = TdiNOT_NUMBER
 
 
-class TdiNULL_PTR(_TdiException):
+class TdiNULL_PTR(TdiException):
   status=265519298
   message="Null pointer where value needed"
   msgnam="NULL_PTR"
@@ -2730,7 +2730,7 @@ class TdiNULL_PTR(_TdiException):
 MDSplusException.statusDict[265519296] = TdiNULL_PTR
 
 
-class TdiRECURSIVE(_TdiException):
+class TdiRECURSIVE(TdiException):
   status=265519306
   message="Overly recursive function, calls itself maybe"
   msgnam="RECURSIVE"
@@ -2738,7 +2738,7 @@ class TdiRECURSIVE(_TdiException):
 MDSplusException.statusDict[265519304] = TdiRECURSIVE
 
 
-class TdiSIG_DIM(_TdiException):
+class TdiSIG_DIM(TdiException):
   status=265519314
   message="Signal dimension does not match data shape"
   msgnam="SIG_DIM"
@@ -2746,7 +2746,7 @@ class TdiSIG_DIM(_TdiException):
 MDSplusException.statusDict[265519312] = TdiSIG_DIM
 
 
-class TdiSYNTAX(_TdiException):
+class TdiSYNTAX(TdiException):
   status=265519322
   message="Bad punctuation or misspelled word or number"
   msgnam="SYNTAX"
@@ -2754,7 +2754,7 @@ class TdiSYNTAX(_TdiException):
 MDSplusException.statusDict[265519320] = TdiSYNTAX
 
 
-class TdiTOO_BIG(_TdiException):
+class TdiTOO_BIG(TdiException):
   status=265519330
   message="Conversion of number lost significant digits"
   msgnam="TOO_BIG"
@@ -2762,7 +2762,7 @@ class TdiTOO_BIG(_TdiException):
 MDSplusException.statusDict[265519328] = TdiTOO_BIG
 
 
-class TdiUNBALANCE(_TdiException):
+class TdiUNBALANCE(TdiException):
   status=265519338
   message="Unbalanced () [] {} '' " " or /**/"
   msgnam="UNBALANCE"
@@ -2770,7 +2770,7 @@ class TdiUNBALANCE(_TdiException):
 MDSplusException.statusDict[265519336] = TdiUNBALANCE
 
 
-class TdiUNKNOWN_VAR(_TdiException):
+class TdiUNKNOWN_VAR(TdiException):
   status=265519346
   message="Unknown/undefined variable name"
   msgnam="UNKNOWN_VAR"
@@ -2778,7 +2778,7 @@ class TdiUNKNOWN_VAR(_TdiException):
 MDSplusException.statusDict[265519344] = TdiUNKNOWN_VAR
 
 
-class TdiSTRTOOLON(_TdiException):
+class TdiSTRTOOLON(TdiException):
   status=265519356
   message="string is too long (greater than 65535)"
   msgnam="STRTOOLON"
@@ -2786,7 +2786,7 @@ class TdiSTRTOOLON(_TdiException):
 MDSplusException.statusDict[265519352] = TdiSTRTOOLON
 
 
-class TdiTIMEOUT(_TdiException):
+class TdiTIMEOUT(TdiException):
   status=265519364
   message="task did not complete in alotted time"
   msgnam="TIMEOUT"
@@ -2797,11 +2797,11 @@ MDSplusException.statusDict[265519360] = TdiTIMEOUT
 
 
 
-class _MdsdclException(MDSplusException):
+class MdsdclException(MDSplusException):
   fac="Mdsdcl"
 
 
-class MdsdclSUCCESS(_MdsdclException):
+class MdsdclSUCCESS(MdsdclException):
   status=134348809
   message="Normal successful completion"
   msgnam="SUCCESS"
@@ -2809,7 +2809,7 @@ class MdsdclSUCCESS(_MdsdclException):
 MDSplusException.statusDict[134348808] = MdsdclSUCCESS
 
 
-class MdsdclEXIT(_MdsdclException):
+class MdsdclEXIT(MdsdclException):
   status=134348817
   message="Normal exit"
   msgnam="EXIT"
@@ -2817,7 +2817,7 @@ class MdsdclEXIT(_MdsdclException):
 MDSplusException.statusDict[134348816] = MdsdclEXIT
 
 
-class MdsdclERROR(_MdsdclException):
+class MdsdclERROR(MdsdclException):
   status=134348824
   message="Unsuccessful execution of command"
   msgnam="ERROR"
@@ -2825,7 +2825,7 @@ class MdsdclERROR(_MdsdclException):
 MDSplusException.statusDict[134348824] = MdsdclERROR
 
 
-class MdsdclNORMAL(_MdsdclException):
+class MdsdclNORMAL(MdsdclException):
   status=134349609
   message="Normal successful completion"
   msgnam="NORMAL"
@@ -2833,7 +2833,7 @@ class MdsdclNORMAL(_MdsdclException):
 MDSplusException.statusDict[134349608] = MdsdclNORMAL
 
 
-class MdsdclPRESENT(_MdsdclException):
+class MdsdclPRESENT(MdsdclException):
   status=134349617
   message="Entity is present"
   msgnam="PRESENT"
@@ -2841,7 +2841,7 @@ class MdsdclPRESENT(_MdsdclException):
 MDSplusException.statusDict[134349616] = MdsdclPRESENT
 
 
-class MdsdclIVVERB(_MdsdclException):
+class MdsdclIVVERB(MdsdclException):
   status=134349626
   message="No such command"
   msgnam="IVVERB"
@@ -2849,7 +2849,7 @@ class MdsdclIVVERB(_MdsdclException):
 MDSplusException.statusDict[134349624] = MdsdclIVVERB
 
 
-class MdsdclABSENT(_MdsdclException):
+class MdsdclABSENT(MdsdclException):
   status=134349632
   message="Entity is absent"
   msgnam="ABSENT"
@@ -2857,7 +2857,7 @@ class MdsdclABSENT(_MdsdclException):
 MDSplusException.statusDict[134349632] = MdsdclABSENT
 
 
-class MdsdclNEGATED(_MdsdclException):
+class MdsdclNEGATED(MdsdclException):
   status=134349640
   message="Entity is present but negated"
   msgnam="NEGATED"
@@ -2865,7 +2865,7 @@ class MdsdclNEGATED(_MdsdclException):
 MDSplusException.statusDict[134349640] = MdsdclNEGATED
 
 
-class MdsdclNOTNEGATABLE(_MdsdclException):
+class MdsdclNOTNEGATABLE(MdsdclException):
   status=134349650
   message="Entity cannot be negated"
   msgnam="NOTNEGATABLE"
@@ -2873,7 +2873,7 @@ class MdsdclNOTNEGATABLE(_MdsdclException):
 MDSplusException.statusDict[134349648] = MdsdclNOTNEGATABLE
 
 
-class MdsdclIVQUAL(_MdsdclException):
+class MdsdclIVQUAL(MdsdclException):
   status=134349658
   message="Invalid qualifier"
   msgnam="IVQUAL"
@@ -2881,7 +2881,7 @@ class MdsdclIVQUAL(_MdsdclException):
 MDSplusException.statusDict[134349656] = MdsdclIVQUAL
 
 
-class MdsdclPROMPT_MORE(_MdsdclException):
+class MdsdclPROMPT_MORE(MdsdclException):
   status=134349666
   message="More input required for command"
   msgnam="PROMPT_MORE"
@@ -2889,7 +2889,7 @@ class MdsdclPROMPT_MORE(_MdsdclException):
 MDSplusException.statusDict[134349664] = MdsdclPROMPT_MORE
 
 
-class MdsdclTOO_MANY_PRMS(_MdsdclException):
+class MdsdclTOO_MANY_PRMS(MdsdclException):
   status=134349674
   message="Too many parameters specified"
   msgnam="TOO_MANY_PRMS"
@@ -2897,7 +2897,7 @@ class MdsdclTOO_MANY_PRMS(_MdsdclException):
 MDSplusException.statusDict[134349672] = MdsdclTOO_MANY_PRMS
 
 
-class MdsdclTOO_MANY_VALS(_MdsdclException):
+class MdsdclTOO_MANY_VALS(MdsdclException):
   status=134349682
   message="Too many values"
   msgnam="TOO_MANY_VALS"
@@ -2905,7 +2905,7 @@ class MdsdclTOO_MANY_VALS(_MdsdclException):
 MDSplusException.statusDict[134349680] = MdsdclTOO_MANY_VALS
 
 
-class MdsdclMISSING_VALUE(_MdsdclException):
+class MdsdclMISSING_VALUE(MdsdclException):
   status=134349690
   message="Qualifier value needed"
   msgnam="MISSING_VALUE"
@@ -2916,11 +2916,11 @@ MDSplusException.statusDict[134349688] = MdsdclMISSING_VALUE
 
 
 
-class _ServerException(MDSplusException):
+class ServerException(MDSplusException):
   fac="Server"
 
 
-class ServerNOT_DISPATCHED(_ServerException):
+class ServerNOT_DISPATCHED(ServerException):
   status=266436616
   message="action not dispatched, depended on failed action"
   msgnam="NOT_DISPATCHED"
@@ -2928,7 +2928,7 @@ class ServerNOT_DISPATCHED(_ServerException):
 MDSplusException.statusDict[266436616] = ServerNOT_DISPATCHED
 
 
-class ServerINVALID_DEPENDENCY(_ServerException):
+class ServerINVALID_DEPENDENCY(ServerException):
   status=266436626
   message="action dependency cannot be evaluated"
   msgnam="INVALID_DEPENDENCY"
@@ -2936,7 +2936,7 @@ class ServerINVALID_DEPENDENCY(_ServerException):
 MDSplusException.statusDict[266436624] = ServerINVALID_DEPENDENCY
 
 
-class ServerCANT_HAPPEN(_ServerException):
+class ServerCANT_HAPPEN(ServerException):
   status=266436634
   message="action contains circular dependency or depends on action which was not dispatched"
   msgnam="CANT_HAPPEN"
@@ -2944,7 +2944,7 @@ class ServerCANT_HAPPEN(_ServerException):
 MDSplusException.statusDict[266436632] = ServerCANT_HAPPEN
 
 
-class ServerINVSHOT(_ServerException):
+class ServerINVSHOT(ServerException):
   status=266436642
   message="invalid shot number, cannot dispatch actions in model"
   msgnam="INVSHOT"
@@ -2952,7 +2952,7 @@ class ServerINVSHOT(_ServerException):
 MDSplusException.statusDict[266436640] = ServerINVSHOT
 
 
-class ServerABORT(_ServerException):
+class ServerABORT(ServerException):
   status=266436658
   message="Server action was aborted"
   msgnam="ABORT"
@@ -2960,7 +2960,7 @@ class ServerABORT(_ServerException):
 MDSplusException.statusDict[266436656] = ServerABORT
 
 
-class ServerPATH_DOWN(_ServerException):
+class ServerPATH_DOWN(ServerException):
   status=266436674
   message="Path to server lost"
   msgnam="PATH_DOWN"
@@ -2968,7 +2968,7 @@ class ServerPATH_DOWN(_ServerException):
 MDSplusException.statusDict[266436672] = ServerPATH_DOWN
 
 
-class ServerSOCKET_ADDR_ERROR(_ServerException):
+class ServerSOCKET_ADDR_ERROR(ServerException):
   status=266436682
   message="Cannot obtain ip address socket is bound to."
   msgnam="SOCKET_ADDR_ERROR"
@@ -2976,7 +2976,7 @@ class ServerSOCKET_ADDR_ERROR(_ServerException):
 MDSplusException.statusDict[266436680] = ServerSOCKET_ADDR_ERROR
 
 
-class ServerINVALID_ACTION_OPERATION(_ServerException):
+class ServerINVALID_ACTION_OPERATION(ServerException):
   status=266436690
   message="None"
   msgnam="INVALID_ACTION_OPERATION"
@@ -2987,11 +2987,11 @@ MDSplusException.statusDict[266436688] = ServerINVALID_ACTION_OPERATION
 
 
 
-class _CamException(MDSplusException):
+class CamException(MDSplusException):
   fac="Cam"
 
 
-class CamDONE_Q(_CamException):
+class CamDONE_Q(CamException):
   status=134316041
   message="I/O completed with X=1, Q=1"
   msgnam="DONE_Q"
@@ -2999,7 +2999,7 @@ class CamDONE_Q(_CamException):
 MDSplusException.statusDict[134316040] = CamDONE_Q
 
 
-class CamDONE_NOQ(_CamException):
+class CamDONE_NOQ(CamException):
   status=134316049
   message="I/O completed with X=1, Q=0"
   msgnam="DONE_NOQ"
@@ -3007,7 +3007,7 @@ class CamDONE_NOQ(_CamException):
 MDSplusException.statusDict[134316048] = CamDONE_NOQ
 
 
-class CamDONE_NOX(_CamException):
+class CamDONE_NOX(CamException):
   status=134320128
   message="I/O completed with X=0 - probable failure"
   msgnam="DONE_NOX"
@@ -3015,7 +3015,7 @@ class CamDONE_NOX(_CamException):
 MDSplusException.statusDict[134320128] = CamDONE_NOX
 
 
-class CamSERTRAERR(_CamException):
+class CamSERTRAERR(CamException):
   status=134322178
   message="serial transmission error on highway"
   msgnam="SERTRAERR"
@@ -3023,7 +3023,7 @@ class CamSERTRAERR(_CamException):
 MDSplusException.statusDict[134322176] = CamSERTRAERR
 
 
-class CamSCCFAIL(_CamException):
+class CamSCCFAIL(CamException):
   status=134322242
   message="serial crate controller failure"
   msgnam="SCCFAIL"
@@ -3031,7 +3031,7 @@ class CamSCCFAIL(_CamException):
 MDSplusException.statusDict[134322240] = CamSCCFAIL
 
 
-class CamOFFLINE(_CamException):
+class CamOFFLINE(CamException):
   status=134322282
   message="crate is offline"
   msgnam="OFFLINE"
@@ -3042,11 +3042,11 @@ MDSplusException.statusDict[134322280] = CamOFFLINE
 
 
 
-class _TclException(MDSplusException):
+class TclException(MDSplusException):
   fac="Tcl"
 
 
-class TclNORMAL(_TclException):
+class TclNORMAL(TclException):
   status=2752521
   message="Normal successful completion"
   msgnam="NORMAL"
@@ -3054,7 +3054,7 @@ class TclNORMAL(_TclException):
 MDSplusException.statusDict[2752520] = TclNORMAL
 
 
-class TclFAILED_ESSENTIAL(_TclException):
+class TclFAILED_ESSENTIAL(TclException):
   status=2752528
   message="Essential action failed"
   msgnam="FAILED_ESSENTIAL"

--- a/mdsshr/gen_messages.py
+++ b/mdsshr/gen_messages.py
@@ -34,7 +34,7 @@ msglist = []
 
 
 def gen_include(root,filename,faclist,msglistm,f_test):
-    pfaclist = []
+    pfaclist = ["MDSplus"]
     print filename
     f_inc=open("%s/include/%sh" % (sourcedir,filename[0:-3]),'w')
     f_inc.write(
@@ -139,6 +139,7 @@ f_py.write("""#
 ########################################################
 
 class MDSplusException(Exception):
+  fac="MDSplus"
   statusDict={}
   severities=["W", "S", "E", "I", "F", "?", "?", "?"]
   def __new__(cls,*argv):

--- a/mdsshr/gen_messages.py
+++ b/mdsshr/gen_messages.py
@@ -88,13 +88,13 @@ def gen_include(root,filename,faclist,msglistm,f_test):
                 pfaclist.append(facnam)
                 f_py.write("""
 
-class _%(fac)sException(MDSplusException):
+class %(fac)sException(MDSplusException):
   fac="%(fac)s"
 """ % {'fac':facnam})
             msglist.append(msg)
             f_py.write("""
 
-class %(fac)s%(msgnam)s(_%(fac)sException):
+class %(fac)s%(msgnam)s(%(fac)sException):
   status=%(status)d
   message="%(message)s"
   msgnam="%(msgnam)s"
@@ -104,7 +104,32 @@ MDSplusException.statusDict[%(msgn_nosev)d] = %(fac)s%(msgnam)s
     f_inc.close()
 
 f_py=open("%s/mdsobjects/python/mdsExceptions.py"%sourcedir,'w')
-f_py.write("""
+f_py.write("""# 
+# Copyright (c) 2017, Massachusetts Institute of Technology All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# Redistributions of source code must retain the above copyright notice, this
+# list of conditions and the following disclaimer.
+#
+# Redistributions in binary form must reproduce the above copyright notice, this
+# list of conditions and the following disclaimer in the documentation and/or
+# other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+
 ########################################################
 # This module was generated using mdsshr/gen_device.py
 # To add new status messages modify one of the
@@ -186,7 +211,33 @@ for filename,filepath in xmllist.items():
 
 f_getmsg=open('%s/mdsshr/MdsGetStdMsg.c'%sourcedir,'w')
 exceptionDict=[]
-f_getmsg.write("#include <config.h>\n\n");
+f_getmsg.write("""/*
+Copyright (c) 2017, Massachusetts Institute of Technology All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+Redistributions of source code must retain the above copyright notice, this
+list of conditions and the following disclaimer.
+
+Redistributions in binary form must reproduce the above copyright notice, this
+list of conditions and the following disclaimer in the documentation and/or
+other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+#include <config.h>
+
+""");
 for facu in faclist:
     f_getmsg.write("static const char *FAC_%s = \"%s\";\n" % (facu,facu))
 f_getmsg.write("""


### PR DESCRIPTION
The MDSplus python exception superclasses were changed to begin
with an underscore to prevent them from being exported but it is
sometimes useful to catch a class of exceptions by using the superclass
name. Some existing applications were doing this and the change to
hide these superclasses broke these applications. This change will
restore their visibility making them useable in user applications.