### PR TITLE
Fix: Repair numerous compiler warnings

### DIFF
--- a/configure
+++ b/configure
@@ -8031,7 +8031,7 @@ case "$host" in
 *mingw*)
        IDLMDSEVENT=""
        LIBPRE=""
-       CFLAGS="$CFLAGS -fno-strict-aliasing -mno-ms-bitfields -Wno-clobbered ";
+       CFLAGS="$CFLAGS -fno-strict-aliasing -mno-ms-bitfields ";
        LD="$CXX -static-libgcc"
        FCFLAGS="$FCFLAGS -fno-range-check"
        FORLD="$FC"
@@ -8065,7 +8065,7 @@ case "$host" in
        jni_md_inc_dir="$with_jdk/include/linux";;
 
 *86*linux*)
-       CFLAGS="$CFLAGS -fpic -shared-libgcc -fsigned-char -fno-strict-aliasing -Wno-clobbered ";
+       CFLAGS="$CFLAGS -fpic -shared-libgcc -fsigned-char -fno-strict-aliasing ";
        FORLD="$FC";
        LD="gcc"
        if ( echo $host| grep 64 > /dev/null )
@@ -8126,7 +8126,7 @@ case "$host" in
        SIZEOF_LONG=4;
        SIZEOF_LONG_LONG=8;
        D64="";
-       CFLAGS="$CFLAGS -fpic -shared-libgcc -fsigned-char -fno-strict-aliasing -Wno-clobbered";
+       CFLAGS="$CFLAGS -fpic -shared-libgcc -fsigned-char -fno-strict-aliasing";
        if (test "$FC" = "gfortran"); then
          FCFLAGS="$FCFLAGS -fno-range-check";
          FORLD="$FC"
@@ -8147,7 +8147,7 @@ case "$host" in
        jni_md_inc_dir="$with_jdk/include/linux";
        HUP_TO_XINETD="/etc/rc.d/init.d/xinetd restart";
        HUP_TO_INETD="kill -HUP \`/sbin/pidof inetd\`";;
-*linux*) CFLAGS="$CFLAGS -fpic -fsigned-char -shared-libgcc -fno-strict-aliasing -Wno-clobbered";
+*linux*) CFLAGS="$CFLAGS -fpic -fsigned-char -shared-libgcc -fno-strict-aliasing";
        FCFLAGS="$FCFLAGS -fno-range-check";
        FORLD="$FC"
        FOR_LDFLAGS="-lg2c"
@@ -8179,9 +8179,9 @@ case "$host" in
        LD_LDSHARE="";
        LDARC="";
        LD_LDARC="";
-       UILPATH=${OPENMOTIF}/bin;
-       MOTIF_LDARC="-Wl,-bind_at_load -multiply_defined suppress -L${OPENMOTIF}/lib"
-       MOTIF_LD_LDARC="-multiply_defined suppress -L${OPENMOTIF}/lib"
+       UILPATH=${OPENMOTIF-/usr}/bin;
+       MOTIF_LDARC="-Wl,-bind_at_load -multiply_defined suppress -L${OPENMOTIF-/usr}/lib"
+       MOTIF_LD_LDARC="-multiply_defined suppress -L${OPENMOTIF-/usr}/lib"
        	   	   LINKSHARED="$LDFLAGS -shared -arch x86_64 -install_name @loader_path/../lib/\$(@F) -headerpad_max_install_names";
            FOR_LINKSHARED="$LDFLAGS -shared";
 	   LINKMODULE="$LDFLAGS -bundle -undefined dynamic_lookup";
@@ -11799,8 +11799,8 @@ fi
 
 case $host in #(
   *darwin*|*apple*) :
-    X_CFLAGS+=" -I${OPENMOTIF}/include"
-                             X_LIBS+=" -L${OPENMOTIF}/lib" ;; #(
+    X_CFLAGS+=" -I${OPENMOTIF-/usr}/include"
+                             X_LIBS+=" -L${OPENMOTIF-/usr}/lib" ;; #(
   *) :
      ;;
 esac
@@ -16917,7 +16917,7 @@ RELEASE_DATE="$(date)"
 RELEASE_TAG="${BRANCH}_release-${RELEASE_MAJOR}-${RELEASE_MINOR}-${RELEASE_RELEASE}"
 
 # Determine common warning options to apply to C, C++, and Fortran languages
-WARNFLAGS="-Wall"
+WARNFLAGS="-Wall -Wextra"
 NOWARNFLAGS=
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether to treat warnings as errors" >&5
 $as_echo_n "checking whether to treat warnings as errors... " >&6; }

--- a/configure.ac
+++ b/configure.ac
@@ -382,7 +382,7 @@ case "$host" in
 *mingw*)
        IDLMDSEVENT=""
        LIBPRE=""
-       CFLAGS="$CFLAGS -fno-strict-aliasing -mno-ms-bitfields -Wno-clobbered ";
+       CFLAGS="$CFLAGS -fno-strict-aliasing -mno-ms-bitfields ";
        LD="$CXX -static-libgcc"
        FCFLAGS="$FCFLAGS -fno-range-check"
        FORLD="$FC"
@@ -416,7 +416,7 @@ case "$host" in
        jni_md_inc_dir="$with_jdk/include/linux";;
 
 *86*linux*)
-       CFLAGS="$CFLAGS -fpic -shared-libgcc -fsigned-char -fno-strict-aliasing -Wno-clobbered ";
+       CFLAGS="$CFLAGS -fpic -shared-libgcc -fsigned-char -fno-strict-aliasing ";
        FORLD="$FC";
        LD="gcc"
        if ( echo $host| grep 64 > /dev/null )
@@ -477,7 +477,7 @@ case "$host" in
        SIZEOF_LONG=4;
        SIZEOF_LONG_LONG=8;
        D64="";
-       CFLAGS="$CFLAGS -fpic -shared-libgcc -fsigned-char -fno-strict-aliasing -Wno-clobbered";
+       CFLAGS="$CFLAGS -fpic -shared-libgcc -fsigned-char -fno-strict-aliasing";
        if (test "$FC" = "gfortran"); then
          FCFLAGS="$FCFLAGS -fno-range-check";
          FORLD="$FC"
@@ -498,7 +498,7 @@ case "$host" in
        jni_md_inc_dir="$with_jdk/include/linux";
        HUP_TO_XINETD="/etc/rc.d/init.d/xinetd restart";
        HUP_TO_INETD="kill -HUP \`/sbin/pidof inetd\`";;
-*linux*) CFLAGS="$CFLAGS -fpic -fsigned-char -shared-libgcc -fno-strict-aliasing -Wno-clobbered";
+*linux*) CFLAGS="$CFLAGS -fpic -fsigned-char -shared-libgcc -fno-strict-aliasing";
        FCFLAGS="$FCFLAGS -fno-range-check";
        FORLD="$FC"
        FOR_LDFLAGS="-lg2c"
@@ -1124,7 +1124,7 @@ RELEASE_DATE="$(date)"
 RELEASE_TAG="${BRANCH}_release-${RELEASE_MAJOR}-${RELEASE_MINOR}-${RELEASE_RELEASE}"
 
 # Determine common warning options to apply to C, C++, and Fortran languages
-AS_VAR_SET([WARNFLAGS], ["-Wall"])
+AS_VAR_SET([WARNFLAGS], ["-Wall -Wextra"])
 AS_VAR_SET([NOWARNFLAGS],[])
 AC_MSG_CHECKING([whether to treat warnings as errors])
 AC_ARG_ENABLE([werror],

--- a/deploy/platform/platform_docker_build.sh
+++ b/deploy/platform/platform_docker_build.sh
@@ -41,7 +41,6 @@ config() {
 	JAVA_OPTS="--with-jars=${JARS_DIR}"
     fi
     :&& ${srcdir}/configure \
-	--disable-wreturns \
         --prefix=${MDSPLUS_DIR} \
         --exec_prefix=${MDSPLUS_DIR} \
         --host=$2 \

--- a/include/pthread_port.h
+++ b/include/pthread_port.h
@@ -88,9 +88,9 @@ typedef struct _Condition_p {
  #define INIT_AND_FREEXD_ON_EXIT(ptr) EMPTYXD(xd);FREEXD_ON_EXIT(&xd);
 #endif
 static void __attribute__((unused)) free_if(void *ptr){
-  if (*(void**)ptr) free(*(void**)ptr);
+  if (ptr) free(ptr);
 }
- #define FREE_ON_EXIT(ptr)   pthread_cleanup_push(free_if, (void*)&ptr)
+ #define FREE_ON_EXIT(ptr)   pthread_cleanup_push(free_if, (void*)ptr)
  #define FREE_IF(ptr,c)      pthread_cleanup_pop(c)
  #define FREE_NOW(ptr)       pthread_cleanup_pop(1)
  #define FREE_CANCEL(ptr)    pthread_cleanup_pop(0)

--- a/include/tcl_messages.h
+++ b/include/tcl_messages.h
@@ -10,3 +10,4 @@
 
 #define TclNORMAL                0x2a0009
 #define TclFAILED_ESSENTIAL      0x2a0010
+#define TclNO_DISPATCH_TABLE     0x2a0018

--- a/mdslib/mdslib_ctest.c
+++ b/mdslib/mdslib_ctest.c
@@ -96,7 +96,7 @@ long testScalarString(int ttype, int conid, char *expression, char *expected, in
 long testSetDefault(int ttype, int conid, char *node)
 {
   printf("Setting default to %s", node);
-  if (ttype << 3)
+  if (ttype < 3)
     return (MdsSetDefault(node));
   else
     return (MdsSetDefaultR(&conid, node));

--- a/mdsobjects/labview/mdsdataobjectswrp.cpp
+++ b/mdsobjects/labview/mdsdataobjectswrp.cpp
@@ -899,7 +899,7 @@ EXPORT void mdsplus_array_getStringArray(const void *lvArrayPtr, LStrArrHdl lvSt
 	}
 
 	// free memory
-	for (std::size_t i = 0; i < stringArrLen; ++i)
+	for (int i = 0; i < stringArrLen; ++i)
 		deleteNativeArray(stringArrOut[i]);
 	deleteNativeArray(stringArrOut);
 

--- a/mdsobjects/python/mdsExceptions.py
+++ b/mdsobjects/python/mdsExceptions.py
@@ -3057,3 +3057,11 @@ class TclFAILED_ESSENTIAL(TclException):
   msgnam="FAILED_ESSENTIAL"
 
 MDSplusException.statusDict[2752528] = TclFAILED_ESSENTIAL
+
+
+class TclNO_DISPATCH_TABLE(TclException):
+  status=2752536
+  message="No dispatch table found. Forgot to do DISPATCH/BUILD?"
+  msgnam="NO_DISPATCH_TABLE"
+
+MDSplusException.statusDict[2752536] = TclNO_DISPATCH_TABLE

--- a/mdsshr/MdsGetStdMsg.c
+++ b/mdsshr/MdsGetStdMsg.c
@@ -3560,6 +3560,16 @@ EXPORT int MdsGetStdMsg(int status, const char **fac_out, const char **msgnam_ou
         sts = 1;}
         break;
 
+/* TclNO_DISPATCH_TABLE */
+      case 0x2a0018:
+        {static const char *text="No dispatch table found. Forgot to do DISPATCH/BUILD?";
+        static const char *msgnam="NO_DISPATCH_TABLE";
+        *fac_out = FAC_TCL;
+        *msgnam_out = msgnam;
+        *text_out = text;
+        sts = 1;}
+        break;
+
     default: sts = 0;
   }
   if (sts == 0) {

--- a/mdstcpip/Connections.c
+++ b/mdstcpip/Connections.c
@@ -119,7 +119,7 @@ int NextConnection(void **ctx, char **info_name, void **info, size_t * info_len)
 }
 
 int SendToConnection(int id, const void *buffer, size_t buflen, int nowait){
-  int res = -1;
+  volatile int res = -1;
   Connection* c = FindConnectionWithLock(id,CON_SEND);
   CONNECTION_UNLOCK_PUSH(c);
   if (c && c->io && c->io->send)
@@ -129,7 +129,7 @@ int SendToConnection(int id, const void *buffer, size_t buflen, int nowait){
 }
 
 int FlushConnection(int id){
-  int res = -1;
+  volatile int res = -1;
   Connection* c = FindConnectionWithLock(id,CON_FLUSH);
   CONNECTION_UNLOCK_PUSH(c);
   if (c && c->io)
@@ -139,7 +139,7 @@ int FlushConnection(int id){
 }
 
 int ReceiveFromConnection(int id, void *buffer, size_t buflen){
-  int res = -1;
+  volatile int res = -1;
   Connection* c = FindConnectionWithLock(id,CON_RECV);
   CONNECTION_UNLOCK_PUSH(c);
   if (c && c->io && c->io->recv)
@@ -247,10 +247,10 @@ void FreeDescriptors(Connection * c){
 ////////////////////////////////////////////////////////////////////////////////
 
 IoRoutines *GetConnectionIo(int conid){
-  IoRoutines *io = NULL;
+  IoRoutines *io;
   CONNECTIONLIST_LOCK;
   Connection *c = _FindConnection(conid, 0);
-  if (c) io = c->io;
+  io = c ? c->io : NULL;
   CONNECTIONLIST_UNLOCK;
   return io;
 }

--- a/mdstcpip/ioroutinesx.h
+++ b/mdstcpip/ioroutinesx.h
@@ -97,7 +97,7 @@ static void ABORT(int sigval __attribute__ ((unused))){
 }
 
 static int GetHostAndPort(char *hostin, struct SOCKADDR_IN *sin){
-  INIT_STATUS_ERROR;
+  int status;
   INITIALIZESOCKETS;
   char *host = strcpy((char *)malloc(strlen(hostin) + 1), hostin);
   FREE_ON_EXIT(host);
@@ -125,9 +125,10 @@ static int GetHostAndPort(char *hostin, struct SOCKADDR_IN *sin){
   struct addrinfo *info = NULL;
   static const struct addrinfo hints = { 0, AF_T, SOCK_STREAM, 0, 0, 0, 0, 0 };
   int err = getaddrinfo(host, service, &hints, &info);
-  if (err)
+  if (err) {
+    status = MDSplusERROR;
     fprintf(stderr,"Error connecting to host: %s, port %s error=%s\n", host, service, gai_strerror(err));
-  else {
+  } else {
     memcpy(sin, info->ai_addr, sizeof(*sin) < info->ai_addrlen ? sizeof(*sin) : info->ai_addrlen);
     status = MDSplusSUCCESS;
   }
@@ -145,7 +146,7 @@ static char *getHostInfo(SOCKET sock, char **iphostptr, char **hostnameptr){
 #if defined(__MACH__) || defined(_WIN32)
     struct hostent* hp = gethostbyaddr((void*)&sin.SIN_ADDR,sizeof(sin.SIN_ADDR),sin.SIN_FAMILY);
 #else
-    size_t memlen = 1024;
+    volatile size_t memlen = 1024;
     struct hostent hostbuf, *hp = NULL;
     int herr;
     char *hp_mem = (char*)malloc(memlen);

--- a/servershr/ServerSendMessage.c
+++ b/servershr/ServerSendMessage.c
@@ -308,9 +308,11 @@ void ServerWait(int jobid)
 static void DoBeforeAst(int jobid)
 {
   Job *j;
-  void *astparam = NULL;
-  void (*before_ast) () = NULL;
+  void *astparam;
+  void (*before_ast) ();
   LOCK_JOBS;
+  astparam = NULL;
+  before_ast = NULL;
   for (j = Jobs; j && (j->jobid != jobid); j = j->next) ;
   if (j) {
     astparam   = j->astparam;
@@ -685,7 +687,7 @@ static void DoMessage(Client * c, fd_set * fdactive)
 static void RemoveClient(Client * c, fd_set * fdactive)
 {
   int client_found = 0;
-  int conid = -1;
+  int conid;
   LOCK_CLIENTS;
   if (Clients == c) {
     client_found = 1;
@@ -710,7 +712,8 @@ static void RemoveClient(Client * c, fd_set * fdactive)
     if (c->conid >= 0)
       DisconnectFromMds(c->conid);
     free(c);
-  }
+  } else
+    conid = -1;
   Job *j;
   for (;;) {
     LOCK_JOBS;
@@ -731,7 +734,7 @@ static int GetHostAddr(char *name)
   struct hostent* hp = gethostbyname(name);
   addr = hp ? *(int *)hp->h_addr_list[0] : (int)inet_addr(name);
 #else
-  size_t memlen = 1024;
+  static size_t memlen = 1024;
   struct hostent hostbuf, *hp = NULL;
   int herr;
   char *hp_mem = (char*)malloc(memlen);

--- a/tcl/tcl_messages.xml
+++ b/tcl/tcl_messages.xml
@@ -27,5 +27,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
   <facility name="Tcl" value="42">
     <status name="NORMAL" value="1" severity="Success" text="Normal successful completion"/>
     <status name="FAILED_ESSENTIAL" value="2" severity="Warning" text="Essential action failed"/>
+    <status name="NO_DISPATCH_TABLE" value="3" severity="Warning" text="No dispatch table found. Forgot to do DISPATCH/BUILD?"/>
   </facility>
 </messages>

--- a/tdishr/TdiDoTask.c
+++ b/tdishr/TdiDoTask.c
@@ -184,7 +184,7 @@ int Tdi1DoTask(int opcode __attribute__ ((unused)),
 {
   INIT_STATUS;
   EMPTYXD(task_xd);
-  int freetask = 1;
+  volatile int freetask = 1;
   FREEXD_ON_EXIT(&task_xd);
   struct descriptor_routine *ptask;
   status = TdiTaskOf(list[0], &task_xd MDS_END_ARG);

--- a/tdishr/TdiMatrix.c
+++ b/tdishr/TdiMatrix.c
@@ -85,7 +85,7 @@ int Tdi1Diagonal(int opcode, int narg, struct descriptor *list[], struct descrip
   INIT_STATUS;
   int cmode = -1, nside = 0;
   struct descriptor_xd fill = EMPTY_XD;
-  struct descriptor *fillptr;
+  struct descriptor *fillptr = NULL;
   struct descriptor_a *pv, *po;
   DESCRIPTOR_A_COEFF(proto, 1, DTYPE_BU, 0, 2, 0);
   struct descriptor_xd sig[1], uni[1], dat[1];

--- a/treeshr/TreeAddNode.c
+++ b/treeshr/TreeAddNode.c
@@ -106,7 +106,7 @@ int _TreeAddNode(void *dbid, char const *name, int *nid_out, char usage)
   INIT_STATUS_AS TreeNORMAL;
   PINO_DATABASE *dblist = (PINO_DATABASE *) dbid;
   NODE *parent;
-  NODE *new_ptr;
+  NODE *new_ptr = NULL;
   char *node_name;
   SEARCH_TYPE node_type;
   int nid;


### PR DESCRIPTION
This should fix several compiler warnings in an attempt to enable -Werror with -Wextra.

It also removes the need for -Wno-clobbered compiler option used on the routines involving threads.
It was tested using fc26 but other platforms may uncover more warnings.