### PR TITLE
Build: Remove incorrect uses of volatile

### DIFF
--- a/mdstcpip/Connections.c
+++ b/mdstcpip/Connections.c
@@ -119,7 +119,7 @@ int NextConnection(void **ctx, char **info_name, void **info, size_t * info_len)
 }
 
 int SendToConnection(int id, const void *buffer, size_t buflen, int nowait){
-  volatile int res = -1;
+  int res = -1;
   Connection* c = FindConnectionWithLock(id,CON_SEND);
   CONNECTION_UNLOCK_PUSH(c);
   if (c && c->io && c->io->send)
@@ -129,7 +129,7 @@ int SendToConnection(int id, const void *buffer, size_t buflen, int nowait){
 }
 
 int FlushConnection(int id){
-  volatile int res = -1;
+  int res = -1;
   Connection* c = FindConnectionWithLock(id,CON_FLUSH);
   CONNECTION_UNLOCK_PUSH(c);
   if (c && c->io)
@@ -139,7 +139,7 @@ int FlushConnection(int id){
 }
 
 int ReceiveFromConnection(int id, void *buffer, size_t buflen){
-  volatile int res = -1;
+  int res = -1;
   Connection* c = FindConnectionWithLock(id,CON_RECV);
   CONNECTION_UNLOCK_PUSH(c);
   if (c && c->io && c->io->recv)

--- a/tdishr/TdiDoTask.c
+++ b/tdishr/TdiDoTask.c
@@ -184,7 +184,7 @@ int Tdi1DoTask(int opcode __attribute__ ((unused)),
 {
   INIT_STATUS;
   EMPTYXD(task_xd);
-  volatile int freetask = 1;
+  int freetask = 1;
   FREEXD_ON_EXIT(&task_xd);
   struct descriptor_routine *ptask;
   status = TdiTaskOf(list[0], &task_xd MDS_END_ARG);


### PR DESCRIPTION
In an attempt to fix various compiler warnings I inadvertently added
some "volatile" keywords to the code which were not needed. After
finding the real reason and solution for the compiler warnings I
removed most but not all of the erroneous volatile additions. This
should remove the remainder of these keywords that were added when
attempting to fix the compiler warnings.