### PR TITLE
Fix: cmdParse.y - remove overlapping arguments to strcat

### DIFF
--- a/mdsdcl/Makefile.in
+++ b/mdsdcl/Makefile.in
@@ -50,7 +50,8 @@ cmdHelp.o: cmdHelp.c
 	$(COMPILE.c) $(CFLAGS) -c -I/usr/include/libxml2 $^
 
 cmdParseLex.o: cmdParseLex.c
-	$(COMPILE.c) $(CFLAGS) -Wno-unused-parameter -c $^
+	$(COMPILE.c) $(CFLAGS) -Wno-sign-compare -Wno-unused-parameter -c $^
+
 
 @MINGW_TRUE@ MAKE_IMPLIB=-Wl,--out-implib,$(IMPLIB)
 @MAKESHLIBDIR@@LIBPRE@Mdsdcl@SHARETYPE@ $(IMPLIB): $(OBJECTS) $(DEF)

--- a/mdsdcl/cmdParse.tab.c
+++ b/mdsdcl/cmdParse.tab.c
@@ -65,17 +65,18 @@
 #line 1 "cmdParse.y" /* yacc.c:339  */
 
   #include "mdsdclthreadsafe.h"
+  #include <config.h>
   #include <stdio.h>
   #include <stdlib.h>
   int yydebug=0;
   #define YYLTYPE void *
   #define yylex dcl_lex
-  #include <dcl.h>
+  #include "dcl_p.h"
   #include <mdsdcl_messages.h>
   #include "dcllex.h"
   static void yyerror(YYLTYPE *yyloc_param, yyscan_t yyscanner, dclCommandPtr *dclcmd, char **error, char *s);
 
-#line 79 "cmdParse.tab.c" /* yacc.c:339  */
+#line 80 "cmdParse.tab.c" /* yacc.c:339  */
 
 # ifndef YY_NULLPTR
 #  if defined __cplusplus && 201103L <= __cplusplus
@@ -137,7 +138,7 @@ int yyparse (YYLTYPE * yylloc_param, yyscan_t yyscanner, dclCommandPtr *dclcmd, 
 
 /* Copy the second part of user declarations.  */
 
-#line 141 "cmdParse.tab.c" /* yacc.c:358  */
+#line 142 "cmdParse.tab.c" /* yacc.c:358  */
 
 #ifdef short
 # undef short
@@ -435,8 +436,8 @@ static const yytype_uint8 yytranslate[] =
   /* YYRLINE[YYN] -- Source line where rule number YYN was defined.  */
 static const yytype_uint8 yyrline[] =
 {
-       0,    46,    46,    61,    65,    66,    75,    88,    94,    98,
-     105,   130,   137,   160
+       0,    47,    47,    62,    66,    67,    76,    89,    95,    99,
+     106,   131,   138,   160
 };
 #endif
 
@@ -446,7 +447,7 @@ static const yytype_uint8 yyrline[] =
 static const char *const yytname[] =
 {
   "$end", "error", "$undefined", "CMDFILE", "VERB", "QUALIFIER", "EQUALS",
-  "VALUE", "PVALUE", "COMMA", "END", "COMMENT", "$accept", "command",
+  "VALUE", "PVALUE_", "COMMA", "END", "COMMENT", "$accept", "command",
   "qualifier", "value_list", "pvalue_list", YY_NULLPTR
 };
 #endif
@@ -1223,7 +1224,7 @@ yyreduce:
   switch (yyn)
     {
         case 2:
-#line 46 "cmdParse.y" /* yacc.c:1646  */
+#line 47 "cmdParse.y" /* yacc.c:1646  */
     {
   (yyval.cmd)=memset(malloc(sizeof(dclCommand)),0,sizeof(dclCommand));
   (yyval.cmd)->verb=strdup("DO");
@@ -1239,26 +1240,26 @@ yyreduce:
   (yyval.cmd)->parameters[0]->values[0]=strdup((yyvsp[0].str)+1);
   free((yyvsp[0].str));
 }
-#line 1243 "cmdParse.tab.c" /* yacc.c:1646  */
+#line 1244 "cmdParse.tab.c" /* yacc.c:1646  */
     break;
 
   case 3:
-#line 61 "cmdParse.y" /* yacc.c:1646  */
+#line 62 "cmdParse.y" /* yacc.c:1646  */
     {
   (yyval.cmd)=memset(malloc(sizeof(dclCommand)),0,sizeof(dclCommand));
   (yyval.cmd)->verb=(yyvsp[0].str);
 }
-#line 1252 "cmdParse.tab.c" /* yacc.c:1646  */
+#line 1253 "cmdParse.tab.c" /* yacc.c:1646  */
     break;
 
   case 4:
-#line 65 "cmdParse.y" /* yacc.c:1646  */
+#line 66 "cmdParse.y" /* yacc.c:1646  */
     {YYACCEPT;}
-#line 1258 "cmdParse.tab.c" /* yacc.c:1646  */
+#line 1259 "cmdParse.tab.c" /* yacc.c:1646  */
     break;
 
   case 5:
-#line 66 "cmdParse.y" /* yacc.c:1646  */
+#line 67 "cmdParse.y" /* yacc.c:1646  */
     {
   (yyvsp[0].qualifier)->position=(yyval.cmd)->parameter_count;
   if ((yyval.cmd)->qualifier_count == 0)
@@ -1268,11 +1269,11 @@ yyreduce:
   (yyval.cmd)->qualifiers[(yyval.cmd)->qualifier_count]=(yyvsp[0].qualifier);
   (yyval.cmd)->qualifier_count++;
 }
-#line 1272 "cmdParse.tab.c" /* yacc.c:1646  */
+#line 1273 "cmdParse.tab.c" /* yacc.c:1646  */
     break;
 
   case 6:
-#line 75 "cmdParse.y" /* yacc.c:1646  */
+#line 76 "cmdParse.y" /* yacc.c:1646  */
     {
   dclParameterPtr param=memset(malloc(sizeof(dclParameter)),0,sizeof(dclParameter));
   param->value_count=(yyvsp[0].value_list)->count;
@@ -1286,39 +1287,39 @@ yyreduce:
   (yyval.cmd)->parameters[(yyval.cmd)->parameter_count]=param;
   (yyval.cmd)->parameter_count++;
 }
-#line 1290 "cmdParse.tab.c" /* yacc.c:1646  */
+#line 1291 "cmdParse.tab.c" /* yacc.c:1646  */
     break;
 
   case 7:
-#line 88 "cmdParse.y" /* yacc.c:1646  */
+#line 89 "cmdParse.y" /* yacc.c:1646  */
     {
   *dclcmd=(yyval.cmd);
   YYACCEPT;
 }
-#line 1299 "cmdParse.tab.c" /* yacc.c:1646  */
+#line 1300 "cmdParse.tab.c" /* yacc.c:1646  */
     break;
 
   case 8:
-#line 94 "cmdParse.y" /* yacc.c:1646  */
+#line 95 "cmdParse.y" /* yacc.c:1646  */
     {
   (yyval.qualifier)=memset(malloc(sizeof(dclQualifier)),0,sizeof(dclQualifier));
   (yyval.qualifier)->name=(yyvsp[0].str);
 }
-#line 1308 "cmdParse.tab.c" /* yacc.c:1646  */
+#line 1309 "cmdParse.tab.c" /* yacc.c:1646  */
     break;
 
   case 9:
-#line 98 "cmdParse.y" /* yacc.c:1646  */
+#line 99 "cmdParse.y" /* yacc.c:1646  */
     {
   (yyval.qualifier)->value_count=(yyvsp[0].value_list)->count;
   (yyval.qualifier)->values=(yyvsp[0].value_list)->values;
   free((yyvsp[0].value_list));
 }
-#line 1318 "cmdParse.tab.c" /* yacc.c:1646  */
+#line 1319 "cmdParse.tab.c" /* yacc.c:1646  */
     break;
 
   case 10:
-#line 105 "cmdParse.y" /* yacc.c:1646  */
+#line 106 "cmdParse.y" /* yacc.c:1646  */
     {
   char *value=(yyvsp[0].str);
   (yyval.value_list)=malloc(sizeof(dclValueList));
@@ -1344,21 +1345,21 @@ yyreduce:
   }
   (yyval.value_list)->values[0]=value;
 }
-#line 1348 "cmdParse.tab.c" /* yacc.c:1646  */
+#line 1349 "cmdParse.tab.c" /* yacc.c:1646  */
     break;
 
   case 11:
-#line 130 "cmdParse.y" /* yacc.c:1646  */
+#line 131 "cmdParse.y" /* yacc.c:1646  */
     {
   (yyval.value_list)->values=realloc((yyval.value_list)->values,sizeof(char *)*((yyval.value_list)->count+1));
   (yyval.value_list)->values[(yyval.value_list)->count]=(yyvsp[0].str);
   (yyval.value_list)->count++;
 }
-#line 1358 "cmdParse.tab.c" /* yacc.c:1646  */
+#line 1359 "cmdParse.tab.c" /* yacc.c:1646  */
     break;
 
   case 12:
-#line 137 "cmdParse.y" /* yacc.c:1646  */
+#line 138 "cmdParse.y" /* yacc.c:1646  */
     {
   dclValuePtr dclvalue=(yyvsp[0].pvalue);
   char *value=dclvalue->value;
@@ -1373,9 +1374,8 @@ yyreduce:
     dq=nval=strdup(value+1);
     free(value);
     while((dq=strstr(dq,"\"\""))) {
-      dq[1]='\0';
-      dq=dq+1;
-      strcat(nval,dq+1);
+      memmove(dq, dq+1, strlen(dq+1)+1);
+      dq++;
     }
     value=nval;
   }
@@ -1665,4 +1665,4 @@ EXPORT int mdsdcl_do_command_extra_args(char const* command, char **prompt, char
   }
   return status;
 }
-
+  

--- a/mdsdcl/cmdParse.y
+++ b/mdsdcl/cmdParse.y
@@ -1,5 +1,6 @@
 %{
-  #include <mdsdclthreadsafe.h>
+  #include "mdsdclthreadsafe.h"
+  #include <config.h>
   #include <stdio.h>
   #include <stdlib.h>
   int yydebug=0;
@@ -135,7 +136,7 @@ VALUE {
 
 pvalue_list:
 PVALUE_ {
-  dclValuePtr dclvalue=$PVALUE;
+  dclValuePtr dclvalue=$PVALUE_;
   char *value=dclvalue->value;
   $$=malloc(sizeof(dclValueList));
   $$->restOfLine=dclvalue->restOfLine;
@@ -148,9 +149,8 @@ PVALUE_ {
     dq=nval=strdup(value+1);
     free(value);
     while((dq=strstr(dq,"\"\""))) {
-      dq[1]='\0';
-      dq=dq+1;
-      strcat(nval,dq+1);      
+      memmove(dq, dq+1, strlen(dq+1)+1);
+      dq++;
     }
     value=nval;
   }
@@ -158,7 +158,7 @@ PVALUE_ {
   $$->values[0]=value;
 }
 | pvalue_list COMMA PVALUE_ {
-  dclValuePtr dclvalue=$PVALUE;
+  dclValuePtr dclvalue=$PVALUE_;
   free(dclvalue->restOfLine);
   $$->values=realloc($$->values,sizeof(char *)*($$->count+1));
   $$->values[$$->count]=dclvalue->value;


### PR DESCRIPTION
The code which removed the double double quotes ("") used strcat
with overlapping arguments to copy the string on top of itself to
turn them in to single double quotes (").

This results in undefined behavior.  On some systems like RHEL7
it works fine but on others (centos -7, 3.10.0-693.5.2.el7.x86_64)
it garbles the string.

Valgrind shows this as an overlapping strcat error.

There were also some bugs in the generated code.  It needed:
local include of mdsthreadsafe.h
include of config.h
consistent naming of PVALUE - missing '_'

For now turn off the sign compare warning