### PR TITLE
Zck int128

### DIFF
--- a/deploy/packaging/debian/devel.noarch
+++ b/deploy/packaging/debian/devel.noarch
@@ -31,6 +31,7 @@
 ./usr/local/mdsplus/include/camshr_messages.h
 ./usr/local/mdsplus/include/dbidef.h
 ./usr/local/mdsplus/include/dcl.h
+./usr/local/mdsplus/include/int128.h
 ./usr/local/mdsplus/include/ipdesc.h
 ./usr/local/mdsplus/include/libroutines.h
 ./usr/local/mdsplus/include/mds_gendevice.h

--- a/deploy/packaging/redhat/devel.noarch
+++ b/deploy/packaging/redhat/devel.noarch
@@ -33,6 +33,7 @@
 ./usr/local/mdsplus/include/camshr_messages.h
 ./usr/local/mdsplus/include/dbidef.h
 ./usr/local/mdsplus/include/dcl.h
+./usr/local/mdsplus/include/int128.h
 ./usr/local/mdsplus/include/ipdesc.h
 ./usr/local/mdsplus/include/libroutines.h
 ./usr/local/mdsplus/include/mds_gendevice.h

--- a/include/int128.h
+++ b/include/int128.h
@@ -2,7 +2,9 @@
 #include <string.h>
 #include <inttypes.h>
 #include <math.h>
+#include <stdio.h>
 
+//#define DEBUG
 
 #define uint64_max 0xffffffffffffffffLL
 #define uint64_min 0x0000000000000000LL
@@ -17,9 +19,6 @@
    uint64_t high;
    uint64_t low;
  } uint128_t;
- #define int128_one  { 0, 1 };
- #define int128_max  { int64_max,-1 };
- #define int128_min  { int64_min, 0 };
 #else
  typedef struct int128_s{
    uint64_t low;
@@ -29,13 +28,65 @@
    uint64_t low;
    uint64_t high;
  } uint128_t;
- #define int128_one  { 1, 0 };
- #define int128_max  {-1, int64_max };
- #define int128_min  { 0, int64_min };
 #endif
-#define int128_zero { 0, 0 };
-#define uint128_max {-1,-1 };
-#define uint128_min { 0, 0 };
+#define  int128_one  { .high=0,         .low=1          };
+#define  int128_zero { .high=0,         .low=0          };
+#define  int128_max  { .high=int64_max, .low=uint64_max };
+#define  int128_min  { .high=int64_min, .low=uint64_max };
+#define uint128_max  { .high=uint64_max,.low=uint64_max };
+#define uint128_min  { .high=uint64_min,.low=uint64_min };
+
+static inline void int128_minus(const int128_t *a, int128_t *ans){
+  ans->high = ~(a->high);
+  ans->low  = ~(a->low);
+  ans->low++;
+  if (ans->low == 0)
+    ans->high++;
+}
+
+static inline int int128_abs(const int128_t* x, int128_t* r){
+  if (x->high>=0) {
+    if (x!=r) memcpy(r,x,sizeof(int128_t));
+    return 0;
+  }
+  int128_minus(x,r);
+  return 1;
+}
+
+#define INT128_BUFLEN 128/3+2
+#define INT128_BUF(buf) char buf[INT128_BUFLEN]
+static char* uint128_deco(const uint128_t* in, char* p){
+  uint128_t n;
+  int i;
+  memset(p, '0', INT128_BUFLEN - 1);
+  p[INT128_BUFLEN - 1] = '\0';
+  memcpy(&n, in, sizeof(n));
+  for (i = 0; i < 128; i++){
+    int j, carry;
+    carry = (n.high > int64_max);
+    // Shift n[] left, doubling it
+    n.high= (n.high << 1) + (n.low > int64_max);
+    n.low = (n.low  << 1);
+    // Add s[] to itself in decimal, doubling it
+    for (j=INT128_BUFLEN-1 ; j-->0 ;) {
+      p[j] += p[j] - '0' + carry;
+      carry = (p[j] > '9');
+      if (carry) p[j] -= 10;
+    }
+  }
+  char *max = &p[INT128_BUFLEN-2];
+  for(;(p[0] == '0') && (p < max); p++);
+  return p;
+}
+
+static inline char* int128_deco(const int128_t* in, char* p){
+ int128_t a;
+ int s = int128_abs(in,&a);
+ p = uint128_deco((uint128_t*)&a, p);
+ if (s) (--p)[0]='-';
+ return p;
+}
+
 
 static inline int uint128_gt(const uint128_t *a, const uint128_t *b){
   if (a->high==b->high)
@@ -59,23 +110,6 @@ static inline int int128_lt(const int128_t *a, const int128_t *b){
   if (a->high==b->high)
     return a->low < b->low;
   return a->high < b->high;
-}
-
-static inline void int128_minus(const int128_t *a, int128_t *ans){
-  ans->high = ~(a->high);
-  ans->low  = ~(a->low);
-  ans->low++;
-  if (ans->low == 0)
-    ans->high++;
-}
-
-static inline int int128_abs(const int128_t* x, int128_t* r){
-  if (x->high>=0) {
-    if (x!=r) memcpy(r,x,sizeof(int128_t));
-    return 0;
-  }
-  int128_minus(x,r);
-  return 1;
 }
 
 static inline int uint128_add(const uint128_t *a, const uint128_t *b, uint128_t *ans){
@@ -114,118 +148,99 @@ static inline int int128_sub(const int128_t* a, const int128_t* b, int128_t *ans
   return ans->high > aa.high;
 }
 
+#define HI_INT 0xFFFFFFFF00000000LL
+#define LO_INT 0x00000000FFFFFFFFLL
 static inline int uint128_mul(const uint128_t* x, const uint128_t* y, uint128_t *ans){
-  #define HI_INT 0xFFFFFFFF00000000LL
-  #define LO_INT 0x00000000FFFFFFFFLL
   /* as by 128-bit integer arithmetic for C++, by Robert Munafo */
-  uint64_t acc, ac2, carry, o1, o2;
-  uint64_t a, b, c, d, e, f, g, h;
+  uint64_t a[4], b[4], A[4];
+  a[0] = (x->high & HI_INT) >> 32LL;
+  a[1] =  x->high & LO_INT;
+  a[2] = (x->low  & HI_INT) >> 32LL;
+  a[3] =  x->low  & LO_INT;
 
-/************************
- x      a  b  c  d
- y      e  f  g  h
--------------------------
-        -o2-  -o1-
- ************************/
-
-  d =  x->low  & LO_INT;
-  c = (x->low  & HI_INT) >> 32LL;
-  b =  x->high & LO_INT;
-  a = (x->high & HI_INT) >> 32LL;
-
-  h =  y->low  & LO_INT;
-  g = (y->low  & HI_INT) >> 32LL;
-  f =  y->high & LO_INT;
-  e = (y->high & HI_INT) >> 32LL;
-
-  acc = d * h;
-  o1  = acc & LO_INT;
-  acc >>= 32LL;
-  carry = 0;
-  ac2 = acc + c * h; if (ac2 < acc) { carry++; }
-  acc = ac2 + d * g; if (acc < ac2) { carry++; }
-  ans->low = o1 | (acc << 32LL);
-  ac2 = (acc >> 32LL) | (carry << 32LL); carry = 0;
-
-  acc = ac2 + b * h; if (acc < ac2) { carry++; }
-  ac2 = acc + c * g; if (ac2 < acc) { carry++; }
-  acc = ac2 + d * f; if (acc < ac2) { carry++; }
-  o2  = acc & LO_INT;
-  ac2 = (acc >> 32LL) | (carry << 32LL);
-
-  acc = ac2 + a * h;
-  ac2 = acc + b * g;
-  acc = ac2 + c * f;
-  ac2 = acc + d * e;
-  ans->high = (ac2 << 32LL) | o2;
-  return ((acc >> 32LL) | (carry << 32LL))==0; // 1 if no overflow
-}
-
-static inline int int128_mul(const int128_t* x, const int128_t* d, int128_t* r){
-  uint128_t ux,ud;
-  int mns = (int128_abs(x,(int128_t*)&ux) ^ int128_abs(d,(int128_t*)&ud));
-  uint128_mul(&ux,&ud,(uint128_t*)r);
-  if (mns) int128_minus(r,r);
-  return 1;
-}
-
-static inline int uint128_div(const uint128_t* x, const uint128_t* d, uint128_t* r){
-  const double hifac = ((double)((uint64_t)-1)+1);
-  memset(r,0,sizeof(int128_t));
-  if ((d->low == 0) && (d->high == 0))
-    return 1;
-  double dd = (double)d->low + hifac*(double)d->high;
-  uint128_t t,a;
-  memcpy(&a,x,sizeof(int128_t));
-  double dr;
-  while ((dr = ((double)a.low + hifac*(double)a.high) / dd)>=1) {
-    t.low  = (uint64_t)fmod(dr,hifac);
-    t.high =  (int64_t)(dr/hifac);
-    uint128_add(&t,r,r);
-    uint128_mul(d,&t,&t);
-    uint128_sub(&a,&t,&a);
-  } // 'a' is the remainder
-  return (a.low == 0) && (a.high == 0); // 1 if no remainder
-}
-
-static inline int int128_div(const int128_t* x, const int128_t* d, int128_t* r){
-  uint128_t ux,ud;
-  int mns = (int128_abs(x,(int128_t*)&ux) ^ int128_abs(d,(int128_t*)&ud));
-  uint128_div(&ux,&ud,(uint128_t*)r);
-  if (mns) int128_minus(r,r);
-  return 1;
-}
-
-#define INT128_BUFLEN 128/3+2
-#define INT128_BUF(buf) char buf[INT128_BUFLEN]
-static inline char* uint128_deco(const uint128_t* in, char* p){
-  uint128_t n;
-  int i;
-  memset(p, '0', INT128_BUFLEN - 1);
-  p[INT128_BUFLEN - 1] = '\0';
-  memcpy(&n, in, sizeof(n));
-  for (i = 0; i < 128; i++){
-    int j, carry;
-    carry = (n.high > int64_max);
-    // Shift n[] left, doubling it
-    n.high= (n.high << 1) + (n.low > int64_max);
-    n.low = (n.low  << 1);
-    // Add s[] to itself in decimal, doubling it
-    for (j=INT128_BUFLEN-1 ; j-->0 ;) {
-      p[j] += p[j] - '0' + carry;
-      carry = (p[j] > '9');
-      if (carry) p[j] -= 10;
+  b[0] = (y->high & HI_INT) >> 32LL;
+  b[1] =  y->high & LO_INT;
+  b[2] = (y->low  & HI_INT) >> 32LL;
+  b[3] =  y->low  & LO_INT;
+  int i,j;
+  uint64_t carry,acc = 0;
+  for (j=4 ; j-->0 ;) {
+    carry = 0;
+    for (i=4; i-->j;) {
+      uint64_t ac2 = acc + a[i] * b[j-i+3];
+      if (ac2 < acc) carry++;
+      acc = ac2;
     }
+    A[j] = acc & LO_INT;
+    acc = (acc >> 32LL) | (carry << 32LL);
   }
-  char *max = &p[INT128_BUFLEN-2];
-  for(;(p[0] == '0') && (p < max); p++);
-  return p;
+  ans->high = A[0] << 32LL | A[1];
+  ans->low  = A[2] << 32LL | A[3];
+  return carry==0 && (acc&HI_INT)==0;
 }
 
-static inline char* int128_deco(const int128_t* in, char* p){
- int128_t a;
- int s = int128_abs(in,&a);
- p = uint128_deco((uint128_t*)&a, p);
- if (s) (--p)[0]='-';
- return p;
+static inline int int128_mul(const int128_t* x, const int128_t* d, int128_t* ans){
+  uint128_t ux,ud;
+  int mns = (int128_abs(x,(int128_t*)&ux) ^ int128_abs(d,(int128_t*)&ud));
+  uint128_mul(&ux,&ud,(uint128_t*)ans);
+  if (mns) int128_minus(ans,ans);
+  return 1;
+}
+
+static inline int uint128_div(const uint128_t* x, const uint128_t* y, uint128_t* ans){
+  if (y->low==0 && y->high==0) {
+    ans->low=0;ans->high=0;
+    return 1;
+  }
+  if (y->low==1 && y->high==0) {
+    memcpy(ans,x,sizeof(uint128_t));
+    return 1;
+  }
+  if (uint128_lt(x,y)) {
+    ans->low=0;ans->high=0;
+    return 0;
+  }
+  int p = 0;
+  uint128_t n;memcpy(&n,x,sizeof(uint128_t));
+  uint128_t d;memcpy(&d,y,sizeof(uint128_t));
+  uint128_sub(&n,&d,&n);
+  while (!uint128_lt(&n,&d)) {
+    uint128_sub(&n,&d,&n);
+    //shift left (*2)
+    d.high=d.high<<1 | d.low>>63; d.low=d.low<<1;
+    p++;
+  }
+  uint128_add(&n,&d,&n);
+  memset(ans,0,sizeof(uint128_t));
+  for (;p>=64;p--) {
+    if (!uint128_lt(&n,&d)) {
+      uint128_sub(&n,&d,&n);
+      ans->high |= 1LL<<(p-64);
+    }
+    //shift right (/2)
+    d.low=d.low>>1|d.high<<63, d.high=d.high>>1;
+  }
+  for (;p>=0;p--) {
+    if (!uint128_lt(&n,&d)) {
+      uint128_sub(&n,&d,&n);
+      ans->low |= 1LL<<p;
+    }
+    //shift right (/2)
+    d.low=d.low>>1|d.high<<63, d.high=d.high>>1;
+  }
+#ifdef DEBUG
+  fprintf(stderr,"  0x%016lx %016lxou\n",x->high,x->low);
+  fprintf(stderr,"/ 0x%016lx %016lxou\n",y->high,y->low);
+  fprintf(stderr,"= 0x%016lx %016lxou\n",ans->high,ans->low);
+  fprintf(stderr,"R 0x%016lx %016lxou\n\n",n.high,n.low);
+#endif
+  return n.low==0 && n.high==0;
+}
+
+static inline int int128_div(const int128_t* x, const int128_t* d, int128_t* ans){
+  uint128_t ux,ud;
+  int mns = (int128_abs(x,(int128_t*)&ux) ^ int128_abs(d,(int128_t*)&ud));
+  uint128_div(&ux,&ud,(uint128_t*)ans);
+  if (mns) int128_minus(ans,ans);
+  return 1;
 }

--- a/include/int128.h
+++ b/include/int128.h
@@ -53,6 +53,49 @@ static inline int int128_abs(const int128_t* x, int128_t* r){
   return 1;
 }
 
+static inline void uint128_lshft(const uint128_t* x, const int n, uint128_t* r){
+  int nn = n%128; if (nn<0) nn+=128;
+  if (nn>63) {
+    r->high = x->low<<(nn-64);               r->low = 0;
+  } else {
+    r->high = x->high<<nn | x->low>>(64-nn); r->low = x->low<<nn;
+  }
+}
+
+static inline void uint128_rshft(const uint128_t* x, const int n, uint128_t* r){
+  int nn = n%128; if (nn<0) nn+=128;
+  if (nn>63) {
+    r->low = x->high>>(nn-64);              r->high = 0;
+  } else {
+    r->low = x->low>>nn | x->high<<(64-nn); r->high = x->high>>nn;
+  }
+}
+
+static inline void int128_lshft(const int128_t* x, const int n, int128_t* r){
+  int nn = n%128; if (nn<0) nn+=128;
+  if (nn>63) {
+    r->high = x->low<<(nn-64);               r->low = 0;
+  } else {
+    r->high = x->high<<nn | x->low>>(64-nn); r->low = x->low<<nn;
+  }
+}
+
+static inline void int128_rshft(const int128_t* x, const int n, int128_t* r){
+  int nn = n%128; if (nn<0) nn+=128;
+  if (nn>63) {
+    r->low = x->high>>(nn-64);              r->high = 0;
+  } else {
+    r->low = x->low>>nn | x->high<<(64-nn); r->high = x->high>>nn;
+  }
+}
+
+static inline void uint128_ishft(const uint128_t* x, const int n, uint128_t* r){
+  if (n<0)
+    return uint128_rshft(x,-n,r);
+  return uint128_lshft(x,n,r);
+}
+#define int128_ishft(x,n,r) uint128_ishft((uint128_t*)x,n,(uint128_t*)r)
+
 #define INT128_BUFLEN 128/3+2
 #define INT128_BUF(buf) char buf[INT128_BUFLEN]
 static char* uint128_deco(const uint128_t* in, char* p){

--- a/include/int128.h
+++ b/include/int128.h
@@ -30,25 +30,25 @@
 #define uint128_max {-1,-1 };
 #define uint128_min { 0, 0 };
 
-int uint128_gt(uint128_t *a, uint128_t *b){
+static inline int uint128_gt(uint128_t *a, uint128_t *b){
   if (a->high==b->high)
     return a->low > b->low;
   return a->high > b->high;
 }
 
-int uint128_lt(uint128_t *a, uint128_t *b){
+static inline int uint128_lt(uint128_t *a, uint128_t *b){
   if (a->high==b->high)
     return a->low < b->low;
   return a->high < b->high;
 }
 
-int int128_gt(int128_t *a, int128_t *b){
+static inline int int128_gt(int128_t *a, int128_t *b){
   if (a->high==b->high)
     return a->low > b->low;
   return a->high > b->high;
 }
 
-int int128_lt(int128_t *a, int128_t *b){
+static inline int int128_lt(int128_t *a, int128_t *b){
   if (a->high==b->high)
     return a->low < b->low;
   return a->high < b->high;

--- a/include/int128.h
+++ b/include/int128.h
@@ -1,0 +1,149 @@
+#pragma once
+
+#ifdef WORDS_BIGENDIAN
+ typedef struct int128_s{
+   uint64_t high;
+   uint64_t low;
+ } int128_t;
+ const int128_t int128_one = {1,0};
+#else
+ typedef struct int128_s{
+   uint64_t low;
+   uint64_t high;
+ } int128_t;
+ const int128_t int128_one = {0,1};
+#endif
+const int128_t int128_zero = {0,0};
+#define HI_INT 0xFFFFFFFF00000000LL
+#define LO_INT 0x00000000FFFFFFFFLL
+
+static inline void int128_minus(const int128_t *a, int128_t *ans){
+  ans->high = ~(a->high);
+  ans->low  = ~(a->low);
+  ans->low++;
+  if (ans->low == 0)
+    ans->high++;
+}
+
+static inline int int128_add(const int128_t *a, const int128_t *b, int128_t *ans){
+  int128_t aa;memcpy(&aa,a,sizeof(int128_t));
+  ans->low  = a->low  + b->low;
+  ans->high = a->high + b->high;
+  if (ans->low < aa.low)
+    ans->high++;
+  return ans->high < aa.high;
+}
+
+static inline int int128_sub(const int128_t* a, const int128_t* b, int128_t *ans){
+  int128_t aa;memcpy(&aa,a,sizeof(int128_t));
+  ans->low  = a->low  - b->low;
+  ans->high = a->high - b->high;
+  if (ans->low > aa.low)
+    ans->high--;
+  return ans->high > aa.high;
+}
+
+static inline int int128_mul(const int128_t* x, const int128_t* y, int128_t *ans){
+  /* as by 128-bit integer arithmetic for C++, by Robert Munafo */
+  uint64_t acc, ac2, carry, o1, o2;
+  uint64_t a, b, c, d, e, f, g, h;
+
+/************************
+ x      a  b  c  d
+ y      e  f  g  h
+-------------------------
+        -o2-  -o1-
+ ************************/
+
+  d =  x->low  & LO_INT;
+  c = (x->low  & HI_INT) >> 32LL;
+  b =  x->high & LO_INT;
+  a = (x->high & HI_INT) >> 32LL;
+
+  h =  y->low  & LO_INT;
+  g = (y->low  & HI_INT) >> 32LL;
+  f =  y->high & LO_INT;
+  e = (y->high & HI_INT) >> 32LL;
+
+  acc = d * h;
+  o1  = acc & LO_INT;
+  acc >>= 32LL;
+  carry = 0;
+  ac2 = acc + c * h; if (ac2 < acc) { carry++; }
+  acc = ac2 + d * g; if (acc < ac2) { carry++; }
+  ans->low = o1 | (acc << 32LL);
+  ac2 = (acc >> 32LL) | (carry << 32LL); carry = 0;
+
+  acc = ac2 + b * h; if (acc < ac2) { carry++; }
+  ac2 = acc + c * g; if (ac2 < acc) { carry++; }
+  acc = ac2 + d * f; if (acc < ac2) { carry++; }
+  o2  = acc & LO_INT;
+  ac2 = (acc >> 32LL) | (carry << 32LL);
+
+  acc = ac2 + a * h;
+  ac2 = acc + b * g;
+  acc = ac2 + c * f;
+  ac2 = acc + d * e;
+  ans->high = (ac2 << 32LL) | o2;
+  return  (acc >> 32LL) | (carry << 32LL);
+}
+
+/*
+int int128_div(const int128_t x, const int128_t d, int128_t *r)
+{
+  int s;
+  int128_t d1, p2, rv;
+
+//printf("divide %.16llX %016llX / %.16llX %016llX\n", x.high, x.low, d.high, d.low);
+
+  // check for divide by zero
+  if ((d.low == 0) && (d.high == 0)) {
+    rv.low = x.low / d.low; // This will cause runtime error
+  }
+
+  s = 1;
+  if (x < ((s128_o) 0)) {
+    // notice that MININT will be unchanged, this is used below.
+    s = - s;
+    x = - x;
+  }
+  if (d < ((s128_o) 0)) {
+    s = - s;
+    d = - d;
+  }
+
+  if (d == ((s128_o) 1)) {
+    // This includes the overflow case MININT/-1
+    rv = x;
+    x = 0;
+  } else if (x < ((s128_o) d)) {
+    // x < d, so quotient is 0 and x is remainder
+    rv = 0;
+  } else {
+    rv = 0;
+
+    // calculate biggest power of 2 times d that's <= x
+    p2 = 1; d1 = d;
+    x = x - d1;
+    while(x >= d1) {
+      x = x - d1;
+      d1 = d1 + d1;
+      p2 = p2 + p2;
+    }
+    x = x + d1;
+
+    while(p2.low != 0 || p2.high != 0) {
+      if (x >= d1) {
+        x = x - d1;
+        rv = rv + p2;
+      }
+      p2 = s128_shr(p2);
+      d1 = s128_shr(d1);
+    }
+  }
+
+  if (s < 0) rv.high = - rv.high;
+  if (r)     *r = x;
+  retrun rv;
+}
+*/

--- a/include/opcbuiltins.h
+++ b/include/opcbuiltins.h
@@ -334,10 +334,10 @@ OPC (	Scan,	SCAN ,		Same,	Ttb,		Scan,	T,T,SUBSCRIPT,SUBSCRIPT,2,3,	OK	)/*;f9	(st
 OPC (	Fseek,	FSEEK ,		Fseek,	undef,		undef,		L,L,	L,L,	1,3,	OK+U	)/*;%cc	(unit,[offset],[origin])*/
 OPC (	SetExponent,	SET_EXPONENT ,	Same,	Long2,		SetExponent,	F,HC,	F,HC,	2,2,	OK	)/*;f9	(x,i)			*/
 OPC (	SetRange,	SET_RANGE ,	SetRange, undef,	undef,		XX,YY,	XX,YY,	2,1+MAXDIM,OK+I	)/*;%	(range...,name)		*/
-OPC (	Ishft,	ISHFT ,		Same,	Shft,		Ishft,		BU,Q,	BU,Q,	2,2,	OK	)/*;f9	(a,shift)		*/
-OPC (	Ishftc,	ISHFTC ,		Same,	Shft,		Ishftc,		BU,Q,	BU,Q,	3,3,	OK	)/*;f9	(a,shift,size)		*/
-OPC (	ShiftLeft,	SHIFT_LEFT ,	Same,	Shft,		ShiftLeft,	BU,Q,	BU,Q,	2,2,	SHIFT+S	)/*;%cc	i<<j			*/
-OPC (	ShiftRight,	SHIFT_RIGHT ,	Same,	Shft,		ShiftRight,	BU,Q,	BU,Q,	2,2,	SHIFT+S	)/*;%cc	i>>j sign=signed	*/
+OPC (	Ishft,	ISHFT ,		Same,	Shft,		Ishft,		BU,O,	BU,O,	2,2,	OK	)/*;f9	(a,shift)		*/
+OPC (	Ishftc,	ISHFTC ,		Same,	Shft,		Ishftc,		BU,O,	BU,O,	3,3,	OK	)/*;f9	(a,shift,size)		*/
+OPC (	ShiftLeft,	SHIFT_LEFT ,	Same,	Shft,		ShiftLeft,	BU,O,	BU,O,	2,2,	SHIFT+S	)/*;%cc	i<<j			*/
+OPC (	ShiftRight,	SHIFT_RIGHT ,	Same,	Shft,		ShiftRight,	BU,O,	BU,O,	2,2,	SHIFT+S	)/*;%cc	i>>j sign=signed	*/
 OPC (	Sign,	SIGN ,		Same,	Sign,		Sign,		BU,HC,	BU,HC,	2,2,	OK	)/*;f9	(a,b)			*/
 OPC (	Signed,	SIGNED ,		Same,	Keep,		undef,		B,O,	B,O,	1,1,	CAST+N+I )/*;%	(a)			*/
 OPC (	Sin,	SIN ,		Same,	NoHc,		Sin,		F,HC,	F,HC,	1,1,	OK	)/*;f9	(x) 			*/

--- a/mdsobjects/cpp/testing/MdsTdiTest.cpp
+++ b/mdsobjects/cpp/testing/MdsTdiTest.cpp
@@ -72,18 +72,20 @@ int SingleThreadTest(int idx, int repeats){
   delete MDSplus::executeWithArgs("_SHOT=$",1,shot);
   delete shot;
   delete MDSplus::execute("_EXPT='T_TDI'");
-  int err = 0;
+  int status, err = 0;
   for (; ii<repeats ; ii++) {
     for (;ic<ncmd; ic++) try {
       if (strlen(cmds[ic])==0 || *cmds[ic] == '#') continue;
-      int status = AutoPointer<Data>(MDSplus::execute(cmds[ic]))->getInt();
-      if (!status) throw std::exception();
-      if (!(status&1)) throw MDSplus::MdsException(status);
+      status = AutoPointer<Data>(MDSplus::execute(cmds[ic]))->getInt();
+      if (!status) {
+        std::cerr << "FAILED in cycle " << ii << " >> " << cmds[ic] << "\n";
+        err = 1;
+      } else if (!(status&1)) throw MDSplus::MdsException(status);
     } catch (MDSplus::MdsException e) {
-      std::cerr << "ERROR in cycle " << ii << " >> " << cmds[ic] << "\n";
+      std::cerr << "ERROR in cycle " << ii << ":=" << status << " >> " << cmds[ic] << "\n";
       err = 1;
     } catch (...) {
-      std::cerr << "FAILED in cycle " << ii << " >> " << cmds[ic] << "\n";
+      std::cerr << "Exception in cycle " << ii << " >> " << cmds[ic] << "\n";
       err = 1;
     }
     if (err) break;

--- a/mdsobjects/cpp/testing/MdsTdiTest.tdi
+++ b/mdsobjects/cpp/testing/MdsTdiTest.tdi
@@ -307,7 +307,7 @@ PRODUCT(_a=[[1,2,3],[4,5,6],[7,8,9]],*,[[0,1,0],[1,0,1],[0,1,0]])==384 && all(PR
 PROGRAM_OF(build_program(1,2))==2
 # project (ARRAY,MASK,FIELD,[DIM])
 # promote (NCOPIES,VALUE)
-PUBLIC(_a)=1;private(_a)=0;PUBLIC(_a)
+# PUBLIC(_a)=1;private(_a)=0;PUBLIC(_a) /*not thread safe, tested elsewhere*/
 
 kind(QUADWORD(1))==9
 kind(QUADWORD_UNSIGNED(1))==5

--- a/mdsobjects/cpp/testing/MdsTdiTest.tdi
+++ b/mdsobjects/cpp/testing/MdsTdiTest.tdi
@@ -438,11 +438,22 @@ treeclose()
   !or(0q,2q) &&   !or_not(0q,3q)
   eqv(1q,3q) &&       eqv(0q,2q)
  neqv(0q,3q) &&      neqv(1q,2q)
+ishft(-1q,-1)==huge(1q)
+-15q >>1== -8q  && -15q >>-63== -8q
+ 15q >>1==  7q  &&  15q >>-63==  7q
+-15q <<1==-30q  && -15q <<-63==-30q
+ 15q <<1== 30q  &&  15q <<-63== 30q
+ 15qu>>1==  7qu &&  15qu>>-63==  7qu
+ 15qu<<1== 30qu &&  15qu<<-63== 30qu
+
 
 #octaword tests require execute
 execute("0x1234567012345670o*16==0x12345670123456700o")
 execute("0x12345670123456701o+0x1234567012345670q==0x13579bd713579bd71o")
 execute("0x12345670123456701o-0x1234567012345670q==0x11111109111111091o")
+0xffffffffffffffffffffffffffffffffou/0xfffffffffffffffffou==0x1000000000000000ou
+0xffffffffffffffffffffffffffffffffou/0xffffffffffffffffou==0x10000000000000001ou
+-100000000000000o/1000000000000o==-100o
 execute("(-0x2468ace02468ace0o)/2==-0x1234567012345670o")
 execute("  and(1o,3o) &&   and_not(1o,2o)")
 execute("!nand(1o,3o) && !nand_not(1o,2o)")
@@ -450,3 +461,11 @@ execute("  nor(0o,2o) &&   nor_not(0o,3o)")
 execute("  !or(0o,2o) &&   !or_not(0o,3o)")
 execute("  eqv(1o,3o) &&       eqv(0o,2o)")
 execute(" neqv(0o,3o) &&      neqv(1o,2o)")
+execute("ishft(-1o,-1)==huge(1o)")
+execute("-15o >>1== -8o  &&-15o >>-127== -8o")
+execute(" 15o >>1==  7o  && 15o >>-127==  7o")
+execute("-15o <<1==-30o  &&-15o <<-127==-30o")
+execute(" 15o <<1== 30o  && 15o <<-127== 30o")
+execute(" 15ou>>1==  7ou && 15ou>>-127==  7ou")
+execute(" 15ou<<1== 30ou && 15ou<<-127== 30ou")
+

--- a/mdsobjects/cpp/testing/MdsTdiTest.tdi
+++ b/mdsobjects/cpp/testing/MdsTdiTest.tdi
@@ -427,3 +427,26 @@ class(_a=DICT(*,"a",1,2,"b"))==196 && kind(_a)==216
 _a["a"]==1 && _a[2]=="b"
 
 treeclose()
+
+#quadword tests
+0x1234567012345670q*2==0x2468ace02468ace0q
+0x1234567012345670q+0x123456701234567q==0x13579bd713579bd7q
+0x2468ace02468ace0q/2==0x1234567012345670q
+  and(1q,3q) &&   and_not(1q,2q)
+!nand(1q,3q) && !nand_not(1q,2q)
+  nor(0q,2q) &&   nor_not(0q,3q)
+  !or(0q,2q) &&   !or_not(0q,3q)
+  eqv(1q,3q) &&       eqv(0q,2q)
+ neqv(0q,3q) &&      neqv(1q,2q)
+
+#octaword tests require execute
+execute("0x1234567012345670o*16==0x12345670123456700o")
+execute("0x12345670123456701o+0x1234567012345670q==0x13579bd713579bd71o")
+execute("0x12345670123456701o-0x1234567012345670q==0x11111109111111091o")
+execute("(-0x2468ace02468ace0o)/2==-0x1234567012345670o")
+execute("  and(1o,3o) &&   and_not(1o,2o)")
+execute("!nand(1o,3o) && !nand_not(1o,2o)")
+execute("  nor(0o,2o) &&   nor_not(0o,3o)")
+execute("  !or(0o,2o) &&   !or_not(0o,3o)")
+execute("  eqv(1o,3o) &&       eqv(0o,2o)")
+execute(" neqv(0o,3o) &&      neqv(1o,2o)")

--- a/tdishr/TdiAbs.c
+++ b/tdishr/TdiAbs.c
@@ -74,35 +74,15 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <tdishr_messages.h>
 #include <math.h>
 #include <STATICdef.h>
+#include <int128.h>
 
 extern int TdiConvert();
-extern int TdiSubtractOctaword();
 extern int TdiUnary();
 extern int Tdi3Multiply();
 extern int CvtConvertFloat();
 
 #define min(a,b) ((a)<(b)) ? (a) : (b)
 #define max(a,b) ((a)<(b)) ? (b) : (a)
-
-typedef struct {
-  int64_t low;
-  int64_t high;
-} Int128;
-typedef Int128 uInt128;
-
-#define negate128 TdiSubtractOctaword(&octazero,&in[i],&out[i])
-
-STATIC_CONSTANT Int128 octazero = {0};
-
-#define zero128 out[i].low=0; out[i].high=0;
-#define copy128 out[i].low=in[i].low;out[i].high=in[i].high;
-#define abs128 if (in[i].high < 0) TdiSubtractOctaword(&octazero,&in[i],&out[i]); else { copy128; }
-#define not128 out[i].low = ~in[i].low; out[i].high = ~in[i].high
-#ifdef WORDS_BIGENDIAN
-#define bool128 out[i]=(uint8_t)(1 & in[i].low)
-#else
-#define bool128 out[i]=(uint8_t)(1 & in[i].low)
-#endif
 
 STATIC_CONSTANT const int roprand = 0x8000;
 
@@ -266,13 +246,13 @@ int Tdi3Abs(struct descriptor *in_ptr, struct descriptor *out_ptr)
     end_operate case DTYPE_WU:start_operate(uint16_t) out[i] = in[i];
     end_operate case DTYPE_LU:start_operate(uint32_t) out[i] = in[i];
     end_operate case DTYPE_QU:start_operate(uint64_t) out[i] = in[i];
-    end_operate case DTYPE_OU:start_operate(uInt128); copy128;
+    end_operate case DTYPE_OU:start_operate(uint128_t); memcpy(&out[i],&in[i],sizeof(uint128_t));
     end_operate case DTYPE_B:start_operate(int8_t) out[i] = (int8_t)(in[i] > 0 ? in[i] : -in[i]);
     end_operate case DTYPE_W:start_operate(int16_t)
         out[i] = (int16_t)(in[i] > 0 ? in[i] : -in[i]);
     end_operate case DTYPE_L:start_operate(int32_t) out[i] = in[i] > 0 ? in[i] : -in[i];
     end_operate case DTYPE_Q:start_operate(int64_t) out[i] = in[i] > 0 ? in[i] : -in[i];
-    end_operate case DTYPE_O:start_operate(Int128) abs128;
+    end_operate case DTYPE_O:start_operate(int128_t) int128_abs(&in[i],&out[i]);
     end_operate case DTYPE_F:start_operate(float) AbsFloat(DTYPE_F)
     end_operate case DTYPE_FS:start_operate(float) AbsFloat(DTYPE_FS)
     end_operate case DTYPE_G:start_operate(double) AbsFloat(DTYPE_G)
@@ -304,13 +284,12 @@ int Tdi3Abs1(struct descriptor *in_ptr, struct descriptor *out_ptr)
     end_operate case DTYPE_WU:start_operate(uint16_t) out[i] = in[i];
     end_operate case DTYPE_LU:start_operate(uint32_t) out[i] = in[i];
     end_operate case DTYPE_QU:start_operate(uint64_t) out[i] = in[i];
-    end_operate case DTYPE_OU:start_operate(uInt128); copy128;
+    end_operate case DTYPE_OU:start_operate(uint128_t); memcpy(&out[i],&in[i],sizeof(uint128_t));
     end_operate case DTYPE_B:start_operate(int8_t) out[i] = (int8_t)(in[i] > 0 ? in[i] : -in[i]);
-    end_operate case DTYPE_W:start_operate(int16_t)
-        out[i] = (int16_t)(in[i] > 0 ? in[i] : -in[i]);
+    end_operate case DTYPE_W:start_operate(int16_t) out[i] = (int16_t)(in[i] > 0 ? in[i] : -in[i]);
     end_operate case DTYPE_L:start_operate(int32_t) out[i] = in[i] > 0 ? in[i] : -in[i];
     end_operate case DTYPE_Q:start_operate(int64_t) out[i] = in[i] > 0 ? in[i] : -in[i];
-    end_operate case DTYPE_O:start_operate(Int128) abs128;
+    end_operate case DTYPE_O:start_operate(int128_t) int128_abs(&in[i],&out[i]);
     end_operate case DTYPE_F:start_operate(float) AbsFloat(DTYPE_F)
     end_operate case DTYPE_FS:start_operate(float) AbsFloat(DTYPE_FS)
     end_operate case DTYPE_G:start_operate(double) AbsFloat(DTYPE_G)
@@ -384,7 +363,7 @@ int Tdi3Aimag(struct descriptor *in_ptr, struct descriptor *out_ptr)
     end_operate case DTYPE_W:case DTYPE_WU:start_operate2(int16_t) out[i] = 0;
     end_operate case DTYPE_L:case DTYPE_LU:start_operate2(int32_t) out[i] = 0;
     end_operate case DTYPE_Q:case DTYPE_QU:start_operate2(int64_t) out[i] = 0;
-    end_operate case DTYPE_O:case DTYPE_OU:start_operate2(Int128)   zero128;
+    end_operate case DTYPE_O:case DTYPE_OU:start_operate2(int128_t)   out[i].low=0;out[i].high=0;;
     end_operate case DTYPE_F:start_operate2(float)
     float ans = (float)0.0;
     CvtConvertFloat(&ans, DTYPE_NATIVE_FLOAT, &out[i], DTYPE_F, 0);
@@ -427,7 +406,7 @@ int Tdi3Conjg(struct descriptor *in_ptr, struct descriptor *out_ptr)
     end_operate case DTYPE_WU:case DTYPE_W:start_operate(uint16_t) out[i] = in[i];
     end_operate case DTYPE_LU:case DTYPE_L:start_operate(uint32_t) out[i] = in[i];
     end_operate case DTYPE_QU:case DTYPE_Q:start_operate(uint64_t) out[i] = in[i];
-    end_operate case DTYPE_OU:case DTYPE_O:start_operate(uInt128)  copy128;
+    end_operate case DTYPE_OU:case DTYPE_O:start_operate(uint128_t)  memcpy(&out[i],&in[i],sizeof(int128_t));
     end_operate case DTYPE_F:case DTYPE_FS:start_operate(float)    out[i] = in[i];
     end_operate case DTYPE_G:case DTYPE_D:case DTYPE_FT:start_operate(double) out[i] = in[i];
     end_operate case DTYPE_FC:start_operate(float) ConjgComplex(DTYPE_F)
@@ -452,16 +431,16 @@ int Tdi3Inot(struct descriptor *in_ptr, struct descriptor *out_ptr)
     return status;
 
   switch (in_ptr->dtype) {
-                case DTYPE_BU:start_operate( int8_t)  out[i] = ~in[i];
-    end_operate case DTYPE_WU:start_operate(uint16_t) out[i] = ~in[i];
-    end_operate case DTYPE_LU:start_operate(uint32_t) out[i] = ~in[i];
-    end_operate case DTYPE_QU:start_operate(uint64_t) out[i] = ~in[i];
-    end_operate case DTYPE_OU:start_operate(uInt128)  not128;
-    end_operate case DTYPE_B: start_operate( int8_t) out[i] = ~in[i];
-    end_operate case DTYPE_W: start_operate(int16_t) out[i] = ~in[i];
-    end_operate case DTYPE_L: start_operate(int32_t) out[i] = ~in[i];
-    end_operate case DTYPE_O: start_operate(int64_t) out[i] = ~in[i];
-    end_operate case DTYPE_Q: start_operate(Int128)  not128;
+                case DTYPE_BU:start_operate(  uint8_t) out[i] = ~in[i];
+    end_operate case DTYPE_WU:start_operate( uint16_t) out[i] = ~in[i];
+    end_operate case DTYPE_LU:start_operate( uint32_t) out[i] = ~in[i];
+    end_operate case DTYPE_QU:start_operate( uint64_t) out[i] = ~in[i];
+    end_operate case DTYPE_OU:start_operate(uint128_t) out[i].low=~in[i].low; out[i].high=~in[i].high;
+    end_operate case DTYPE_B: start_operate(   int8_t) out[i] = ~in[i];
+    end_operate case DTYPE_W: start_operate(  int16_t) out[i] = ~in[i];
+    end_operate case DTYPE_L: start_operate(  int32_t) out[i] = ~in[i];
+    end_operate case DTYPE_O: start_operate(  int64_t) out[i] = ~in[i];
+    end_operate case DTYPE_Q: start_operate( int128_t) out[i].low=~in[i].low; out[i].high=~in[i].high;
     end_operate default:status = TdiINVDTYDSC;
   }
 
@@ -478,16 +457,16 @@ int Tdi3Logical(struct descriptor *in_ptr, struct descriptor *kind __attribute__
     return status;
 
   switch (in_ptr->dtype) {
-  case DTYPE_BU:              start_operate1( uint8_t, uint8_t) out[i] = (uint8_t)(1 & in[i]);
-    end_operate case DTYPE_WU:start_operate1(uint16_t, uint8_t)	out[i] = (uint8_t)(1 & in[i]);
-    end_operate case DTYPE_LU:start_operate1(uint32_t, uint8_t)	out[i] = (uint8_t)(1 & in[i]);
-    end_operate case DTYPE_QU:start_operate1(uint64_t, uint8_t) out[i] = (uint8_t)(1 & in[i]);
-    end_operate case DTYPE_OU:start_operate1( uInt128, uint8_t) bool128;
-    end_operate case DTYPE_B: start_operate1( int8_t, uint8_t) out[i] =	(uint8_t)(1 & in[i]);
-    end_operate case DTYPE_W: start_operate1(int16_t, uint8_t) out[i] =	(uint8_t)(1 & in[i]);
-    end_operate case DTYPE_L: start_operate1(int32_t, uint8_t) out[i] = (uint8_t)(1 & in[i]);
-    end_operate case DTYPE_Q: start_operate1(int64_t, uint8_t) out[i] = (uint8_t)(1 & in[i]);
-    end_operate case DTYPE_O: start_operate1( Int128, uint8_t) bool128;
+  case DTYPE_BU:              start_operate1(  uint8_t, uint8_t) out[i] = (uint8_t)(1 & in[i]);
+    end_operate case DTYPE_WU:start_operate1( uint16_t, uint8_t) out[i] = (uint8_t)(1 & in[i]);
+    end_operate case DTYPE_LU:start_operate1( uint32_t, uint8_t) out[i] = (uint8_t)(1 & in[i]);
+    end_operate case DTYPE_QU:start_operate1( uint64_t, uint8_t) out[i] = (uint8_t)(1 & in[i]);
+    end_operate case DTYPE_OU:start_operate1(uint128_t, uint8_t) out[i] = (uint8_t)(1 & in[i].low);
+    end_operate case DTYPE_B: start_operate1(   int8_t, uint8_t) out[i] = (uint8_t)(1 & in[i]);
+    end_operate case DTYPE_W: start_operate1(  int16_t, uint8_t) out[i] = (uint8_t)(1 & in[i]);
+    end_operate case DTYPE_L: start_operate1(  int32_t, uint8_t) out[i] = (uint8_t)(1 & in[i]);
+    end_operate case DTYPE_Q: start_operate1(  int64_t, uint8_t) out[i] = (uint8_t)(1 & in[i]);
+    end_operate case DTYPE_O: start_operate1( int128_t, uint8_t) out[i] = (uint8_t)(1 & in[i].low);
     end_operate default:status = TdiINVDTYDSC;
   }
 
@@ -502,20 +481,17 @@ int Tdi3Not(struct descriptor *in_ptr, struct descriptor *out_ptr)
   status = TdiUnary(in_ptr, out_ptr, &out_count);
   if STATUS_NOT_OK
     return status;
-
   switch (in_ptr->dtype) {
-  case DTYPE_BU:
-    start_operate1(uint8_t, uint8_t) out[i] = (uint8_t)!(in[i] & 1);
-    end_operate case DTYPE_WU:start_operate1(uint16_t, uint8_t)
-	out[i] = (uint8_t)!(in[i] & 1);
-    end_operate case DTYPE_LU:start_operate1(uint32_t, uint8_t)	out[i] = (uint8_t)!(in[i] & 1);
-    end_operate case DTYPE_QU:start_operate1(uint64_t, uint8_t) out[i] = (uint8_t)!(in[i] & 1);
-    end_operate case DTYPE_OU:start_operate1( uInt128, uint8_t) bool128; out[i] = (uint8_t)!out[i];
-    end_operate case DTYPE_B: start_operate1(int8_t, uint8_t)	out[i] = (uint8_t)!(in[i] & 1);
-    end_operate case DTYPE_W: start_operate1(int16_t, uint8_t)  out[i] = (uint8_t)!(in[i] & 1);
-    end_operate case DTYPE_L: start_operate1(int32_t, uint8_t)  out[i] = (uint8_t)!(in[i] & 1);
-    end_operate case DTYPE_Q: start_operate1(int64_t, uint8_t)  out[i] = (uint8_t)!(in[i] & 1);
-    end_operate case DTYPE_O: start_operate1( Int128, uint8_t)  bool128; out[i] = (uint8_t)!out[i];
+                case DTYPE_BU:start_operate1(  uint8_t,uint8_t) out[i] = (uint8_t)!(in[i] & 1);
+    end_operate case DTYPE_WU:start_operate1( uint16_t,uint8_t) out[i] = (uint8_t)!(in[i] & 1);
+    end_operate case DTYPE_LU:start_operate1( uint32_t,uint8_t) out[i] = (uint8_t)!(in[i] & 1);
+    end_operate case DTYPE_QU:start_operate1( uint64_t,uint8_t) out[i] = (uint8_t)!(in[i] & 1);
+    end_operate case DTYPE_OU:start_operate1(uint128_t,uint8_t) out[i] = (uint8_t)!(1 & in[i].low);
+    end_operate case DTYPE_B: start_operate1(   int8_t,uint8_t) out[i] = (uint8_t)!(in[i] & 1);
+    end_operate case DTYPE_W: start_operate1(  int16_t,uint8_t) out[i] = (uint8_t)!(in[i] & 1);
+    end_operate case DTYPE_L: start_operate1(  int32_t,uint8_t) out[i] = (uint8_t)!(in[i] & 1);
+    end_operate case DTYPE_Q: start_operate1(  int64_t,uint8_t) out[i] = (uint8_t)!(in[i] & 1);
+    end_operate case DTYPE_O: start_operate1( int128_t,uint8_t) out[i] = (uint8_t)!(1 & in[i].low);
     end_operate default:status = TdiINVDTYDSC;
   }
 
@@ -533,26 +509,25 @@ int Tdi3Nint(struct descriptor *in_ptr, struct descriptor *kind __attribute__ ((
     return status;
 
   switch (in_ptr->dtype) {
-  case DTYPE_BU:
-    start_operate(uint8_t) out[i] = in[i];
-    end_operate case DTYPE_WU:start_operate(uint16_t) out[i] = in[i];
-    end_operate case DTYPE_LU:start_operate(uint32_t) out[i] = in[i];
-    end_operate case DTYPE_QU:start_operate(uint64_t) out[i] = in[i];
-    end_operate case DTYPE_OU:start_operate(uInt128)  copy128;
-    end_operate case DTYPE_B:start_operate(int8_t) out[i] = in[i];
-    end_operate case DTYPE_W:start_operate(int16_t) out[i] = in[i];
-    end_operate case DTYPE_L:start_operate(int32_t) out[i] = in[i];
-    end_operate case DTYPE_Q:start_operate(int64_t) out[i] = in[i];
-    end_operate case DTYPE_O:start_operate(Int128)  copy128;
-    end_operate case DTYPE_F:start_operate1(float, int) NintFloat(DTYPE_F);
-    end_operate case DTYPE_FS:start_operate1(float, int) NintFloat(DTYPE_FS);
-    end_operate case DTYPE_G:start_operate1(double, int) NintFloat(DTYPE_G);
-    end_operate case DTYPE_D:start_operate1(double, int) NintFloat(DTYPE_D);
-    end_operate case DTYPE_FT:start_operate1(double, int) NintFloat(DTYPE_FT);
-    end_operate case DTYPE_FC:start_operate1(float, int) NintComplex(DTYPE_F);
-    end_operate case DTYPE_FSC:start_operate1(float, int) NintComplex(DTYPE_FS);
-    end_operate case DTYPE_GC:start_operate1(double, int) NintComplex(DTYPE_G);
-    end_operate case DTYPE_DC:start_operate1(double, int) NintComplex(DTYPE_D);
+                case DTYPE_BU: start_operate(  uint8_t) out[i] = in[i];
+    end_operate case DTYPE_WU: start_operate( uint16_t) out[i] = in[i];
+    end_operate case DTYPE_LU: start_operate( uint32_t) out[i] = in[i];
+    end_operate case DTYPE_QU: start_operate( uint64_t) out[i] = in[i];
+    end_operate case DTYPE_OU: start_operate(uint128_t) memcpy(&out[i],&in[i],sizeof(uint128_t));
+    end_operate case DTYPE_B:  start_operate(   int8_t) out[i] = in[i];
+    end_operate case DTYPE_W:  start_operate(  int16_t) out[i] = in[i];
+    end_operate case DTYPE_L:  start_operate(  int32_t) out[i] = in[i];
+    end_operate case DTYPE_Q:  start_operate(  int64_t) out[i] = in[i];
+    end_operate case DTYPE_O:  start_operate( int128_t) memcpy(&out[i],&in[i],sizeof(int128_t));
+    end_operate case DTYPE_F:  start_operate1(float,  int) NintFloat(DTYPE_F);
+    end_operate case DTYPE_FS: start_operate1(float,  int) NintFloat(DTYPE_FS);
+    end_operate case DTYPE_G:  start_operate1(double, int) NintFloat(DTYPE_G);
+    end_operate case DTYPE_D:  start_operate1(double, int) NintFloat(DTYPE_D);
+    end_operate case DTYPE_FT: start_operate1(double, int) NintFloat(DTYPE_FT);
+    end_operate case DTYPE_FC: start_operate1(float,  int) NintComplex(DTYPE_F);
+    end_operate case DTYPE_FSC:start_operate1(float,  int) NintComplex(DTYPE_FS);
+    end_operate case DTYPE_GC: start_operate1(double, int) NintComplex(DTYPE_G);
+    end_operate case DTYPE_DC: start_operate1(double, int) NintComplex(DTYPE_D);
     end_operate case DTYPE_FTC:start_operate1(double, int) NintComplex(DTYPE_FT);
     end_operate default:status = TdiINVDTYDSC;
   }
@@ -571,25 +546,25 @@ int Tdi3UnaryMinus(struct descriptor *in_ptr, struct descriptor *out_ptr)
     return status;
 
   switch (in_ptr->dtype) {
-  case DTYPE_BU:              start_operate( int8_t) out[i] = -in[i];
-    end_operate case DTYPE_WU:start_operate(int16_t) out[i] = -in[i];
-    end_operate case DTYPE_LU:start_operate(int32_t) out[i] = -in[i];
-    end_operate case DTYPE_QU:start_operate(int64_t) out[i] = -in[i];
-    end_operate case DTYPE_OU:start_operate(uInt128) TdiSubtractOctaword(&octazero, &in[i], &out[i]);
-    end_operate case DTYPE_B:start_operate( int8_t) out[i] = -in[i];
-    end_operate case DTYPE_W:start_operate(int16_t) out[i] = -in[i];
-    end_operate case DTYPE_L:start_operate(int32_t) out[i] = -in[i];
-    end_operate case DTYPE_Q:start_operate(int64_t) out[i] = -in[i];
-    end_operate case DTYPE_O:start_operate(Int128) TdiSubtractOctaword(&octazero, &in[i], &out[i]);
-    end_operate case DTYPE_F:start_operate(float)  UnaryMinusFloat(DTYPE_F)
-    end_operate	case DTYPE_FS:start_operate(float) UnaryMinusFloat(DTYPE_FS)
-    end_operate case DTYPE_G:start_operate(double) UnaryMinusFloat(DTYPE_G)
-    end_operate case DTYPE_D:start_operate(double) UnaryMinusFloat(DTYPE_D)
-    end_operate case DTYPE_FT:start_operate(double) UnaryMinusFloat(DTYPE_FT)
-    end_operate case DTYPE_FC:start_operate(float) UnaryMinusComplex(DTYPE_F)
-    end_operate case DTYPE_FSC:start_operate(float) UnaryMinusComplex(DTYPE_FS)
-    end_operate case DTYPE_GC:start_operate(double) UnaryMinusComplex(DTYPE_G)
-    end_operate case DTYPE_DC:start_operate(double) UnaryMinusComplex(DTYPE_D)
+                case DTYPE_BU: start_operate(  int8_t) out[i] = -in[i];
+    end_operate case DTYPE_WU: start_operate( int16_t) out[i] = -in[i];
+    end_operate case DTYPE_LU: start_operate( int32_t) out[i] = -in[i];
+    end_operate case DTYPE_QU: start_operate( int64_t) out[i] = -in[i];
+    end_operate case DTYPE_OU: start_operate(int128_t) int128_minus((int128_t*)&in[i], &out[i]);
+    end_operate case DTYPE_B:  start_operate(  int8_t) out[i] = -in[i];
+    end_operate case DTYPE_W:  start_operate( int16_t) out[i] = -in[i];
+    end_operate case DTYPE_L:  start_operate( int32_t) out[i] = -in[i];
+    end_operate case DTYPE_Q:  start_operate( int64_t) out[i] = -in[i];
+    end_operate case DTYPE_O:  start_operate(int128_t) int128_minus((int128_t*)&in[i], &out[i]);
+    end_operate case DTYPE_F:  start_operate(float)  UnaryMinusFloat(DTYPE_F)
+    end_operate	case DTYPE_FS: start_operate(float)  UnaryMinusFloat(DTYPE_FS)
+    end_operate case DTYPE_G:  start_operate(double) UnaryMinusFloat(DTYPE_G)
+    end_operate case DTYPE_D:  start_operate(double) UnaryMinusFloat(DTYPE_D)
+    end_operate case DTYPE_FT: start_operate(double) UnaryMinusFloat(DTYPE_FT)
+    end_operate case DTYPE_FC: start_operate(float)  UnaryMinusComplex(DTYPE_F)
+    end_operate case DTYPE_FSC:start_operate(float)  UnaryMinusComplex(DTYPE_FS)
+    end_operate case DTYPE_GC: start_operate(double) UnaryMinusComplex(DTYPE_G)
+    end_operate case DTYPE_DC: start_operate(double) UnaryMinusComplex(DTYPE_D)
     end_operate case DTYPE_FTC:start_operate(double) UnaryMinusComplex(DTYPE_FT)
     end_operate default:status = TdiINVDTYDSC;
   }

--- a/tdishr/TdiAbs.c
+++ b/tdishr/TdiAbs.c
@@ -439,8 +439,8 @@ int Tdi3Inot(struct descriptor *in_ptr, struct descriptor *out_ptr)
     end_operate case DTYPE_B: start_operate(   int8_t) out[i] = ~in[i];
     end_operate case DTYPE_W: start_operate(  int16_t) out[i] = ~in[i];
     end_operate case DTYPE_L: start_operate(  int32_t) out[i] = ~in[i];
-    end_operate case DTYPE_O: start_operate(  int64_t) out[i] = ~in[i];
-    end_operate case DTYPE_Q: start_operate( int128_t) out[i].low=~in[i].low; out[i].high=~in[i].high;
+    end_operate case DTYPE_Q: start_operate(  int64_t) out[i] = ~in[i];
+    end_operate case DTYPE_O: start_operate( int128_t) out[i].low=~in[i].low; out[i].high=~in[i].high;
     end_operate default:status = TdiINVDTYDSC;
   }
 

--- a/tdishr/TdiAdd.c
+++ b/tdishr/TdiAdd.c
@@ -185,16 +185,16 @@ STATIC_CONSTANT const int roprand = 0x8000;
   break;\
 }
 
-#define OperateFun(routine) \
-{ int128_t *in1p = (int128_t*)in1->pointer;\
-  int128_t *in2p = (int128_t*)in2->pointer;\
-  int128_t *outp = (int128_t*)out->pointer;\
+#define Operate128(type,routine) \
+{ type##_t *in1p = (type##_t*)in1->pointer;\
+  type##_t *in2p = (type##_t*)in2->pointer;\
+  type##_t *outp = (type##_t*)out->pointer;\
   switch (scalars)\
   {\
     case 0:\
-    case 3: while (nout--) routine(in1p++, in2p++, outp++); break; \
-    case 1: while (nout--) routine(in1p,   in2p++, outp++); break; \
-    case 2: while (nout--) routine(in1p++, in2p,   outp++); break; \
+    case 3: while (nout--) type##_##routine(in1p++, in2p++, outp++); break; \
+    case 1: while (nout--) type##_##routine(in1p,   in2p++, outp++); break; \
+    case 2: while (nout--) type##_##routine(in1p++, in2p,   outp++); break; \
   }\
   break;\
 }
@@ -210,8 +210,8 @@ int Tdi3Add(struct descriptor *in1, struct descriptor *in2, struct descriptor *o
     case DTYPE_LU: Operate(uint32_t, +)
     case DTYPE_Q:  Operate( int64_t, +)
     case DTYPE_QU: Operate(uint64_t, +)
-    case DTYPE_O:  OperateFun(int128_add)
-    case DTYPE_OU: OperateFun(int128_add)
+    case DTYPE_O:  Operate128( int128,add)
+    case DTYPE_OU: Operate128(uint128,add)
     case DTYPE_F:  OperateFloat(float, DTYPE_F, DTYPE_NATIVE_FLOAT, +)
     case DTYPE_FS: OperateFloat(float, DTYPE_FS, DTYPE_NATIVE_FLOAT, +)
     case DTYPE_D:  OperateFloat(double, DTYPE_D, DTYPE_NATIVE_DOUBLE, +)
@@ -238,8 +238,8 @@ int Tdi3Subtract(struct descriptor *in1, struct descriptor *in2, struct descript
     case DTYPE_LU: Operate(uint32_t, -)
     case DTYPE_Q:  Operate( int64_t, -)
     case DTYPE_QU: Operate(uint64_t, -)
-    case DTYPE_O:  OperateFun(int128_sub)
-    case DTYPE_OU: OperateFun(int128_sub)
+    case DTYPE_O:  Operate128( int128,sub)
+    case DTYPE_OU: Operate128(uint128,sub)
     case DTYPE_F:  OperateFloat(float, DTYPE_F, DTYPE_NATIVE_FLOAT, -)
     case DTYPE_FS: OperateFloat(float, DTYPE_FS, DTYPE_NATIVE_FLOAT, -)
     case DTYPE_D:  OperateFloat(double, DTYPE_D, DTYPE_NATIVE_DOUBLE, -)
@@ -266,8 +266,8 @@ int Tdi3Multiply(struct descriptor *in1, struct descriptor *in2, struct descript
     case DTYPE_LU: Operate(uint32_t, *)
     case DTYPE_Q:  Operate( int64_t, *)
     case DTYPE_QU: Operate(uint64_t, *)
-    case DTYPE_O:  OperateFun(int128_mul)
-    case DTYPE_OU: OperateFun(int128_mul)
+    case DTYPE_O:  Operate128( int128,mul)
+    case DTYPE_OU: Operate128(uint128,mul)
     case DTYPE_F:  OperateFloat(float, DTYPE_F, DTYPE_NATIVE_FLOAT, *)
     case DTYPE_FS: OperateFloat(float, DTYPE_FS, DTYPE_NATIVE_FLOAT, *)
     case DTYPE_D:  OperateFloat(double, DTYPE_D, DTYPE_NATIVE_DOUBLE, *)

--- a/tdishr/TdiChar.c
+++ b/tdishr/TdiChar.c
@@ -106,15 +106,12 @@ int Tdi3Char(struct descriptor *in_ptr, struct descriptor *kind_ptr __attribute_
   char *p1 = in_ptr->pointer;
   char *p2 = out_ptr->pointer;
   int step = in_ptr->length, n;
-
-  N_ELEMENTS(out_ptr, n);
 #ifdef WORDS_BIGENDIAN
-  for (; --n >= 0; p1 += step)
-    *p2++ = *(p1 + step - 1);
-#else
+  p1 += step - 1;
+#endif
+  N_ELEMENTS(out_ptr, n);
   for (; --n >= 0; p1 += step)
     *p2++ = *(p1);
-#endif
   return status;
 }
 
@@ -216,25 +213,8 @@ int Tdi3Extract(struct descriptor *start_ptr,
                 byte = IACHAR(ascii-text)
                 byte = ICHAR(text)
 */
-int Tdi3Ichar(struct descriptor *in_ptr, struct descriptor *out_ptr)
-{
-  INIT_STATUS;
-  int step = in_ptr->length;
-  char *p1 = in_ptr->pointer;
-  char *p2 = out_ptr->pointer;
-  int n;
-
-  N_ELEMENTS(out_ptr, n);
-#ifdef WORDS_BIGENDIAN
-  if STATUS_OK
-    for (; --n >= 0; p1 += step)
-      *p2++ = *(p1 + step - 1);
-#else
-  if STATUS_OK
-    for (; --n >= 0; p1 += step)
-      *p2++ = *(p1);
-#endif
-  return status;
+int Tdi3Ichar(struct descriptor *in_ptr, struct descriptor *out_ptr){
+  return Tdi3Char(in_ptr,NULL,out_ptr);
 }
 
 /*------------------------------------------------------------------------------

--- a/tdishr/TdiConvert.c
+++ b/tdishr/TdiConvert.c
@@ -24,7 +24,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 #include <string.h>
 #include <stdio.h>
-#include <inttypes.h>
+#include <int128.h>
 #include <mdsdescrip.h>
 #include <tdishr_messages.h>
 #include <math.h>
@@ -834,16 +834,16 @@ STATIC_ROUTINE void DOUBLEC_TO_TEXT(int itype, char *pa, char *pb, int numb, int
   }
 }
 
-#define BU_T(lena,pa,lenb,pb,numb)  TO_TEXT(pa,unsigned char,pb,numb,sprintf(text,"%u",(unsigned int)*ip++))
-#define WU_T(lena,pa,lenb,pb,numb)  TO_TEXT(pa,unsigned short,pb,numb,sprintf(text,"%u",(unsigned int)*ip++))
-#define LU_T(lena,pa,lenb,pb,numb)  TO_TEXT(pa,unsigned int,pb,numb,sprintf(text,"%u",(unsigned int)*ip++))
-#define QU_T(lena,pa,lenb,pb,numb)  TO_TEXT(pa,uint64_t,pb,numb,sprintf(text,"%"PRIu64,(uint64_t)*ip++))
-#define B_T(lena,pa,lenb,pb,numb)   TO_TEXT(pa,char,pb,numb,sprintf(text,"%d",(int)*ip++))
-#define W_T(lena,pa,lenb,pb,numb)   TO_TEXT(pa,short,pb,numb,sprintf(text,"%d",(int)*ip++))
-#define L_T(lena,pa,lenb,pb,numb)   TO_TEXT(pa,int,pb,numb,sprintf(text,"%d",(int)*ip++))
-#define Q_T(lena,pa,lenb,pb,numb)   TO_TEXT(pa,int64_t,pb,numb,sprintf(text,"%"PRId64,(int64_t)*ip++))
-#define OU_T(lena,pa,lenb,pb,numb)  TO_TEXT(pa,unsigned int,pb,numb,sprintf(text,"%#x%08x%08x%08x",ip[3],ip[2],ip[1],ip[0]);ip +=4)
-#define O_T(lena,pa,lenb,pb,numb)   TO_TEXT(pa,unsigned int,pb,numb,sprintf(text,"%#x%08x%08x%08x",ip[3],ip[2],ip[1],ip[0]);ip +=4)
+#define BU_T(lena,pa,lenb,pb,numb)  TO_TEXT(pa,  uint8_t,pb,numb,sprintf(text,"%"PRIu8, *ip++))
+#define WU_T(lena,pa,lenb,pb,numb)  TO_TEXT(pa, uint16_t,pb,numb,sprintf(text,"%"PRIu16,*ip++))
+#define LU_T(lena,pa,lenb,pb,numb)  TO_TEXT(pa, uint32_t,pb,numb,sprintf(text,"%"PRIu32,*ip++))
+#define QU_T(lena,pa,lenb,pb,numb)  TO_TEXT(pa, uint64_t,pb,numb,sprintf(text,"%"PRIu64,*ip++))
+#define B_T(lena,pa,lenb,pb,numb)   TO_TEXT(pa,   int8_t,pb,numb,sprintf(text,"%"PRId8, *ip++))
+#define W_T(lena,pa,lenb,pb,numb)   TO_TEXT(pa,  int16_t,pb,numb,sprintf(text,"%"PRId16,*ip++))
+#define L_T(lena,pa,lenb,pb,numb)   TO_TEXT(pa,  int32_t,pb,numb,sprintf(text,"%"PRId32,*ip++))
+#define Q_T(lena,pa,lenb,pb,numb)   TO_TEXT(pa,  int64_t,pb,numb,sprintf(text,"%"PRId64,*ip++))
+#define OU_T(lena,pa,lenb,pb,numb)  TO_TEXT(pa,uint128_t,pb,numb,sprintf(text,"%s",uint128_deco(ip++,int128_buf)))
+#define O_T(lena,pa,lenb,pb,numb)   TO_TEXT(pa, int128_t,pb,numb,sprintf(text,"%s", int128_deco(ip++,int128_buf)))
 #if DTYPE_F == DTYPE_NATIVE_FLOAT
 #define F_T(lena,pa,lenb,pb,numb)   FLOAT_TO_TEXT(DTYPE_F,pa,pb,numb,lenb,'E'); status=1
 #define FS_T(lena,pa,lenb,pb,numb)  FLOAT_TO_TEXT(DTYPE_FS,pa,pb,numb,lenb,'S'); status=1
@@ -987,6 +987,7 @@ EXPORT int TdiConvert(struct descriptor_a *pdin, struct descriptor_a *pdout)
     goto same;
   } else {
 	/** big branch **/
+    INT128_BUF(int128_buf);
     n = MAXTYPE * dtypea + dtypeb;
     switch (n) {
       defset(BU)

--- a/tdishr/TdiDecompile.c
+++ b/tdishr/TdiDecompile.c
@@ -97,10 +97,10 @@ int Tdi1Decompile(int opcode __attribute__ ((unused)), int narg, struct descript
         Precedence is used by function evaluation.
 */
 #define P_ARG   88
-STATIC_CONSTANT unsigned char htab[16] =
-    { '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e',
-  'f'
-};
+//STATIC_CONSTANT unsigned char htab[16] =
+//    { '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e',
+//  'f'
+//};
 
 STATIC_CONSTANT DESCRIPTOR(BUILD_EVENT, "BuildEvent(\"");
 STATIC_CONSTANT DESCRIPTOR(CLASS, "??Class_");
@@ -110,7 +110,7 @@ STATIC_CONSTANT DESCRIPTOR(COMMA, ",");
 STATIC_CONSTANT DESCRIPTOR(COMMA_SPACE, ", ");
 STATIC_CONSTANT DESCRIPTOR(CMPLX, "Cmplx(");
 STATIC_CONSTANT DESCRIPTOR(DTYPE, "??Dtype_");
-STATIC_CONSTANT DESCRIPTOR(HEX, "0X");
+//STATIC_CONSTANT DESCRIPTOR(HEX, "0X");
 STATIC_CONSTANT DESCRIPTOR(LEFT_BRACKET, "[");
 STATIC_CONSTANT DESCRIPTOR(MISSING, "$Missing");
 STATIC_CONSTANT DESCRIPTOR(MORE, " /*** etc. ***/");
@@ -500,6 +500,8 @@ int Tdi0Decompile(struct descriptor *in_ptr, int prec, struct descriptor_d *out_
     case DTYPE_LU:
     case DTYPE_Q:
     case DTYPE_QU:
+    case DTYPE_O:
+    case DTYPE_OU:
       cdsc.length = (unsigned short)(in_ptr->length * 2.4 + 1.6);
       status = TdiConvert(in_ptr, &cdsc MDS_END_ARG);
       if STATUS_OK
@@ -513,41 +515,6 @@ int Tdi0Decompile(struct descriptor *in_ptr, int prec, struct descriptor_d *out_
 		      (struct descriptor *)out_ptr, &cdsc, &sdsc MDS_END_ARG);
       }
       break;
-
-		/***********************************************
-                Assumes: low-order byte is first. right-to-left.
-                ***********************************************/
-    case DTYPE_O:
-    case DTYPE_OU:
-      cptr = c0;
-      j = in_ptr->length;
-#ifdef WORDS_BIGENDIAN
-      bptr = in_ptr->pointer - 1;
-      while (--j >= 0) {
-	*cptr++ = htab[(*(++bptr) >> 4) & 15];
-	*cptr++ = htab[*bptr & 15];
-      }
-#else
-      bptr = in_ptr->pointer + j;
-      while (--j >= 0) {
-	*cptr++ = htab[(*(--bptr) >> 4) & 15];
-	*cptr++ = htab[*bptr & 15];
-      }
-#endif
-      while (cdsc.pointer < cptr - 1 && *cdsc.pointer == '0') {
-	cdsc.pointer++;
-      }
-      cdsc.length = (unsigned short)(cptr - cdsc.pointer);
-      {
-	struct descriptor sdsc = { 0, DTYPE_T, CLASS_S, 0 };
-	sdsc.length = (unsigned short)strlen(TdiREF_CAT[dtype].name);
-	sdsc.pointer = TdiREF_CAT[dtype].name;
-	status =
-	    StrConcat((struct descriptor *)out_ptr,
-		      (struct descriptor *)out_ptr, &HEX, &cdsc, &sdsc MDS_END_ARG);
-      }
-      break;
-
     case DTYPE_D:
     case DTYPE_F:
     case DTYPE_G:

--- a/tdishr/TdiDim.c
+++ b/tdishr/TdiDim.c
@@ -84,6 +84,7 @@ int Tdi3xxxxx(struct descriptor *in1, struct descriptor *in2,
 #include <mdsdescrip.h>
 #include <tdishr_messages.h>
 #include <STATICdef.h>
+#include <limits.h>
 #include <int128.h>
 
 
@@ -598,12 +599,6 @@ int Tdi3Dim(struct descriptor *in1, struct descriptor *in2, struct descriptor *o
   return status;
 }
 
-#define int8_t_min  -128
-#define int16_t_min -32768
-#define int32_t_min 0x80000000
-#define int64_t_min LONG_LONG_CONSTANT(0x8000000000000000)
-#define min_struct(type) type##_min
-
 #undef Operate
 #define Operate(type1,type2) \
 { type1 *in1p = (type1 *)in1->pointer;\
@@ -652,20 +647,21 @@ int Tdi3Ishft(struct descriptor *in1, struct descriptor *in2, struct descriptor 
 }
 
 #undef Operate
-#define Operate(type,operator) \
-{ type *in1p = (type *)in1->pointer;\
-  type *in2p = (type *)in2->pointer;\
-  type *outp = (type *)out->pointer;\
+#define in2p_to_n(type1,type2,in2p) type2 n = *in2p%(sizeof(type1)*CHAR_BIT); if (n<0) n+=(sizeof(type1)*CHAR_BIT)
+#define Operate(type1,type2,operator) { \
+  type1 *in1p = (type1 *)in1->pointer;\
+  type2 *in2p = (type2 *)in2->pointer;\
+  type1 *outp = (type1 *)out->pointer;\
   switch (scalars)\
   {\
-    case 0: while (nout--) {*outp++ = (type)(*in1p++ operator *in2p++); \
-            } break;\
-    case 1: while (nout--) {*outp++ = (type)(*in1p operator *in2p++); \
-            } break;\
-    case 2: while (nout--) {*outp++ = (type)(*in1p++ operator *in2p); \
-            } break;\
-    case 3: *outp = (type)(*in1p operator *in2p); \
-            break;\
+    case 0: while (nout--) {in2p_to_n(type1,type2,in2p++);\
+                            *outp++ = (type1)(*in1p++ operator n); } break;\
+    case 1: while (nout--) {in2p_to_n(type1,type2,in2p++);\
+                            *outp++ = (type1)(*in1p   operator n); } break;\
+    case 2:                {in2p_to_n(type1,type2,in2p  );\
+            while (nout--) {*outp++ = (type1)(*in1p++ operator n); }}break;\
+    case 3:                {in2p_to_n(type1,type2,in2p  );\
+                            *outp   = (type1)(*in1p   operator n); } break;\
   }\
   break;\
 }
@@ -673,14 +669,14 @@ int Tdi3Ishft(struct descriptor *in1, struct descriptor *in2, struct descriptor 
 int Tdi3ShiftRight(struct descriptor *in1, struct descriptor *in2, struct descriptor *out)
 {
   SetupArgs switch (in1->dtype) {
-    case DTYPE_B: Operate(  int8_t, >>)
-    case DTYPE_BU:Operate( uint8_t, >>)
-    case DTYPE_W: Operate( int16_t, >>)
-    case DTYPE_WU:Operate(uint16_t, >>)
-    case DTYPE_L: Operate( int32_t, >>)
-    case DTYPE_LU:Operate(uint32_t, >>)
-    case DTYPE_Q: Operate( int64_t, >>)
-    case DTYPE_QU:Operate(uint64_t, >>)
+    case DTYPE_B: Operate(  int8_t, int8_t, >>)
+    case DTYPE_BU:Operate( uint8_t, int8_t, >>)
+    case DTYPE_W: Operate( int16_t,int16_t, >>)
+    case DTYPE_WU:Operate(uint16_t,int16_t, >>)
+    case DTYPE_L: Operate( int32_t,int32_t, >>)
+    case DTYPE_LU:Operate(uint32_t,int32_t, >>)
+    case DTYPE_Q: Operate( int64_t,int64_t, >>)
+    case DTYPE_QU:Operate(uint64_t,int64_t, >>)
     case DTYPE_O: Operate128( int128,rshft)
     case DTYPE_OU:Operate128(uint128,rshft)
     default:return TdiINVDTYDSC;
@@ -691,15 +687,14 @@ int Tdi3ShiftRight(struct descriptor *in1, struct descriptor *in2, struct descri
 int Tdi3ShiftLeft(struct descriptor *in1, struct descriptor *in2, struct descriptor *out)
 {
   SetupArgs switch (in1->dtype) {
-  case DTYPE_B:
-    Operate(char, <<)
-    case DTYPE_BU:Operate(unsigned char, <<)
-    case DTYPE_W:Operate(int16_t, <<)
-    case DTYPE_WU:Operate(uint16_t, <<)
-    case DTYPE_L:Operate(int, <<)
-    case DTYPE_LU:Operate(unsigned int, <<)
-    case DTYPE_Q:Operate(int64_t, <<)
-    case DTYPE_QU:Operate(uint64_t, <<)
+    case DTYPE_B: Operate(  int8_t, int8_t, <<)
+    case DTYPE_BU:Operate( uint8_t, int8_t, <<)
+    case DTYPE_W: Operate( int16_t,int16_t, <<)
+    case DTYPE_WU:Operate(uint16_t,int16_t, <<)
+    case DTYPE_L: Operate( int32_t,int32_t, <<)
+    case DTYPE_LU:Operate(uint32_t,int32_t, <<)
+    case DTYPE_Q: Operate( int64_t,int64_t, <<)
+    case DTYPE_QU:Operate(uint64_t,int64_t, <<)
     case DTYPE_O: Operate128( int128,lshft)
     case DTYPE_OU:Operate128(uint128,lshft)
     default:return TdiINVDTYDSC;

--- a/tdishr/TdiDivide.c
+++ b/tdishr/TdiDivide.c
@@ -56,19 +56,12 @@ int Tdi3Divide(struct descriptor *in1, struct descriptor *in2, struct descriptor
 #include <mdsdescrip.h>
 #include <mdstypes.h>
 #include <tdishr_messages.h>
+#include <int128.h>
 
 
 
 extern int CvtConvertFloat();
-extern double WideIntToDouble();
-extern void DoubleToWideInt();
 STATIC_CONSTANT int roprand = 0x8000;
-typedef struct {
-  int longword[2];
-} quadword;
-typedef struct {
-  int longword[4];
-} octaword;
 
 #define SetupArgs \
   struct descriptor_a *ina1 = (struct descriptor_a *)in1;\
@@ -136,22 +129,15 @@ typedef struct {
   break;\
 }
 
-#define OperateWideOne(type,size,is_signed) \
-  double a = WideIntToDouble(in1p,size,is_signed);	\
-  double b = WideIntToDouble(in2p,size,is_signed);	\
-  double ans = (b != 0) ? a/b : (double)0.0;			\
-  DoubleToWideInt(&ans,size,outp++);
-
-#define OperateWide(type,size,is_signed) \
-{ type *in1p = (type *)in1->pointer;\
-  type *in2p = (type *)in2->pointer;\
-  type *outp = (type *)out->pointer;\
-  switch (scalars)\
-  {\
-    case 0: \
-    case 3: while (nout--) { OperateWideOne(type,size,is_signed) in1p++; in2p++; } break;\
-    case 1: while (nout--) { OperateWideOne(type,size,is_signed)         in2p++; } break;\
-    case 2: while (nout--) { OperateWideOne(type,size,is_signed) in1p++;         } break;\
+#define Operate128(type) {\
+  type##_t *in1p = (type##_t *)in1->pointer;\
+  type##_t *in2p = (type##_t *)in2->pointer;\
+  type##_t *outp = (type##_t *)out->pointer;\
+  switch (scalars) {\
+    case 0: while (nout--) type##_div(in1p++,in2p++,outp++); break;\
+    case 1: while (nout--) type##_div(in1p  ,in2p++,outp++); break;\
+    case 2: while (nout--) type##_div(in1p  ,in2p++,outp++); break;\
+    case 3:                type##_div(in1p  ,in2p  ,outp  ); break;\
   }\
   break;\
 }
@@ -214,8 +200,8 @@ int Tdi3Divide(struct descriptor *in1, struct descriptor *in2, struct descriptor
     case DTYPE_LU: Operate(unsigned int)
     case DTYPE_Q:  Operate(int64_t);
     case DTYPE_QU: Operate(uint64_t);
-    case DTYPE_O:  OperateWide(octaword, 4, 1);
-    case DTYPE_OU: OperateWide(octaword, 4, 0);
+    case DTYPE_O:  Operate128( int128);
+    case DTYPE_OU: Operate128(uint128);
     case DTYPE_F:  OperateF(float, DTYPE_F, DTYPE_NATIVE_FLOAT)
     case DTYPE_FS: OperateF(float, DTYPE_FS, DTYPE_NATIVE_FLOAT)
     case DTYPE_G:  OperateF(double, DTYPE_G, DTYPE_NATIVE_DOUBLE)
@@ -230,27 +216,3 @@ int Tdi3Divide(struct descriptor *in1, struct descriptor *in2, struct descriptor
   }
   return 1;
 }
-
-/*  CMS REPLACEMENT HISTORY, Element Tdi3Divide.C */
-/*  *21   15-AUG-1996 15:48:38 TWF "Fix complex divide" */
-/*  *20   15-AUG-1996 15:32:03 TWF "Fix complex divide" */
-/*  *19   15-AUG-1996 15:04:55 TWF "Ieee support" */
-/*  *18    6-AUG-1996 11:33:54 TWF "Fix complex divide" */
-/*  *17    1-AUG-1996 17:21:14 TWF "Use int instead of long" */
-/*  *16   30-JUL-1996 09:05:31 TWF "Fix divide of complex" */
-/*  *15   29-JUL-1996 15:40:37 TWF "Fix addx and subx calls" */
-/*  *14   26-JUL-1996 12:24:51 TWF "Special handling for alpha and vms" */
-/*  *13   24-JUN-1996 14:44:08 TWF "Port to Unix/Windows" */
-/*  *12   17-OCT-1995 16:16:59 TWF "use <builtins.h> form" */
-/*  *11   19-OCT-1994 12:26:23 TWF "Use TDI$MESSAGES" */
-/*  *10   19-OCT-1994 10:39:13 TWF "No longer support VAXC" */
-/*  *9    19-OCT-1994 10:33:34 TWF "No longer support VAXC" */
-/*  *8    15-NOV-1993 10:09:44 TWF "Add memory block" */
-/*  *7    15-NOV-1993 09:42:20 TWF "Add memory block" */
-/*  *6    16-OCT-1993 13:01:50 MRL "" */
-/*  *5    16-OCT-1993 12:51:23 MRL "" */
-/*  *4    15-OCT-1993 18:11:03 MRL "" */
-/*  *3    15-OCT-1993 17:53:26 MRL "" */
-/*  *2     8-OCT-1993 09:51:06 MRL "" */
-/*  *1     7-OCT-1993 15:40:08 MRL "" */
-/*  CMS REPLACEMENT HISTORY, Element Tdi3Divide.C */

--- a/tdishr/TdiMaxVal.c
+++ b/tdishr/TdiMaxVal.c
@@ -93,19 +93,14 @@ const int roprand = 0x8000;
 #define  int64_min 0x8000000000000000;
 
 #if DTYPE_NATIVE_DOUBLE == DTYPE_D
-#define HUGE 1.7E38
+#define DHUGE 1.7E38
 #elif DTYPE_NATIVE_DOUBLE == DTYPE_G
-#define HUGE 8.9E307
+#define DHUGE 8.9E307
 #else
-#define HUGE 1.7E308
+#define DHUGE 1.7E308
 #endif
-
-static void TdiDivO(const char *in1,const char *in2,char *out){
- //DESCRIPTOR_A(name, len, type, ptr, arsize)
- const DESCRIPTOR_A(i1, sizeof(int128_t), DTYPE_O, in1, sizeof(int128_t));
- const DESCRIPTOR_A(i2, sizeof(int128_t), DTYPE_O, in2, sizeof(int128_t));
-       DESCRIPTOR_A(o,  sizeof(int128_t), DTYPE_O, out, sizeof(int128_t));
- Tdi3Divide(&i1,&i2,&o);
+static inline void TdiDivO(const char *in1,const char *in2,char *out){
+  int128_div(( int128_t*)in1,( int128_t*)in2,( int128_t*)out);
 }
 
 int TdiLtO(unsigned int *in1, unsigned int *in2, int is_signed){
@@ -316,11 +311,11 @@ int Tdi3MaxLoc(struct descriptor *in, struct descriptor *mask,
   case DTYPE_QU: OperateIloc( uint64_t,          0, uint64_gt);break;
   case DTYPE_O:  OperateIloc( int128_t, int128_min,(void*)int128_gt);break;
   case DTYPE_OU: OperateIloc(uint128_t,uint128_min,(void*)uint128_gt);break;
-  case DTYPE_F:  OperateFloc(DTYPE_F, -HUGE, gt,&args);break;
-  case DTYPE_FS: OperateFloc(DTYPE_FS,-HUGE, gt,&args);break;
-  case DTYPE_G:  OperateFloc(DTYPE_G, -HUGE, gt,&args);break;
-  case DTYPE_D:  OperateFloc(DTYPE_D, -HUGE, gt,&args);break;
-  case DTYPE_FT: OperateFloc(DTYPE_FT,-HUGE, gt,&args);break;
+  case DTYPE_F:  OperateFloc(DTYPE_F, -DHUGE, gt,&args);break;
+  case DTYPE_FS: OperateFloc(DTYPE_FS,-DHUGE, gt,&args);break;
+  case DTYPE_G:  OperateFloc(DTYPE_G, -DHUGE, gt,&args);break;
+  case DTYPE_D:  OperateFloc(DTYPE_D, -DHUGE, gt,&args);break;
+  case DTYPE_FT: OperateFloc(DTYPE_FT,-DHUGE, gt,&args);break;
   default:return TdiINVDTYDSC;
   }
   return 1;
@@ -342,11 +337,11 @@ int Tdi3MinLoc(struct descriptor *in, struct descriptor *mask,
   case DTYPE_QU: {OperateIloc( uint64_t,         -1, uint64_lt);break;}
   case DTYPE_O:  {OperateIloc( int128_t, int128_max,(void*) int128_lt);break;}
   case DTYPE_OU: {OperateIloc(uint128_t,uint128_max,(void*)uint128_lt);break;}
-  case DTYPE_F:  {OperateFloc(DTYPE_F, -HUGE, lt,&args);break;}
-  case DTYPE_FS: {OperateFloc(DTYPE_FS,-HUGE, lt,&args);break;}
-  case DTYPE_G:  {OperateFloc(DTYPE_G, -HUGE, lt,&args);break;}
-  case DTYPE_D:  {OperateFloc(DTYPE_D, -HUGE, lt,&args);break;}
-  case DTYPE_FT: {OperateFloc(DTYPE_FT,-HUGE, lt,&args);break;}
+  case DTYPE_F:  {OperateFloc(DTYPE_F,  DHUGE, lt,&args);break;}
+  case DTYPE_FS: {OperateFloc(DTYPE_FS, DHUGE, lt,&args);break;}
+  case DTYPE_G:  {OperateFloc(DTYPE_G,  DHUGE, lt,&args);break;}
+  case DTYPE_D:  {OperateFloc(DTYPE_D,  DHUGE, lt,&args);break;}
+  case DTYPE_FT: {OperateFloc(DTYPE_FT, DHUGE, lt,&args);break;}
   default:return TdiINVDTYDSC;
   }
   return 1;
@@ -431,11 +426,11 @@ int Tdi3MaxVal(struct descriptor *in, struct descriptor *mask,
   case DTYPE_QU: OperateIval( uint64_t,          0, uint64_gt);break;
   case DTYPE_O:  OperateIval( int128_t, int128_min,(void*) int128_gt);break;
   case DTYPE_OU: OperateIval(uint128_t,uint128_min,(void*)uint128_gt);break;
-  case DTYPE_F:  OperateFval(DTYPE_F, -HUGE, gt,&args);break;
-  case DTYPE_FS: OperateFval(DTYPE_FS,-HUGE, gt,&args);break;
-  case DTYPE_G:  OperateFval(DTYPE_G, -HUGE, gt,&args);break;
-  case DTYPE_D:  OperateFval(DTYPE_D, -HUGE, gt,&args);break;
-  case DTYPE_FT: OperateFval(DTYPE_FT,-HUGE, gt,&args);break;
+  case DTYPE_F:  OperateFval(DTYPE_F, -DHUGE, gt,&args);break;
+  case DTYPE_FS: OperateFval(DTYPE_FS,-DHUGE, gt,&args);break;
+  case DTYPE_G:  OperateFval(DTYPE_G, -DHUGE, gt,&args);break;
+  case DTYPE_D:  OperateFval(DTYPE_D, -DHUGE, gt,&args);break;
+  case DTYPE_FT: OperateFval(DTYPE_FT,-DHUGE, gt,&args);break;
   default:return TdiINVDTYDSC;
   }
   return 1;
@@ -457,11 +452,11 @@ int Tdi3MinVal(struct descriptor *in, struct descriptor *mask,
   case DTYPE_QU: OperateIval( uint64_t,         -1, uint64_lt);break;
   case DTYPE_O:  OperateIval( int128_t, int128_max,(void*) int128_lt);break;
   case DTYPE_OU: OperateIval(uint128_t,uint128_max,(void*)uint128_lt);break;
-  case DTYPE_F:  OperateFval(DTYPE_F, -HUGE, lt,&args);break;
-  case DTYPE_FS: OperateFval(DTYPE_FS,-HUGE, lt,&args);break;
-  case DTYPE_G:  OperateFval(DTYPE_G, -HUGE, lt,&args);break;
-  case DTYPE_D:  OperateFval(DTYPE_D, -HUGE, lt,&args);break;
-  case DTYPE_FT: OperateFval(DTYPE_FT,-HUGE, lt,&args);break;
+  case DTYPE_F:  OperateFval(DTYPE_F,  DHUGE, lt,&args);break;
+  case DTYPE_FS: OperateFval(DTYPE_FS, DHUGE, lt,&args);break;
+  case DTYPE_G:  OperateFval(DTYPE_G,  DHUGE, lt,&args);break;
+  case DTYPE_D:  OperateFval(DTYPE_D,  DHUGE, lt,&args);break;
+  case DTYPE_FT: OperateFval(DTYPE_FT, DHUGE, lt,&args);break;
   default:return TdiINVDTYDSC;
   }
   return 1;

--- a/tdishr/TdiMaxVal.c
+++ b/tdishr/TdiMaxVal.c
@@ -87,11 +87,6 @@ extern int CvtConvertFloat();
 
 const int roprand = 0x8000;
 
-#define uint64_max 0xffffffffffffffff;
-#define uint64_min 0x0000000000000000;
-#define  int64_max 0x7fffffffffffffff;
-#define  int64_min 0x8000000000000000;
-
 #if DTYPE_NATIVE_DOUBLE == DTYPE_D
 #define DHUGE 1.7E38
 #elif DTYPE_NATIVE_DOUBLE == DTYPE_G


### PR DESCRIPTION
* use u/int64_t datatypes instead of own typedefs
* fixes many issues with octaword operations e.g. division, decompile to decimal
* use system's RNG
* removed redundant code in TdiAnd
* centralized int128 operations in int128.h header