### PR TITLE
Fix: decompile must return a primitive python string

### DIFF
--- a/mdsobjects/python/mdsdata.py
+++ b/mdsobjects/python/mdsdata.py
@@ -386,7 +386,7 @@ class Data(object):
     def decompile(self):
         """Return string representation
         @rtype: string"""
-        return _cmp.DECOMPILE(self)._setTree(self.tree).evaluate()
+        return str(_cmp.DECOMPILE(self)._setTree(self.tree).evaluate())
 
     def __getitem__(self,y):
         """Subscript: x.__getitem__(y) <==> x[y]


### PR DESCRIPTION
for the python widgets to use the result.

Expression widgets in python setups were being displayed as, and reset to, empty unless they were
numeric scalars.

This was because the decompile of record of a node was getting returned as an MDSplus String instead
of a python string.

Closes: #1238