### PR TITLE
Zck python3

### DIFF
--- a/mdsobjects/python/apd.py
+++ b/mdsobjects/python/apd.py
@@ -190,7 +190,7 @@ class Dictionary(dict,Apd):
     """dictionary class"""
     class dict_np(_N.ndarray):
         def __new__(cls,items):
-            return _N.asarray(tuple(d.value for d in items),'object').view(Dictionary.dict_np)
+            return _N.asarray(tuple(d for d in items),'object').view(Dictionary.dict_np)
         def tolist(self):
             return dict(super(Dictionary.dict_np,self).tolist())
 

--- a/mdsobjects/python/mdsarray.py
+++ b/mdsobjects/python/mdsarray.py
@@ -115,8 +115,8 @@ class Array(_dat.Data):
     def _str_bad_ref(self):
         return _ver.tostr(self._value)
 
-    def __getattr__(self,name):
-        try: return super(Array,self).__getattr__(name)
+    def __getattribute__(self,name):
+        try: return super(Array,self).__getattribute__(name)
         except AttributeError: pass
         if name=='_value': raise Exception('_value undefined')
         try: return self._value.__getattribute__(name)

--- a/mdsobjects/python/mdsdata.py
+++ b/mdsobjects/python/mdsdata.py
@@ -163,7 +163,7 @@ class Data(object):
             return self
         if name.startswith('set'):
             return setXxx
-        raise AttributeError
+        return self.__getattribute__(name)
 
     @property
     def deref(self):

--- a/mdsobjects/python/tests/dataUnitTest.py
+++ b/mdsobjects/python/tests/dataUnitTest.py
@@ -133,6 +133,8 @@ class Tests(TestCase):
     def testData(self):
         self.assertEqual(m.Data(2).compare(2),True)
         self.assertEqual(m.Data(2).compare(1),False)
+        self.assertEqual(m.Dictionary([1,'a',2,'b']).data().tolist(),{1: 'a', 2: 'b'})
+        self.assertEqual(m.List([1,'a',2,'b']).data().tolist(),[1, 'a', 2, 'b'])
 
     def testScalars(self):
         def doTest(suffix,cl,scl,ucl,**kw):


### PR DESCRIPTION
in python3 it is more obvious which one to use __getattribute__ vs __getattr__. 
this fixes MDSplus.Dictionary.data()