### PR TITLE
Feature:handle names longer than 12 chars

### DIFF
--- a/javatraverser/CompileTree.java
+++ b/javatraverser/CompileTree.java
@@ -253,8 +253,9 @@ public class CompileTree extends Thread
             if(type.equals("node"))
             {
                 try  {
-                    if(name.length() > 12) name = name.substring(0,12);
-                    nid = tree.addNode("."+name, NodeInfo.USAGE_STRUCTURE, 0);
+//                    if(name.length() > 12) name = name.substring(0,12);
+//                    nid = tree.addNode("."+name, NodeInfo.USAGE_STRUCTURE, 0);
+                    nid = addNode("."+name, NodeInfo.USAGE_STRUCTURE);
                     if(usageStr != null && usageStr.equals("SUBTREE"))
                         subtreeNids.addElement(nid);
                     tree.setDefault(nid, 0);
@@ -277,8 +278,9 @@ public class CompileTree extends Thread
                 if(usageStr.equals("AXIS")) usage = NodeInfo.USAGE_AXIS;
                 if(usageStr.equals("DISPATCH")) usage = NodeInfo.USAGE_DISPATCH;
                 try {
-                    if(name.length() > 12) name = name.substring(0,12);
-                    nid = tree.addNode(":"+name, usage, 0);
+//                    if(name.length() > 12) name = name.substring(0,12);
+//                    nid = tree.addNode(":"+name, usage, 0);
+                    nid = addNode(":"+name, usage);
                     tree.setDefault(nid, 0);
                     success = true;
                 }catch(Exception exc)
@@ -395,6 +397,21 @@ public class CompileTree extends Thread
         }
     }
 
-
+    NidData  addNode(String name, int usage) throws Exception
+    {
+	NidData prevNid = tree.getDefault(0);
+        String currName = name.substring(1);
+	String prevNode = "";
+	while(currName.length() > 12)
+	{
+	      String shortName = currName.substring(0, 12);
+	      currName = currName.substring(12);
+	      try {
+		tree.addNode(prevNode + "."+shortName, NodeInfo.USAGE_STRUCTURE, 0);
+	      }catch(Exception exc){}
+	      prevNode += "."+shortName;
+	}
+	return tree.addNode(prevNode+name.substring(0,1)+currName, usage, 0);
+    }
 }
 


### PR DESCRIPTION
Node names longer that 12 chars are now splitted and a subtree created. For example, adding a node whose name 'THISISALONGNODENAME' will ceate a subtree whose root is names 'THISISALONGN' and a son names 'ODENAME'. This feature is intended for usage in ITER IMAS where a way for mapping long names into tree nodes is required.