### PR TITLE
Fix: Repair rpm repo public signing key

### DIFF
--- a/deploy/platform/redhat/redhat_docker_build.sh
+++ b/deploy/platform/redhat/redhat_docker_build.sh
@@ -68,6 +68,10 @@ buildrelease(){
         echo "WARNING: Signing Keys Unavailable. Building unsigned RPMS"
         GPGCHECK="0"
     fi
+    if [ -r /sign_keys/RPM-GPG-KEY-MDSplus ]
+    then
+	cp /sign_keys/RPM-GPG-KEY-MDSplus ${BUILDROOT}/etc/pki/rpm-gpg/;
+    fi
     cat - > ${BUILDROOT}/etc/yum.repos.d/mdsplus${BNAME}.repo <<EOF
 [MDSplus${BNAME}]
 name=MDSplus${BNAME}


### PR DESCRIPTION
The signing key for MDSplus has been changed to use a more secure
key. This was fixed because of warnings occurring for debian repositories
but the public key installed for the rpm repository was not updated to
match the new signing key. This should cause a new public key to be
included in the repo rpm.