### PR TITLE
Fix: use proper integer division for accuracy and performance

### DIFF
--- a/include/treeshr.h
+++ b/include/treeshr.h
@@ -183,8 +183,8 @@ extern int TREE_BLOCKID;
   extern EXPORT int _TreeMakeSegment(void *dbid, int nid, struct descriptor *start,
 				     struct descriptor *end, struct descriptor *dim,
 				     struct descriptor_a *initialData, int idx, int filled);
-  extern EXPORT int TreePutSegment(int nid, int rowidx, struct descriptor_a *data);
-  extern EXPORT int _TreePutSegment(void *dbid, int nid, int rowidx, struct descriptor_a *data);
+  extern EXPORT int TreePutSegment(int nid, const int rowidx, struct descriptor_a *data);
+  extern EXPORT int _TreePutSegment(void *dbid, int nid, const int rowidx, struct descriptor_a *data);
   extern EXPORT int TreeUpdateSegment(int nid, struct descriptor *start, struct descriptor *end,
 				      struct descriptor *dim, int idx);
   extern EXPORT int _TreeUpdateSegment(void *dbid, int nid, struct descriptor *start,

--- a/mdslib/MdsLib.c
+++ b/mdslib/MdsLib.c
@@ -150,7 +150,7 @@ extern EXPORT int descr(int *dtype, void *data, int *dim1, ...)
     }
     ndim = ndim - 1;		/* ndim is actually the number of dimensions specified */
 
-    /* if requested descriptor is for a DTYPE_CSTRING, then following the null terminated 
+    /* if requested descriptor is for a DTYPE_CSTRING, then following the null terminated
      * list of dimensions there will be an int * to the length of each string in the array
      */
 
@@ -215,7 +215,7 @@ extern EXPORT int descr(int *dtype, void *data, int *dim1, ...)
 EXPORT int descr2(int *dtype, int *dim1, ...)
 {
 
-  /* variable length argument list: 
+  /* variable length argument list:
    * (# elements in dim 1), (# elements in dim 2) ... 0, [length of (each) string if DTYPE_CSTRING]
    */
 
@@ -279,7 +279,7 @@ EXPORT int descr2(int *dtype, int *dim1, ...)
     }
     ndim = ndim - 1;		/* ndim is actually the number of dimensions specified */
 
-    /* if requested descriptor is for a DTYPE_CSTRING, then following the null terminated 
+    /* if requested descriptor is for a DTYPE_CSTRING, then following the null terminated
      * list of dimensions there will be an int * to the length of each string in the array
      */
 
@@ -337,7 +337,7 @@ EXPORT int descr2(int *dtype, int *dim1, ...)
     next = 0;
   return retval;
 }
-
+#ifndef _CLIENT_ONLY
 static inline struct descriptor *fixDtypes(struct descriptor *dsc) {
   switch (dsc->dtype) {
   case DTYPE_FLOAT:
@@ -357,8 +357,9 @@ static inline struct descriptor *fixDtypes(struct descriptor *dsc) {
   }
   return dsc;
 }
+#endif
 
-static inline int MdsValueVargs(va_list incrmtr, int connection, char *expression, ...) 
+static inline int MdsValueVargs(va_list incrmtr, int connection, char *expression, ...)
 {
   int a_count;
   int i;
@@ -398,7 +399,7 @@ static inline int MdsValueVargs(va_list incrmtr, int connection, char *expressio
       descnum = va_arg(incrmtr, int *);
     dscAnswer = GetDescriptorCache()[*descnum - 1];
 
-    /* 
+    /*
      * Send expression descriptor first.
      * MdsValueRemoteExpression wraps expression with type conversion function.
      * It malloc's space for newexpression that needs to be freed after
@@ -550,7 +551,7 @@ static inline int MdsValueVargs(va_list incrmtr, int connection, char *expressio
 	int templen = (xd2.pointer)->length;
 	status = TdiCvt(&xd2, dsc, &xd3 MDS_END_ARG);
 	  /**  get string length right if scalar string (if answer descriptor has longer
-	   **  length than returned value, then make sure the length is the length of the 
+	   **  length than returned value, then make sure the length is the length of the
            **  returned value
            **/
 	if ((xd3.pointer)->dtype == DTYPE_CSTRING && (xd3.pointer->class != CLASS_A))
@@ -623,7 +624,7 @@ static inline int MdsValue2Vargs(va_list incrmtr, int connection, char *expressi
       descnum = va_arg(incrmtr, int *);
     dscAnswer = GetDescriptorCache()[*descnum - 1];
     dscAnswer->pointer = va_arg(incrmtr, void *);
-    /* 
+    /*
      * Send expression descriptor first.
      * MdsValueRemoteExpression wraps expression with type conversion function.
      * It malloc's space for newexpression that needs to be freed after
@@ -779,7 +780,7 @@ static inline int MdsValue2Vargs(va_list incrmtr, int connection, char *expressi
 	int templen = (xd2.pointer)->length;
 	status = TdiCvt(&xd2, dsc, &xd3 MDS_END_ARG);
 	  /**  get string length right if scalar string (if answer descriptor has longer
-	   **  length than returned value, then make sure the length is the length of the 
+	   **  length than returned value, then make sure the length is the length of the
            **  returned value
            **/
 	if ((xd3.pointer)->dtype == DTYPE_CSTRING && (xd3.pointer->class != CLASS_A))
@@ -1065,7 +1066,7 @@ static int dtype_length(struct descriptor *d)
 {
   short len;
 
-  /*  This function needs to handle the DTYPE values in ipdesc.h as well 
+  /*  This function needs to handle the DTYPE values in ipdesc.h as well
    *  as the "native" DTYPEs, as it is called both for descriptors before
    *  evaluation, and for the answer descriptor, which for local access will
    *  be returned with native DTYPE.

--- a/mdslib/mdslib_ctest.c
+++ b/mdslib/mdslib_ctest.c
@@ -450,7 +450,7 @@ void TestArray2D(int ttype, int conid)
 
 int main(int argc, char *argv[])
 {
-  int connection=-1;
+  SOCKET connection=-1;
   int pconnection=-1;
   if (argc > 1) {
     printf("*** Connecting to: %s", argv[1]);

--- a/mdsobjects/python/apd.py
+++ b/mdsobjects/python/apd.py
@@ -83,7 +83,7 @@ class Apd(_array.Array):
 
     @classmethod
     def fromDescriptor(cls,d):
-        num   = int(d.arsize/d.length)
+        num   = d.arsize//d.length
         dptrs = _C.cast(d.pointer,_C.POINTER(_C.c_void_p*num)).contents
         descs = [_descriptor.pointerToObject(dptr,d.tree) for dptr in dptrs]
         return cls(descs)._setTree(d.tree)

--- a/mdsobjects/python/mdsarray.py
+++ b/mdsobjects/python/mdsarray.py
@@ -233,7 +233,7 @@ class Array(_dat.Data):
                 d.arsize=d.arsize*dim
                 shape.append(dim)
         else:
-            shape=[int(d.arsize/d.length),]
+            shape=[d.arsize//d.length]
         if d.dtype == StringArray.dtype_id:
             if d.length == 0:
                 strarr=''
@@ -246,12 +246,12 @@ class Array(_dat.Data):
             return ans
         if d.dtype == _tre.TreeNode.dtype_id:
             d.dtype=Int32Array.dtype_id
-            nids=getNumpy(_N.int32,_C.c_int32,int(d.arsize/d.length))
+            nids=getNumpy(_N.int32,_C.c_int32,d.arsize//d.length)
             return _tre.TreeNodeArray(list(nids))
         if d.dtype == Complex64Array.dtype_id:
-            return Array(getNumpy(_N.complex64,_C.c_float,int(d.arsize*2/d.length)))
+            return Array(getNumpy(_N.complex64,_C.c_float,(d.arsize<<1)//d.length))
         if d.dtype == Complex128Array.dtype_id:
-            return Array(getNumpy(_N.complex128,_C.c_double,int(d.arsize*2/d.length)))
+            return Array(getNumpy(_N.complex128,_C.c_double,(d.arsize<<1)//d.length))
         if d.dtype == FloatFArray.dtype_id:
             return _cmp.FS_FLOAT(d).evaluate()
         if d.dtype == FloatDArray.dtype_id:
@@ -267,7 +267,7 @@ class Array(_dat.Data):
         if d.dtype in _dsc.dtypeToArrayClass:
             cls = _dsc.dtypeToArrayClass[d.dtype]
             if cls.ctype is not None:
-                return Array(getNumpy(cls.ctype,cls.ctype,int(d.arsize/d.length)))
+                return Array(getNumpy(cls.ctype,cls.ctype,d.arsize//d.length))
         raise TypeError('Arrays of dtype %d are unsupported.' % d.dtype)
 makeArray = Array
 

--- a/mdsobjects/python/tests/segmentsUnitTest.py
+++ b/mdsobjects/python/tests/segmentsUnitTest.py
@@ -82,7 +82,7 @@ class Tests(TestCase):
         shape     = segment.getShape()
         node.makeSegment(startTime, endTime, dim, segment)
         retShape  = node.getShape()
-        self.assertEquals(shape,retShape)
+        self.assertEqual(shape,retShape)
       test()
       self.cleanup()
 
@@ -164,7 +164,7 @@ class Tests(TestCase):
         ### putSegment ###
         node = ptree.PS
         seglen = 4
-        segbuf = zeros((int(length/seglen),width),int32)
+        segbuf = zeros((length//seglen,width),int32)
         for i in range(0,length,seglen):
             node.beginSegment(dim[i]-1,dim[i+seglen-1]+1,ndim[i:i+seglen],segbuf)
             for j in range(seglen):
@@ -258,7 +258,7 @@ class Tests(TestCase):
         self.assertTrue(sig.dim_of().tolist(),(arange(0,length,dtype=int64)*int(1e9/clk)+trg).tolist())
         self.assertTrue((abs(sig.data()-(ones(length,dtype=int16)*slp+off))<1e-5).all(),"Stored data does not match expected array")
         trig.record = 0
-        for i in range(int(length/seglen)):
+        for i in range(length//seglen):
             dim = raw.getSegmentDim(i)
             raw.updateSegment(dim.data()[0],dim.data()[-1],dim,i)
         self.assertEqual(str(raw.getSegment(0)),"Build_Signal(Word([1,1,1,1,1,1,1,1,1,1]), *, Build_Dim(Build_Window(0Q, 9Q, TRG), * : * : 1000000000Q / CLK))")
@@ -267,7 +267,7 @@ class Tests(TestCase):
         ptree.compressDatafile() # this will break the functionality of updateSegment
         ptree.open()
         trig.record = 0
-        for i in range(int(length/seglen)):
+        for i in range(length//seglen):
             raw.updateSegment(i*seglen,i*seglen-1,None,i)
         self.assertEqual(str(raw.getSegment(0)),"Build_Signal(Word([1,1,1,1,1,1,1,1,1,1]), *, Build_Dim(Build_Window(0Q, 9Q, TRG), * : * : 1000000000Q / CLK))")
         self.assertTrue(sig.dim_of().tolist(),(arange(0,length,dtype=int64)*int(1e9/clk)).tolist())
@@ -278,7 +278,7 @@ class Tests(TestCase):
       def test():
         from MDSplus import Tree,Int64,Int64Array,Int32Array,tdi
         #Tree.setTimeContext() # test initPinoDb
-        #self.assertEquals(Tree.getTimeContext(),(None,None,None))
+        #self.assertEqual(Tree.getTimeContext(),(None,None,None))
         with Tree(self.tree,self.shot,'NEW') as ptree:
             node = ptree.addNode('S')
             ptree.write()
@@ -293,28 +293,28 @@ class Tests(TestCase):
         self.assertEqual(node.record.data().tolist(),list(range(-9,9)))
         node.tree.setTimeContext(Int64(30),Int64(70),Int64(20))
 #        Tree.setTimeContext(1,2,3) # test privacy to Tree
-        self.assertEquals(node.tree.getTimeContext(),(30,70,20))
- #       self.assertEquals(Tree.getTimeContext(),(1,2,3))
+        self.assertEqual(node.tree.getTimeContext(),(30,70,20))
+ #       self.assertEqual(Tree.getTimeContext(),(1,2,3))
         self.assertEqual(node.record.data().tolist(),[3,5]+[6])  # delta is applied per segment
         node.tree.setTimeContext()
 
-        self.assertEquals(node.tree.getTimeContext(),(None,None,None))
+        self.assertEqual(node.tree.getTimeContext(),(None,None,None))
         self.assertEqual(node.record.data().tolist(),list(range(-9,9)))
 
-        #self.assertEquals(Tree.getTimeContext(),(1,2,3))
+        #self.assertEqual(Tree.getTimeContext(),(1,2,3))
         tdi('treeopen($,$)',self.tree,self.shot)
         Tree.setTimeContext(1,2,3) # test privacy to Tree
-        self.assertEquals(Tree.getTimeContext(),(1,2,3))
+        self.assertEqual(Tree.getTimeContext(),(1,2,3))
         tdi('treeopennew($,$)',self.tree,self.shot+1)
-        self.assertEquals(Tree.getTimeContext(),(None,None,None))
+        self.assertEqual(Tree.getTimeContext(),(None,None,None))
         Tree.setTimeContext(2,3,4) # test privacy to Tree
-        self.assertEquals(Tree.getTimeContext(),(2,3,4))
+        self.assertEqual(Tree.getTimeContext(),(2,3,4))
         tdi('treeopen($,$)',self.tree,self.shot)
-        self.assertEquals(Tree.getTimeContext(),(1,2,3))
+        self.assertEqual(Tree.getTimeContext(),(1,2,3))
         tdi('treeclose()')
-        self.assertEquals(Tree.getTimeContext(),(2,3,4))
+        self.assertEqual(Tree.getTimeContext(),(2,3,4))
         tdi('treeclose()',self.tree,self.shot)
-        self.assertEquals(Tree.getTimeContext(),(1,2,3))
+        self.assertEqual(Tree.getTimeContext(),(1,2,3))
       test()
       self.cleanup()
 

--- a/mdstcpip/ioroutinesx.h
+++ b/mdstcpip/ioroutinesx.h
@@ -251,16 +251,16 @@ static void ChildSignalHandler(int num __attribute__ ((unused))){
 ////////////////////////////////////////////////////////////////////////////////
 
 static int io_authorize(Connection* c, char *username){
+  int ans;
+  char *iphost = NULL,*hoststr = NULL ,*info = NULL;
+  FREE_ON_EXIT(iphost);
+  FREE_ON_EXIT(hoststr);
+  FREE_ON_EXIT(info);
+  ans = C_OK;
   SOCKET sock = getSocket(c);
   time_t tim = time(0);
   char *timestr = ctime(&tim);
-  int ans = C_OK;
-  char *iphost = NULL;
-  FREE_ON_EXIT(iphost);
-  char *hoststr = NULL;
-  FREE_ON_EXIT(hoststr);
-  char *info = getHostInfo(sock, &iphost, &hoststr);
-  FREE_ON_EXIT(info);
+  info = getHostInfo(sock, &iphost, &hoststr);
   if (info) {
     char *matchString[2] = { NULL, NULL };
     FREE_ON_EXIT(matchString[0]);

--- a/tdishr/CvtConvertFloat.c
+++ b/tdishr/CvtConvertFloat.c
@@ -25,6 +25,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <string.h>
 #include <mdsdescrip.h>
 #include <mdsplus/mdsplus.h>
+#include <inttypes.h>
 #include <STATICdef.h>
 
 /** Adapted from VMS V7.0 sources CvtConvertFloat.lis                      **/
@@ -201,13 +202,7 @@ struct cvt_r_conversion_options {
 #define CvtOVERFLOW 100302922
 #define CvtPOSINF 100302930
 #define CvtUNDERFLOW 100302938
-typedef char Int_8;
-typedef unsigned char U_Int_8;
-typedef short Int_16;
-typedef unsigned short U_Int_16;
-typedef int Int_32;
-typedef unsigned int U_Int_32;
-typedef U_Int_8 CVT_BYTE;
+typedef uint8_t CVT_BYTE;
 typedef CVT_BYTE *CVT_BYTE_PTR;
 typedef CVT_BYTE CVT_VAX_F[4];
 typedef CVT_BYTE CVT_VAX_D[8];
@@ -219,7 +214,7 @@ typedef CVT_BYTE CVT_IEEE_X[16];
 typedef CVT_BYTE CVT_IBM_SHORT[4];
 typedef CVT_BYTE CVT_IBM_LONG[8];
 typedef CVT_BYTE CVT_CRAY[8];
-typedef U_Int_32 CVT_STATUS;
+typedef uint32_t CVT_STATUS;
 /*
 typedef struct {unsigned hi : 7; unsigned exp :  8; unsigned sign : 1; unsigned low : 16;} f_float;
 typedef struct {unsigned hi : 7; unsigned exp :  8; unsigned sign : 1; unsigned low : 16; unsigned int low2;} d_float;
@@ -271,7 +266,7 @@ typedef struct {unsigned int low2; unsigned low:16; unsigned hi : 4; unsigned ex
 **=============================================================================
 */
 
-typedef U_Int_32 UNPACKED_REAL[6];
+typedef uint32_t UNPACKED_REAL[6];
 typedef UNPACKED_REAL *UNPACKED_REAL_PTR;
 
 /*
@@ -293,7 +288,7 @@ typedef UNPACKED_REAL *UNPACKED_REAL_PTR;
 ** Special floating point constant definitions
 **=============================================================================
 */
-STATIC_CONSTANT U_Int_32 const vax_c[] = {
+STATIC_CONSTANT uint32_t const vax_c[] = {
 
   0x00008000, 0x00000000, 0x00000000, 0x00000000,	/* ROPs */
   0x00000000, 0x00000000, 0x00000000, 0x00000000,	/* zeros */
@@ -301,7 +296,7 @@ STATIC_CONSTANT U_Int_32 const vax_c[] = {
   0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff,	/* -huge */
 };
 
-STATIC_CONSTANT U_Int_32 const ieee_s[] = {
+STATIC_CONSTANT uint32_t const ieee_s[] = {
 
   0x7fbfffff,			/* little endian ieee s nan */
   0xffffbf7f,			/* big endian ieee s nan */
@@ -319,7 +314,7 @@ STATIC_CONSTANT U_Int_32 const ieee_s[] = {
   0x000080ff,			/* be ieee s -infinity */
 };
 
-STATIC_CONSTANT U_Int_32 const ieee_t[] = {
+STATIC_CONSTANT uint32_t const ieee_t[] = {
 
   0xffffffff, 0x7ff7ffff,	/* le ieee t nan */
   0xfffff77f, 0xffffffff,	/* be ieee t nan */
@@ -337,7 +332,7 @@ STATIC_CONSTANT U_Int_32 const ieee_t[] = {
   0x0000f0ff, 0x00000000,	/* be ieee t -infinity */
 };
 
-STATIC_CONSTANT U_Int_32 const ieee_x[] = {
+STATIC_CONSTANT uint32_t const ieee_x[] = {
 
   0xffffffff, 0xffffffff, 0xffffffff, 0x7fff7fff,	/* le ieee x nan */
   0xff7fff7f, 0xffffffff, 0xffffffff, 0xffffffff,	/* be ieee x nan */
@@ -355,7 +350,7 @@ STATIC_CONSTANT U_Int_32 const ieee_x[] = {
   0x0000ffff, 0x00000000, 0x00000000, 0x00000000,	/* be ieee x -infinity */
 };
 
-STATIC_CONSTANT U_Int_32 const ibm_s[] = {
+STATIC_CONSTANT uint32_t const ibm_s[] = {
 
   0x000000ff,			/* ibm s invalid */
   0x00000000,			/* ibm s +zero */
@@ -367,7 +362,7 @@ STATIC_CONSTANT U_Int_32 const ibm_s[] = {
 
 };
 
-STATIC_CONSTANT U_Int_32 const ibm_l[] = {
+STATIC_CONSTANT uint32_t const ibm_l[] = {
 
   0x000000ff, 0x00000000,	/* ibm t invalid */
   0x00000000, 0x00000000,	/* ibm t +zero */
@@ -379,7 +374,7 @@ STATIC_CONSTANT U_Int_32 const ibm_l[] = {
 
 };
 
-STATIC_CONSTANT U_Int_32 const cray[] = {
+STATIC_CONSTANT uint32_t const cray[] = {
 
   0x00000060, 0x00000000,	/* cray invalid */
   0x00000000, 0x00000000,	/* cray +zero */
@@ -496,70 +491,70 @@ STATIC_CONSTANT U_Int_32 const cray[] = {
 **-----------------------------------------------------------------------------
 */
 STATIC_ROUTINE CVT_STATUS pack_vax_f(UNPACKED_REAL intermediate_value,
-				     CVT_VAX_F output_value, U_Int_32 options __attribute__ ((unused)));
+				     CVT_VAX_F output_value, uint32_t options __attribute__ ((unused)));
 
 STATIC_ROUTINE CVT_STATUS pack_vax_d(UNPACKED_REAL intermediate_value,
-				     CVT_VAX_D output_value, U_Int_32 options __attribute__ ((unused)));
+				     CVT_VAX_D output_value, uint32_t options __attribute__ ((unused)));
 
 STATIC_ROUTINE CVT_STATUS pack_vax_g(UNPACKED_REAL intermediate_value,
-				     CVT_VAX_G output_value, U_Int_32 options __attribute__ ((unused)));
+				     CVT_VAX_G output_value, uint32_t options __attribute__ ((unused)));
 
 STATIC_ROUTINE CVT_STATUS pack_vax_h(UNPACKED_REAL intermediate_value,
-				     CVT_VAX_H output_value, U_Int_32 options __attribute__ ((unused)));
+				     CVT_VAX_H output_value, uint32_t options __attribute__ ((unused)));
 
 STATIC_ROUTINE CVT_STATUS pack_ieee_s(UNPACKED_REAL intermediate_value,
-				      CVT_IEEE_S output_value, U_Int_32 options __attribute__ ((unused)));
+				      CVT_IEEE_S output_value, uint32_t options __attribute__ ((unused)));
 
 STATIC_ROUTINE CVT_STATUS pack_ieee_t(UNPACKED_REAL intermediate_value,
-				      CVT_IEEE_T output_value, U_Int_32 options __attribute__ ((unused)));
+				      CVT_IEEE_T output_value, uint32_t options __attribute__ ((unused)));
 
 STATIC_ROUTINE CVT_STATUS pack_ieee_x(UNPACKED_REAL intermediate_value,
-				      CVT_IEEE_X output_value, U_Int_32 options __attribute__ ((unused)));
+				      CVT_IEEE_X output_value, uint32_t options __attribute__ ((unused)));
 
 STATIC_ROUTINE CVT_STATUS pack_ibm_l(UNPACKED_REAL intermediate_value,
-				     CVT_IBM_LONG output_value, U_Int_32 options __attribute__ ((unused)));
+				     CVT_IBM_LONG output_value, uint32_t options __attribute__ ((unused)));
 
 STATIC_ROUTINE CVT_STATUS pack_ibm_s(UNPACKED_REAL intermediate_value,
-				     CVT_IBM_SHORT output_value, U_Int_32 options __attribute__ ((unused)));
+				     CVT_IBM_SHORT output_value, uint32_t options __attribute__ ((unused)));
 
 STATIC_ROUTINE CVT_STATUS pack_cray(UNPACKED_REAL intermediate_value,
-				    CVT_CRAY output_value, U_Int_32 options __attribute__ ((unused)));
+				    CVT_CRAY output_value, uint32_t options __attribute__ ((unused)));
 
 STATIC_ROUTINE void _round(UNPACKED_REAL intermediate_value,
-			   U_Int_32 round_bit_position, U_Int_32 options __attribute__ ((unused)));
+			   uint32_t round_bit_position, uint32_t options __attribute__ ((unused)));
 
 STATIC_ROUTINE void unpack_vax_f(CVT_VAX_F input_value,
-				 UNPACKED_REAL intermediate_value, U_Int_32 options __attribute__ ((unused)));
+				 UNPACKED_REAL intermediate_value, uint32_t options __attribute__ ((unused)));
 
 STATIC_ROUTINE void unpack_vax_d(CVT_VAX_D input_value,
-				 UNPACKED_REAL intermediate_value, U_Int_32 options __attribute__ ((unused)));
+				 UNPACKED_REAL intermediate_value, uint32_t options __attribute__ ((unused)));
 
 STATIC_ROUTINE void unpack_vax_g(CVT_VAX_G input_value,
-				 UNPACKED_REAL output_value, U_Int_32 options __attribute__ ((unused)));
+				 UNPACKED_REAL output_value, uint32_t options __attribute__ ((unused)));
 
 STATIC_ROUTINE void unpack_vax_h(CVT_VAX_H input_value,
-				 UNPACKED_REAL intermediate_value, U_Int_32 options __attribute__ ((unused)));
+				 UNPACKED_REAL intermediate_value, uint32_t options __attribute__ ((unused)));
 
 STATIC_ROUTINE void unpack_ieee_s(CVT_IEEE_S input_value,
-				  UNPACKED_REAL intermediate_value, U_Int_32 options __attribute__ ((unused)));
+				  UNPACKED_REAL intermediate_value, uint32_t options __attribute__ ((unused)));
 
 STATIC_ROUTINE void unpack_ieee_t(CVT_IEEE_T input_value,
-				  UNPACKED_REAL intermediate_value, U_Int_32 options __attribute__ ((unused)));
+				  UNPACKED_REAL intermediate_value, uint32_t options __attribute__ ((unused)));
 
 STATIC_ROUTINE void unpack_ieee_x(CVT_IEEE_X input_value,
-				  UNPACKED_REAL intermediate_value, U_Int_32 options __attribute__ ((unused)));
+				  UNPACKED_REAL intermediate_value, uint32_t options __attribute__ ((unused)));
 
 STATIC_ROUTINE void unpack_ibm_l(CVT_IBM_LONG input_value,
-				 UNPACKED_REAL intermediate_value, U_Int_32 options __attribute__ ((unused)));
+				 UNPACKED_REAL intermediate_value, uint32_t options __attribute__ ((unused)));
 
 STATIC_ROUTINE void unpack_ibm_s(CVT_IBM_SHORT input_value,
-				 UNPACKED_REAL intermediate_value, U_Int_32 options __attribute__ ((unused)));
+				 UNPACKED_REAL intermediate_value, uint32_t options __attribute__ ((unused)));
 
 STATIC_ROUTINE void unpack_cray(CVT_CRAY input_value,
-				UNPACKED_REAL intermediate_value, U_Int_32 options __attribute__ ((unused)));
+				UNPACKED_REAL intermediate_value, uint32_t options __attribute__ ((unused)));
 
 extern EXPORT CVT_STATUS CvtConvertFloat(void *input_value,
-			   U_Int_32 input_type, void *output_value, U_Int_32 output_type)
+			   uint32_t input_type, void *output_value, uint32_t output_type)
 
 /*
 **=============================================================================
@@ -630,7 +625,7 @@ extern EXPORT CVT_STATUS CvtConvertFloat(void *input_value,
    ** Local variable definitions.
    ** ==========================================================================
    */
-  U_Int_32 options = 0;
+  uint32_t options = 0;
   CVT_STATUS return_status;
   UNPACKED_REAL intermediate_value;
 
@@ -833,7 +828,7 @@ STATIC_ROUTINE void FlipDouble(int *in)
 }
 
 STATIC_ROUTINE CVT_STATUS pack_vax_f(UNPACKED_REAL intermediate_value,
-				     CVT_VAX_F output_value, U_Int_32 options __attribute__ ((unused)))
+				     CVT_VAX_F output_value, uint32_t options __attribute__ ((unused)))
 /*
 **=============================================================================
 **
@@ -1009,7 +1004,7 @@ STATIC_ROUTINE CVT_STATUS pack_vax_f(UNPACKED_REAL intermediate_value,
 }
 
 STATIC_ROUTINE CVT_STATUS pack_vax_d(UNPACKED_REAL intermediate_value,
-				     CVT_VAX_D output_value, U_Int_32 options __attribute__ ((unused)))
+				     CVT_VAX_D output_value, uint32_t options __attribute__ ((unused)))
 /*
 **=============================================================================
 **
@@ -1197,7 +1192,7 @@ STATIC_ROUTINE CVT_STATUS pack_vax_d(UNPACKED_REAL intermediate_value,
 }
 
 STATIC_ROUTINE CVT_STATUS pack_vax_g(UNPACKED_REAL intermediate_value,
-				     CVT_VAX_G output_value, U_Int_32 options __attribute__ ((unused)))
+				     CVT_VAX_G output_value, uint32_t options __attribute__ ((unused)))
 /*
 **=============================================================================
 **
@@ -1378,7 +1373,7 @@ STATIC_ROUTINE CVT_STATUS pack_vax_g(UNPACKED_REAL intermediate_value,
 }
 
 STATIC_ROUTINE CVT_STATUS pack_vax_h(UNPACKED_REAL intermediate_value,
-				     CVT_VAX_H output_value, U_Int_32 options __attribute__ ((unused)))
+				     CVT_VAX_H output_value, uint32_t options __attribute__ ((unused)))
 /*
 **=============================================================================
 **
@@ -1526,20 +1521,20 @@ STATIC_ROUTINE CVT_STATUS pack_vax_h(UNPACKED_REAL intermediate_value,
       intermediate_value[2] |= (intermediate_value[1] << 17);
       intermediate_value[1] >>= 15;
 
-      /*          
+      /*
        ** Clear implicit bit.
        ** ----------------------------------------------------------------------
        */
       intermediate_value[1] &= 0x0000FFFFL;
 
-      /*          
+      /*
        ** OR in exponent and sign bit.
        ** ----------------------------------------------------------------------
        */
       intermediate_value[1] |= (intermediate_value[U_R_EXP] << 16);
       intermediate_value[1] |= (intermediate_value[U_R_FLAGS] << 31);
 
-      /*          
+      /*
        ** Adjust for VAX 16 bit floating format.
        ** ----------------------------------------------------------------------
        */
@@ -1552,7 +1547,7 @@ STATIC_ROUTINE CVT_STATUS pack_vax_h(UNPACKED_REAL intermediate_value,
     }
   }
 
-  /*      
+  /*
    ** Exit the routine.
    ** ==========================================================================
    */
@@ -1561,7 +1556,7 @@ STATIC_ROUTINE CVT_STATUS pack_vax_h(UNPACKED_REAL intermediate_value,
 }
 
 STATIC_ROUTINE CVT_STATUS pack_ieee_s(UNPACKED_REAL intermediate_value,
-				      CVT_IEEE_S output_value, U_Int_32 options __attribute__ ((unused)))
+				      CVT_IEEE_S output_value, uint32_t options __attribute__ ((unused)))
 /*
 **=============================================================================
 **
@@ -1576,7 +1571,7 @@ STATIC_ROUTINE CVT_STATUS pack_ieee_s(UNPACKED_REAL intermediate_value,
 **
 **        1.0 <= fraction < 2.0, MSB implicit
 **
-**      For more details see "Mips R2000 Risc Architecture" by Gerry Kane, 
+**      For more details see "Mips R2000 Risc Architecture" by Gerry Kane,
 **      page 6-8 or ANSI/IEEE Std 754-1985.
 **
 **
@@ -1611,7 +1606,7 @@ STATIC_ROUTINE CVT_STATUS pack_ieee_s(UNPACKED_REAL intermediate_value,
 **=============================================================================
 */
 {
-  /*      
+  /*
    ** Local variable definition.
    ** ==========================================================================
    */
@@ -1619,13 +1614,13 @@ STATIC_ROUTINE CVT_STATUS pack_ieee_s(UNPACKED_REAL intermediate_value,
   int i;
   CVT_STATUS return_status;
 
-  /*      
+  /*
    ** Initialization.
    ** ==========================================================================
    */
   return_status = cvt_s_normal;
 
-  /*      
+  /*
    ** Check for unusual situations in the intermediate value.
    ** ie. zero, infinity or invalid numbers.
    ** ==========================================================================
@@ -1652,8 +1647,8 @@ STATIC_ROUTINE CVT_STATUS pack_ieee_s(UNPACKED_REAL intermediate_value,
     }
   }
 
-  /*      
-   ** Precision varies if value will be a denorm.  So, figure out where to 
+  /*
+   ** Precision varies if value will be a denorm.  So, figure out where to
    ** round (0 <= i <= 24).
    ** ==========================================================================
    */
@@ -1666,13 +1661,13 @@ STATIC_ROUTINE CVT_STATUS pack_ieee_s(UNPACKED_REAL intermediate_value,
 
     _round(intermediate_value, round_bit_position, options);
 
-    /*    
+    /*
      ** Check for Denorm or underflow.
      ** ========================================================================
      */
     if (intermediate_value[U_R_EXP] < (U_R_BIAS - 125)) {
       /*
-       ** Value is too small for a denorm, so underflow. 
+       ** Value is too small for a denorm, so underflow.
        ** ----------------------------------------------------------------------
        */
       if (intermediate_value[U_R_EXP] < ((U_R_BIAS - 125) - 23)) {
@@ -1711,7 +1706,7 @@ STATIC_ROUTINE CVT_STATUS pack_ieee_s(UNPACKED_REAL intermediate_value,
       }
     }
 
-    /*    
+    /*
      ** Check for overflow.
      ** ========================================================================
      */
@@ -1736,30 +1731,30 @@ STATIC_ROUTINE CVT_STATUS pack_ieee_s(UNPACKED_REAL intermediate_value,
       RAISE(cvt_s_overflow);
     }
 
-    /*    
+    /*
      ** Pack up the output value and return it.
      ** ========================================================================
      */
     else {
-      /*          
+      /*
        ** Adjust the bias of the exponent.
        ** ----------------------------------------------------------------------
        */
       intermediate_value[U_R_EXP] -= (U_R_BIAS - 126);
 
-      /*          
+      /*
        ** Make room for exponent and sign bit.
        ** ----------------------------------------------------------------------
        */
       intermediate_value[1] >>= 8;
 
-      /*          
+      /*
        ** Clear implicit bit.
        ** ----------------------------------------------------------------------
        */
       intermediate_value[1] &= 0x007FFFFFL;
 
-      /*          
+      /*
        ** OR in exponent and sign bit.
        ** ----------------------------------------------------------------------
        */
@@ -1777,7 +1772,7 @@ STATIC_ROUTINE CVT_STATUS pack_ieee_s(UNPACKED_REAL intermediate_value,
     }
   }
 
-  /*      
+  /*
    ** Exit the routine.
    ** ==========================================================================
    */
@@ -1786,7 +1781,7 @@ STATIC_ROUTINE CVT_STATUS pack_ieee_s(UNPACKED_REAL intermediate_value,
 }
 
 STATIC_ROUTINE CVT_STATUS pack_ieee_t(UNPACKED_REAL intermediate_value,
-				      CVT_IEEE_T output_value, U_Int_32 options __attribute__ ((unused)))
+				      CVT_IEEE_T output_value, uint32_t options __attribute__ ((unused)))
 /*
 **=============================================================================
 **
@@ -1802,7 +1797,7 @@ STATIC_ROUTINE CVT_STATUS pack_ieee_t(UNPACKED_REAL intermediate_value,
 **
 **          1.0 <= fraction < 2.0, MSB implicit
 **
-**      For more details see "Mips R2000 Risc Architecture" by Gerry Kane, 
+**      For more details see "Mips R2000 Risc Architecture" by Gerry Kane,
 **      page 6-8 or ANSI/IEEE Std 754-1985.
 **
 ** INPUT PARAMETERS:
@@ -1836,7 +1831,7 @@ STATIC_ROUTINE CVT_STATUS pack_ieee_t(UNPACKED_REAL intermediate_value,
 **=============================================================================
 */
 {
-  /*      
+  /*
    ** Local variable definition.
    ** ==========================================================================
    */
@@ -1846,13 +1841,13 @@ STATIC_ROUTINE CVT_STATUS pack_ieee_t(UNPACKED_REAL intermediate_value,
   STATIC_CONSTANT double fliptest = 42.;
   int flip = *(int *)&fliptest != 0;
 
-  /*      
+  /*
    ** Initialization.
    ** ==========================================================================
    */
   return_status = cvt_s_normal;
 
-  /*      
+  /*
    ** Check for unusual situations in the intermediate value.
    ** ie. zero, infinity or invalid numbers.
    ** ==========================================================================
@@ -1889,8 +1884,8 @@ STATIC_ROUTINE CVT_STATUS pack_ieee_t(UNPACKED_REAL intermediate_value,
     }
   }
 
-  /*      
-   ** Precision varies if value will be a denorm.  So, figure out where to 
+  /*
+   ** Precision varies if value will be a denorm.  So, figure out where to
    ** round (0 <= i <= 53).
    ** ==========================================================================
    */
@@ -1903,13 +1898,13 @@ STATIC_ROUTINE CVT_STATUS pack_ieee_t(UNPACKED_REAL intermediate_value,
 
     _round(intermediate_value, round_bit_position, options);
 
-    /*    
+    /*
      ** Check for Denorm or underflow.
      ** ========================================================================
      */
     if (intermediate_value[U_R_EXP] < (U_R_BIAS - 1021)) {
       /*
-       ** Value is too small for a denorm, so underflow. 
+       ** Value is too small for a denorm, so underflow.
        ** ----------------------------------------------------------------------
        */
       if (intermediate_value[U_R_EXP] < ((U_R_BIAS - 1021) - 52)) {
@@ -1964,7 +1959,7 @@ STATIC_ROUTINE CVT_STATUS pack_ieee_t(UNPACKED_REAL intermediate_value,
       }
     }
 
-    /*    
+    /*
      ** Check for overflow.
      ** ========================================================================
      */
@@ -2007,18 +2002,18 @@ STATIC_ROUTINE CVT_STATUS pack_ieee_t(UNPACKED_REAL intermediate_value,
       RAISE(cvt_s_overflow);
     }
 
-    /*    
+    /*
      ** Pack up the output value and return it.
      ** ========================================================================
      */
     else {
-      /*          
+      /*
        ** Adjust the bias of the exponent.
        ** ----------------------------------------------------------------------
        */
       intermediate_value[U_R_EXP] -= (U_R_BIAS - 1022);
 
-      /*          
+      /*
        ** Make room for exponent and sign bit.
        ** ----------------------------------------------------------------------
        */
@@ -2026,13 +2021,13 @@ STATIC_ROUTINE CVT_STATUS pack_ieee_t(UNPACKED_REAL intermediate_value,
       intermediate_value[2] |= (intermediate_value[1] << 21);
       intermediate_value[1] >>= 11;
 
-      /*          
+      /*
        ** Clear implicit bit.
        ** ----------------------------------------------------------------------
        */
       intermediate_value[1] &= 0x000FFFFFL;
 
-      /*          
+      /*
        ** OR in exponent and sign bit.
        ** ----------------------------------------------------------------------
        */
@@ -2055,7 +2050,7 @@ STATIC_ROUTINE CVT_STATUS pack_ieee_t(UNPACKED_REAL intermediate_value,
     }
   }
 
-  /*      
+  /*
    ** Exit the routine.
    ** ==========================================================================
    */
@@ -2064,7 +2059,7 @@ STATIC_ROUTINE CVT_STATUS pack_ieee_t(UNPACKED_REAL intermediate_value,
 }
 
 STATIC_ROUTINE CVT_STATUS pack_ieee_x(UNPACKED_REAL intermediate_value,
-				      CVT_IEEE_X output_value, U_Int_32 options __attribute__ ((unused)))
+				      CVT_IEEE_X output_value, uint32_t options __attribute__ ((unused)))
 /*
 **=============================================================================
 **
@@ -2116,7 +2111,7 @@ STATIC_ROUTINE CVT_STATUS pack_ieee_x(UNPACKED_REAL intermediate_value,
 **=============================================================================
 */
 {
-  /*      
+  /*
    ** Local variable definition.
    ** ==========================================================================
    */
@@ -2124,13 +2119,13 @@ STATIC_ROUTINE CVT_STATUS pack_ieee_x(UNPACKED_REAL intermediate_value,
   int i;
   CVT_STATUS return_status;
 
-  /*      
+  /*
    ** Initialization.
    ** ==========================================================================
    */
   return_status = cvt_s_normal;
 
-  /*      
+  /*
    ** Check for unusual situations in the intermediate value.
    ** ie. zero, infinity or invalid numbers.
    ** ==========================================================================
@@ -2157,8 +2152,8 @@ STATIC_ROUTINE CVT_STATUS pack_ieee_x(UNPACKED_REAL intermediate_value,
     }
   }
 
-  /*      
-   ** Precision varies if value will be a denorm.  So, figure out where to 
+  /*
+   ** Precision varies if value will be a denorm.  So, figure out where to
    ** round (0 <= i <= 113).
    ** ==========================================================================
    */
@@ -2171,13 +2166,13 @@ STATIC_ROUTINE CVT_STATUS pack_ieee_x(UNPACKED_REAL intermediate_value,
 
     _round(intermediate_value, round_bit_position, options);
 
-    /*    
+    /*
      ** Check for Denorm or underflow.
      ** ========================================================================
      */
     if (intermediate_value[U_R_EXP] < (U_R_BIAS - 16381)) {
       /*
-       ** Value is too small for a denorm, so underflow. 
+       ** Value is too small for a denorm, so underflow.
        ** ----------------------------------------------------------------------
        */
       if (intermediate_value[U_R_EXP] < ((U_R_BIAS - 16381) - 112)) {
@@ -2259,7 +2254,7 @@ STATIC_ROUTINE CVT_STATUS pack_ieee_x(UNPACKED_REAL intermediate_value,
       }
     }
 
-    /*    
+    /*
      ** Check for overflow.
      ** ========================================================================
      */
@@ -2290,18 +2285,18 @@ STATIC_ROUTINE CVT_STATUS pack_ieee_x(UNPACKED_REAL intermediate_value,
       RAISE(cvt_s_overflow);
     }
 
-    /*    
+    /*
      ** Pack up the output value and return it.
      ** ========================================================================
      */
     else {
-      /*          
+      /*
        ** Adjust the bias of the exponent.
        ** ----------------------------------------------------------------------
        */
       intermediate_value[U_R_EXP] -= (U_R_BIAS - 16382);
 
-      /*          
+      /*
        ** Make room for exponent and sign bit.
        ** ----------------------------------------------------------------------
        */
@@ -2313,13 +2308,13 @@ STATIC_ROUTINE CVT_STATUS pack_ieee_x(UNPACKED_REAL intermediate_value,
       intermediate_value[2] |= (intermediate_value[1] << 17);
       intermediate_value[1] >>= 15;
 
-      /*          
+      /*
        ** Clear implicit bit.
        ** ----------------------------------------------------------------------
        */
       intermediate_value[1] &= 0x0000FFFFL;
 
-      /*          
+      /*
        ** OR in exponent and sign bit.
        ** ----------------------------------------------------------------------
        */
@@ -2352,7 +2347,7 @@ STATIC_ROUTINE CVT_STATUS pack_ieee_x(UNPACKED_REAL intermediate_value,
     }
   }
 
-  /*      
+  /*
    ** Exit the routine.
    ** ==========================================================================
    */
@@ -2361,7 +2356,7 @@ STATIC_ROUTINE CVT_STATUS pack_ieee_x(UNPACKED_REAL intermediate_value,
 }
 
 STATIC_ROUTINE CVT_STATUS pack_ibm_l(UNPACKED_REAL intermediate_value,
-				     CVT_IBM_LONG output_value, U_Int_32 options __attribute__ ((unused)))
+				     CVT_IBM_LONG output_value, uint32_t options __attribute__ ((unused)))
 /*
 **=============================================================================
 **
@@ -2411,7 +2406,7 @@ STATIC_ROUTINE CVT_STATUS pack_ibm_l(UNPACKED_REAL intermediate_value,
 **=============================================================================
 */
 {
-  /*      
+  /*
    ** Local variable definition.
    ** ==========================================================================
    */
@@ -2419,13 +2414,13 @@ STATIC_ROUTINE CVT_STATUS pack_ibm_l(UNPACKED_REAL intermediate_value,
   int i, j;
   CVT_STATUS return_status;
 
-  /*      
+  /*
    ** Initialization.
    ** ==========================================================================
    */
   return_status = cvt_s_normal;
 
-  /*      
+  /*
    ** Check for unusual situations in the intermediate value.
    ** ie. zero, infinity or invalid numbers.
    ** ==========================================================================
@@ -2450,9 +2445,9 @@ STATIC_ROUTINE CVT_STATUS pack_ibm_l(UNPACKED_REAL intermediate_value,
     }
   }
 
-  /*      
+  /*
    ** Precision varies because binary exp must be multiple of 4 (since we must
-   ** convert it to a hexadecimal exponent).  So, figure out where to round 
+   ** convert it to a hexadecimal exponent).  So, figure out where to round
    ** (53 <= i <= 56).
    ** ==========================================================================
    */
@@ -2465,13 +2460,13 @@ STATIC_ROUTINE CVT_STATUS pack_ibm_l(UNPACKED_REAL intermediate_value,
 
     _round(intermediate_value, round_bit_position, options);
 
-    /*    
+    /*
      ** Check for underflow.
      ** ========================================================================
      */
     if (intermediate_value[U_R_EXP] < (U_R_BIAS - 255)) {
       /*
-       ** Value is too small, so underflow. 
+       ** Value is too small, so underflow.
        ** ----------------------------------------------------------------------
        */
       if (intermediate_value[U_R_FLAGS] & U_R_NEGATIVE) {
@@ -2483,13 +2478,13 @@ STATIC_ROUTINE CVT_STATUS pack_ibm_l(UNPACKED_REAL intermediate_value,
       if (options & CVT_M_ERR_UNDERFLOW)
 	RAISE(cvt_s_underflow);
     }
-    /*    
+    /*
      ** Check for overflow.
      ** ========================================================================
      */
     else if (intermediate_value[U_R_EXP] > (U_R_BIAS + 252)) {
       /*
-       ** Value is too large, so overflow. 
+       ** Value is too large, so overflow.
        ** ----------------------------------------------------------------------
        */
       if (options & CVT_M_TRUNCATE) {
@@ -2512,7 +2507,7 @@ STATIC_ROUTINE CVT_STATUS pack_ibm_l(UNPACKED_REAL intermediate_value,
       RAISE(cvt_s_overflow);
     }
 
-    /*    
+    /*
      ** Pack up the output value and return it.
      ** ========================================================================
      */
@@ -2533,7 +2528,7 @@ STATIC_ROUTINE CVT_STATUS pack_ibm_l(UNPACKED_REAL intermediate_value,
       }
 
       /*
-       ** Make room for exponent and sign bit 
+       ** Make room for exponent and sign bit
        ** ----------------------------------------------------------------------
        */
       intermediate_value[2] >>= i;
@@ -2541,14 +2536,14 @@ STATIC_ROUTINE CVT_STATUS pack_ibm_l(UNPACKED_REAL intermediate_value,
       intermediate_value[1] >>= i;
 
       /*
-       ** OR in exponent and sign bit 
+       ** OR in exponent and sign bit
        ** ----------------------------------------------------------------------
        */
       intermediate_value[1] |= (j << 24);
       intermediate_value[1] |= (intermediate_value[U_R_FLAGS] << 31);
 
       /*
-       ** Shuffle bytes to big endian format 
+       ** Shuffle bytes to big endian format
        ** ----------------------------------------------------------------------
        */
       intermediate_value[0] = ((intermediate_value[1] << 24) | (intermediate_value[1] >> 24));
@@ -2562,7 +2557,7 @@ STATIC_ROUTINE CVT_STATUS pack_ibm_l(UNPACKED_REAL intermediate_value,
     }
   }
 
-  /*      
+  /*
    ** Exit the routine.
    ** ==========================================================================
    */
@@ -2571,7 +2566,7 @@ STATIC_ROUTINE CVT_STATUS pack_ibm_l(UNPACKED_REAL intermediate_value,
 }
 
 STATIC_ROUTINE CVT_STATUS pack_ibm_s(UNPACKED_REAL intermediate_value,
-				     CVT_IBM_SHORT output_value, U_Int_32 options __attribute__ ((unused)))
+				     CVT_IBM_SHORT output_value, uint32_t options __attribute__ ((unused)))
 /*
 **=============================================================================
 **
@@ -2620,7 +2615,7 @@ STATIC_ROUTINE CVT_STATUS pack_ibm_s(UNPACKED_REAL intermediate_value,
 **=============================================================================
 */
 {
-  /*      
+  /*
    ** Local variable definition.
    ** ==========================================================================
    */
@@ -2628,13 +2623,13 @@ STATIC_ROUTINE CVT_STATUS pack_ibm_s(UNPACKED_REAL intermediate_value,
   int i, j;
   CVT_STATUS return_status;
 
-  /*      
+  /*
    ** Initialization.
    ** ==========================================================================
    */
   return_status = cvt_s_normal;
 
-  /*      
+  /*
    ** Check for unusual situations in the intermediate value.
    ** ie. zero, infinity or invalid numbers.
    ** ==========================================================================
@@ -2658,9 +2653,9 @@ STATIC_ROUTINE CVT_STATUS pack_ibm_s(UNPACKED_REAL intermediate_value,
     }
   }
 
-  /*      
+  /*
    ** Precision varies because exp must be multiple of 4 (since we must convert
-   ** it to a hexadecimal exponent).  So, figure out where to round 
+   ** it to a hexadecimal exponent).  So, figure out where to round
    ** (21 <= i <=24).
    ** ==========================================================================
    */
@@ -2673,7 +2668,7 @@ STATIC_ROUTINE CVT_STATUS pack_ibm_s(UNPACKED_REAL intermediate_value,
 
     _round(intermediate_value, round_bit_position, options);
 
-    /*    
+    /*
      ** Check for underflow.
      ** ========================================================================
      */
@@ -2689,7 +2684,7 @@ STATIC_ROUTINE CVT_STATUS pack_ibm_s(UNPACKED_REAL intermediate_value,
       }
     }
 
-    /*    
+    /*
      ** Check for overflow.
      ** ========================================================================
      */
@@ -2714,12 +2709,12 @@ STATIC_ROUTINE CVT_STATUS pack_ibm_s(UNPACKED_REAL intermediate_value,
       RAISE(cvt_s_overflow);
     }
 
-    /*    
+    /*
      ** Pack up the output value and return it.
      ** ========================================================================
      */
     else {
-      /* 
+      /*
        ** Figure leading zeros (i) and biased exponent (j)
        ** ----------------------------------------------------------------------
        */
@@ -2734,20 +2729,20 @@ STATIC_ROUTINE CVT_STATUS pack_ibm_s(UNPACKED_REAL intermediate_value,
 	i = 8;
       }
 
-      /* 
+      /*
        ** Make room for exponent and sign bit
        ** ----------------------------------------------------------------------
        */
       intermediate_value[1] >>= i;
 
-      /* 
+      /*
        ** OR in exponent and sign bit
        ** ----------------------------------------------------------------------
        */
       intermediate_value[1] |= (j << 24);
       intermediate_value[1] |= (intermediate_value[U_R_FLAGS] << 31);
 
-      /* 
+      /*
        ** Shuffle bytes to big endian format
        ** ----------------------------------------------------------------------
        */
@@ -2760,7 +2755,7 @@ STATIC_ROUTINE CVT_STATUS pack_ibm_s(UNPACKED_REAL intermediate_value,
     }
   }
 
-  /*      
+  /*
    ** Exit the routine.
    ** ==========================================================================
    */
@@ -2769,7 +2764,7 @@ STATIC_ROUTINE CVT_STATUS pack_ibm_s(UNPACKED_REAL intermediate_value,
 }
 
 STATIC_ROUTINE CVT_STATUS pack_cray(UNPACKED_REAL intermediate_value,
-				    CVT_CRAY output_value, U_Int_32 options __attribute__ ((unused)))
+				    CVT_CRAY output_value, uint32_t options __attribute__ ((unused)))
 /*
 **=============================================================================
 **
@@ -2785,7 +2780,7 @@ STATIC_ROUTINE CVT_STATUS pack_cray(UNPACKED_REAL intermediate_value,
 **          [0]: Sign bit, 15 exp bits (bias 16384), 16 fraction bits
 **          [1]: 32 low order fraction bits
 **
-**          0.5 <= fraction < 1.0, MSB explicit 
+**          0.5 <= fraction < 1.0, MSB explicit
 **          Since CRAY has no hidden bits the MSB must always be set.
 **
 **      Some of the CRAY exponent range is not used.
@@ -2825,20 +2820,20 @@ STATIC_ROUTINE CVT_STATUS pack_cray(UNPACKED_REAL intermediate_value,
 **=============================================================================
 */
 {
-  /*      
+  /*
    ** Local variable definition.
    ** ==========================================================================
    */
   int round_bit_position;
   CVT_STATUS return_status;
 
-  /*      
+  /*
    ** Initialization.
    ** ==========================================================================
    */
   return_status = cvt_s_normal;
 
-  /*      
+  /*
    ** Check for unusual situations in the intermediate value.
    ** ie. zero, infinity or invalid numbers.
    ** ==========================================================================
@@ -2874,7 +2869,7 @@ STATIC_ROUTINE CVT_STATUS pack_cray(UNPACKED_REAL intermediate_value,
 
     _round(intermediate_value, round_bit_position, options);
 
-    /*    
+    /*
      ** Check for underflow.
      ** ========================================================================
      */
@@ -2890,7 +2885,7 @@ STATIC_ROUTINE CVT_STATUS pack_cray(UNPACKED_REAL intermediate_value,
       }
     }
 
-    /*    
+    /*
      ** Check for overflow.
      ** ========================================================================
      */
@@ -2916,13 +2911,13 @@ STATIC_ROUTINE CVT_STATUS pack_cray(UNPACKED_REAL intermediate_value,
      ** ========================================================================
      */
     else {
-      /* 
+      /*
        ** Adjust bias of exponent
        ** ----------------------------------------------------------------------
        */
       intermediate_value[U_R_EXP] -= (U_R_BIAS - 16384);
 
-      /* 
+      /*
        ** Make room for exponent and sign bit
        ** ----------------------------------------------------------------------
        */
@@ -2930,14 +2925,14 @@ STATIC_ROUTINE CVT_STATUS pack_cray(UNPACKED_REAL intermediate_value,
       intermediate_value[2] |= (intermediate_value[1] << 16);
       intermediate_value[1] >>= 16;
 
-      /* 
+      /*
        ** OR in exponent and sign bit
        ** ----------------------------------------------------------------------
        */
       intermediate_value[1] |= (intermediate_value[U_R_EXP] << 16);
       intermediate_value[1] |= (intermediate_value[U_R_FLAGS] << 31);
 
-      /* 
+      /*
        ** Shuffle bytes to big endian format
        ** ----------------------------------------------------------------------
        */
@@ -2953,7 +2948,7 @@ STATIC_ROUTINE CVT_STATUS pack_cray(UNPACKED_REAL intermediate_value,
     }
   }
 
-  /*      
+  /*
    ** Exit the routine.
    ** ==========================================================================
    */
@@ -2962,7 +2957,7 @@ STATIC_ROUTINE CVT_STATUS pack_cray(UNPACKED_REAL intermediate_value,
 }
 
 STATIC_ROUTINE void _round(UNPACKED_REAL intermediate_value,
-			   U_Int_32 round_bit_position, U_Int_32 options __attribute__ ((unused)))
+			   uint32_t round_bit_position, uint32_t options __attribute__ ((unused)))
 /*
 **=============================================================================
 **
@@ -3014,7 +3009,7 @@ STATIC_ROUTINE void _round(UNPACKED_REAL intermediate_value,
 **              rounding towards zero, implies input data are rounded such
 **              that the representable value closest to and no greater in
 **              magnitude than the infinitely precise result is delivered.
-** 
+**
 **      Note: for efficiency this routine performs no explicit error checking.
 **
 **
@@ -3023,7 +3018,7 @@ STATIC_ROUTINE void _round(UNPACKED_REAL intermediate_value,
 **      intermediate_value      - address of the UNPACKED_REAL to be rounded.
 **
 **      round_bit_position      - An integer specifying the position to round
-**                                to.  0 <= round_bit_position <= 127.  
+**                                to.  0 <= round_bit_position <= 127.
 **
 **                                Note: Valid CVT mantissa bits are addressed
 **                                as 1 through 128.  Accordingly, specifying 0
@@ -3032,7 +3027,7 @@ STATIC_ROUTINE void _round(UNPACKED_REAL intermediate_value,
 **                                truncation: truncation always leaves a CVT
 **                                number untouched.
 **
-**      options                 - A valid CVT options bit mask in which at 
+**      options                 - A valid CVT options bit mask in which at
 **                                least one, and only one, CVT rounding mode is
 **                                specified.  If no rounding mode is specified,
 **                                results are unpredictable.  Rounding is
@@ -3061,41 +3056,41 @@ STATIC_ROUTINE void _round(UNPACKED_REAL intermediate_value,
 **=============================================================================
 */
 {
-  /*      
+  /*
    ** Local variable definition.
    ** ==========================================================================
    */
-  U_Int_32 bit_mask;
+  uint32_t bit_mask;
   int i;
   int more_bits;
   int roundup;
 
-  /*      
+  /*
    ** If we are not going to TRUNCATE the number.
    ** ==========================================================================
    */
   if (!(options & CVT_M_TRUNCATE)) {
 
-    /*    
+    /*
      ** Determine which word the round bit resides in.
      ** ========================================================================
      */
     i = (round_bit_position >> 5) + 1;
 
-    /*    
+    /*
      ** Create a mask isolating the round bit.
      ** ========================================================================
      */
     bit_mask = 0x1L << (31 - (round_bit_position & 0x1FL));
 
-    /*    
+    /*
      ** If we are doing VAX ROUNDING.
      ** ========================================================================
      */
     if (options & CVT_M_VAX_ROUNDING)
       roundup = intermediate_value[i] & bit_mask;
 
-    /*    
+    /*
      ** Else handle the other rounding options.
      ** ========================================================================
      */
@@ -3169,27 +3164,27 @@ STATIC_ROUTINE void _round(UNPACKED_REAL intermediate_value,
       }
     }
 
-    /*    
+    /*
      ** Perform rounding if necessary.
      ** ========================================================================
      */
     if (roundup) {
 
-      /*          
+      /*
        ** Add 1 at round position.
        ** ----------------------------------------------------------------------
        */
       bit_mask <<= 1;
       intermediate_value[i] = (intermediate_value[i] & ~(bit_mask - 1)) + bit_mask;
 
-      /*          
+      /*
        ** Propagate any carry.
        ** ----------------------------------------------------------------------
        */
       while (!intermediate_value[i])
 	intermediate_value[--i] += 1;
 
-      /*          
+      /*
        ** If carry reaches exponent MSB gets zeroed and must be reset.
        ** ----------------------------------------------------------------------
        */
@@ -3198,7 +3193,7 @@ STATIC_ROUTINE void _round(UNPACKED_REAL intermediate_value,
     }
   }
 
-  /*      
+  /*
    ** Exit the routine.
    ** ==========================================================================
    */
@@ -3207,7 +3202,7 @@ STATIC_ROUTINE void _round(UNPACKED_REAL intermediate_value,
 }
 
 STATIC_ROUTINE void unpack_vax_f(CVT_VAX_F input_value,
-				 UNPACKED_REAL output_value, U_Int_32 options __attribute__ ((unused)))
+				 UNPACKED_REAL output_value, uint32_t options __attribute__ ((unused)))
 /*
 **=============================================================================
 **
@@ -3234,7 +3229,7 @@ STATIC_ROUTINE void unpack_vax_f(CVT_VAX_F input_value,
 **
 ** OUTPUT PARAMETERS:
 **
-**      output_value            - address of where to place the UNPACKED_REAL 
+**      output_value            - address of where to place the UNPACKED_REAL
 **                                result value
 **
 ** IMPLICIT OUTPUTS:
@@ -3252,26 +3247,26 @@ STATIC_ROUTINE void unpack_vax_f(CVT_VAX_F input_value,
 **=============================================================================
 */
 {
-  /*      
+  /*
    ** Initialization.
    ** ==========================================================================
    */
   memcpy(&output_value[1], input_value, 4);
 
-  /*      
+  /*
    ** Initialize FLAGS and perhaps set NEGATIVE bit.
    ** ==========================================================================
    */
   output_value[U_R_FLAGS] = (output_value[1] >> 15) & U_R_NEGATIVE;
 
-  /*      
+  /*
    ** Extract VAX biased exponent.
    ** ==========================================================================
    */
   output_value[U_R_EXP] = (output_value[1] >> 7) & 0x000000FFL;
 
-  /*      
-   ** If the exponent is zero, determine if we have an invalid number or 
+  /*
+   ** If the exponent is zero, determine if we have an invalid number or
    ** a zero value.  Set the flag bits accordingly.
    ** ==========================================================================
    */
@@ -3282,32 +3277,32 @@ STATIC_ROUTINE void unpack_vax_f(CVT_VAX_F input_value,
       output_value[U_R_FLAGS] = U_R_ZERO;
   }
 
-  /*      
+  /*
    ** Else the exponent is not zero and we will always have a valid number.
    ** ==========================================================================
    */
   else {
     output_value[1] = ((output_value[1] << 16) | (output_value[1] >> 16));
 
-    /*    
+    /*
      ** Adjust for VAX 16 bit floating format.
      ** ------------------------------------------------------------------------
      */
     output_value[U_R_EXP] += (U_R_BIAS - 128);
 
-    /*    
+    /*
      ** Set hidden bit.
      ** ------------------------------------------------------------------------
      */
     output_value[1] |= 0x00800000L;
 
-    /*    
+    /*
      ** Left justify fraction bits.
      ** ------------------------------------------------------------------------
      */
     output_value[1] <<= 8;
 
-    /*    
+    /*
      ** Clear uninitialized parts for unpacked real.
      ** ------------------------------------------------------------------------
      */
@@ -3316,7 +3311,7 @@ STATIC_ROUTINE void unpack_vax_f(CVT_VAX_F input_value,
     output_value[4] = 0;
   }
 
-  /*      
+  /*
    ** Exit the routine.
    ** ==========================================================================
    */
@@ -3325,7 +3320,7 @@ STATIC_ROUTINE void unpack_vax_f(CVT_VAX_F input_value,
 }
 
 STATIC_ROUTINE void unpack_vax_d(CVT_VAX_D input_value,
-				 UNPACKED_REAL output_value, U_Int_32 options __attribute__ ((unused)))
+				 UNPACKED_REAL output_value, uint32_t options __attribute__ ((unused)))
 /*
 **=============================================================================
 **
@@ -3354,7 +3349,7 @@ STATIC_ROUTINE void unpack_vax_d(CVT_VAX_D input_value,
 **
 ** OUTPUT PARAMETERS:
 **
-**      output_value            - address of where to place the UNPACKED_REAL 
+**      output_value            - address of where to place the UNPACKED_REAL
 **                                result value
 **
 ** IMPLICIT OUTPUTS:
@@ -3372,7 +3367,7 @@ STATIC_ROUTINE void unpack_vax_d(CVT_VAX_D input_value,
 **=============================================================================
 */
 {
-  /*      
+  /*
    ** Initialization.
    ** ==========================================================================
    */
@@ -3382,20 +3377,20 @@ STATIC_ROUTINE void unpack_vax_d(CVT_VAX_D input_value,
 #else
   memcpy(&output_value[1], input_value, 8);
 #endif
-  /*      
+  /*
    ** Initialize FLAGS and perhaps set NEGATIVE bit.
    ** ==========================================================================
    */
   output_value[U_R_FLAGS] = (output_value[1] >> 15) & U_R_NEGATIVE;
 
-  /*      
+  /*
    ** Extract VAX biased exponent.
    ** ==========================================================================
    */
   output_value[U_R_EXP] = (output_value[1] >> 7) & 0x000000FFL;
 
-  /*      
-   ** If the exponent is zero, determine if we have an invalid number or 
+  /*
+   ** If the exponent is zero, determine if we have an invalid number or
    ** a zero value.  Set the flag bits accordingly.
    ** ==========================================================================
    */
@@ -3406,31 +3401,31 @@ STATIC_ROUTINE void unpack_vax_d(CVT_VAX_D input_value,
       output_value[U_R_FLAGS] = U_R_ZERO;
   }
 
-  /*      
+  /*
    ** Else the exponent is not zero and we will always have a valid number.
    ** ==========================================================================
    */
   else {
-    /*    
+    /*
      ** Adjust for VAX 16 bit floating format.
      ** ------------------------------------------------------------------------
      */
     output_value[1] = ((output_value[1] << 16) | (output_value[1] >> 16));
     output_value[2] = ((output_value[2] << 16) | (output_value[2] >> 16));
 
-    /*    
+    /*
      ** Add unpacked real bias and subtract VAX bias.
      ** ------------------------------------------------------------------------
      */
     output_value[U_R_EXP] += (U_R_BIAS - 128);
 
-    /*    
+    /*
      ** Set hidden bit.
      ** ------------------------------------------------------------------------
      */
     output_value[1] |= 0x00800000L;
 
-    /*    
+    /*
      ** Left justify fraction bits.
      ** ------------------------------------------------------------------------
      */
@@ -3438,7 +3433,7 @@ STATIC_ROUTINE void unpack_vax_d(CVT_VAX_D input_value,
     output_value[1] |= (output_value[2] >> 24);
     output_value[2] <<= 8;
 
-    /*    
+    /*
      ** Clear uninitialized part of unpacked real.
      ** ------------------------------------------------------------------------
      */
@@ -3446,7 +3441,7 @@ STATIC_ROUTINE void unpack_vax_d(CVT_VAX_D input_value,
     output_value[4] = 0;
   }
 
-  /*      
+  /*
    ** Exit the routine.
    ** ==========================================================================
    */
@@ -3455,7 +3450,7 @@ STATIC_ROUTINE void unpack_vax_d(CVT_VAX_D input_value,
 }
 
 STATIC_ROUTINE void unpack_vax_g(CVT_VAX_G input_value,
-				 UNPACKED_REAL output_value, U_Int_32 options __attribute__ ((unused)))
+				 UNPACKED_REAL output_value, uint32_t options __attribute__ ((unused)))
 /*
 **=============================================================================
 **
@@ -3465,7 +3460,7 @@ STATIC_ROUTINE void unpack_vax_g(CVT_VAX_G input_value,
 **      number and to initialize an UNPACKED_REAL structure with those bits.
 **
 **      A VAX g_floating number in (16 bit words) looks like:
-** 
+**
 **          [0]: Sign bit, 11 exp bits (bias 1024), 4 fraction bits
 **          [1]: 16 more fraction bits
 **          [2]: 16 more fraction bits
@@ -3484,7 +3479,7 @@ STATIC_ROUTINE void unpack_vax_g(CVT_VAX_G input_value,
 **
 ** OUTPUT PARAMETERS:
 **
-**      output_value            - address of where to place the UNPACKED_REAL 
+**      output_value            - address of where to place the UNPACKED_REAL
 **                                result value
 **
 ** IMPLICIT OUTPUTS:
@@ -3502,7 +3497,7 @@ STATIC_ROUTINE void unpack_vax_g(CVT_VAX_G input_value,
 **=============================================================================
 */
 {
-  /*      
+  /*
    ** Initialization.
    ** ==========================================================================
    */
@@ -3513,20 +3508,20 @@ STATIC_ROUTINE void unpack_vax_g(CVT_VAX_G input_value,
   memcpy(&output_value[1], input_value, 8);
 #endif
 
-  /*      
+  /*
    ** Initialize FLAGS and perhaps set NEGATIVE bit.
    ** ==========================================================================
    */
   output_value[U_R_FLAGS] = (output_value[1] >> 15) & U_R_NEGATIVE;
 
-  /*      
+  /*
    ** Extract VAX biased exponent.
    ** ==========================================================================
    */
   output_value[U_R_EXP] = (output_value[1] >> 4) & 0x000007FFL;
 
-  /*      
-   ** If the exponent is zero, determine if we have an invalid number or 
+  /*
+   ** If the exponent is zero, determine if we have an invalid number or
    ** a zero value.  Set the flag bits accordingly.
    ** ==========================================================================
    */
@@ -3537,31 +3532,31 @@ STATIC_ROUTINE void unpack_vax_g(CVT_VAX_G input_value,
       output_value[U_R_FLAGS] = U_R_ZERO;
   }
 
-  /*      
+  /*
    ** Else the exponent is not zero and we will always have a valid number.
    ** ==========================================================================
    */
   else {
-    /*    
+    /*
      ** Adjust for VAX 16 bit floating format.
      ** ------------------------------------------------------------------------
      */
     output_value[1] = ((output_value[1] << 16) | (output_value[1] >> 16));
     output_value[2] = ((output_value[2] << 16) | (output_value[2] >> 16));
 
-    /*    
+    /*
      ** Add unpacked real bias and subtract VAX bias.
      ** ------------------------------------------------------------------------
      */
     output_value[U_R_EXP] += (U_R_BIAS - 1024);
 
-    /*    
+    /*
      ** Set hidden bit.
      ** ------------------------------------------------------------------------
      */
     output_value[1] |= 0x00100000L;
 
-    /*    
+    /*
      ** Left justify fraction bits.
      ** ------------------------------------------------------------------------
      */
@@ -3569,7 +3564,7 @@ STATIC_ROUTINE void unpack_vax_g(CVT_VAX_G input_value,
     output_value[1] |= (output_value[2] >> 21);
     output_value[2] <<= 11;
 
-    /*    
+    /*
      ** Clear uninitialized part of unpacked real.
      ** ------------------------------------------------------------------------
      */
@@ -3577,7 +3572,7 @@ STATIC_ROUTINE void unpack_vax_g(CVT_VAX_G input_value,
     output_value[4] = 0;
   }
 
-  /*      
+  /*
    ** Exit the routine.
    ** ==========================================================================
    */
@@ -3586,7 +3581,7 @@ STATIC_ROUTINE void unpack_vax_g(CVT_VAX_G input_value,
 }
 
 STATIC_ROUTINE void unpack_vax_h(CVT_VAX_H input_value,
-				 UNPACKED_REAL output_value, U_Int_32 options __attribute__ ((unused)))
+				 UNPACKED_REAL output_value, uint32_t options __attribute__ ((unused)))
 /*
 **=============================================================================
 **
@@ -3619,7 +3614,7 @@ STATIC_ROUTINE void unpack_vax_h(CVT_VAX_H input_value,
 **
 ** OUTPUT PARAMETERS:
 **
-**      output_value            - address of where to place the UNPACKED_REAL 
+**      output_value            - address of where to place the UNPACKED_REAL
 **                                result value
 **
 ** IMPLICIT OUTPUTS:
@@ -3637,26 +3632,26 @@ STATIC_ROUTINE void unpack_vax_h(CVT_VAX_H input_value,
 **=============================================================================
 */
 {
-  /*      
+  /*
    ** Initialization.
    ** ==========================================================================
    */
   memcpy(&output_value[1], input_value, 16);
 
-  /*      
+  /*
    ** Initialize FLAGS and perhaps set NEGATIVE bit.
    ** ==========================================================================
    */
   output_value[U_R_FLAGS] = (output_value[1] >> 15) & U_R_NEGATIVE;
 
-  /*      
+  /*
    ** Extract VAX biased exponent.
    ** ==========================================================================
    */
   output_value[U_R_EXP] = output_value[1] & 0x00007FFFL;
 
-  /*      
-   ** If the exponent is zero, determine if we have an invalid number or 
+  /*
+   ** If the exponent is zero, determine if we have an invalid number or
    ** a zero value.  Set the flag bits accordingly.
    ** ==========================================================================
    */
@@ -3667,12 +3662,12 @@ STATIC_ROUTINE void unpack_vax_h(CVT_VAX_H input_value,
       output_value[U_R_FLAGS] = U_R_ZERO;
   }
 
-  /*      
+  /*
    ** Else the exponent is not zero and we will always have a valid number.
    ** ==========================================================================
    */
   else {
-    /*    
+    /*
      ** Adjust for VAX 16 bit floating format.
      ** ------------------------------------------------------------------------
      */
@@ -3681,19 +3676,19 @@ STATIC_ROUTINE void unpack_vax_h(CVT_VAX_H input_value,
     output_value[3] = ((output_value[3] << 16) | (output_value[3] >> 16));
     output_value[4] = ((output_value[4] << 16) | (output_value[4] >> 16));
 
-    /*    
+    /*
      ** Add unpacked real bias and subtract VAX bias.
      ** ------------------------------------------------------------------------
      */
     output_value[U_R_EXP] += (U_R_BIAS - 16384);
 
-    /*    
+    /*
      ** Set hidden bit.
      ** ------------------------------------------------------------------------
      */
     output_value[1] |= 0x00010000L;
 
-    /*    
+    /*
      ** Left justify fraction bits.
      ** ------------------------------------------------------------------------
      */
@@ -3706,7 +3701,7 @@ STATIC_ROUTINE void unpack_vax_h(CVT_VAX_H input_value,
     output_value[4] <<= 15;
   }
 
-  /*      
+  /*
    ** Exit the routine.
    ** ==========================================================================
    */
@@ -3715,7 +3710,7 @@ STATIC_ROUTINE void unpack_vax_h(CVT_VAX_H input_value,
 }
 
 STATIC_ROUTINE void unpack_ieee_s(CVT_IEEE_S input_value,
-				  UNPACKED_REAL output_value, U_Int_32 options __attribute__ ((unused)))
+				  UNPACKED_REAL output_value, uint32_t options __attribute__ ((unused)))
 /*
 **=============================================================================
 **
@@ -3731,7 +3726,7 @@ STATIC_ROUTINE void unpack_ieee_s(CVT_IEEE_S input_value,
 **
 **          1.0 <= fraction < 2.0, MSB implicit
 **
-**      For more details see "Mips R2000 Risc Architecture" by Gerry Kane, 
+**      For more details see "Mips R2000 Risc Architecture" by Gerry Kane,
 **      page 6-8 or ANSI/IEEE Std 754-1985.
 **
 ** INPUT PARAMETERS:
@@ -3745,7 +3740,7 @@ STATIC_ROUTINE void unpack_ieee_s(CVT_IEEE_S input_value,
 **
 ** OUTPUT PARAMETERS:
 **
-**      output_value            - address of where to place the UNPACKED_REAL 
+**      output_value            - address of where to place the UNPACKED_REAL
 **                                result value
 **
 ** IMPLICIT OUTPUTS:
@@ -3763,20 +3758,20 @@ STATIC_ROUTINE void unpack_ieee_s(CVT_IEEE_S input_value,
 **=============================================================================
 */
 {
-  /*      
+  /*
    ** Local variable definition.
    ** ==========================================================================
    */
   int i;
 
-  /*      
+  /*
    ** Initialization.
    ** ==========================================================================
    */
   if (options & CVT_M_BIG_ENDIAN) {
     memcpy(output_value, input_value, 4);
 
-    /*    
+    /*
      ** Shuffle bytes to little endian format.
      ** ------------------------------------------------------------------------
      */
@@ -3787,35 +3782,35 @@ STATIC_ROUTINE void unpack_ieee_s(CVT_IEEE_S input_value,
     memcpy(&output_value[1], input_value, 4);
   }
 
-  /*      
+  /*
    ** Initialize FLAGS and perhaps set NEGATIVE bit.
    ** ==========================================================================
    */
   output_value[U_R_FLAGS] = (output_value[1] >> 31);
 
-  /*      
+  /*
    ** Extract biased exponent.
    ** ==========================================================================
    */
   output_value[U_R_EXP] = (output_value[1] >> 23) & 0x000000FFL;
 
-  /*      
+  /*
    ** Check for denormalized values.
    ** ==========================================================================
    */
   if (output_value[U_R_EXP] == 0) {
-    /*    
+    /*
      ** Clear sign bit.
      ** ------------------------------------------------------------------------
      */
     output_value[1] &= 0x7FFFFFFFL;
 
-    /*    
+    /*
      ** If fraction is non-zero then normalize it.
      ** ------------------------------------------------------------------------
      */
     if (output_value[1] != 0) {
-      /*          
+      /*
        ** Count leading zeros.
        ** ----------------------------------------------------------------------
        */
@@ -3825,14 +3820,14 @@ STATIC_ROUTINE void unpack_ieee_s(CVT_IEEE_S input_value,
 	i += 1;
       }
 
-      /*          
+      /*
        ** Adjust exponent and normalize fraction.
        ** ----------------------------------------------------------------------
        */
       output_value[U_R_EXP] = U_R_BIAS - 126 - i;
       output_value[1] <<= 9;
 
-      /*          
+      /*
        ** Clear uninitialized part of unpacked real.
        ** ----------------------------------------------------------------------
        */
@@ -3846,12 +3841,12 @@ STATIC_ROUTINE void unpack_ieee_s(CVT_IEEE_S input_value,
     }
   }
 
-  /*      
+  /*
    ** Check for NANs and INFINITIES.
    ** ==========================================================================
    */
   else if (output_value[U_R_EXP] == 255) {
-    /*    
+    /*
      ** Clear sign bit and exponent.
      ** ------------------------------------------------------------------------
      */
@@ -3862,30 +3857,30 @@ STATIC_ROUTINE void unpack_ieee_s(CVT_IEEE_S input_value,
       output_value[U_R_FLAGS] |= U_R_INFINITY;
   }
 
-  /*      
+  /*
    ** We have ourselves a genuine valid number.
    ** ==========================================================================
    */
   else {
-    /*    
+    /*
      ** Adjust exponent bias.
      ** ------------------------------------------------------------------------
      */
     output_value[U_R_EXP] += (U_R_BIAS - 126);
 
-    /*    
+    /*
      ** Set hidden bit.
      ** ------------------------------------------------------------------------
      */
     output_value[1] |= 0x00800000L;
 
-    /*    
+    /*
      ** Left justify fraction bits.
      ** ------------------------------------------------------------------------
      */
     output_value[1] <<= 8;
 
-    /*    
+    /*
      ** Clear uninitialized part of unpacked real.
      ** ------------------------------------------------------------------------
      */
@@ -3894,7 +3889,7 @@ STATIC_ROUTINE void unpack_ieee_s(CVT_IEEE_S input_value,
     output_value[4] = 0;
   }
 
-  /*      
+  /*
    ** Exit the routine.
    ** ==========================================================================
    */
@@ -3903,7 +3898,7 @@ STATIC_ROUTINE void unpack_ieee_s(CVT_IEEE_S input_value,
 }
 
 STATIC_ROUTINE void unpack_ieee_t(CVT_IEEE_T input_value,
-				  UNPACKED_REAL output_value, U_Int_32 options __attribute__ ((unused)))
+				  UNPACKED_REAL output_value, uint32_t options __attribute__ ((unused)))
 /*
 **=============================================================================
 **
@@ -3920,7 +3915,7 @@ STATIC_ROUTINE void unpack_ieee_t(CVT_IEEE_T input_value,
 **
 **          1.0 <= fraction < 2.0, MSB implicit
 **
-**      For more details see "Mips R2000 Risc Architecture" by Gerry Kane, 
+**      For more details see "Mips R2000 Risc Architecture" by Gerry Kane,
 **      page 6-8 or ANSI/IEEE Std 754-1985.
 **
 ** INPUT PARAMETERS:
@@ -3934,7 +3929,7 @@ STATIC_ROUTINE void unpack_ieee_t(CVT_IEEE_T input_value,
 **
 ** OUTPUT PARAMETERS:
 **
-**      output_value            - address of where to place the UNPACKED_REAL 
+**      output_value            - address of where to place the UNPACKED_REAL
 **                                result value
 **
 ** IMPLICIT OUTPUTS:
@@ -3952,7 +3947,7 @@ STATIC_ROUTINE void unpack_ieee_t(CVT_IEEE_T input_value,
 **=============================================================================
 */
 {
-  /*      
+  /*
    ** Local variable definition.
    ** ==========================================================================
    */
@@ -3960,7 +3955,7 @@ STATIC_ROUTINE void unpack_ieee_t(CVT_IEEE_T input_value,
   STATIC_CONSTANT double fliptest = 42.;
   int flip = *(int *)&fliptest != 0;
 
-  /*      
+  /*
    ** Initialization.
    ** ==========================================================================
    */
@@ -3968,7 +3963,7 @@ STATIC_ROUTINE void unpack_ieee_t(CVT_IEEE_T input_value,
   if (flip)
     FlipDouble((int *)output_value);
   if (options & CVT_M_BIG_ENDIAN) {
-    /*    
+    /*
      ** Shuffle bytes to little endian format.
      ** ------------------------------------------------------------------------
      */
@@ -3982,35 +3977,35 @@ STATIC_ROUTINE void unpack_ieee_t(CVT_IEEE_T input_value,
     output_value[2] = output_value[0];
   }
 
-  /*      
+  /*
    ** Initialize FLAGS and perhaps set NEGATIVE bit.
    ** ==========================================================================
    */
   output_value[U_R_FLAGS] = (output_value[1] >> 31);
 
-  /*      
+  /*
    ** Extract biased exponent.
    ** ==========================================================================
    */
   output_value[U_R_EXP] = (output_value[1] >> 20) & 0x000007FFL;
 
-  /*      
+  /*
    ** Check for denormalized values.
    ** ==========================================================================
    */
   if (output_value[U_R_EXP] == 0) {
-    /*    
+    /*
      ** Clear sign bit.
      ** ------------------------------------------------------------------------
      */
     output_value[1] &= 0x7FFFFFFFL;
 
-    /*    
+    /*
      ** If fraction is non-zero then normalize it.
      ** ------------------------------------------------------------------------
      */
     if (output_value[1] != 0) {
-      /*          
+      /*
        ** Count leading zeros in fraction.
        ** ----------------------------------------------------------------------
        */
@@ -4020,7 +4015,7 @@ STATIC_ROUTINE void unpack_ieee_t(CVT_IEEE_T input_value,
 	i += 1;
       }
 
-      /*          
+      /*
        ** Adjust exponent and normalize fraction.
        ** ----------------------------------------------------------------------
        */
@@ -4030,7 +4025,7 @@ STATIC_ROUTINE void unpack_ieee_t(CVT_IEEE_T input_value,
       output_value[1] |= (output_value[2] >> (32 - i));
       output_value[2] <<= i;
 
-      /*          
+      /*
        ** Clear uninitialized part of unpacked real.
        ** ----------------------------------------------------------------------
        */
@@ -4041,7 +4036,7 @@ STATIC_ROUTINE void unpack_ieee_t(CVT_IEEE_T input_value,
     else if (output_value[2]) {
       output_value[1] = output_value[2];
 
-      /*          
+      /*
        ** Count leading zeros in fraction.
        ** ----------------------------------------------------------------------
        */
@@ -4051,13 +4046,13 @@ STATIC_ROUTINE void unpack_ieee_t(CVT_IEEE_T input_value,
 	i += 1;
       }
 
-      /*          
+      /*
        ** Adjust exponent.
        ** ----------------------------------------------------------------------
        */
       output_value[U_R_EXP] = U_R_BIAS - 1022 - i;
 
-      /*          
+      /*
        ** Clear uninitialized part of unpacked real.
        ** ----------------------------------------------------------------------
        */
@@ -4069,12 +4064,12 @@ STATIC_ROUTINE void unpack_ieee_t(CVT_IEEE_T input_value,
     }
   }
 
-  /*      
+  /*
    ** Check for NANs and INFINITIES.
    ** ==========================================================================
    */
   else if (output_value[U_R_EXP] == 2047) {
-    /*    
+    /*
      ** Clear sign bit and exponent.
      ** ------------------------------------------------------------------------
      */
@@ -4086,24 +4081,24 @@ STATIC_ROUTINE void unpack_ieee_t(CVT_IEEE_T input_value,
       output_value[U_R_FLAGS] |= U_R_INFINITY;
   }
 
-  /*      
+  /*
    ** We have ourselves a genuine valid number.
    ** ==========================================================================
    */
   else {
-    /*    
+    /*
      ** Adjust exponent.
      ** ------------------------------------------------------------------------
      */
     output_value[U_R_EXP] += (U_R_BIAS - 1022);
 
-    /*    
+    /*
      ** Set hidden bit.
      ** ------------------------------------------------------------------------
      */
     output_value[1] |= 0x00100000L;
 
-    /*    
+    /*
      ** Left justify fraction bits.
      ** ------------------------------------------------------------------------
      */
@@ -4111,14 +4106,14 @@ STATIC_ROUTINE void unpack_ieee_t(CVT_IEEE_T input_value,
     output_value[1] |= (output_value[2] >> 21);
     output_value[2] <<= 11;
 
-    /*    
+    /*
      ** Clear uninitialized part of unpacked real.
      ** ------------------------------------------------------------------------
      */
     output_value[3] = 0;
     output_value[4] = 0;
   }
-  /*      
+  /*
    ** Exit the routine.
    ** ==========================================================================
    */
@@ -4127,7 +4122,7 @@ STATIC_ROUTINE void unpack_ieee_t(CVT_IEEE_T input_value,
 }
 
 STATIC_ROUTINE void unpack_ieee_x(CVT_IEEE_X input_value,
-				  UNPACKED_REAL output_value, U_Int_32 options __attribute__ ((unused)))
+				  UNPACKED_REAL output_value, uint32_t options __attribute__ ((unused)))
 /*
 **=============================================================================
 **
@@ -4159,7 +4154,7 @@ STATIC_ROUTINE void unpack_ieee_x(CVT_IEEE_X input_value,
 **
 ** OUTPUT PARAMETERS:
 **
-**      output_value            - address of where to place the UNPACKED_REAL 
+**      output_value            - address of where to place the UNPACKED_REAL
 **                                result value
 **
 ** IMPLICIT OUTPUTS:
@@ -4177,20 +4172,20 @@ STATIC_ROUTINE void unpack_ieee_x(CVT_IEEE_X input_value,
 **=============================================================================
 */
 {
-  /*      
+  /*
    ** Local variable definition.
    ** ==========================================================================
    */
   int i;
 
-  /*      
+  /*
    ** Initialization.
    ** ==========================================================================
    */
   memcpy(output_value, input_value, 16);
 
   if (options & CVT_M_BIG_ENDIAN) {
-    /*    
+    /*
      ** Shuffle bytes to little endian format.
      ** ------------------------------------------------------------------------
      */
@@ -4216,35 +4211,35 @@ STATIC_ROUTINE void unpack_ieee_x(CVT_IEEE_X input_value,
     output_value[1] = output_value[0];
   }
 
-  /*      
+  /*
    ** Initialize FLAGS and perhaps set NEGATIVE bit.
    ** ==========================================================================
    */
   output_value[U_R_FLAGS] = (output_value[1] >> 31);
 
-  /*      
+  /*
    ** Extract biased exponent.
    ** ==========================================================================
    */
   output_value[U_R_EXP] = (output_value[1] >> 16) & 0x00007FFFL;
 
-  /*      
+  /*
    ** Check for denormalized values.
    ** ==========================================================================
    */
   if (output_value[U_R_EXP] == 0) {
-    /*    
+    /*
      ** Clear sign bit.
      ** ------------------------------------------------------------------------
      */
     output_value[1] &= 0x7FFFFFFFL;
 
-    /*    
+    /*
      ** If fraction is non-zero then normalize it.
      ** ------------------------------------------------------------------------
      */
     if (output_value[1] != 0) {
-      /*          
+      /*
        ** Count leading zeros in fraction.
        ** ----------------------------------------------------------------------
        */
@@ -4254,7 +4249,7 @@ STATIC_ROUTINE void unpack_ieee_x(CVT_IEEE_X input_value,
 	i += 1;
       }
 
-      /*          
+      /*
        ** Adjust exponent and normalize fraction.
        ** ----------------------------------------------------------------------
        */
@@ -4269,7 +4264,7 @@ STATIC_ROUTINE void unpack_ieee_x(CVT_IEEE_X input_value,
       output_value[4] <<= i;
     }
 
-    /*    
+    /*
      ** If fraction in first 32 bits is zero then move each longword up one
      ** longword and then normalize it.
      ** ------------------------------------------------------------------------
@@ -4279,7 +4274,7 @@ STATIC_ROUTINE void unpack_ieee_x(CVT_IEEE_X input_value,
       output_value[2] = output_value[3];
       output_value[3] = output_value[4];
 
-      /*          
+      /*
        ** Count leading zeros in fraction.
        ** ----------------------------------------------------------------------
        */
@@ -4289,7 +4284,7 @@ STATIC_ROUTINE void unpack_ieee_x(CVT_IEEE_X input_value,
 	i += 1;
       }
 
-      /*          
+      /*
        ** Adjust exponent.
        ** ----------------------------------------------------------------------
        */
@@ -4299,14 +4294,14 @@ STATIC_ROUTINE void unpack_ieee_x(CVT_IEEE_X input_value,
       output_value[2] |= (output_value[3] >> (32 - i));
       output_value[3] <<= i;
 
-      /*          
+      /*
        ** Clear uninitialized part of unpacked real.
        ** ----------------------------------------------------------------------
        */
       output_value[4] = 0;
     }
 
-    /*    
+    /*
      ** If fraction in first 64 bits is zero then move each longword up two
      ** longwords and then normalize it.
      ** ------------------------------------------------------------------------
@@ -4315,7 +4310,7 @@ STATIC_ROUTINE void unpack_ieee_x(CVT_IEEE_X input_value,
       output_value[1] = output_value[3];
       output_value[2] = output_value[4];
 
-      /*          
+      /*
        ** Count leading zeros in fraction.
        ** ----------------------------------------------------------------------
        */
@@ -4325,7 +4320,7 @@ STATIC_ROUTINE void unpack_ieee_x(CVT_IEEE_X input_value,
 	i += 1;
       }
 
-      /*          
+      /*
        ** Adjust exponent.
        ** ----------------------------------------------------------------------
        */
@@ -4333,7 +4328,7 @@ STATIC_ROUTINE void unpack_ieee_x(CVT_IEEE_X input_value,
       output_value[1] |= (output_value[2] >> (32 - i));
       output_value[2] <<= i;
 
-      /*          
+      /*
        ** Clear uninitialized part of unpacked real.
        ** ----------------------------------------------------------------------
        */
@@ -4341,7 +4336,7 @@ STATIC_ROUTINE void unpack_ieee_x(CVT_IEEE_X input_value,
       output_value[4] = 0;
     }
 
-    /*    
+    /*
      ** If fraction in first 96 bits is zero then move each longword up three
      ** longwords and then normalize it.
      ** ------------------------------------------------------------------------
@@ -4349,7 +4344,7 @@ STATIC_ROUTINE void unpack_ieee_x(CVT_IEEE_X input_value,
     else if (output_value[4]) {
       output_value[1] = output_value[4];
 
-      /*          
+      /*
        ** Count leading zeros in fraction.
        ** ----------------------------------------------------------------------
        */
@@ -4359,13 +4354,13 @@ STATIC_ROUTINE void unpack_ieee_x(CVT_IEEE_X input_value,
 	i += 1;
       }
 
-      /*          
+      /*
        ** Adjust exponent.
        ** ----------------------------------------------------------------------
        */
       output_value[U_R_EXP] = U_R_BIAS - 16382 - (i + 80);
 
-      /*          
+      /*
        ** Clear uninitialized part of unpacked real.
        ** ----------------------------------------------------------------------
        */
@@ -4374,7 +4369,7 @@ STATIC_ROUTINE void unpack_ieee_x(CVT_IEEE_X input_value,
       output_value[4] = 0;
     }
 
-    /*    
+    /*
      ** Otherwise the fraction is completely zero, so set the zero flag.
      ** ------------------------------------------------------------------------
      */
@@ -4383,12 +4378,12 @@ STATIC_ROUTINE void unpack_ieee_x(CVT_IEEE_X input_value,
     }
   }
 
-  /*      
+  /*
    ** Check for NANs and INFINITIES.
    ** ==========================================================================
    */
   else if (output_value[U_R_EXP] == 32767) {
-    /*    
+    /*
      ** Clear sign bit and exponent.
      ** ------------------------------------------------------------------------
      */
@@ -4400,24 +4395,24 @@ STATIC_ROUTINE void unpack_ieee_x(CVT_IEEE_X input_value,
       output_value[U_R_FLAGS] |= U_R_INFINITY;
   }
 
-  /*      
+  /*
    ** We have ourselves a genuine valid number.
    ** ==========================================================================
    */
   else {
-    /*    
+    /*
      ** Adjust exponent.
      ** ------------------------------------------------------------------------
      */
     output_value[U_R_EXP] += (U_R_BIAS - 16382);
 
-    /*    
+    /*
      ** Set hidden bit.
      ** ------------------------------------------------------------------------
      */
     output_value[1] |= 0x00010000L;
 
-    /*    
+    /*
      ** Left justify fraction bits.
      ** ------------------------------------------------------------------------
      */
@@ -4430,7 +4425,7 @@ STATIC_ROUTINE void unpack_ieee_x(CVT_IEEE_X input_value,
     output_value[4] <<= 15;
   }
 
-  /*      
+  /*
    ** Exit the routine.
    ** ==========================================================================
    */
@@ -4439,7 +4434,7 @@ STATIC_ROUTINE void unpack_ieee_x(CVT_IEEE_X input_value,
 }
 
 STATIC_ROUTINE void unpack_ibm_l(CVT_IBM_LONG input_value,
-				 UNPACKED_REAL output_value, U_Int_32 options __attribute__ ((unused)))
+				 UNPACKED_REAL output_value, uint32_t options __attribute__ ((unused)))
 /*
 **=============================================================================
 **
@@ -4470,7 +4465,7 @@ STATIC_ROUTINE void unpack_ibm_l(CVT_IBM_LONG input_value,
 **
 ** OUTPUT PARAMETERS:
 **
-**      output_value            - address of where to place the UNPACKED_REAL 
+**      output_value            - address of where to place the UNPACKED_REAL
 **                                result value
 **
 ** IMPLICIT OUTPUTS:
@@ -4488,19 +4483,19 @@ STATIC_ROUTINE void unpack_ibm_l(CVT_IBM_LONG input_value,
 **=============================================================================
 */
 {
-  /*      
+  /*
    ** Local variable definition.
    ** ==========================================================================
    */
   int i;
 
-  /*      
+  /*
    ** Initialization.
    ** ==========================================================================
    */
   memcpy(output_value, input_value, 8);
 
-  /*      
+  /*
    ** Shuffle bytes to little endian format.
    ** ==========================================================================
    */
@@ -4511,19 +4506,19 @@ STATIC_ROUTINE void unpack_ibm_l(CVT_IBM_LONG input_value,
   output_value[1] |= ((output_value[0] << 8) & 0x00FF0000L);
   output_value[1] |= ((output_value[0] >> 8) & 0x0000FF00L);
 
-  /*      
+  /*
    ** Initialize FLAGS and perhaps set NEGATIVE bit.
    ** ==========================================================================
    */
   output_value[U_R_FLAGS] = (output_value[1] >> 31);
 
-  /*      
+  /*
    ** Clear sign bit.
    ** ==========================================================================
    */
   output_value[1] &= 0x7FFFFFFFL;
 
-  /*      
+  /*
    ** Check if 0.
    ** ==========================================================================
    */
@@ -4531,7 +4526,7 @@ STATIC_ROUTINE void unpack_ibm_l(CVT_IBM_LONG input_value,
     output_value[U_R_FLAGS] |= U_R_ZERO;
   }
 
-  /*      
+  /*
    ** Ok, we know that the number is not zero.
    ** ==========================================================================
    */
@@ -4592,7 +4587,7 @@ STATIC_ROUTINE void unpack_ibm_l(CVT_IBM_LONG input_value,
     }
   }
 
-  /*      
+  /*
    ** Exit the routine.
    ** ==========================================================================
    */
@@ -4601,7 +4596,7 @@ STATIC_ROUTINE void unpack_ibm_l(CVT_IBM_LONG input_value,
 }
 
 STATIC_ROUTINE void unpack_ibm_s(CVT_IBM_SHORT input_value,
-				 UNPACKED_REAL output_value, U_Int_32 options __attribute__ ((unused)))
+				 UNPACKED_REAL output_value, uint32_t options __attribute__ ((unused)))
 /*
 **=============================================================================
 **
@@ -4631,7 +4626,7 @@ STATIC_ROUTINE void unpack_ibm_s(CVT_IBM_SHORT input_value,
 **
 ** OUTPUT PARAMETERS:
 **
-**      output_value            - address of where to place the UNPACKED_REAL 
+**      output_value            - address of where to place the UNPACKED_REAL
 **                                result value
 **
 ** IMPLICIT OUTPUTS:
@@ -4649,19 +4644,19 @@ STATIC_ROUTINE void unpack_ibm_s(CVT_IBM_SHORT input_value,
 **=============================================================================
 */
 {
-  /*      
+  /*
    ** Local variable definition.
    ** ==========================================================================
    */
   int i;
 
-  /*      
+  /*
    ** Initialization.
    ** ==========================================================================
    */
   memcpy(output_value, input_value, 4);
 
-  /*      
+  /*
    ** Shuffle bytes to little endian format.
    ** ==========================================================================
    */
@@ -4669,19 +4664,19 @@ STATIC_ROUTINE void unpack_ibm_s(CVT_IBM_SHORT input_value,
   output_value[1] |= ((output_value[0] << 8) & 0x00FF0000L);
   output_value[1] |= ((output_value[0] >> 8) & 0x0000FF00L);
 
-  /*      
+  /*
    ** Initialize FLAGS and perhaps set NEGATIVE bit.
    ** ==========================================================================
    */
   output_value[U_R_FLAGS] = (output_value[1] >> 31);
 
-  /*      
+  /*
    ** Clear sign bit.
    ** ==========================================================================
    */
   output_value[1] &= 0x7FFFFFFFL;
 
-  /*      
+  /*
    ** Check if 0.
    ** ==========================================================================
    */
@@ -4689,7 +4684,7 @@ STATIC_ROUTINE void unpack_ibm_s(CVT_IBM_SHORT input_value,
     output_value[U_R_FLAGS] |= U_R_ZERO;
   }
 
-  /*      
+  /*
    ** Ok, we know that the number is not zero.
    ** ==========================================================================
    */
@@ -4748,7 +4743,7 @@ STATIC_ROUTINE void unpack_ibm_s(CVT_IBM_SHORT input_value,
     }
   }
 
-  /*      
+  /*
    ** Exit the routine.
    ** ==========================================================================
    */
@@ -4756,7 +4751,7 @@ STATIC_ROUTINE void unpack_ibm_s(CVT_IBM_SHORT input_value,
 
 }
 
-STATIC_ROUTINE void unpack_cray(CVT_CRAY input_value, UNPACKED_REAL output_value, U_Int_32 options __attribute__ ((unused)))
+STATIC_ROUTINE void unpack_cray(CVT_CRAY input_value, UNPACKED_REAL output_value, uint32_t options __attribute__ ((unused)))
 /*
 **=============================================================================
 **
@@ -4775,7 +4770,7 @@ STATIC_ROUTINE void unpack_cray(CVT_CRAY input_value, UNPACKED_REAL output_value
 **          0.5 <= fraction < 1.0, MSB explicit
 **          Since CRAY has no hidden bits the MSB must always be set.
 **
-**      Some of the CRAY exponent range is not used.  
+**      Some of the CRAY exponent range is not used.
 **      Exponents < 0x2000 and >= 0x6000 are invalid.
 **
 ** INPUT PARAMETERS:
@@ -4789,7 +4784,7 @@ STATIC_ROUTINE void unpack_cray(CVT_CRAY input_value, UNPACKED_REAL output_value
 **
 ** OUTPUT PARAMETERS:
 **
-**      output_value            - address of where to place the UNPACKED_REAL 
+**      output_value            - address of where to place the UNPACKED_REAL
 **                                result value
 **
 ** IMPLICIT OUTPUTS:
@@ -4807,17 +4802,17 @@ STATIC_ROUTINE void unpack_cray(CVT_CRAY input_value, UNPACKED_REAL output_value
 **=============================================================================
 */
 {
-  /*      
+  /*
    ** Local variable definition.
    ** ==========================================================================
    */
-  /*      
+  /*
    ** Initialization.
    ** ==========================================================================
    */
   memcpy(output_value, input_value, 8);
 
-  /*      
+  /*
    ** Shuffle bytes to little endian format.
    ** ==========================================================================
    */
@@ -4828,25 +4823,25 @@ STATIC_ROUTINE void unpack_cray(CVT_CRAY input_value, UNPACKED_REAL output_value
   output_value[1] |= ((output_value[0] << 8) & 0x00FF0000L);
   output_value[1] |= ((output_value[0] >> 8) & 0x0000FF00L);
 
-  /*      
+  /*
    ** Initialize FLAGS and perhaps set NEGATIVE bit.
    ** ==========================================================================
    */
   output_value[U_R_FLAGS] = (output_value[1] >> 31);
 
-  /*      
+  /*
    ** Clear sign bit.
    ** ==========================================================================
    */
   output_value[1] &= 0x7FFFFFFFL;
 
-  /*      
+  /*
    ** Extract CRAY biased exponent.
    ** ==========================================================================
    */
   output_value[U_R_EXP] = output_value[1] >> 16;
 
-  /*      
+  /*
    ** Check if 0 or an invalid exponent.
    ** ==========================================================================
    */
@@ -4857,7 +4852,7 @@ STATIC_ROUTINE void unpack_cray(CVT_CRAY input_value, UNPACKED_REAL output_value
     output_value[U_R_FLAGS] |= U_R_INVALID;
   }
 
-  /*      
+  /*
    ** Ok, we know that the number is not zero.
    ** ==========================================================================
    */
@@ -4884,7 +4879,7 @@ STATIC_ROUTINE void unpack_cray(CVT_CRAY input_value, UNPACKED_REAL output_value
     output_value[4] = 0;
   }
 
-  /*      
+  /*
    ** Exit the routine.
    ** ==========================================================================
    */

--- a/tdishr/TdiMaxVal.c
+++ b/tdishr/TdiMaxVal.c
@@ -94,9 +94,6 @@ const int roprand = 0x8000;
 #else
 #define DHUGE 1.7E308
 #endif
-static inline void TdiDivO(const char *in1,const char *in2,char *out){
-  int128_div(( int128_t*)in1,( int128_t*)in2,( int128_t*)out);
-}
 
 int TdiLtO(unsigned int *in1, unsigned int *in2, int is_signed){
   if (is_signed)

--- a/tdishr/TdiVar.c
+++ b/tdishr/TdiVar.c
@@ -650,13 +650,13 @@ int TdiDoFun(struct descriptor *ident_ptr,
         ******************************************/
   static pthread_mutex_t lock = PTHREAD_MUTEX_INITIALIZER;
   int status, ispython;
-  char *filename, *dirspec;
+  char *filename = NULL, *dirspec = NULL;
   FREE_ON_EXIT(filename);
   FREE_ON_EXIT(dirspec);
   // look up method: check cached, check python, or load
   pthread_mutex_lock(&lock);
   pthread_cleanup_push((void*)pthread_mutex_unlock,&lock);
-  dirspec = NULL; filename = NULL; ispython = B_FALSE;
+  ispython = B_FALSE;
   status = TdiFindIdent(7, (struct descriptor_r *)ident_ptr, 0, &node_ptr, 0);
   if (status==TdiUNKNOWN_VAR) {
     // check if method is python

--- a/treeshr/TreeDoMethod.c
+++ b/treeshr/TreeDoMethod.c
@@ -172,15 +172,16 @@ int _TreeDoMethod(void *dbid, struct descriptor *nid_dsc, struct descriptor *met
       /**** Try python class ***/
       struct descriptor_d exp = { 0, DTYPE_T, CLASS_D, 0 };
       FREED_ON_EXIT(&exp);
+      int _nargs = nargs;
       STATIC_CONSTANT DESCRIPTOR(open, "PyDoMethod(");
       StrCopyDx((struct descriptor *)&exp, (struct descriptor *)&open);
-      if (nargs == 4
+      if (_nargs == 4
        && method_ptr->length == strlen("DW_SETUP")
        && strncmp(method_ptr->pointer, "DW_SETUP", strlen("DW_SETUP")) == 0) {
 	arglist[3] = arglist[4];
-	nargs--;
+	_nargs--;
       }
-      for (i = 1; i < nargs - 1; i++)
+      for (i = 1; i < _nargs - 1; i++)
 	StrAppend(&exp, (struct descriptor *)&arg);
       StrAppend(&exp, (struct descriptor *)&close);
       static pthread_mutex_t lock = PTHREAD_MUTEX_INITIALIZER;
@@ -189,12 +190,12 @@ int _TreeDoMethod(void *dbid, struct descriptor *nid_dsc, struct descriptor *met
 	status = LibFindImageSymbol(&tdishr, &tdiexecute, &TdiExecute);
       pthread_mutex_unlock(&lock);
       if STATUS_OK {
-	for (i = nargs; i > 0; i--)
+	for (i = _nargs; i > 0; i--)
 	  arglist[i + 1] = arglist[i];
-	nargs += 2;
-	arglist[0] = arglist_nargs(nargs);
+	_nargs += 2;
+	arglist[0] = arglist_nargs(_nargs);
 	arglist[1] = &exp;
-	arglist[nargs] = MdsEND_ARG;
+	arglist[_nargs] = MdsEND_ARG;
 	status = (int)((char *)LibCallg(arglist, TdiExecute) - (char *)0);
       }
       FREED_NOW(&exp);

--- a/treeshr/TreeFindNode.c
+++ b/treeshr/TreeFindNode.c
@@ -376,7 +376,7 @@ STATIC_ROUTINE NODE *Pop(SEARCH_CONTEXT * search)
 
 /****************************************************
    Push(sctx, node) -
-     pushes a node onto the que of places that need 
+     pushes a node onto the que of places that need
    to be explored in the future of this *** search.
 *****************************************************/
 STATIC_ROUTINE void Push(SEARCH_CONTEXT * search, NODE * node)
@@ -955,25 +955,24 @@ EXPORT char *_TreeAbsPath(void *dbid, char const *inpath)
 
 STATIC_ROUTINE char *AbsPath(void *dbid, char const *inpath, int nid_in)
 {
-  char *answer;
-  char *tmppath = NULL;
+  char *answer = NULL, *pathptr = NULL;
   SEARCH_CONTEXT ctx[MAX_SEARCH_LEVELS];
   memset(ctx, 0, sizeof(SEARCH_CONTEXT) * MAX_SEARCH_LEVELS);
   FREE_ON_EXIT(ctx->string);
+  FREE_ON_EXIT(pathptr);
   PINO_DATABASE *dblist = (PINO_DATABASE *) dbid;
   _TreeSetDefaultNid(dbid, nid_in);
-  FREE_ON_EXIT(tmppath);
-  const char *pathptr;
-  size_t len;
-  size_t i;
-  if (strlen(inpath)) {
+  size_t i,len = strlen(inpath);
+  if (len) {
     int nid;
-    if (_TreeFindNode(dbid, inpath, &nid) & 1)
-      pathptr = tmppath = _TreeGetPath(dbid, nid);
-    else pathptr = inpath;
-  } else
-    pathptr = tmppath = _TreeGetPath(dbid, nid_in);
-  len = strlen(pathptr);
+    if (_TreeFindNode(dbid, inpath, &nid) & 1) {
+      pathptr = _TreeGetPath(dbid, nid);
+      len = strlen(pathptr);
+    } else pathptr = strcpy(malloc(len+1),inpath);
+  } else {
+    pathptr = _TreeGetPath(dbid, nid_in);
+    len = strlen(pathptr);
+  }
   ctx->type = EOL;
   ctx->string = malloc(len + 1);
   for (i = 0; i < len && pathptr[i] != ' '; i++)
@@ -1020,7 +1019,7 @@ STATIC_ROUTINE char *AbsPath(void *dbid, char const *inpath, int nid_in)
     }
   } else answer = NULL;
   FREE_NOW(ctx->string);
-  FREE_NOW(tmppath);
+  FREE_NOW(pathptr);
   return answer;
 }
 

--- a/treeshr/TreeSegments.c
+++ b/treeshr/TreeSegments.c
@@ -237,8 +237,8 @@ int TreeUpdateSegment(int nid, struct descriptor *start, struct descriptor *end,
   return _TreeUpdateSegment(*TreeCtx(), nid, start, end, dimension, idx);
 }
 
-int _TreePutSegment(void *dbid, int nid, int startIdx, struct descriptor_a *data);
-int TreePutSegment(int nid, int startIdx, struct descriptor_a *data){
+int _TreePutSegment(void *dbid, int nid, const int startIdx, struct descriptor_a *data);
+int TreePutSegment(const int nid, const int startIdx, struct descriptor_a *data){
   return _TreePutSegment(*TreeCtx(), nid, startIdx, data);
 }
 
@@ -784,11 +784,10 @@ end: ;
   return status;
 }
 
-int _TreePutSegment(void *dbid, int nid, int startIdx, struct descriptor_a *data_in) {
+int _TreePutSegment(void *dbid, int nid, const int startIdx, struct descriptor_a *data) {
+  A_COEFF_TYPE *a_coeff = (A_COEFF_TYPE *) data;
   INIT_VARS;
   CLEANUP_NCI_PUSH;
-  struct descriptor_a *data = data_in;
-  GOTO_END_ON_ERROR(open_datafile_write0(vars));
   DESCRIPTOR_A(data_a, 0, 0, 0, 0);/*CHECK_DATA*/{
     while (data && data->dtype == DTYPE_DSC)
       data = (struct descriptor_a *)data->pointer;
@@ -802,9 +801,9 @@ int _TreePutSegment(void *dbid, int nid, int startIdx, struct descriptor_a *data
       data = (struct descriptor_a *)&data_a;
     }
     if (data == NULL || data->class != CLASS_A || data->dimct < 1 || data->dimct > 8)
-      {status = TreeINVDTPUSG;goto end;}
+      {status = TreeINVDTPUSG; goto end;}
   }
-  A_COEFF_TYPE *a_coeff = (A_COEFF_TYPE *) data;
+  GOTO_END_ON_ERROR(open_datafile_write0(vars));
   GOTO_END_ON_ERROR(open_datafile_write1(vars));
   IF_NO_EXTENDED_NCI   {status = TreeNOSEGMENTS;goto end;}
   IF_NO_SEGMENT_HEADER {status = TreeNOSEGMENTS;goto end;}


### PR DESCRIPTION
- int(x/y) might cause rounding errors although unlikely as arsize is 32 bit only
- performance increase: no int-to-double and double-to-int conversion