### PR TITLE
Build: Remove jar creation output from trigger console

### DIFF
--- a/deploy/trigger.sh
+++ b/deploy/trigger.sh
@@ -251,13 +251,14 @@ NORMAL() {
 
 if [ ! -z "${MAKE_JARS}" ]
 then
-    if ( ! ${SRCDIR}/deploy/build.sh --make-jars --os=${MAKE_JARS} --workspace=${SRCDIR} )
+    if ( ! ${SRCDIR}/deploy/build.sh --make-jars --os=${MAKE_JARS} --workspace=${SRCDIR} > make_jars.log 2>&1 )
     then
 	RED $COLOR
 	cat <<EOF >&2
 ===============================================
 
-Error creating java jar files. Trigger failed.
+Error creating java jar files. Trigger failed. 
+Look at make_jars.log artifact for more info.
 
 ===============================================
 EOF


### PR DESCRIPTION
The trigger console log is getting obscured by the output of
the making of the jar files for use in installers so this output
is moved to a make_jars.log file which can be included in the trigger
job artifacts.