### PR TITLE
Zck valgrind fs26 32bit

### DIFF
--- a/conf/valgrind-python.supp
+++ b/conf/valgrind-python.supp
@@ -428,3 +428,11 @@
    ...
    fun:PyThread_start_new_thread
 }
+
+{
+   python 32bit problem in PyObject_Realloc
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:realloc
+   fun:PyObject_Realloc
+}

--- a/conf/valgrind-python.supp
+++ b/conf/valgrind-python.supp
@@ -436,3 +436,21 @@
    fun:realloc
    fun:PyObject_Realloc
 }
+
+{
+   python 32bit problem during thread creation
+   Helgrind:Race
+   ...
+   fun:blas_memory_*
+   fun:blas_thread_server
+   fun:mythread_wrapper
+   fun:start_thread
+   fun:clone
+}
+
+{
+   python 32bit problem during thread shutdown via fork
+   Helgrind:Race
+   fun:blas_thread_shutdown_
+   fun:fork
+}

--- a/include/pthread_port.h
+++ b/include/pthread_port.h
@@ -164,7 +164,7 @@ _CONDITION_UNLOCK(input);\
 }
 //"
 #if defined(__MACH__) || defined(_WIN32)
-#define _ALLOC_HP struct hostent *hp;
+#define _ALLOC_HP struct hostent *hp = NULL;
 #define _GETHOSTBYADDR(addr,type) gethostbyaddr(((void *)&addr),sizeof(addr),type)
 #define _GETHOSTBYNAME(name)      gethostbyname(name)
 #define _GETHOST(gethost) hp = gethost
@@ -172,9 +172,10 @@ _CONDITION_UNLOCK(input);\
 #else
 #define _ALLOC_HP \
 size_t memlen = 1024;\
-struct hostent hostbuf, *hp;\
+struct hostent hostbuf, *hp = NULL;\
 int herr;\
-char *hp_mem = (char*)malloc(memlen)
+char *hp_mem = (char*)malloc(memlen);\
+FREE_ON_EXIT(hp_mem)
 
 #define _GETHOST(gethost_r) \
 while ( hp_mem && (gethost_r == ERANGE) ) {\
@@ -184,7 +185,7 @@ while ( hp_mem && (gethost_r == ERANGE) ) {\
 }
 #define _GETHOSTBYADDR(addr,type) gethostbyaddr_r(((void *)&addr),sizeof(addr),type,&hostbuf,hp_mem,memlen,&hp,&herr)
 #define _GETHOSTBYNAME(name)      gethostbyname_r(name,&hostbuf,hp_mem,memlen,&hp,&herr)
-#define FREE_HP if (hp_mem) free(hp_mem)
+#define FREE_HP FREE_NOW(hp_mem)
 #endif
 
 #define GETHOSTBYADDR(addr,type) \

--- a/mdsobjects/cpp/testing/MdsConnectionTest.cpp
+++ b/mdsobjects/cpp/testing/MdsConnectionTest.cpp
@@ -60,15 +60,13 @@ using namespace testing;
 void test_tree_open(const char *prot)
 {
     MdsIpInstancer mdsip(prot);
-    bool server_started =  mdsip.waitForServer(20,2E5); // try 20 times x 0.2s
-    TEST1(server_started);
-
 
     // get address form instancer for the specified protocol //
     std::string addr = mdsip.getAddress();
 
     std::cout << "attempt to connect to: " << addr << "\n";
-    Connection cnx(const_cast<char*>(addr.c_str()),0);
+    usleep(1000000);
+    Connection cnx(const_cast<char*>(addr.c_str()));
 
     // test client-server communication //
     unique_ptr<Data> data = cnx.get("ZERO(10)");
@@ -108,10 +106,9 @@ void test_tree_open(const char *prot)
 
 int main(int argc UNUSED_ARGUMENT, char *argv[] UNUSED_ARGUMENT)
 {
-    TEST_TIMEOUT(15);
-    BEGIN_TESTING(Connection);
-
+    TEST_TIMEOUT(30);
     setenv("test_tree_path",".",1);
+
 
     ////////////////////////////////////////////////////////////////////////////////
     //  Generate Tree  /////////////////////////////////////////////////////////////
@@ -146,15 +143,18 @@ int main(int argc UNUSED_ARGUMENT, char *argv[] UNUSED_ARGUMENT)
     ////////////////////////////////////////////////////////////////////////////////
 
     // tcp //
+    BEGIN_TESTING(Connection tcp);
     test_tree_open("tcp");
+    END_TESTING;
 
     // udt //
-    
+
 #ifndef __ARM_ARCH
+    BEGIN_TESTING(Connection udt);
     test_tree_open("udt");
+    END_TESTING;
 #endif
 
-    END_TESTING;
 }
 
 #endif

--- a/mdsshr/UdpEvents.c
+++ b/mdsshr/UdpEvents.c
@@ -378,11 +378,35 @@ int MDSUdpEvent(char const *eventName, unsigned int bufLen, char const *buf)
 
   memset((char *)&sin, 0, sizeof(sin));
   sin.sin_family = AF_INET;
-  int addr;
-  GETHOSTBYNAMEORADDR(multiIp,addr);
-  if (hp)
-    memcpy(&sin.sin_addr, hp->h_addr_list[0], (size_t)hp->h_length);
-  FREE_HP;
+#if defined(__MACH__) || defined(_WIN32)
+  struct hostent* hp = gethostbyname(multiIp);
+  if (!hp) {
+    int addr = inet_addr(multiIp);
+    if (addr != -1)  hp = gethostbyaddr(((void *)&addr),sizeof(int),AF_INET);
+  }
+  if (hp) memcpy(&sin.sin_addr, hp->h_addr_list[0], (size_t)hp->h_length);
+#else
+  size_t memlen = 1024;
+  struct hostent hostbuf, *hp = NULL;
+  int herr;
+  char *hp_mem = (char*)malloc(memlen);
+  FREE_ON_EXIT(hp_mem);
+  while ( hp_mem && (gethostbyname_r(multiIp,&hostbuf,hp_mem,memlen,&hp,&herr) == ERANGE) ) {
+    memlen *=2;
+    free(hp_mem);
+    hp_mem = (char*)malloc(memlen);
+  }
+  if (!hp) {
+    int addr = (int)inet_addr(multiIp);
+    while ( hp_mem && (gethostbyaddr_r(((void *)&addr),sizeof(int),AF_INET,&hostbuf,hp_mem,memlen,&hp,&herr) == ERANGE) ) {
+      memlen *=2;
+      free(hp_mem);
+      hp_mem = (char*)malloc(memlen);
+    }
+  }
+  if (hp) memcpy(&sin.sin_addr, hp->h_addr_list[0], (size_t)hp->h_length);
+  FREE_NOW(hp_mem);
+#endif
   UdpEventGetPort(&port);
   sin.sin_port = htons(port);
   nameLen = (unsigned int)strlen(eventName);

--- a/mdstcpip/ioroutinesx.h
+++ b/mdstcpip/ioroutinesx.h
@@ -104,16 +104,16 @@ static int GetHostAndPort(char *hostin, struct SOCKADDR_IN *sin){
       }
     }
   }
-  struct addrinfo *info;
+  struct addrinfo *info = NULL;
   static const struct addrinfo hints = { 0, AF_T, SOCK_STREAM, 0, 0, 0, 0, 0 };
   int err = getaddrinfo(host, service, &hints, &info);
   if (err)
     fprintf(stderr,"Error connecting to host: %s, port %s error=%s\n", host, service, gai_strerror(err));
   else {
     memcpy(sin, info->ai_addr, sizeof(*sin) < info->ai_addrlen ? sizeof(*sin) : info->ai_addrlen);
-    freeaddrinfo(info);
     status = MDSplusSUCCESS;
   }
+  if (info) freeaddrinfo(info);
   FREE_NOW(host);
   return status;
 }


### PR DESCRIPTION
* removed GETHOST__ macros from pthread_port
* fixed fc26 valgrind on 32bit by suppressing third party issues (e.g. python and fork)
* improved cancel-ability by adding more FREE_ON_EXIT
* it also cleans up the MDSConnectionTest with predictable ports as tests are now running on isolated machines