### PR TITLE
Build: Rever --enable-werror for release builds

### DIFF
--- a/deploy/platform/platform_docker_build.sh
+++ b/deploy/platform/platform_docker_build.sh
@@ -41,7 +41,6 @@ config() {
 	JAVA_OPTS="--with-jars=${JARS_DIR}"
     fi
     :&& ${srcdir}/configure \
-	--enable-werror \
 	--disable-wreturns \
         --prefix=${MDSPLUS_DIR} \
         --exec_prefix=${MDSPLUS_DIR} \

--- a/mdsmisc/bwfilter.c
+++ b/mdsmisc/bwfilter.c
@@ -99,7 +99,7 @@ EXPORT int bwfilter(float *w_cut_in, int *order_in, int *num, float *in, float *
     for (i = M; i >= 1; i--) {
       x_current[i] = x_current[i - 1];
     }
-    for (j = N; j >= 1; j--) {
+    for (j = N; j > 0; j--) {
       y_filtered[j] = y_filtered[j - 1];
     }
 


### PR DESCRIPTION
There are still unresolved compiler warnings when compiling
with optimization. Until they are resolved we cannot use --enable-werror.