### PR TITLE
Zck int128

### DIFF
--- a/deploy/packaging/debian/devel.noarch
+++ b/deploy/packaging/debian/devel.noarch
@@ -31,6 +31,7 @@
 ./usr/local/mdsplus/include/camshr_messages.h
 ./usr/local/mdsplus/include/dbidef.h
 ./usr/local/mdsplus/include/dcl.h
+./usr/local/mdsplus/include/int128.h
 ./usr/local/mdsplus/include/ipdesc.h
 ./usr/local/mdsplus/include/libroutines.h
 ./usr/local/mdsplus/include/mds_gendevice.h

--- a/deploy/packaging/redhat/devel.noarch
+++ b/deploy/packaging/redhat/devel.noarch
@@ -33,6 +33,7 @@
 ./usr/local/mdsplus/include/camshr_messages.h
 ./usr/local/mdsplus/include/dbidef.h
 ./usr/local/mdsplus/include/dcl.h
+./usr/local/mdsplus/include/int128.h
 ./usr/local/mdsplus/include/ipdesc.h
 ./usr/local/mdsplus/include/libroutines.h
 ./usr/local/mdsplus/include/mds_gendevice.h

--- a/include/int128.h
+++ b/include/int128.h
@@ -30,25 +30,25 @@
 #define uint128_max {-1,-1 };
 #define uint128_min { 0, 0 };
 
-int uint128_gt(uint128_t *a, uint128_t *b){
+static inline int uint128_gt(uint128_t *a, uint128_t *b){
   if (a->high==b->high)
     return a->low > b->low;
   return a->high > b->high;
 }
 
-int uint128_lt(uint128_t *a, uint128_t *b){
+static inline int uint128_lt(uint128_t *a, uint128_t *b){
   if (a->high==b->high)
     return a->low < b->low;
   return a->high < b->high;
 }
 
-int int128_gt(int128_t *a, int128_t *b){
+static inline int int128_gt(int128_t *a, int128_t *b){
   if (a->high==b->high)
     return a->low > b->low;
   return a->high > b->high;
 }
 
-int int128_lt(int128_t *a, int128_t *b){
+static inline int int128_lt(int128_t *a, int128_t *b){
   if (a->high==b->high)
     return a->low < b->low;
   return a->high < b->high;

--- a/include/int128.h
+++ b/include/int128.h
@@ -1,0 +1,149 @@
+#pragma once
+
+#ifdef WORDS_BIGENDIAN
+ typedef struct int128_s{
+   uint64_t high;
+   uint64_t low;
+ } int128_t;
+ const int128_t int128_one = {1,0};
+#else
+ typedef struct int128_s{
+   uint64_t low;
+   uint64_t high;
+ } int128_t;
+ const int128_t int128_one = {0,1};
+#endif
+const int128_t int128_zero = {0,0};
+#define HI_INT 0xFFFFFFFF00000000LL
+#define LO_INT 0x00000000FFFFFFFFLL
+
+static inline void int128_minus(const int128_t *a, int128_t *ans){
+  ans->high = ~(a->high);
+  ans->low  = ~(a->low);
+  ans->low++;
+  if (ans->low == 0)
+    ans->high++;
+}
+
+static inline int int128_add(const int128_t *a, const int128_t *b, int128_t *ans){
+  int128_t aa;memcpy(&aa,a,sizeof(int128_t));
+  ans->low  = a->low  + b->low;
+  ans->high = a->high + b->high;
+  if (ans->low < aa.low)
+    ans->high++;
+  return ans->high < aa.high;
+}
+
+static inline int int128_sub(const int128_t* a, const int128_t* b, int128_t *ans){
+  int128_t aa;memcpy(&aa,a,sizeof(int128_t));
+  ans->low  = a->low  - b->low;
+  ans->high = a->high - b->high;
+  if (ans->low > aa.low)
+    ans->high--;
+  return ans->high > aa.high;
+}
+
+static inline int int128_mul(const int128_t* x, const int128_t* y, int128_t *ans){
+  /* as by 128-bit integer arithmetic for C++, by Robert Munafo */
+  uint64_t acc, ac2, carry, o1, o2;
+  uint64_t a, b, c, d, e, f, g, h;
+
+/************************
+ x      a  b  c  d
+ y      e  f  g  h
+-------------------------
+        -o2-  -o1-
+ ************************/
+
+  d =  x->low  & LO_INT;
+  c = (x->low  & HI_INT) >> 32LL;
+  b =  x->high & LO_INT;
+  a = (x->high & HI_INT) >> 32LL;
+
+  h =  y->low  & LO_INT;
+  g = (y->low  & HI_INT) >> 32LL;
+  f =  y->high & LO_INT;
+  e = (y->high & HI_INT) >> 32LL;
+
+  acc = d * h;
+  o1  = acc & LO_INT;
+  acc >>= 32LL;
+  carry = 0;
+  ac2 = acc + c * h; if (ac2 < acc) { carry++; }
+  acc = ac2 + d * g; if (acc < ac2) { carry++; }
+  ans->low = o1 | (acc << 32LL);
+  ac2 = (acc >> 32LL) | (carry << 32LL); carry = 0;
+
+  acc = ac2 + b * h; if (acc < ac2) { carry++; }
+  ac2 = acc + c * g; if (ac2 < acc) { carry++; }
+  acc = ac2 + d * f; if (acc < ac2) { carry++; }
+  o2  = acc & LO_INT;
+  ac2 = (acc >> 32LL) | (carry << 32LL);
+
+  acc = ac2 + a * h;
+  ac2 = acc + b * g;
+  acc = ac2 + c * f;
+  ac2 = acc + d * e;
+  ans->high = (ac2 << 32LL) | o2;
+  return  (acc >> 32LL) | (carry << 32LL);
+}
+
+/*
+int int128_div(const int128_t x, const int128_t d, int128_t *r)
+{
+  int s;
+  int128_t d1, p2, rv;
+
+//printf("divide %.16llX %016llX / %.16llX %016llX\n", x.high, x.low, d.high, d.low);
+
+  // check for divide by zero
+  if ((d.low == 0) && (d.high == 0)) {
+    rv.low = x.low / d.low; // This will cause runtime error
+  }
+
+  s = 1;
+  if (x < ((s128_o) 0)) {
+    // notice that MININT will be unchanged, this is used below.
+    s = - s;
+    x = - x;
+  }
+  if (d < ((s128_o) 0)) {
+    s = - s;
+    d = - d;
+  }
+
+  if (d == ((s128_o) 1)) {
+    // This includes the overflow case MININT/-1
+    rv = x;
+    x = 0;
+  } else if (x < ((s128_o) d)) {
+    // x < d, so quotient is 0 and x is remainder
+    rv = 0;
+  } else {
+    rv = 0;
+
+    // calculate biggest power of 2 times d that's <= x
+    p2 = 1; d1 = d;
+    x = x - d1;
+    while(x >= d1) {
+      x = x - d1;
+      d1 = d1 + d1;
+      p2 = p2 + p2;
+    }
+    x = x + d1;
+
+    while(p2.low != 0 || p2.high != 0) {
+      if (x >= d1) {
+        x = x - d1;
+        rv = rv + p2;
+      }
+      p2 = s128_shr(p2);
+      d1 = s128_shr(d1);
+    }
+  }
+
+  if (s < 0) rv.high = - rv.high;
+  if (r)     *r = x;
+  retrun rv;
+}
+*/

--- a/mdsobjects/cpp/testing/MdsTdiTest.cpp
+++ b/mdsobjects/cpp/testing/MdsTdiTest.cpp
@@ -72,18 +72,20 @@ int SingleThreadTest(int idx, int repeats){
   delete MDSplus::executeWithArgs("_SHOT=$",1,shot);
   delete shot;
   delete MDSplus::execute("_EXPT='T_TDI'");
-  int err = 0;
+  int status, err = 0;
   for (; ii<repeats ; ii++) {
     for (;ic<ncmd; ic++) try {
       if (strlen(cmds[ic])==0 || *cmds[ic] == '#') continue;
-      int status = AutoPointer<Data>(MDSplus::execute(cmds[ic]))->getInt();
-      if (!status) throw std::exception();
-      if (!(status&1)) throw MDSplus::MdsException(status);
+      status = AutoPointer<Data>(MDSplus::execute(cmds[ic]))->getInt();
+      if (!status) {
+        std::cerr << "FAILED in cycle " << ii << " >> " << cmds[ic] << "\n";
+        err = 1;
+      } else if (!(status&1)) throw MDSplus::MdsException(status);
     } catch (MDSplus::MdsException e) {
-      std::cerr << "ERROR in cycle " << ii << " >> " << cmds[ic] << "\n";
+      std::cerr << "ERROR in cycle " << ii << ":=" << status << " >> " << cmds[ic] << "\n";
       err = 1;
     } catch (...) {
-      std::cerr << "FAILED in cycle " << ii << " >> " << cmds[ic] << "\n";
+      std::cerr << "Exception in cycle " << ii << " >> " << cmds[ic] << "\n";
       err = 1;
     }
     if (err) break;

--- a/mdsobjects/cpp/testing/MdsTdiTest.tdi
+++ b/mdsobjects/cpp/testing/MdsTdiTest.tdi
@@ -307,7 +307,7 @@ PRODUCT(_a=[[1,2,3],[4,5,6],[7,8,9]],*,[[0,1,0],[1,0,1],[0,1,0]])==384 && all(PR
 PROGRAM_OF(build_program(1,2))==2
 # project (ARRAY,MASK,FIELD,[DIM])
 # promote (NCOPIES,VALUE)
-PUBLIC(_a)=1;private(_a)=0;PUBLIC(_a)
+# PUBLIC(_a)=1;private(_a)=0;PUBLIC(_a) /*not thread safe, tested elsewhere*/
 
 kind(QUADWORD(1))==9
 kind(QUADWORD_UNSIGNED(1))==5

--- a/mdsobjects/cpp/testing/MdsTdiTest.tdi
+++ b/mdsobjects/cpp/testing/MdsTdiTest.tdi
@@ -427,3 +427,26 @@ class(_a=DICT(*,"a",1,2,"b"))==196 && kind(_a)==216
 _a["a"]==1 && _a[2]=="b"
 
 treeclose()
+
+#quadword tests
+0x1234567012345670q*2==0x2468ace02468ace0q
+0x1234567012345670q+0x123456701234567q==0x13579bd713579bd7q
+0x2468ace02468ace0q/2==0x1234567012345670q
+  and(1q,3q) &&   and_not(1q,2q)
+!nand(1q,3q) && !nand_not(1q,2q)
+  nor(0q,2q) &&   nor_not(0q,3q)
+  !or(0q,2q) &&   !or_not(0q,3q)
+  eqv(1q,3q) &&       eqv(0q,2q)
+ neqv(0q,3q) &&      neqv(1q,2q)
+
+#octaword tests require execute
+execute("0x1234567012345670o*16==0x12345670123456700o")
+execute("0x12345670123456701o+0x1234567012345670q==0x13579bd713579bd71o")
+execute("0x12345670123456701o-0x1234567012345670q==0x11111109111111091o")
+execute("(-0x2468ace02468ace0o)/2==-0x1234567012345670o")
+execute("  and(1o,3o) &&   and_not(1o,2o)")
+execute("!nand(1o,3o) && !nand_not(1o,2o)")
+execute("  nor(0o,2o) &&   nor_not(0o,3o)")
+execute("  !or(0o,2o) &&   !or_not(0o,3o)")
+execute("  eqv(1o,3o) &&       eqv(0o,2o)")
+execute(" neqv(0o,3o) &&      neqv(1o,2o)")

--- a/tdishr/TdiAbs.c
+++ b/tdishr/TdiAbs.c
@@ -74,35 +74,15 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <tdishr_messages.h>
 #include <math.h>
 #include <STATICdef.h>
+#include <int128.h>
 
 extern int TdiConvert();
-extern int TdiSubtractOctaword();
 extern int TdiUnary();
 extern int Tdi3Multiply();
 extern int CvtConvertFloat();
 
 #define min(a,b) ((a)<(b)) ? (a) : (b)
 #define max(a,b) ((a)<(b)) ? (b) : (a)
-
-typedef struct {
-  int64_t low;
-  int64_t high;
-} Int128;
-typedef Int128 uInt128;
-
-#define negate128 TdiSubtractOctaword(&octazero,&in[i],&out[i])
-
-STATIC_CONSTANT Int128 octazero = {0};
-
-#define zero128 out[i].low=0; out[i].high=0;
-#define copy128 out[i].low=in[i].low;out[i].high=in[i].high;
-#define abs128 if (in[i].high < 0) TdiSubtractOctaword(&octazero,&in[i],&out[i]); else { copy128; }
-#define not128 out[i].low = ~in[i].low; out[i].high = ~in[i].high
-#ifdef WORDS_BIGENDIAN
-#define bool128 out[i]=(uint8_t)(1 & in[i].low)
-#else
-#define bool128 out[i]=(uint8_t)(1 & in[i].low)
-#endif
 
 STATIC_CONSTANT const int roprand = 0x8000;
 
@@ -266,13 +246,13 @@ int Tdi3Abs(struct descriptor *in_ptr, struct descriptor *out_ptr)
     end_operate case DTYPE_WU:start_operate(uint16_t) out[i] = in[i];
     end_operate case DTYPE_LU:start_operate(uint32_t) out[i] = in[i];
     end_operate case DTYPE_QU:start_operate(uint64_t) out[i] = in[i];
-    end_operate case DTYPE_OU:start_operate(uInt128); copy128;
+    end_operate case DTYPE_OU:start_operate(uint128_t); memcpy(&out[i],&in[i],sizeof(uint128_t));
     end_operate case DTYPE_B:start_operate(int8_t) out[i] = (int8_t)(in[i] > 0 ? in[i] : -in[i]);
     end_operate case DTYPE_W:start_operate(int16_t)
         out[i] = (int16_t)(in[i] > 0 ? in[i] : -in[i]);
     end_operate case DTYPE_L:start_operate(int32_t) out[i] = in[i] > 0 ? in[i] : -in[i];
     end_operate case DTYPE_Q:start_operate(int64_t) out[i] = in[i] > 0 ? in[i] : -in[i];
-    end_operate case DTYPE_O:start_operate(Int128) abs128;
+    end_operate case DTYPE_O:start_operate(int128_t) int128_abs(&in[i],&out[i]);
     end_operate case DTYPE_F:start_operate(float) AbsFloat(DTYPE_F)
     end_operate case DTYPE_FS:start_operate(float) AbsFloat(DTYPE_FS)
     end_operate case DTYPE_G:start_operate(double) AbsFloat(DTYPE_G)
@@ -304,13 +284,12 @@ int Tdi3Abs1(struct descriptor *in_ptr, struct descriptor *out_ptr)
     end_operate case DTYPE_WU:start_operate(uint16_t) out[i] = in[i];
     end_operate case DTYPE_LU:start_operate(uint32_t) out[i] = in[i];
     end_operate case DTYPE_QU:start_operate(uint64_t) out[i] = in[i];
-    end_operate case DTYPE_OU:start_operate(uInt128); copy128;
+    end_operate case DTYPE_OU:start_operate(uint128_t); memcpy(&out[i],&in[i],sizeof(uint128_t));
     end_operate case DTYPE_B:start_operate(int8_t) out[i] = (int8_t)(in[i] > 0 ? in[i] : -in[i]);
-    end_operate case DTYPE_W:start_operate(int16_t)
-        out[i] = (int16_t)(in[i] > 0 ? in[i] : -in[i]);
+    end_operate case DTYPE_W:start_operate(int16_t) out[i] = (int16_t)(in[i] > 0 ? in[i] : -in[i]);
     end_operate case DTYPE_L:start_operate(int32_t) out[i] = in[i] > 0 ? in[i] : -in[i];
     end_operate case DTYPE_Q:start_operate(int64_t) out[i] = in[i] > 0 ? in[i] : -in[i];
-    end_operate case DTYPE_O:start_operate(Int128) abs128;
+    end_operate case DTYPE_O:start_operate(int128_t) int128_abs(&in[i],&out[i]);
     end_operate case DTYPE_F:start_operate(float) AbsFloat(DTYPE_F)
     end_operate case DTYPE_FS:start_operate(float) AbsFloat(DTYPE_FS)
     end_operate case DTYPE_G:start_operate(double) AbsFloat(DTYPE_G)
@@ -384,7 +363,7 @@ int Tdi3Aimag(struct descriptor *in_ptr, struct descriptor *out_ptr)
     end_operate case DTYPE_W:case DTYPE_WU:start_operate2(int16_t) out[i] = 0;
     end_operate case DTYPE_L:case DTYPE_LU:start_operate2(int32_t) out[i] = 0;
     end_operate case DTYPE_Q:case DTYPE_QU:start_operate2(int64_t) out[i] = 0;
-    end_operate case DTYPE_O:case DTYPE_OU:start_operate2(Int128)   zero128;
+    end_operate case DTYPE_O:case DTYPE_OU:start_operate2(int128_t)   out[i].low=0;out[i].high=0;;
     end_operate case DTYPE_F:start_operate2(float)
     float ans = (float)0.0;
     CvtConvertFloat(&ans, DTYPE_NATIVE_FLOAT, &out[i], DTYPE_F, 0);
@@ -427,7 +406,7 @@ int Tdi3Conjg(struct descriptor *in_ptr, struct descriptor *out_ptr)
     end_operate case DTYPE_WU:case DTYPE_W:start_operate(uint16_t) out[i] = in[i];
     end_operate case DTYPE_LU:case DTYPE_L:start_operate(uint32_t) out[i] = in[i];
     end_operate case DTYPE_QU:case DTYPE_Q:start_operate(uint64_t) out[i] = in[i];
-    end_operate case DTYPE_OU:case DTYPE_O:start_operate(uInt128)  copy128;
+    end_operate case DTYPE_OU:case DTYPE_O:start_operate(uint128_t)  memcpy(&out[i],&in[i],sizeof(int128_t));
     end_operate case DTYPE_F:case DTYPE_FS:start_operate(float)    out[i] = in[i];
     end_operate case DTYPE_G:case DTYPE_D:case DTYPE_FT:start_operate(double) out[i] = in[i];
     end_operate case DTYPE_FC:start_operate(float) ConjgComplex(DTYPE_F)
@@ -452,16 +431,16 @@ int Tdi3Inot(struct descriptor *in_ptr, struct descriptor *out_ptr)
     return status;
 
   switch (in_ptr->dtype) {
-                case DTYPE_BU:start_operate( int8_t)  out[i] = ~in[i];
-    end_operate case DTYPE_WU:start_operate(uint16_t) out[i] = ~in[i];
-    end_operate case DTYPE_LU:start_operate(uint32_t) out[i] = ~in[i];
-    end_operate case DTYPE_QU:start_operate(uint64_t) out[i] = ~in[i];
-    end_operate case DTYPE_OU:start_operate(uInt128)  not128;
-    end_operate case DTYPE_B: start_operate( int8_t) out[i] = ~in[i];
-    end_operate case DTYPE_W: start_operate(int16_t) out[i] = ~in[i];
-    end_operate case DTYPE_L: start_operate(int32_t) out[i] = ~in[i];
-    end_operate case DTYPE_O: start_operate(int64_t) out[i] = ~in[i];
-    end_operate case DTYPE_Q: start_operate(Int128)  not128;
+                case DTYPE_BU:start_operate(  uint8_t) out[i] = ~in[i];
+    end_operate case DTYPE_WU:start_operate( uint16_t) out[i] = ~in[i];
+    end_operate case DTYPE_LU:start_operate( uint32_t) out[i] = ~in[i];
+    end_operate case DTYPE_QU:start_operate( uint64_t) out[i] = ~in[i];
+    end_operate case DTYPE_OU:start_operate(uint128_t) out[i].low=~in[i].low; out[i].high=~in[i].high;
+    end_operate case DTYPE_B: start_operate(   int8_t) out[i] = ~in[i];
+    end_operate case DTYPE_W: start_operate(  int16_t) out[i] = ~in[i];
+    end_operate case DTYPE_L: start_operate(  int32_t) out[i] = ~in[i];
+    end_operate case DTYPE_O: start_operate(  int64_t) out[i] = ~in[i];
+    end_operate case DTYPE_Q: start_operate( int128_t) out[i].low=~in[i].low; out[i].high=~in[i].high;
     end_operate default:status = TdiINVDTYDSC;
   }
 
@@ -478,16 +457,16 @@ int Tdi3Logical(struct descriptor *in_ptr, struct descriptor *kind __attribute__
     return status;
 
   switch (in_ptr->dtype) {
-  case DTYPE_BU:              start_operate1( uint8_t, uint8_t) out[i] = (uint8_t)(1 & in[i]);
-    end_operate case DTYPE_WU:start_operate1(uint16_t, uint8_t)	out[i] = (uint8_t)(1 & in[i]);
-    end_operate case DTYPE_LU:start_operate1(uint32_t, uint8_t)	out[i] = (uint8_t)(1 & in[i]);
-    end_operate case DTYPE_QU:start_operate1(uint64_t, uint8_t) out[i] = (uint8_t)(1 & in[i]);
-    end_operate case DTYPE_OU:start_operate1( uInt128, uint8_t) bool128;
-    end_operate case DTYPE_B: start_operate1( int8_t, uint8_t) out[i] =	(uint8_t)(1 & in[i]);
-    end_operate case DTYPE_W: start_operate1(int16_t, uint8_t) out[i] =	(uint8_t)(1 & in[i]);
-    end_operate case DTYPE_L: start_operate1(int32_t, uint8_t) out[i] = (uint8_t)(1 & in[i]);
-    end_operate case DTYPE_Q: start_operate1(int64_t, uint8_t) out[i] = (uint8_t)(1 & in[i]);
-    end_operate case DTYPE_O: start_operate1( Int128, uint8_t) bool128;
+  case DTYPE_BU:              start_operate1(  uint8_t, uint8_t) out[i] = (uint8_t)(1 & in[i]);
+    end_operate case DTYPE_WU:start_operate1( uint16_t, uint8_t) out[i] = (uint8_t)(1 & in[i]);
+    end_operate case DTYPE_LU:start_operate1( uint32_t, uint8_t) out[i] = (uint8_t)(1 & in[i]);
+    end_operate case DTYPE_QU:start_operate1( uint64_t, uint8_t) out[i] = (uint8_t)(1 & in[i]);
+    end_operate case DTYPE_OU:start_operate1(uint128_t, uint8_t) out[i] = (uint8_t)(1 & in[i].low);
+    end_operate case DTYPE_B: start_operate1(   int8_t, uint8_t) out[i] = (uint8_t)(1 & in[i]);
+    end_operate case DTYPE_W: start_operate1(  int16_t, uint8_t) out[i] = (uint8_t)(1 & in[i]);
+    end_operate case DTYPE_L: start_operate1(  int32_t, uint8_t) out[i] = (uint8_t)(1 & in[i]);
+    end_operate case DTYPE_Q: start_operate1(  int64_t, uint8_t) out[i] = (uint8_t)(1 & in[i]);
+    end_operate case DTYPE_O: start_operate1( int128_t, uint8_t) out[i] = (uint8_t)(1 & in[i].low);
     end_operate default:status = TdiINVDTYDSC;
   }
 
@@ -502,20 +481,17 @@ int Tdi3Not(struct descriptor *in_ptr, struct descriptor *out_ptr)
   status = TdiUnary(in_ptr, out_ptr, &out_count);
   if STATUS_NOT_OK
     return status;
-
   switch (in_ptr->dtype) {
-  case DTYPE_BU:
-    start_operate1(uint8_t, uint8_t) out[i] = (uint8_t)!(in[i] & 1);
-    end_operate case DTYPE_WU:start_operate1(uint16_t, uint8_t)
-	out[i] = (uint8_t)!(in[i] & 1);
-    end_operate case DTYPE_LU:start_operate1(uint32_t, uint8_t)	out[i] = (uint8_t)!(in[i] & 1);
-    end_operate case DTYPE_QU:start_operate1(uint64_t, uint8_t) out[i] = (uint8_t)!(in[i] & 1);
-    end_operate case DTYPE_OU:start_operate1( uInt128, uint8_t) bool128; out[i] = (uint8_t)!out[i];
-    end_operate case DTYPE_B: start_operate1(int8_t, uint8_t)	out[i] = (uint8_t)!(in[i] & 1);
-    end_operate case DTYPE_W: start_operate1(int16_t, uint8_t)  out[i] = (uint8_t)!(in[i] & 1);
-    end_operate case DTYPE_L: start_operate1(int32_t, uint8_t)  out[i] = (uint8_t)!(in[i] & 1);
-    end_operate case DTYPE_Q: start_operate1(int64_t, uint8_t)  out[i] = (uint8_t)!(in[i] & 1);
-    end_operate case DTYPE_O: start_operate1( Int128, uint8_t)  bool128; out[i] = (uint8_t)!out[i];
+                case DTYPE_BU:start_operate1(  uint8_t,uint8_t) out[i] = (uint8_t)!(in[i] & 1);
+    end_operate case DTYPE_WU:start_operate1( uint16_t,uint8_t) out[i] = (uint8_t)!(in[i] & 1);
+    end_operate case DTYPE_LU:start_operate1( uint32_t,uint8_t) out[i] = (uint8_t)!(in[i] & 1);
+    end_operate case DTYPE_QU:start_operate1( uint64_t,uint8_t) out[i] = (uint8_t)!(in[i] & 1);
+    end_operate case DTYPE_OU:start_operate1(uint128_t,uint8_t) out[i] = (uint8_t)!(1 & in[i].low);
+    end_operate case DTYPE_B: start_operate1(   int8_t,uint8_t) out[i] = (uint8_t)!(in[i] & 1);
+    end_operate case DTYPE_W: start_operate1(  int16_t,uint8_t) out[i] = (uint8_t)!(in[i] & 1);
+    end_operate case DTYPE_L: start_operate1(  int32_t,uint8_t) out[i] = (uint8_t)!(in[i] & 1);
+    end_operate case DTYPE_Q: start_operate1(  int64_t,uint8_t) out[i] = (uint8_t)!(in[i] & 1);
+    end_operate case DTYPE_O: start_operate1( int128_t,uint8_t) out[i] = (uint8_t)!(1 & in[i].low);
     end_operate default:status = TdiINVDTYDSC;
   }
 
@@ -533,26 +509,25 @@ int Tdi3Nint(struct descriptor *in_ptr, struct descriptor *kind __attribute__ ((
     return status;
 
   switch (in_ptr->dtype) {
-  case DTYPE_BU:
-    start_operate(uint8_t) out[i] = in[i];
-    end_operate case DTYPE_WU:start_operate(uint16_t) out[i] = in[i];
-    end_operate case DTYPE_LU:start_operate(uint32_t) out[i] = in[i];
-    end_operate case DTYPE_QU:start_operate(uint64_t) out[i] = in[i];
-    end_operate case DTYPE_OU:start_operate(uInt128)  copy128;
-    end_operate case DTYPE_B:start_operate(int8_t) out[i] = in[i];
-    end_operate case DTYPE_W:start_operate(int16_t) out[i] = in[i];
-    end_operate case DTYPE_L:start_operate(int32_t) out[i] = in[i];
-    end_operate case DTYPE_Q:start_operate(int64_t) out[i] = in[i];
-    end_operate case DTYPE_O:start_operate(Int128)  copy128;
-    end_operate case DTYPE_F:start_operate1(float, int) NintFloat(DTYPE_F);
-    end_operate case DTYPE_FS:start_operate1(float, int) NintFloat(DTYPE_FS);
-    end_operate case DTYPE_G:start_operate1(double, int) NintFloat(DTYPE_G);
-    end_operate case DTYPE_D:start_operate1(double, int) NintFloat(DTYPE_D);
-    end_operate case DTYPE_FT:start_operate1(double, int) NintFloat(DTYPE_FT);
-    end_operate case DTYPE_FC:start_operate1(float, int) NintComplex(DTYPE_F);
-    end_operate case DTYPE_FSC:start_operate1(float, int) NintComplex(DTYPE_FS);
-    end_operate case DTYPE_GC:start_operate1(double, int) NintComplex(DTYPE_G);
-    end_operate case DTYPE_DC:start_operate1(double, int) NintComplex(DTYPE_D);
+                case DTYPE_BU: start_operate(  uint8_t) out[i] = in[i];
+    end_operate case DTYPE_WU: start_operate( uint16_t) out[i] = in[i];
+    end_operate case DTYPE_LU: start_operate( uint32_t) out[i] = in[i];
+    end_operate case DTYPE_QU: start_operate( uint64_t) out[i] = in[i];
+    end_operate case DTYPE_OU: start_operate(uint128_t) memcpy(&out[i],&in[i],sizeof(uint128_t));
+    end_operate case DTYPE_B:  start_operate(   int8_t) out[i] = in[i];
+    end_operate case DTYPE_W:  start_operate(  int16_t) out[i] = in[i];
+    end_operate case DTYPE_L:  start_operate(  int32_t) out[i] = in[i];
+    end_operate case DTYPE_Q:  start_operate(  int64_t) out[i] = in[i];
+    end_operate case DTYPE_O:  start_operate( int128_t) memcpy(&out[i],&in[i],sizeof(int128_t));
+    end_operate case DTYPE_F:  start_operate1(float,  int) NintFloat(DTYPE_F);
+    end_operate case DTYPE_FS: start_operate1(float,  int) NintFloat(DTYPE_FS);
+    end_operate case DTYPE_G:  start_operate1(double, int) NintFloat(DTYPE_G);
+    end_operate case DTYPE_D:  start_operate1(double, int) NintFloat(DTYPE_D);
+    end_operate case DTYPE_FT: start_operate1(double, int) NintFloat(DTYPE_FT);
+    end_operate case DTYPE_FC: start_operate1(float,  int) NintComplex(DTYPE_F);
+    end_operate case DTYPE_FSC:start_operate1(float,  int) NintComplex(DTYPE_FS);
+    end_operate case DTYPE_GC: start_operate1(double, int) NintComplex(DTYPE_G);
+    end_operate case DTYPE_DC: start_operate1(double, int) NintComplex(DTYPE_D);
     end_operate case DTYPE_FTC:start_operate1(double, int) NintComplex(DTYPE_FT);
     end_operate default:status = TdiINVDTYDSC;
   }
@@ -571,25 +546,25 @@ int Tdi3UnaryMinus(struct descriptor *in_ptr, struct descriptor *out_ptr)
     return status;
 
   switch (in_ptr->dtype) {
-  case DTYPE_BU:              start_operate( int8_t) out[i] = -in[i];
-    end_operate case DTYPE_WU:start_operate(int16_t) out[i] = -in[i];
-    end_operate case DTYPE_LU:start_operate(int32_t) out[i] = -in[i];
-    end_operate case DTYPE_QU:start_operate(int64_t) out[i] = -in[i];
-    end_operate case DTYPE_OU:start_operate(uInt128) TdiSubtractOctaword(&octazero, &in[i], &out[i]);
-    end_operate case DTYPE_B:start_operate( int8_t) out[i] = -in[i];
-    end_operate case DTYPE_W:start_operate(int16_t) out[i] = -in[i];
-    end_operate case DTYPE_L:start_operate(int32_t) out[i] = -in[i];
-    end_operate case DTYPE_Q:start_operate(int64_t) out[i] = -in[i];
-    end_operate case DTYPE_O:start_operate(Int128) TdiSubtractOctaword(&octazero, &in[i], &out[i]);
-    end_operate case DTYPE_F:start_operate(float)  UnaryMinusFloat(DTYPE_F)
-    end_operate	case DTYPE_FS:start_operate(float) UnaryMinusFloat(DTYPE_FS)
-    end_operate case DTYPE_G:start_operate(double) UnaryMinusFloat(DTYPE_G)
-    end_operate case DTYPE_D:start_operate(double) UnaryMinusFloat(DTYPE_D)
-    end_operate case DTYPE_FT:start_operate(double) UnaryMinusFloat(DTYPE_FT)
-    end_operate case DTYPE_FC:start_operate(float) UnaryMinusComplex(DTYPE_F)
-    end_operate case DTYPE_FSC:start_operate(float) UnaryMinusComplex(DTYPE_FS)
-    end_operate case DTYPE_GC:start_operate(double) UnaryMinusComplex(DTYPE_G)
-    end_operate case DTYPE_DC:start_operate(double) UnaryMinusComplex(DTYPE_D)
+                case DTYPE_BU: start_operate(  int8_t) out[i] = -in[i];
+    end_operate case DTYPE_WU: start_operate( int16_t) out[i] = -in[i];
+    end_operate case DTYPE_LU: start_operate( int32_t) out[i] = -in[i];
+    end_operate case DTYPE_QU: start_operate( int64_t) out[i] = -in[i];
+    end_operate case DTYPE_OU: start_operate(int128_t) int128_minus((int128_t*)&in[i], &out[i]);
+    end_operate case DTYPE_B:  start_operate(  int8_t) out[i] = -in[i];
+    end_operate case DTYPE_W:  start_operate( int16_t) out[i] = -in[i];
+    end_operate case DTYPE_L:  start_operate( int32_t) out[i] = -in[i];
+    end_operate case DTYPE_Q:  start_operate( int64_t) out[i] = -in[i];
+    end_operate case DTYPE_O:  start_operate(int128_t) int128_minus((int128_t*)&in[i], &out[i]);
+    end_operate case DTYPE_F:  start_operate(float)  UnaryMinusFloat(DTYPE_F)
+    end_operate	case DTYPE_FS: start_operate(float)  UnaryMinusFloat(DTYPE_FS)
+    end_operate case DTYPE_G:  start_operate(double) UnaryMinusFloat(DTYPE_G)
+    end_operate case DTYPE_D:  start_operate(double) UnaryMinusFloat(DTYPE_D)
+    end_operate case DTYPE_FT: start_operate(double) UnaryMinusFloat(DTYPE_FT)
+    end_operate case DTYPE_FC: start_operate(float)  UnaryMinusComplex(DTYPE_F)
+    end_operate case DTYPE_FSC:start_operate(float)  UnaryMinusComplex(DTYPE_FS)
+    end_operate case DTYPE_GC: start_operate(double) UnaryMinusComplex(DTYPE_G)
+    end_operate case DTYPE_DC: start_operate(double) UnaryMinusComplex(DTYPE_D)
     end_operate case DTYPE_FTC:start_operate(double) UnaryMinusComplex(DTYPE_FT)
     end_operate default:status = TdiINVDTYDSC;
   }

--- a/tdishr/TdiAdd.c
+++ b/tdishr/TdiAdd.c
@@ -185,16 +185,16 @@ STATIC_CONSTANT const int roprand = 0x8000;
   break;\
 }
 
-#define OperateFun(routine) \
-{ int128_t *in1p = (int128_t*)in1->pointer;\
-  int128_t *in2p = (int128_t*)in2->pointer;\
-  int128_t *outp = (int128_t*)out->pointer;\
+#define Operate128(type,routine) \
+{ type##_t *in1p = (type##_t*)in1->pointer;\
+  type##_t *in2p = (type##_t*)in2->pointer;\
+  type##_t *outp = (type##_t*)out->pointer;\
   switch (scalars)\
   {\
     case 0:\
-    case 3: while (nout--) routine(in1p++, in2p++, outp++); break; \
-    case 1: while (nout--) routine(in1p,   in2p++, outp++); break; \
-    case 2: while (nout--) routine(in1p++, in2p,   outp++); break; \
+    case 3: while (nout--) type##_##routine(in1p++, in2p++, outp++); break; \
+    case 1: while (nout--) type##_##routine(in1p,   in2p++, outp++); break; \
+    case 2: while (nout--) type##_##routine(in1p++, in2p,   outp++); break; \
   }\
   break;\
 }
@@ -210,8 +210,8 @@ int Tdi3Add(struct descriptor *in1, struct descriptor *in2, struct descriptor *o
     case DTYPE_LU: Operate(uint32_t, +)
     case DTYPE_Q:  Operate( int64_t, +)
     case DTYPE_QU: Operate(uint64_t, +)
-    case DTYPE_O:  OperateFun(int128_add)
-    case DTYPE_OU: OperateFun(int128_add)
+    case DTYPE_O:  Operate128( int128,add)
+    case DTYPE_OU: Operate128(uint128,add)
     case DTYPE_F:  OperateFloat(float, DTYPE_F, DTYPE_NATIVE_FLOAT, +)
     case DTYPE_FS: OperateFloat(float, DTYPE_FS, DTYPE_NATIVE_FLOAT, +)
     case DTYPE_D:  OperateFloat(double, DTYPE_D, DTYPE_NATIVE_DOUBLE, +)
@@ -238,8 +238,8 @@ int Tdi3Subtract(struct descriptor *in1, struct descriptor *in2, struct descript
     case DTYPE_LU: Operate(uint32_t, -)
     case DTYPE_Q:  Operate( int64_t, -)
     case DTYPE_QU: Operate(uint64_t, -)
-    case DTYPE_O:  OperateFun(int128_sub)
-    case DTYPE_OU: OperateFun(int128_sub)
+    case DTYPE_O:  Operate128( int128,sub)
+    case DTYPE_OU: Operate128(uint128,sub)
     case DTYPE_F:  OperateFloat(float, DTYPE_F, DTYPE_NATIVE_FLOAT, -)
     case DTYPE_FS: OperateFloat(float, DTYPE_FS, DTYPE_NATIVE_FLOAT, -)
     case DTYPE_D:  OperateFloat(double, DTYPE_D, DTYPE_NATIVE_DOUBLE, -)
@@ -266,8 +266,8 @@ int Tdi3Multiply(struct descriptor *in1, struct descriptor *in2, struct descript
     case DTYPE_LU: Operate(uint32_t, *)
     case DTYPE_Q:  Operate( int64_t, *)
     case DTYPE_QU: Operate(uint64_t, *)
-    case DTYPE_O:  OperateFun(int128_mul)
-    case DTYPE_OU: OperateFun(int128_mul)
+    case DTYPE_O:  Operate128( int128,mul)
+    case DTYPE_OU: Operate128(uint128,mul)
     case DTYPE_F:  OperateFloat(float, DTYPE_F, DTYPE_NATIVE_FLOAT, *)
     case DTYPE_FS: OperateFloat(float, DTYPE_FS, DTYPE_NATIVE_FLOAT, *)
     case DTYPE_D:  OperateFloat(double, DTYPE_D, DTYPE_NATIVE_DOUBLE, *)

--- a/tdishr/TdiArray.c
+++ b/tdishr/TdiArray.c
@@ -46,6 +46,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <tdishr_messages.h>
 #include <mdsshr.h>
 #include <time.h>
+#include <pthread_port.h>
 #include "tdinelements.h"
 #include "tdirefcat.h"
 #include "tdireffunction.h"
@@ -57,10 +58,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif
-
-
-
-int Tdi_RandomSeed = 1234567;
 
 extern int TdiData();
 extern int Tdi3Add();
@@ -177,23 +174,24 @@ int Tdi3Ramp(struct descriptor *out_ptr)
 
   N_ELEMENTS(out_ptr, n);
   switch (out_ptr->dtype) {
-
-  case DTYPE_B:
-  case DTYPE_BU:
-    LoadRamp(char)
-    case DTYPE_W:case DTYPE_WU:LoadRamp(short)
-    case DTYPE_L:case DTYPE_LU:LoadRamp(int)
-    case DTYPE_F:LoadRampF(float, DTYPE_F, DTYPE_NATIVE_FLOAT)
-    case DTYPE_FS:LoadRampF(float, DTYPE_FS, DTYPE_NATIVE_FLOAT)
-    case DTYPE_D:LoadRampF(double, DTYPE_D, DTYPE_NATIVE_DOUBLE)
-    case DTYPE_G:LoadRampF(double, DTYPE_G, DTYPE_NATIVE_DOUBLE)
+    case DTYPE_B: LoadRamp(  int8_t)
+    case DTYPE_BU:LoadRamp( uint8_t)
+    case DTYPE_W: LoadRamp( int16_t)
+    case DTYPE_WU:LoadRamp(uint16_t)
+    case DTYPE_L: LoadRamp( int32_t)
+    case DTYPE_LU:LoadRamp(uint32_t)
+    case DTYPE_Q: LoadRamp( int64_t)
+    case DTYPE_QU:LoadRamp(uint64_t)
+    case DTYPE_F: LoadRampF(float,  DTYPE_F, DTYPE_NATIVE_FLOAT)
+    case DTYPE_FS:LoadRampF(float,  DTYPE_FS, DTYPE_NATIVE_FLOAT)
+    case DTYPE_D: LoadRampF(double, DTYPE_D, DTYPE_NATIVE_DOUBLE)
+    case DTYPE_G: LoadRampF(double, DTYPE_G, DTYPE_NATIVE_DOUBLE)
     case DTYPE_FT:LoadRampF(double, DTYPE_FT, DTYPE_NATIVE_DOUBLE)
-
 	/**********************************************************
         WARNING this depends on order of operations in ADD routine.
         Make a zero and a one. Add 1 to this starter, but offset.
         **********************************************************/
-	default: {
+    default: {
       struct descriptor new = *out_ptr;
       new.class = CLASS_S;
       if (n > 0)
@@ -225,105 +223,114 @@ int Tdi3Ramp(struct descriptor *out_ptr)
         Limitation: This method is for 32-bit machine only.
         Limitation: Low-order bits are not random.
 */
-#define Randomize Tdi_RandomSeed = Tdi_RandomSeed * 69069 + 1
 
-int Tdi3Random(struct descriptor_a *out_ptr)
-{
-  INIT_STATUS;
-  double half = .5;
-  double norm = half / 2147483648.;
-  int i, n;
 
-  if (Tdi_RandomSeed == 1234567) {
-#ifdef _WIN32
-    srand((unsigned int)time(0) + _getpid());
-    Tdi_RandomSeed = rand();
-#else
-    srandom(time(0) + getpid());
-    Tdi_RandomSeed = random();
-
+/********************************
+ guarantee a 32 bit random number
+ ********************************/
+const double norm = .5/2147483648.;
+#define rand8 rand
+#if RAND_MAX==2147483647
+#define rand16 rand
+static uint32_t rand32() {
+  static int bit = 0;
+  static uint32_t bitbuf;
+  if (bit==0) {
+    bitbuf = rand();
+    bit = 31;
+  } else bit--;
+  bitbuf = bitbuf<<1;
+  return ((uint32_t)rand()&0x7fffffff) | (bitbuf & 0x80000000);
+}
+#else // assume RAND_MAX==32767
+static uint32_t rand16() {
+  static int      bit = 0;
+  static uint32_t bitbuf;
+  if (bit==0) {
+    bitbuf = rand();
+    bit = 15;
+  } else bit--;
+  bitbuf = bitbuf<<1;
+  return ((uint32_t)rand()&0x7fff) | (bitbuf & 0x8000);
+}
+#define rand32() (rand16()|(rand16()<<16))
 #endif
-  }
+
+static pthread_once_t once = PTHREAD_ONCE_INIT;
+static void once_random(){
+  srand(time(0));
+}
+
+int Tdi3Random(struct descriptor_a *out_ptr){
+  pthread_mutex_t lock = PTHREAD_MUTEX_INITIALIZER;
+  pthread_mutex_lock(&lock);
+  pthread_once(&once,once_random);
+  INIT_STATUS;
+  int i, n;
   N_ELEMENTS(out_ptr, n);
   switch (out_ptr->dtype) {
   default:
     status = TdiINVDTYDSC;
     break;
 
-#define LoadRandom(type,shift) { type *ptr = (type *)out_ptr->pointer; int ranval; for (i=0;i<n;i++) \
-   Randomize; ranval = Tdi_RandomSeed >> shift; ptr[i] = (type)(ranval);}
-#define LoadRandomFloat(dtype,type,value) { type *ptr = (type *)out_ptr->pointer; double val; \
-                     for (i=0;i<n;i++) {Randomize; val = value; CvtConvertFloat(&val,DTYPE_NATIVE_DOUBLE,&ptr[i],dtype,0);}}
-
-	/*********************
-        WARNING falls through.
-        *********************/
+#define LoadRandom(type,randx) {type *ptr = (type *)out_ptr->pointer; for (i=0;i<n;i++) ptr[i] = (type)randx();}
+#define LoadRandomFloat(dtype,type,value) { type *ptr = (type *)out_ptr->pointer; for (i=0;i<n;i++) {double val = value; CvtConvertFloat(&val,DTYPE_NATIVE_DOUBLE,&ptr[i],dtype,0);}}
   case DTYPE_O:
   case DTYPE_OU:
-    n += n;
+    n *= 2; // use 2 random int64
     MDS_ATTR_FALLTHROUGH
   case DTYPE_Q:
   case DTYPE_QU:
-    n += n;
+    n *= 2; // use 2 random int32
     MDS_ATTR_FALLTHROUGH
   case DTYPE_L:
   case DTYPE_LU:
-    LoadRandom(int, 0);
-    break;
+    LoadRandom(uint32_t,rand32) break;
   case DTYPE_W:
   case DTYPE_WU:
-    LoadRandom(short, 16) break;
+    LoadRandom(uint16_t,rand16) break;
   case DTYPE_B:
   case DTYPE_BU:
-    LoadRandom(char, 24) break;
-
-	/*********************
-        WARNING falls through.
-        *********************/
+    LoadRandom( uint8_t, rand8) break;
   case DTYPE_FC:
-    n += n;
+    n *= 2; // use 2 random float
     MDS_ATTR_FALLTHROUGH
   case DTYPE_F:
-    LoadRandomFloat(DTYPE_F, float, Tdi_RandomSeed * norm + half);
+    LoadRandomFloat(DTYPE_F, float, rand32()*norm);
     break;
-
   case DTYPE_FSC:
-    n += n;
+    n *= 2; // use 2 random float
     MDS_ATTR_FALLTHROUGH
   case DTYPE_FS:
-    LoadRandomFloat(DTYPE_FS, float, Tdi_RandomSeed * norm + half);
+    LoadRandomFloat(DTYPE_FS, float, rand32()*norm);
     break;
-
   case DTYPE_DC:
-    n += n;
+    n *= 2; // use 2 random float
     MDS_ATTR_FALLTHROUGH
   case DTYPE_D:
-    LoadRandomFloat(DTYPE_D, double, (Tdi_RandomSeed * norm + Tdi_RandomSeed) * norm + half);
+    LoadRandomFloat(DTYPE_D, double, (rand32()*norm+rand32())*norm);
     break;
-
   case DTYPE_GC:
-    n += n;
+    n *= 2; // use 2 random double
     MDS_ATTR_FALLTHROUGH
   case DTYPE_G:
-    LoadRandomFloat(DTYPE_G, double, (Tdi_RandomSeed * norm + Tdi_RandomSeed) * norm + half);
+    LoadRandomFloat(DTYPE_G, double, (rand32()*norm+rand32())*norm);
     break;
-
   case DTYPE_FTC:
-    n += n;
+    n *= 2; // use 2 random double
     MDS_ATTR_FALLTHROUGH
   case DTYPE_FT:
-    LoadRandomFloat(DTYPE_FT, double, (Tdi_RandomSeed * norm + Tdi_RandomSeed) * norm + half);
+    LoadRandomFloat(DTYPE_FT, double, (rand32()*norm+rand32())*norm);
     break;
-
   }
+  pthread_mutex_unlock(&lock);
   return status;
 }
 
 /*---------------------------------------------------------------------
         Create an array of zeroes.
 */
-int Tdi3Zero(struct descriptor_a *out_ptr)
-{
+int Tdi3Zero(struct descriptor_a *out_ptr){
   STATIC_CONSTANT int i0 = 0;
   STATIC_CONSTANT struct descriptor con0 = { sizeof(int), DTYPE_L, CLASS_S, (char *)&i0 };
   return TdiConvert(&con0, out_ptr);

--- a/tdishr/TdiChar.c
+++ b/tdishr/TdiChar.c
@@ -106,15 +106,12 @@ int Tdi3Char(struct descriptor *in_ptr, struct descriptor *kind_ptr __attribute_
   char *p1 = in_ptr->pointer;
   char *p2 = out_ptr->pointer;
   int step = in_ptr->length, n;
-
-  N_ELEMENTS(out_ptr, n);
 #ifdef WORDS_BIGENDIAN
-  for (; --n >= 0; p1 += step)
-    *p2++ = *(p1 + step - 1);
-#else
+  p1 += step - 1;
+#endif
+  N_ELEMENTS(out_ptr, n);
   for (; --n >= 0; p1 += step)
     *p2++ = *(p1);
-#endif
   return status;
 }
 
@@ -216,25 +213,8 @@ int Tdi3Extract(struct descriptor *start_ptr,
                 byte = IACHAR(ascii-text)
                 byte = ICHAR(text)
 */
-int Tdi3Ichar(struct descriptor *in_ptr, struct descriptor *out_ptr)
-{
-  INIT_STATUS;
-  int step = in_ptr->length;
-  char *p1 = in_ptr->pointer;
-  char *p2 = out_ptr->pointer;
-  int n;
-
-  N_ELEMENTS(out_ptr, n);
-#ifdef WORDS_BIGENDIAN
-  if STATUS_OK
-    for (; --n >= 0; p1 += step)
-      *p2++ = *(p1 + step - 1);
-#else
-  if STATUS_OK
-    for (; --n >= 0; p1 += step)
-      *p2++ = *(p1);
-#endif
-  return status;
+int Tdi3Ichar(struct descriptor *in_ptr, struct descriptor *out_ptr){
+  return Tdi3Char(in_ptr,NULL,out_ptr);
 }
 
 /*------------------------------------------------------------------------------

--- a/tdishr/TdiConvert.c
+++ b/tdishr/TdiConvert.c
@@ -24,7 +24,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 #include <string.h>
 #include <stdio.h>
-#include <inttypes.h>
+#include <int128.h>
 #include <mdsdescrip.h>
 #include <tdishr_messages.h>
 #include <math.h>
@@ -834,16 +834,16 @@ STATIC_ROUTINE void DOUBLEC_TO_TEXT(int itype, char *pa, char *pb, int numb, int
   }
 }
 
-#define BU_T(lena,pa,lenb,pb,numb)  TO_TEXT(pa,unsigned char,pb,numb,sprintf(text,"%u",(unsigned int)*ip++))
-#define WU_T(lena,pa,lenb,pb,numb)  TO_TEXT(pa,unsigned short,pb,numb,sprintf(text,"%u",(unsigned int)*ip++))
-#define LU_T(lena,pa,lenb,pb,numb)  TO_TEXT(pa,unsigned int,pb,numb,sprintf(text,"%u",(unsigned int)*ip++))
-#define QU_T(lena,pa,lenb,pb,numb)  TO_TEXT(pa,uint64_t,pb,numb,sprintf(text,"%"PRIu64,(uint64_t)*ip++))
-#define B_T(lena,pa,lenb,pb,numb)   TO_TEXT(pa,char,pb,numb,sprintf(text,"%d",(int)*ip++))
-#define W_T(lena,pa,lenb,pb,numb)   TO_TEXT(pa,short,pb,numb,sprintf(text,"%d",(int)*ip++))
-#define L_T(lena,pa,lenb,pb,numb)   TO_TEXT(pa,int,pb,numb,sprintf(text,"%d",(int)*ip++))
-#define Q_T(lena,pa,lenb,pb,numb)   TO_TEXT(pa,int64_t,pb,numb,sprintf(text,"%"PRId64,(int64_t)*ip++))
-#define OU_T(lena,pa,lenb,pb,numb)  TO_TEXT(pa,unsigned int,pb,numb,sprintf(text,"%#x%08x%08x%08x",ip[3],ip[2],ip[1],ip[0]);ip +=4)
-#define O_T(lena,pa,lenb,pb,numb)   TO_TEXT(pa,unsigned int,pb,numb,sprintf(text,"%#x%08x%08x%08x",ip[3],ip[2],ip[1],ip[0]);ip +=4)
+#define BU_T(lena,pa,lenb,pb,numb)  TO_TEXT(pa,  uint8_t,pb,numb,sprintf(text,"%"PRIu8, *ip++))
+#define WU_T(lena,pa,lenb,pb,numb)  TO_TEXT(pa, uint16_t,pb,numb,sprintf(text,"%"PRIu16,*ip++))
+#define LU_T(lena,pa,lenb,pb,numb)  TO_TEXT(pa, uint32_t,pb,numb,sprintf(text,"%"PRIu32,*ip++))
+#define QU_T(lena,pa,lenb,pb,numb)  TO_TEXT(pa, uint64_t,pb,numb,sprintf(text,"%"PRIu64,*ip++))
+#define B_T(lena,pa,lenb,pb,numb)   TO_TEXT(pa,   int8_t,pb,numb,sprintf(text,"%"PRId8, *ip++))
+#define W_T(lena,pa,lenb,pb,numb)   TO_TEXT(pa,  int16_t,pb,numb,sprintf(text,"%"PRId16,*ip++))
+#define L_T(lena,pa,lenb,pb,numb)   TO_TEXT(pa,  int32_t,pb,numb,sprintf(text,"%"PRId32,*ip++))
+#define Q_T(lena,pa,lenb,pb,numb)   TO_TEXT(pa,  int64_t,pb,numb,sprintf(text,"%"PRId64,*ip++))
+#define OU_T(lena,pa,lenb,pb,numb)  TO_TEXT(pa,uint128_t,pb,numb,sprintf(text,"%s",uint128_deco(ip++,int128_buf)))
+#define O_T(lena,pa,lenb,pb,numb)   TO_TEXT(pa, int128_t,pb,numb,sprintf(text,"%s", int128_deco(ip++,int128_buf)))
 #if DTYPE_F == DTYPE_NATIVE_FLOAT
 #define F_T(lena,pa,lenb,pb,numb)   FLOAT_TO_TEXT(DTYPE_F,pa,pb,numb,lenb,'E'); status=1
 #define FS_T(lena,pa,lenb,pb,numb)  FLOAT_TO_TEXT(DTYPE_FS,pa,pb,numb,lenb,'S'); status=1
@@ -987,6 +987,7 @@ EXPORT int TdiConvert(struct descriptor_a *pdin, struct descriptor_a *pdout)
     goto same;
   } else {
 	/** big branch **/
+    INT128_BUF(int128_buf);
     n = MAXTYPE * dtypea + dtypeb;
     switch (n) {
       defset(BU)

--- a/tdishr/TdiDecompile.c
+++ b/tdishr/TdiDecompile.c
@@ -500,6 +500,8 @@ int Tdi0Decompile(struct descriptor *in_ptr, int prec, struct descriptor_d *out_
     case DTYPE_LU:
     case DTYPE_Q:
     case DTYPE_QU:
+    case DTYPE_O:
+    case DTYPE_OU:
       cdsc.length = (unsigned short)(in_ptr->length * 2.4 + 1.6);
       status = TdiConvert(in_ptr, &cdsc MDS_END_ARG);
       if STATUS_OK
@@ -513,41 +515,6 @@ int Tdi0Decompile(struct descriptor *in_ptr, int prec, struct descriptor_d *out_
 		      (struct descriptor *)out_ptr, &cdsc, &sdsc MDS_END_ARG);
       }
       break;
-
-		/***********************************************
-                Assumes: low-order byte is first. right-to-left.
-                ***********************************************/
-    case DTYPE_O:
-    case DTYPE_OU:
-      cptr = c0;
-      j = in_ptr->length;
-#ifdef WORDS_BIGENDIAN
-      bptr = in_ptr->pointer - 1;
-      while (--j >= 0) {
-	*cptr++ = htab[(*(++bptr) >> 4) & 15];
-	*cptr++ = htab[*bptr & 15];
-      }
-#else
-      bptr = in_ptr->pointer + j;
-      while (--j >= 0) {
-	*cptr++ = htab[(*(--bptr) >> 4) & 15];
-	*cptr++ = htab[*bptr & 15];
-      }
-#endif
-      while (cdsc.pointer < cptr - 1 && *cdsc.pointer == '0') {
-	cdsc.pointer++;
-      }
-      cdsc.length = (unsigned short)(cptr - cdsc.pointer);
-      {
-	struct descriptor sdsc = { 0, DTYPE_T, CLASS_S, 0 };
-	sdsc.length = (unsigned short)strlen(TdiREF_CAT[dtype].name);
-	sdsc.pointer = TdiREF_CAT[dtype].name;
-	status =
-	    StrConcat((struct descriptor *)out_ptr,
-		      (struct descriptor *)out_ptr, &HEX, &cdsc, &sdsc MDS_END_ARG);
-      }
-      break;
-
     case DTYPE_D:
     case DTYPE_F:
     case DTYPE_G:

--- a/tdishr/TdiDivide.c
+++ b/tdishr/TdiDivide.c
@@ -56,19 +56,12 @@ int Tdi3Divide(struct descriptor *in1, struct descriptor *in2, struct descriptor
 #include <mdsdescrip.h>
 #include <mdstypes.h>
 #include <tdishr_messages.h>
+#include <int128.h>
 
 
 
 extern int CvtConvertFloat();
-extern double WideIntToDouble();
-extern void DoubleToWideInt();
 STATIC_CONSTANT int roprand = 0x8000;
-typedef struct {
-  int longword[2];
-} quadword;
-typedef struct {
-  int longword[4];
-} octaword;
 
 #define SetupArgs \
   struct descriptor_a *ina1 = (struct descriptor_a *)in1;\
@@ -136,22 +129,15 @@ typedef struct {
   break;\
 }
 
-#define OperateWideOne(type,size,is_signed) \
-  double a = WideIntToDouble(in1p,size,is_signed);	\
-  double b = WideIntToDouble(in2p,size,is_signed);	\
-  double ans = (b != 0) ? a/b : (double)0.0;			\
-  DoubleToWideInt(&ans,size,outp++);
-
-#define OperateWide(type,size,is_signed) \
-{ type *in1p = (type *)in1->pointer;\
-  type *in2p = (type *)in2->pointer;\
-  type *outp = (type *)out->pointer;\
-  switch (scalars)\
-  {\
-    case 0: \
-    case 3: while (nout--) { OperateWideOne(type,size,is_signed) in1p++; in2p++; } break;\
-    case 1: while (nout--) { OperateWideOne(type,size,is_signed)         in2p++; } break;\
-    case 2: while (nout--) { OperateWideOne(type,size,is_signed) in1p++;         } break;\
+#define Operate128(type) {\
+  type##_t *in1p = (type##_t *)in1->pointer;\
+  type##_t *in2p = (type##_t *)in2->pointer;\
+  type##_t *outp = (type##_t *)out->pointer;\
+  switch (scalars) {\
+    case 0: while (nout--) type##_div(in1p++,in2p++,outp++); break;\
+    case 1: while (nout--) type##_div(in1p  ,in2p++,outp++); break;\
+    case 2: while (nout--) type##_div(in1p  ,in2p++,outp++); break;\
+    case 3:                type##_div(in1p  ,in2p  ,outp  ); break;\
   }\
   break;\
 }
@@ -214,8 +200,8 @@ int Tdi3Divide(struct descriptor *in1, struct descriptor *in2, struct descriptor
     case DTYPE_LU: Operate(unsigned int)
     case DTYPE_Q:  Operate(int64_t);
     case DTYPE_QU: Operate(uint64_t);
-    case DTYPE_O:  OperateWide(octaword, 4, 1);
-    case DTYPE_OU: OperateWide(octaword, 4, 0);
+    case DTYPE_O:  Operate128( int128);
+    case DTYPE_OU: Operate128(uint128);
     case DTYPE_F:  OperateF(float, DTYPE_F, DTYPE_NATIVE_FLOAT)
     case DTYPE_FS: OperateF(float, DTYPE_FS, DTYPE_NATIVE_FLOAT)
     case DTYPE_G:  OperateF(double, DTYPE_G, DTYPE_NATIVE_DOUBLE)
@@ -230,27 +216,3 @@ int Tdi3Divide(struct descriptor *in1, struct descriptor *in2, struct descriptor
   }
   return 1;
 }
-
-/*  CMS REPLACEMENT HISTORY, Element Tdi3Divide.C */
-/*  *21   15-AUG-1996 15:48:38 TWF "Fix complex divide" */
-/*  *20   15-AUG-1996 15:32:03 TWF "Fix complex divide" */
-/*  *19   15-AUG-1996 15:04:55 TWF "Ieee support" */
-/*  *18    6-AUG-1996 11:33:54 TWF "Fix complex divide" */
-/*  *17    1-AUG-1996 17:21:14 TWF "Use int instead of long" */
-/*  *16   30-JUL-1996 09:05:31 TWF "Fix divide of complex" */
-/*  *15   29-JUL-1996 15:40:37 TWF "Fix addx and subx calls" */
-/*  *14   26-JUL-1996 12:24:51 TWF "Special handling for alpha and vms" */
-/*  *13   24-JUN-1996 14:44:08 TWF "Port to Unix/Windows" */
-/*  *12   17-OCT-1995 16:16:59 TWF "use <builtins.h> form" */
-/*  *11   19-OCT-1994 12:26:23 TWF "Use TDI$MESSAGES" */
-/*  *10   19-OCT-1994 10:39:13 TWF "No longer support VAXC" */
-/*  *9    19-OCT-1994 10:33:34 TWF "No longer support VAXC" */
-/*  *8    15-NOV-1993 10:09:44 TWF "Add memory block" */
-/*  *7    15-NOV-1993 09:42:20 TWF "Add memory block" */
-/*  *6    16-OCT-1993 13:01:50 MRL "" */
-/*  *5    16-OCT-1993 12:51:23 MRL "" */
-/*  *4    15-OCT-1993 18:11:03 MRL "" */
-/*  *3    15-OCT-1993 17:53:26 MRL "" */
-/*  *2     8-OCT-1993 09:51:06 MRL "" */
-/*  *1     7-OCT-1993 15:40:08 MRL "" */
-/*  CMS REPLACEMENT HISTORY, Element Tdi3Divide.C */

--- a/tdishr/TdiMaxVal.c
+++ b/tdishr/TdiMaxVal.c
@@ -93,19 +93,14 @@ const int roprand = 0x8000;
 #define  int64_min 0x8000000000000000;
 
 #if DTYPE_NATIVE_DOUBLE == DTYPE_D
-#define HUGE 1.7E38
+#define DHUGE 1.7E38
 #elif DTYPE_NATIVE_DOUBLE == DTYPE_G
-#define HUGE 8.9E307
+#define DHUGE 8.9E307
 #else
-#define HUGE 1.7E308
+#define DHUGE 1.7E308
 #endif
-
-static void TdiDivO(const char *in1,const char *in2,char *out){
- //DESCRIPTOR_A(name, len, type, ptr, arsize)
- const DESCRIPTOR_A(i1, sizeof(int128_t), DTYPE_O, in1, sizeof(int128_t));
- const DESCRIPTOR_A(i2, sizeof(int128_t), DTYPE_O, in2, sizeof(int128_t));
-       DESCRIPTOR_A(o,  sizeof(int128_t), DTYPE_O, out, sizeof(int128_t));
- Tdi3Divide(&i1,&i2,&o);
+static inline void TdiDivO(const char *in1,const char *in2,char *out){
+  int128_div(( int128_t*)in1,( int128_t*)in2,( int128_t*)out);
 }
 
 int TdiLtO(unsigned int *in1, unsigned int *in2, int is_signed){
@@ -316,11 +311,11 @@ int Tdi3MaxLoc(struct descriptor *in, struct descriptor *mask,
   case DTYPE_QU: OperateIloc( uint64_t,          0, uint64_gt);break;
   case DTYPE_O:  OperateIloc( int128_t, int128_min,(void*)int128_gt);break;
   case DTYPE_OU: OperateIloc(uint128_t,uint128_min,(void*)uint128_gt);break;
-  case DTYPE_F:  OperateFloc(DTYPE_F, -HUGE, gt,&args);break;
-  case DTYPE_FS: OperateFloc(DTYPE_FS,-HUGE, gt,&args);break;
-  case DTYPE_G:  OperateFloc(DTYPE_G, -HUGE, gt,&args);break;
-  case DTYPE_D:  OperateFloc(DTYPE_D, -HUGE, gt,&args);break;
-  case DTYPE_FT: OperateFloc(DTYPE_FT,-HUGE, gt,&args);break;
+  case DTYPE_F:  OperateFloc(DTYPE_F, -DHUGE, gt,&args);break;
+  case DTYPE_FS: OperateFloc(DTYPE_FS,-DHUGE, gt,&args);break;
+  case DTYPE_G:  OperateFloc(DTYPE_G, -DHUGE, gt,&args);break;
+  case DTYPE_D:  OperateFloc(DTYPE_D, -DHUGE, gt,&args);break;
+  case DTYPE_FT: OperateFloc(DTYPE_FT,-DHUGE, gt,&args);break;
   default:return TdiINVDTYDSC;
   }
   return 1;
@@ -342,11 +337,11 @@ int Tdi3MinLoc(struct descriptor *in, struct descriptor *mask,
   case DTYPE_QU: {OperateIloc( uint64_t,         -1, uint64_lt);break;}
   case DTYPE_O:  {OperateIloc( int128_t, int128_max,(void*) int128_lt);break;}
   case DTYPE_OU: {OperateIloc(uint128_t,uint128_max,(void*)uint128_lt);break;}
-  case DTYPE_F:  {OperateFloc(DTYPE_F, -HUGE, lt,&args);break;}
-  case DTYPE_FS: {OperateFloc(DTYPE_FS,-HUGE, lt,&args);break;}
-  case DTYPE_G:  {OperateFloc(DTYPE_G, -HUGE, lt,&args);break;}
-  case DTYPE_D:  {OperateFloc(DTYPE_D, -HUGE, lt,&args);break;}
-  case DTYPE_FT: {OperateFloc(DTYPE_FT,-HUGE, lt,&args);break;}
+  case DTYPE_F:  {OperateFloc(DTYPE_F,  DHUGE, lt,&args);break;}
+  case DTYPE_FS: {OperateFloc(DTYPE_FS, DHUGE, lt,&args);break;}
+  case DTYPE_G:  {OperateFloc(DTYPE_G,  DHUGE, lt,&args);break;}
+  case DTYPE_D:  {OperateFloc(DTYPE_D,  DHUGE, lt,&args);break;}
+  case DTYPE_FT: {OperateFloc(DTYPE_FT, DHUGE, lt,&args);break;}
   default:return TdiINVDTYDSC;
   }
   return 1;
@@ -431,11 +426,11 @@ int Tdi3MaxVal(struct descriptor *in, struct descriptor *mask,
   case DTYPE_QU: OperateIval( uint64_t,          0, uint64_gt);break;
   case DTYPE_O:  OperateIval( int128_t, int128_min,(void*) int128_gt);break;
   case DTYPE_OU: OperateIval(uint128_t,uint128_min,(void*)uint128_gt);break;
-  case DTYPE_F:  OperateFval(DTYPE_F, -HUGE, gt,&args);break;
-  case DTYPE_FS: OperateFval(DTYPE_FS,-HUGE, gt,&args);break;
-  case DTYPE_G:  OperateFval(DTYPE_G, -HUGE, gt,&args);break;
-  case DTYPE_D:  OperateFval(DTYPE_D, -HUGE, gt,&args);break;
-  case DTYPE_FT: OperateFval(DTYPE_FT,-HUGE, gt,&args);break;
+  case DTYPE_F:  OperateFval(DTYPE_F, -DHUGE, gt,&args);break;
+  case DTYPE_FS: OperateFval(DTYPE_FS,-DHUGE, gt,&args);break;
+  case DTYPE_G:  OperateFval(DTYPE_G, -DHUGE, gt,&args);break;
+  case DTYPE_D:  OperateFval(DTYPE_D, -DHUGE, gt,&args);break;
+  case DTYPE_FT: OperateFval(DTYPE_FT,-DHUGE, gt,&args);break;
   default:return TdiINVDTYDSC;
   }
   return 1;
@@ -457,11 +452,11 @@ int Tdi3MinVal(struct descriptor *in, struct descriptor *mask,
   case DTYPE_QU: OperateIval( uint64_t,         -1, uint64_lt);break;
   case DTYPE_O:  OperateIval( int128_t, int128_max,(void*) int128_lt);break;
   case DTYPE_OU: OperateIval(uint128_t,uint128_max,(void*)uint128_lt);break;
-  case DTYPE_F:  OperateFval(DTYPE_F, -HUGE, lt,&args);break;
-  case DTYPE_FS: OperateFval(DTYPE_FS,-HUGE, lt,&args);break;
-  case DTYPE_G:  OperateFval(DTYPE_G, -HUGE, lt,&args);break;
-  case DTYPE_D:  OperateFval(DTYPE_D, -HUGE, lt,&args);break;
-  case DTYPE_FT: OperateFval(DTYPE_FT,-HUGE, lt,&args);break;
+  case DTYPE_F:  OperateFval(DTYPE_F,  DHUGE, lt,&args);break;
+  case DTYPE_FS: OperateFval(DTYPE_FS, DHUGE, lt,&args);break;
+  case DTYPE_G:  OperateFval(DTYPE_G,  DHUGE, lt,&args);break;
+  case DTYPE_D:  OperateFval(DTYPE_D,  DHUGE, lt,&args);break;
+  case DTYPE_FT: OperateFval(DTYPE_FT, DHUGE, lt,&args);break;
   default:return TdiINVDTYDSC;
   }
   return 1;

--- a/tdishr/TdiMaxVal.c
+++ b/tdishr/TdiMaxVal.c
@@ -87,11 +87,6 @@ extern int CvtConvertFloat();
 
 const int roprand = 0x8000;
 
-#define uint64_max 0xffffffffffffffff;
-#define uint64_min 0x0000000000000000;
-#define  int64_max 0x7fffffffffffffff;
-#define  int64_min 0x8000000000000000;
-
 #if DTYPE_NATIVE_DOUBLE == DTYPE_D
 #define DHUGE 1.7E38
 #elif DTYPE_NATIVE_DOUBLE == DTYPE_G


### PR DESCRIPTION
* use u/int64_t datatypes instead of own typedefs
* fixes many issues with octaword operations e.g. division, decompile to decimal
* use system's RNG
* removed redundant code in TdiAnd
* centralized int128 operations in int128.h header