### PR TITLE
Gm fix settimecontext

### DIFF
--- a/mdsobjects/cpp/testing/MdsConnectionTest.cpp
+++ b/mdsobjects/cpp/testing/MdsConnectionTest.cpp
@@ -73,6 +73,10 @@ void test_tree_open(const char *prot, const unsigned short port)
     TEST1( AutoString(data->getString()).string
            == "[0.,0.,0.,0.,0.,0.,0.,0.,0.,0.]" );
 
+    // this should not hang //
+    data = cnx.get("setTimeContext()");
+    std::cout << AutoString(data->getString()).string;
+
     // test tree opening //
     cnx.openTree((char*)"t_connect",1);
 

--- a/treeshr/TreeSegments.c
+++ b/treeshr/TreeSegments.c
@@ -2037,6 +2037,7 @@ int TreeCopyExtended(PINO_DATABASE * dbid_in, PINO_DATABASE * dbid_out, int nid,
  *****************************************/
 int _TreeSetTimeContext(void *dbid, struct descriptor *start, struct descriptor *end, struct descriptor *delta){
   timecontext_t* tc = &((PINO_DATABASE*)dbid)->timecontext;
+  if(!dbid) return 1;
   INIT_STATUS_AS MdsCopyDxXd(start, &tc->start);
   if STATUS_OK {
     status = MdsCopyDxXd(end, &tc->end);


### PR DESCRIPTION
There were still cases in which TreeSetTimeConcest() was called with a null dbid, e.g. when called within mdsip. This check avoids crashes in mdsip that occurred using jScope (in turn using SetTimeContext via mdsip). When no dbid is defined, success is returned  (TreeSetTimeContext is void)