### PR TITLE
Fix: Repair bug caused during removal of VMS specific code

### DIFF
--- a/idl/mdsvalue.pro
+++ b/idl/mdsvalue.pro
@@ -80,7 +80,7 @@ function MdsValue,expression,arg1,arg2,arg3,arg4,arg5,arg6,arg7,arg8,arg9,arg10,
     if !version.memory_bits eq 64 then ansptr = 0ll 
 ;;;;  status = call_external(MdsIPImage(),MdsRoutinePrefix()+'GetAnsInfo',sock,dtype,length,ndims,dims,numbytes,ansptr,value=[1,0,0,0,0,0,0])
 ;;; temporary fix Jeff Schachte 98.05.13
-    status = call_external(MdsIPImage(),MdsGetAnsFn(),sock,dtype,length,ndims,dims,numbytes,ansptr,value=[1,0,0,0,0,0,0])
+    status = call_external(MdsIPImage(),'IdlGetAnsInfo',sock,dtype,length,ndims,dims,numbytes,ansptr,value=[1,0,0,0,0,0,0])
     if numbytes gt 0 then begin
       if dtype eq 14 then begin
         if ndims ne 0 then begin


### PR DESCRIPTION
The IDL mdsvalue function had been broken by a change to remove obsolete
VMS code. This fix should restore the ability to invoke mdsvalue on
remote connections.