### PR TITLE
Build: Retry docker run if it gets a container command not found error

### DIFF
--- a/deploy/platform/platform_build.sh
+++ b/deploy/platform/platform_build.sh
@@ -84,47 +84,53 @@ rundocker(){
         else port_forwarding="-p ${FORWARD_PORT}:${FORWARD_PORT}"
              echo $port_forwarding
         fi
-        docker run --cap-add=SYS_PTRACE -t $stdio --cidfile=${WORKSPACE}/${OS}_docker-cid \
-           -u $(id -u):$(id -g) --privileged \
-           -h $DISTNAME \
-           -e "ARCH=${arch}" \
-           -e "ARCHES=${ARCH}" \
-           -e "BRANCH" \
-           -e "COLOR" \
-           -e "DISPLAY" \
-           -e "DISTNAME" \
-           -e "GIT_COMMIT" \
-           -e "OS" \
-           -e "PLATFORM" \
-           -e "PUBLISH" \
-           -e "RELEASE" \
-           -e "RELEASE_VERSION"  \
-           -e "SANITIZE" \
-           -e "TEST" \
-           -e "TESTFORMAT" \
-           -e "UPDATEPKG" \
-           -e "VALGRIND_TOOLS" \
-	   -e "MAKE_JARS" \
-           -e "CONFIGURE_PARAMS" \
-           -e "mdsevent_port=$EVENT_PORT" \
-           -e "HOME=/workspace" \
-           -e "JARS_DIR=$jars_dir" \
-	   -e "TEST_TIMEUNIT" \
-           -v ${SRCDIR}:${DOCKER_SRCDIR} \
-           -v ${WORKSPACE}:/workspace \
-           $port_forwarding \
-           $(volume "${JARS_DIR}" /jars_dir) \
-           $(volume "${RELEASEDIR}" /release) \
-           $(volume "${PUBLISHDIR}" /publish) \
-           $(volume "${KEYS}" /sign_keys) \
-           ${image} $program
-        status=$?
-        if [ -r ${WORKSPACE}/${OS}_docker-cid ]
-        then
-          sleep 3
-          docker rm $(cat ${WORKSPACE}/${OS}_docker-cid)
-          rm -f ${WORKSPACE}/${OS}_docker-cid
-        fi
+	status=127
+	loop_count=0
+	while [ $status = 127 -a $loop_count -lt 5 ]
+	do
+	    let loop_count=$loop_count+1
+            docker run --cap-add=SYS_PTRACE -t $stdio --cidfile=${WORKSPACE}/${OS}_docker-cid \
+		   -u $(id -u):$(id -g) --privileged \
+		   -h $DISTNAME \
+		   -e "ARCH=${arch}" \
+		   -e "ARCHES=${ARCH}" \
+		   -e "BRANCH" \
+		   -e "COLOR" \
+		   -e "DISPLAY" \
+		   -e "DISTNAME" \
+		   -e "GIT_COMMIT" \
+		   -e "OS" \
+		   -e "PLATFORM" \
+		   -e "PUBLISH" \
+		   -e "RELEASE" \
+		   -e "RELEASE_VERSION"  \
+		   -e "SANITIZE" \
+		   -e "TEST" \
+		   -e "TESTFORMAT" \
+		   -e "UPDATEPKG" \
+		   -e "VALGRIND_TOOLS" \
+		   -e "MAKE_JARS" \
+		   -e "CONFIGURE_PARAMS" \
+		   -e "mdsevent_port=$EVENT_PORT" \
+		   -e "HOME=/workspace" \
+		   -e "JARS_DIR=$jars_dir" \
+		   -e "TEST_TIMEUNIT" \
+		   -v ${SRCDIR}:${DOCKER_SRCDIR} \
+		   -v ${WORKSPACE}:/workspace \
+		   $port_forwarding \
+		   $(volume "${JARS_DIR}" /jars_dir) \
+		   $(volume "${RELEASEDIR}" /release) \
+		   $(volume "${PUBLISHDIR}" /publish) \
+		   $(volume "${KEYS}" /sign_keys) \
+		   ${image} $program
+            status=$?
+            if [ -r ${WORKSPACE}/${OS}_docker-cid ]
+            then
+		sleep 3
+		docker rm $(cat ${WORKSPACE}/${OS}_docker-cid)
+		rm -f ${WORKSPACE}/${OS}_docker-cid
+            fi
+	done
         if [ ! "$status" = "0" ]
         then
     	RED $COLOR


### PR DESCRIPTION
For unknown reasons the docker run command sometimes gets a command
not found error. This may be an nfs cacheing problem. This change will
repeat the docker run command several times before giving up.