### PR TITLE
Fix: cmdParse.y - remove overlapping arguments to strcat

### DIFF
--- a/mdsdcl/Makefile.in
+++ b/mdsdcl/Makefile.in
@@ -50,7 +50,7 @@ cmdHelp.o: cmdHelp.c
 	$(COMPILE.c) $(CFLAGS) -c -I/usr/include/libxml2 $^
 
 cmdParseLex.o: cmdParseLex.c
-	$(COMPILE.c) $(CFLAGS) -Wno-unused-parameter -c $^
+	$(COMPILE.c) $(CFLAGS) -Wno-sign-compare -Wno-unused-parameter -c $^
 
 @MINGW_TRUE@ MAKE_IMPLIB=-Wl,--out-implib,$(IMPLIB)
 @MAKESHLIBDIR@@LIBPRE@Mdsdcl@SHARETYPE@ $(IMPLIB): $(OBJECTS) $(DEF)

--- a/mdsdcl/cmdParse.tab.c
+++ b/mdsdcl/cmdParse.tab.c
@@ -1,27 +1,3 @@
-/*
-Copyright (c) 2017, Massachusetts Institute of Technology All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are met:
-
-Redistributions of source code must retain the above copyright notice, this
-list of conditions and the following disclaimer.
-
-Redistributions in binary form must reproduce the above copyright notice, this
-list of conditions and the following disclaimer in the documentation and/or
-other materials provided with the distribution.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
 /* A Bison parser, made by GNU Bison 3.0.4.  */
 
 /* Bison implementation for Yacc-like parsers in C
@@ -88,18 +64,19 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 /* Copy the first part of user declarations.  */
 #line 1 "cmdParse.y" /* yacc.c:339  */
 
-  #include "mdsdclthreadsafe.h"
   #include <stdio.h>
   #include <stdlib.h>
   int yydebug=0;
   #define YYLTYPE void *
   #define yylex dcl_lex
-  #include <dcl.h>
+  #include "dcl_p.h"
   #include <mdsdcl_messages.h>
+  #include <config.h>
   #include "dcllex.h"
+  #include "mdsdclthreadsafe.h"
   static void yyerror(YYLTYPE *yyloc_param, yyscan_t yyscanner, dclCommandPtr *dclcmd, char **error, char *s);
 
-#line 79 "cmdParse.tab.c" /* yacc.c:339  */
+#line 80 "cmdParse.tab.c" /* yacc.c:339  */
 
 # ifndef YY_NULLPTR
 #  if defined __cplusplus && 201103L <= __cplusplus
@@ -161,7 +138,7 @@ int yyparse (YYLTYPE * yylloc_param, yyscan_t yyscanner, dclCommandPtr *dclcmd, 
 
 /* Copy the second part of user declarations.  */
 
-#line 141 "cmdParse.tab.c" /* yacc.c:358  */
+#line 142 "cmdParse.tab.c" /* yacc.c:358  */
 
 #ifdef short
 # undef short
@@ -459,8 +436,8 @@ static const yytype_uint8 yytranslate[] =
   /* YYRLINE[YYN] -- Source line where rule number YYN was defined.  */
 static const yytype_uint8 yyrline[] =
 {
-       0,    46,    46,    61,    65,    66,    75,    88,    94,    98,
-     105,   130,   137,   160
+       0,    47,    47,    62,    66,    67,    76,    89,    95,    99,
+     106,   131,   138,   160
 };
 #endif
 
@@ -470,7 +447,7 @@ static const yytype_uint8 yyrline[] =
 static const char *const yytname[] =
 {
   "$end", "error", "$undefined", "CMDFILE", "VERB", "QUALIFIER", "EQUALS",
-  "VALUE", "PVALUE", "COMMA", "END", "COMMENT", "$accept", "command",
+  "VALUE", "PVALUE_", "COMMA", "END", "COMMENT", "$accept", "command",
   "qualifier", "value_list", "pvalue_list", YY_NULLPTR
 };
 #endif
@@ -1247,7 +1224,7 @@ yyreduce:
   switch (yyn)
     {
         case 2:
-#line 46 "cmdParse.y" /* yacc.c:1646  */
+#line 47 "cmdParse.y" /* yacc.c:1646  */
     {
   (yyval.cmd)=memset(malloc(sizeof(dclCommand)),0,sizeof(dclCommand));
   (yyval.cmd)->verb=strdup("DO");
@@ -1263,26 +1240,26 @@ yyreduce:
   (yyval.cmd)->parameters[0]->values[0]=strdup((yyvsp[0].str)+1);
   free((yyvsp[0].str));
 }
-#line 1243 "cmdParse.tab.c" /* yacc.c:1646  */
+#line 1244 "cmdParse.tab.c" /* yacc.c:1646  */
     break;
 
   case 3:
-#line 61 "cmdParse.y" /* yacc.c:1646  */
+#line 62 "cmdParse.y" /* yacc.c:1646  */
     {
   (yyval.cmd)=memset(malloc(sizeof(dclCommand)),0,sizeof(dclCommand));
   (yyval.cmd)->verb=(yyvsp[0].str);
 }
-#line 1252 "cmdParse.tab.c" /* yacc.c:1646  */
+#line 1253 "cmdParse.tab.c" /* yacc.c:1646  */
     break;
 
   case 4:
-#line 65 "cmdParse.y" /* yacc.c:1646  */
+#line 66 "cmdParse.y" /* yacc.c:1646  */
     {YYACCEPT;}
-#line 1258 "cmdParse.tab.c" /* yacc.c:1646  */
+#line 1259 "cmdParse.tab.c" /* yacc.c:1646  */
     break;
 
   case 5:
-#line 66 "cmdParse.y" /* yacc.c:1646  */
+#line 67 "cmdParse.y" /* yacc.c:1646  */
     {
   (yyvsp[0].qualifier)->position=(yyval.cmd)->parameter_count;
   if ((yyval.cmd)->qualifier_count == 0)
@@ -1292,11 +1269,11 @@ yyreduce:
   (yyval.cmd)->qualifiers[(yyval.cmd)->qualifier_count]=(yyvsp[0].qualifier);
   (yyval.cmd)->qualifier_count++;
 }
-#line 1272 "cmdParse.tab.c" /* yacc.c:1646  */
+#line 1273 "cmdParse.tab.c" /* yacc.c:1646  */
     break;
 
   case 6:
-#line 75 "cmdParse.y" /* yacc.c:1646  */
+#line 76 "cmdParse.y" /* yacc.c:1646  */
     {
   dclParameterPtr param=memset(malloc(sizeof(dclParameter)),0,sizeof(dclParameter));
   param->value_count=(yyvsp[0].value_list)->count;
@@ -1310,39 +1287,39 @@ yyreduce:
   (yyval.cmd)->parameters[(yyval.cmd)->parameter_count]=param;
   (yyval.cmd)->parameter_count++;
 }
-#line 1290 "cmdParse.tab.c" /* yacc.c:1646  */
+#line 1291 "cmdParse.tab.c" /* yacc.c:1646  */
     break;
 
   case 7:
-#line 88 "cmdParse.y" /* yacc.c:1646  */
+#line 89 "cmdParse.y" /* yacc.c:1646  */
     {
   *dclcmd=(yyval.cmd);
   YYACCEPT;
 }
-#line 1299 "cmdParse.tab.c" /* yacc.c:1646  */
+#line 1300 "cmdParse.tab.c" /* yacc.c:1646  */
     break;
 
   case 8:
-#line 94 "cmdParse.y" /* yacc.c:1646  */
+#line 95 "cmdParse.y" /* yacc.c:1646  */
     {
   (yyval.qualifier)=memset(malloc(sizeof(dclQualifier)),0,sizeof(dclQualifier));
   (yyval.qualifier)->name=(yyvsp[0].str);
 }
-#line 1308 "cmdParse.tab.c" /* yacc.c:1646  */
+#line 1309 "cmdParse.tab.c" /* yacc.c:1646  */
     break;
 
   case 9:
-#line 98 "cmdParse.y" /* yacc.c:1646  */
+#line 99 "cmdParse.y" /* yacc.c:1646  */
     {
   (yyval.qualifier)->value_count=(yyvsp[0].value_list)->count;
   (yyval.qualifier)->values=(yyvsp[0].value_list)->values;
   free((yyvsp[0].value_list));
 }
-#line 1318 "cmdParse.tab.c" /* yacc.c:1646  */
+#line 1319 "cmdParse.tab.c" /* yacc.c:1646  */
     break;
 
   case 10:
-#line 105 "cmdParse.y" /* yacc.c:1646  */
+#line 106 "cmdParse.y" /* yacc.c:1646  */
     {
   char *value=(yyvsp[0].str);
   (yyval.value_list)=malloc(sizeof(dclValueList));
@@ -1368,21 +1345,21 @@ yyreduce:
   }
   (yyval.value_list)->values[0]=value;
 }
-#line 1348 "cmdParse.tab.c" /* yacc.c:1646  */
+#line 1349 "cmdParse.tab.c" /* yacc.c:1646  */
     break;
 
   case 11:
-#line 130 "cmdParse.y" /* yacc.c:1646  */
+#line 131 "cmdParse.y" /* yacc.c:1646  */
     {
   (yyval.value_list)->values=realloc((yyval.value_list)->values,sizeof(char *)*((yyval.value_list)->count+1));
   (yyval.value_list)->values[(yyval.value_list)->count]=(yyvsp[0].str);
   (yyval.value_list)->count++;
 }
-#line 1358 "cmdParse.tab.c" /* yacc.c:1646  */
+#line 1359 "cmdParse.tab.c" /* yacc.c:1646  */
     break;
 
   case 12:
-#line 137 "cmdParse.y" /* yacc.c:1646  */
+#line 138 "cmdParse.y" /* yacc.c:1646  */
     {
   dclValuePtr dclvalue=(yyvsp[0].pvalue);
   char *value=dclvalue->value;
@@ -1397,9 +1374,8 @@ yyreduce:
     dq=nval=strdup(value+1);
     free(value);
     while((dq=strstr(dq,"\"\""))) {
-      dq[1]='\0';
-      dq=dq+1;
-      strcat(nval,dq+1);
+      memmove(dq, dq+1, strlen(dq+1)+1);
+      dq++;
     }
     value=nval;
   }
@@ -1689,4 +1665,4 @@ EXPORT int mdsdcl_do_command_extra_args(char const* command, char **prompt, char
   }
   return status;
 }
-
+  

--- a/mdsdcl/cmdParse.y
+++ b/mdsdcl/cmdParse.y
@@ -1,5 +1,4 @@
 %{
-  #include <mdsdclthreadsafe.h>
   #include <stdio.h>
   #include <stdlib.h>
   int yydebug=0;
@@ -7,7 +6,9 @@
   #define yylex dcl_lex
   #include "dcl_p.h"
   #include <mdsdcl_messages.h>
+  #include <config.h>
   #include "dcllex.h"
+  #include "mdsdclthreadsafe.h"
   static void yyerror(YYLTYPE *yyloc_param, yyscan_t yyscanner, dclCommandPtr *dclcmd, char **error, char *s);
 %}
 %define api.pure full
@@ -135,7 +136,7 @@ VALUE {
 
 pvalue_list:
 PVALUE_ {
-  dclValuePtr dclvalue=$PVALUE;
+  dclValuePtr dclvalue=$PVALUE_;
   char *value=dclvalue->value;
   $$=malloc(sizeof(dclValueList));
   $$->restOfLine=dclvalue->restOfLine;
@@ -148,9 +149,8 @@ PVALUE_ {
     dq=nval=strdup(value+1);
     free(value);
     while((dq=strstr(dq,"\"\""))) {
-      dq[1]='\0';
-      dq=dq+1;
-      strcat(nval,dq+1);      
+      memmove(dq, dq+1, strlen(dq+1)+1);
+      dq++;
     }
     value=nval;
   }
@@ -158,7 +158,7 @@ PVALUE_ {
   $$->values[0]=value;
 }
 | pvalue_list COMMA PVALUE_ {
-  dclValuePtr dclvalue=$PVALUE;
+  dclValuePtr dclvalue=$PVALUE_;
   free(dclvalue->restOfLine);
   $$->values=realloc($$->values,sizeof(char *)*($$->count+1));
   $$->values[$$->count]=dclvalue->value;

--- a/mdsdcl/cmdParseLex.c
+++ b/mdsdcl/cmdParseLex.c
@@ -1,27 +1,3 @@
-/*
-Copyright (c) 2017, Massachusetts Institute of Technology All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are met:
-
-Redistributions of source code must retain the above copyright notice, this
-list of conditions and the following disclaimer.
-
-Redistributions in binary form must reproduce the above copyright notice, this
-list of conditions and the following disclaimer in the documentation and/or
-other materials provided with the distribution.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
 #line 2 "cmdParseLex.c"
 
 #line 4 "cmdParseLex.c"
@@ -33,7 +9,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define FLEX_SCANNER
 #define YY_FLEX_MAJOR_VERSION 2
 #define YY_FLEX_MINOR_VERSION 5
-#define YY_FLEX_SUBMINOR_VERSION 35
+#define YY_FLEX_SUBMINOR_VERSION 37
 #if YY_FLEX_SUBMINOR_VERSION > 0
 #define FLEX_BETA
 #endif
@@ -78,7 +54,6 @@ typedef int flex_int32_t;
 typedef unsigned char flex_uint8_t; 
 typedef unsigned short int flex_uint16_t;
 typedef unsigned int flex_uint32_t;
-#endif /* ! C99 */
 
 /* Limits of integral types. */
 #ifndef INT8_MIN
@@ -108,6 +83,8 @@ typedef unsigned int flex_uint32_t;
 #ifndef UINT32_MAX
 #define UINT32_MAX             (4294967295U)
 #endif
+
+#endif /* ! C99 */
 
 #endif /* ! FLEXINT_H */
 
@@ -194,6 +171,11 @@ typedef void* yyscan_t;
 typedef struct yy_buffer_state *YY_BUFFER_STATE;
 #endif
 
+#ifndef YY_TYPEDEF_YY_SIZE_T
+#define YY_TYPEDEF_YY_SIZE_T
+typedef size_t yy_size_t;
+#endif
+
 #define EOB_ACT_CONTINUE_SCAN 0
 #define EOB_ACT_END_OF_FILE 1
 #define EOB_ACT_LAST_MATCH 2
@@ -229,11 +211,6 @@ typedef struct yy_buffer_state *YY_BUFFER_STATE;
 
 #define unput(c) yyunput( c, yyg->yytext_ptr , yyscanner )
 
-#ifndef YY_TYPEDEF_YY_SIZE_T
-#define YY_TYPEDEF_YY_SIZE_T
-typedef size_t yy_size_t;
-#endif
-
 #ifndef YY_STRUCT_YY_BUFFER_STATE
 #define YY_STRUCT_YY_BUFFER_STATE
 struct yy_buffer_state
@@ -251,7 +228,7 @@ struct yy_buffer_state
 	/* Number of characters read into yy_ch_buf, not including EOB
 	 * characters.
 	 */
-	int yy_n_chars;
+	yy_size_t yy_n_chars;
 
 	/* Whether we "own" the buffer - i.e., we know we created it,
 	 * and can realloc() it to grow it, and should free() it to
@@ -330,7 +307,7 @@ static void dcl__init_buffer (YY_BUFFER_STATE b,FILE *file ,yyscan_t yyscanner )
 
 YY_BUFFER_STATE dcl__scan_buffer (char *base,yy_size_t size ,yyscan_t yyscanner );
 YY_BUFFER_STATE dcl__scan_string (yyconst char *yy_str ,yyscan_t yyscanner );
-YY_BUFFER_STATE dcl__scan_bytes (yyconst char *bytes,int len ,yyscan_t yyscanner );
+YY_BUFFER_STATE dcl__scan_bytes (yyconst char *bytes,yy_size_t len ,yyscan_t yyscanner );
 
 void *dcl_alloc (yy_size_t ,yyscan_t yyscanner );
 void *dcl_realloc (void *,yy_size_t ,yyscan_t yyscanner );
@@ -362,7 +339,7 @@ void dcl_free (void * ,yyscan_t yyscanner );
 
 /* Begin user sect3 */
 
-#define dcl_wrap(n) 1
+#define dcl_wrap(yyscanner) 1
 #define YY_SKIP_YYWRAP
 
 typedef unsigned char YY_CHAR;
@@ -622,7 +599,7 @@ int debug=0;
 char *restOfLine=0;
 #define YY_NO_INPUT 1
 
-#line 602 "cmdParseLex.c"
+#line 603 "cmdParseLex.c"
 
 #define INITIAL 0
 #define command 1
@@ -660,8 +637,8 @@ struct yyguts_t
     size_t yy_buffer_stack_max; /**< capacity of stack. */
     YY_BUFFER_STATE * yy_buffer_stack; /**< Stack as an array. */
     char yy_hold_char;
-    int yy_n_chars;
-    int yyleng_r;
+    yy_size_t yy_n_chars;
+    yy_size_t yyleng_r;
     char *yy_c_buf_p;
     int yy_init;
     int yy_start;
@@ -729,13 +706,17 @@ FILE *dcl_get_out (yyscan_t yyscanner );
 
 void dcl_set_out  (FILE * out_str ,yyscan_t yyscanner );
 
-int dcl_get_leng (yyscan_t yyscanner );
+yy_size_t dcl_get_leng (yyscan_t yyscanner );
 
 char *dcl_get_text (yyscan_t yyscanner );
 
 int dcl_get_lineno (yyscan_t yyscanner );
 
 void dcl_set_lineno (int line_number ,yyscan_t yyscanner );
+
+int dcl_get_column  (yyscan_t yyscanner );
+
+void dcl_set_column (int column_no ,yyscan_t yyscanner );
 
 YYSTYPE * dcl_get_lval (yyscan_t yyscanner );
 
@@ -798,7 +779,7 @@ static int input (yyscan_t yyscanner );
 	if ( YY_CURRENT_BUFFER_LVALUE->yy_is_interactive ) \
 		{ \
 		int c = '*'; \
-		unsigned n; \
+		size_t n; \
 		for ( n = 0; n < max_size && \
 			     (c = getc( yyin )) != EOF && c != '\n'; ++n ) \
 			buf[n] = (char) c; \
@@ -889,7 +870,7 @@ YY_DECL
 #line 28 "cmdParse.x"
 
 
-#line 869 "cmdParseLex.c"
+#line 874 "cmdParseLex.c"
 
     yylval = yylval_param;
 
@@ -1193,7 +1174,7 @@ YY_RULE_SETUP
 #line 134 "cmdParse.x"
 YY_FATAL_ERROR( "flex scanner jammed" );
 	YY_BREAK
-#line 1173 "cmdParseLex.c"
+#line 1178 "cmdParseLex.c"
 			case YY_STATE_EOF(INITIAL):
 			case YY_STATE_EOF(command):
 			case YY_STATE_EOF(verb):
@@ -1389,7 +1370,7 @@ static int yy_get_next_buffer (yyscan_t yyscanner)
 
 	else
 		{
-			int num_to_read =
+			yy_size_t num_to_read =
 			YY_CURRENT_BUFFER_LVALUE->yy_buf_size - number_to_move - 1;
 
 		while ( num_to_read <= 0 )
@@ -1405,7 +1386,7 @@ static int yy_get_next_buffer (yyscan_t yyscanner)
 
 		/* Read in more data. */
 		YY_INPUT( (&YY_CURRENT_BUFFER_LVALUE->yy_ch_buf[number_to_move]),
-			yyg->yy_n_chars, (size_t) num_to_read );
+			yyg->yy_n_chars, num_to_read );
 
 		YY_CURRENT_BUFFER_LVALUE->yy_n_chars = yyg->yy_n_chars;
 		}
@@ -1498,6 +1479,7 @@ static int yy_get_next_buffer (yyscan_t yyscanner)
 	if ( ! yy_is_jam )
 		*yyg->yy_state_ptr++ = yy_current_state;
 
+	(void)yyg;
 	return yy_is_jam ? 0 : yy_current_state;
 }
 
@@ -1514,7 +1496,7 @@ static int yy_get_next_buffer (yyscan_t yyscanner)
 	if ( yy_cp < YY_CURRENT_BUFFER_LVALUE->yy_ch_buf + 2 )
 		{ /* need to shift things up to make room */
 		/* +2 for EOB chars. */
-		register int number_to_move = yyg->yy_n_chars + 2;
+		register yy_size_t number_to_move = yyg->yy_n_chars + 2;
 		register char *dest = &YY_CURRENT_BUFFER_LVALUE->yy_ch_buf[
 					YY_CURRENT_BUFFER_LVALUE->yy_buf_size + 2];
 		register char *source =
@@ -1568,7 +1550,7 @@ static int yy_get_next_buffer (yyscan_t yyscanner)
 
 		else
 			{ /* need more input */
-			int offset = yyg->yy_c_buf_p - yyg->yytext_ptr;
+			yy_size_t offset = yyg->yy_c_buf_p - yyg->yytext_ptr;
 			++yyg->yy_c_buf_p;
 
 			switch ( yy_get_next_buffer( yyscanner ) )
@@ -1740,10 +1722,6 @@ static void dcl__load_buffer_state  (yyscan_t yyscanner)
 	dcl_free((void *) b ,yyscanner );
 }
 
-#ifndef __cplusplus
-extern int isatty (int );
-#endif /* __cplusplus */
-    
 /* Initializes or reinitializes a buffer.
  * This function is sometimes called more than once on the same buffer,
  * such as during a dcl_restart() or at EOF.
@@ -1860,7 +1838,7 @@ void dcl_pop_buffer_state (yyscan_t yyscanner)
  */
 static void dcl_ensure_buffer_stack (yyscan_t yyscanner)
 {
-	int num_to_alloc;
+	yy_size_t num_to_alloc;
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
 
 	if (!yyg->yy_buffer_stack) {
@@ -1953,12 +1931,12 @@ YY_BUFFER_STATE dcl__scan_string (yyconst char * yystr , yyscan_t yyscanner)
 
 /** Setup the input buffer state to scan the given bytes. The next call to dcl_lex() will
  * scan from a @e copy of @a bytes.
- * @param bytes the byte buffer to scan
- * @param len the number of bytes in the buffer pointed to by @a bytes.
+ * @param yybytes the byte buffer to scan
+ * @param _yybytes_len the number of bytes in the buffer pointed to by @a bytes.
  * @param yyscanner The scanner object.
  * @return the newly allocated buffer state object.
  */
-YY_BUFFER_STATE dcl__scan_bytes  (yyconst char * yybytes, int  _yybytes_len , yyscan_t yyscanner)
+YY_BUFFER_STATE dcl__scan_bytes  (yyconst char * yybytes, yy_size_t  _yybytes_len , yyscan_t yyscanner)
 {
 	YY_BUFFER_STATE b;
 	char *buf;
@@ -2073,7 +2051,7 @@ FILE *dcl_get_out  (yyscan_t yyscanner)
 /** Get the length of the current token.
  * @param yyscanner The scanner object.
  */
-int dcl_get_leng  (yyscan_t yyscanner)
+yy_size_t dcl_get_leng  (yyscan_t yyscanner)
 {
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
     return yyleng;
@@ -2109,7 +2087,7 @@ void dcl_set_lineno (int  line_number , yyscan_t yyscanner)
 
         /* lineno is only valid if an input buffer exists. */
         if (! YY_CURRENT_BUFFER )
-           yy_fatal_error( "dcl_set_lineno called with no buffer" , yyscanner); 
+           YY_FATAL_ERROR( "dcl_set_lineno called with no buffer" );
     
     yylineno = line_number;
 }
@@ -2124,7 +2102,7 @@ void dcl_set_column (int  column_no , yyscan_t yyscanner)
 
         /* column is only valid if an input buffer exists. */
         if (! YY_CURRENT_BUFFER )
-           yy_fatal_error( "dcl_set_column called with no buffer" , yyscanner); 
+           YY_FATAL_ERROR( "dcl_set_column called with no buffer" );
     
     yycolumn = column_no;
 }

--- a/mdsdcl/dcllex.h
+++ b/mdsdcl/dcllex.h
@@ -13,7 +13,7 @@
 #define FLEX_SCANNER
 #define YY_FLEX_MAJOR_VERSION 2
 #define YY_FLEX_MINOR_VERSION 5
-#define YY_FLEX_SUBMINOR_VERSION 35
+#define YY_FLEX_SUBMINOR_VERSION 37
 #if YY_FLEX_SUBMINOR_VERSION > 0
 #define FLEX_BETA
 #endif
@@ -58,7 +58,6 @@ typedef int flex_int32_t;
 typedef unsigned char flex_uint8_t; 
 typedef unsigned short int flex_uint16_t;
 typedef unsigned int flex_uint32_t;
-#endif /* ! C99 */
 
 /* Limits of integral types. */
 #ifndef INT8_MIN
@@ -88,6 +87,8 @@ typedef unsigned int flex_uint32_t;
 #ifndef UINT32_MAX
 #define UINT32_MAX             (4294967295U)
 #endif
+
+#endif /* ! C99 */
 
 #endif /* ! FLEXINT_H */
 
@@ -161,7 +162,7 @@ struct yy_buffer_state
 	/* Number of characters read into yy_ch_buf, not including EOB
 	 * characters.
 	 */
-	int yy_n_chars;
+	yy_size_t yy_n_chars;
 
 	/* Whether we "own" the buffer - i.e., we know we created it,
 	 * and can realloc() it to grow it, and should free() it to
@@ -205,7 +206,7 @@ void dcl_pop_buffer_state (yyscan_t yyscanner );
 
 YY_BUFFER_STATE dcl__scan_buffer (char *base,yy_size_t size ,yyscan_t yyscanner );
 YY_BUFFER_STATE dcl__scan_string (yyconst char *yy_str ,yyscan_t yyscanner );
-YY_BUFFER_STATE dcl__scan_bytes (yyconst char *bytes,int len ,yyscan_t yyscanner );
+YY_BUFFER_STATE dcl__scan_bytes (yyconst char *bytes,yy_size_t len ,yyscan_t yyscanner );
 
 void *dcl_alloc (yy_size_t ,yyscan_t yyscanner );
 void *dcl_realloc (void *,yy_size_t ,yyscan_t yyscanner );
@@ -213,7 +214,7 @@ void dcl_free (void * ,yyscan_t yyscanner );
 
 /* Begin user sect3 */
 
-#define dcl_wrap(n) 1
+#define dcl_wrap(yyscanner) 1
 #define YY_SKIP_YYWRAP
 
 #define yytext_ptr yytext_r
@@ -269,13 +270,17 @@ FILE *dcl_get_out (yyscan_t yyscanner );
 
 void dcl_set_out  (FILE * out_str ,yyscan_t yyscanner );
 
-int dcl_get_leng (yyscan_t yyscanner );
+yy_size_t dcl_get_leng (yyscan_t yyscanner );
 
 char *dcl_get_text (yyscan_t yyscanner );
 
 int dcl_get_lineno (yyscan_t yyscanner );
 
 void dcl_set_lineno (int line_number ,yyscan_t yyscanner );
+
+int dcl_get_column  (yyscan_t yyscanner );
+
+void dcl_set_column (int column_no ,yyscan_t yyscanner );
 
 YYSTYPE * dcl_get_lval (yyscan_t yyscanner );
 
@@ -349,6 +354,6 @@ extern int dcl_lex \
 #line 134 "cmdParse.x"
 
 
-#line 353 "dcllex.h"
+#line 358 "dcllex.h"
 #undef dcl_IN_HEADER
 #endif /* dcl_HEADER_H */


### PR DESCRIPTION
The code which removed the double double quotes ("") used strcat
with overlapping arguments to copy the string on top of itself to
turn them in to single double quotes (").

This results in undefined behavior.  On some systems like RHEL7
it works fine but on others (centos -7, 3.10.0-693.5.2.el7.x86_64)
it garbles the string.

Valgrind shows this as an overlapping strcat error.

There were also some bugs in the generated code.  It needed:
local include of mdsthreadsafe.h
include of config.h
consistent naming of PVALUE - missing '_'

For now turn off the sign compare warning