### PR TITLE
Fix: Prevent hangs during removal of python packages

### DIFF
--- a/deploy/packaging/linux.xml
+++ b/deploy/packaging/linux.xml
@@ -91,7 +91,7 @@ then
 else
   export PYTHONPATH=""
   easy_install -q pip &gt;/dev/null 2&gt;&amp;1
-  while (pip uninstall -q MitDevices 2&gt;/dev/null);do :;done
+  while (/usr/bin/yes | pip uninstall -q MitDevices 2&gt;/dev/null);do :;done
 fi
     </preinst>
     <postinst>
@@ -109,7 +109,7 @@ python -m compileall  __INSTALL_PREFIX__/mdsplus/pydevices/MitDevices &gt;/dev/n
 
 export PYTHONPATH=""
 easy_install -q pip &gt;/dev/null 2&gt;&amp;1
-while (pip uninstall -q MitDevices 2&gt;/dev/null);do :;done
+while (/usr/bin/yes | pip uninstall -q MitDevices 2&gt;/dev/null);do :;done
 
     </pre-install>
     <post-install>
@@ -557,7 +557,7 @@ then
 else
   export PYTHONPATH=""
   easy_install -q pip &gt;/dev/null 2&gt;&amp;1
-  while (pip uninstall -q RfxDevices 2&gt;/dev/null);do :;done
+  while (/usr/bin/yes | pip uninstall -q RfxDevices 2&gt;/dev/null);do :;done
 fi
     </preinst>
     <postinst>
@@ -575,7 +575,7 @@ python -m compileall  __INSTALL_PREFIX__/mdsplus/pydevices/RfxDevices &gt;/dev/n
 
 export PYTHONPATH=""
 easy_install -q pip &gt;/dev/null 2&gt;&amp;1
-while (pip uninstall -q RfxDevices 2&gt;/dev/null);do :;done
+while (/usr/bin/yes | pip uninstall -q RfxDevices 2&gt;/dev/null);do :;done
 
     </pre-install>
     <post-install>
@@ -597,7 +597,7 @@ then
 else
   export PYTHONPATH=""
   easy_install -q pip &gt;/dev/null 2&gt;&amp;1
-  while (pip uninstall -q W7xDevices 2&gt;/dev/null);do :;done
+  while (/usr/bin/yes | pip uninstall -q W7xDevices 2&gt;/dev/null);do :;done
 fi
     </preinst>
     <postinst>
@@ -615,7 +615,7 @@ python -m compileall  __INSTALL_PREFIX__/mdsplus/pydevices/W7xDevices &gt;/dev/n
 
 export PYTHONPATH=""
 easy_install -q pip &gt;/dev/null 2&gt;&amp;1
-while (pip uninstall -q W7xDevices 2&gt;/dev/null);do :;done
+while (/usr/bin/yes | pip uninstall -q W7xDevices 2&gt;/dev/null);do :;done
 
     </pre-install>
     <post-install>
@@ -681,7 +681,7 @@ python -m compileall  __INSTALL_PREFIX__/mdsplus/pydevices/W7xDevices &gt;/dev/n
       else
 	export PYTHONPATH=""
         easy_install -q pip &gt;/dev/null 2&gt;&amp;1
-        while (pip uninstall -q MDSplus 2&gt;/dev/null);do :;done
+        while (/usr/bin/yes | pip uninstall -q MDSplus 2&gt;/dev/null);do :;done
       fi
 
     </prerm>


### PR DESCRIPTION
The installer scripts were changed to use pip to remove old python
packages left from previous installations. Unfortunately pip prompts
for yes/no verification and this hung the removal when done using the
package install/remove scripts which are not done interactively. This
should fix this problem. Unfortunately to update any of the python
packages it may be necessary to manually edit the mdsplus-python.prerm
script found in /var/lib/dpkg/info on debian based linux systems
to change the line:

 while (pip uninstall -q -y MDSplus 2>/dev/null);do :;done

to be:

 while (/usr/bin/yes | pip uninstall -q MDSplus 2>/dev/null);do :;done

before an update or removal can be performed.