### PR TITLE
Build: Restore Visual Studio support for windows installer

### DIFF
--- a/deploy/platform/platform_build.sh
+++ b/deploy/platform/platform_build.sh
@@ -115,6 +115,8 @@ rundocker(){
 		   -e "HOME=/workspace" \
 		   -e "JARS_DIR=$jars_dir" \
 		   -e "TEST_TIMEUNIT" \
+		   -e "WINHOST" \
+                   -e "WINREMBLD" \
 		   -v ${SRCDIR}:${DOCKER_SRCDIR} \
 		   -v ${WORKSPACE}:/workspace \
 		   $port_forwarding \
@@ -122,6 +124,7 @@ rundocker(){
 		   $(volume "${RELEASEDIR}" /release) \
 		   $(volume "${PUBLISHDIR}" /publish) \
 		   $(volume "${KEYS}" /sign_keys) \
+		   $(volume "${WINBLD}" /winbld) \
 		   ${image} $program
             status=$?
             if [ -r ${WORKSPACE}/${OS}_docker-cid ]

--- a/deploy/platform/windows/windows_docker_build.sh
+++ b/deploy/platform/windows/windows_docker_build.sh
@@ -57,7 +57,7 @@ buildrelease() {
 	topsrcdir=${WINREMBLD}/${tmpdir}
 	cd ${tmpdir}
 	rsync -am --include="*/" --include="*.h*" --include="*.def" --exclude="*" ${srcdir}/ ./
-	rsync -am /workspace/64/include ./
+	rsync -am /workspace/releasebld/64/include ./
 	rsync -a ${srcdir}/mdsobjects/cpp ${srcdir}/mdsobjects/MdsObjects* ${srcdir}/mdsobjects/VS-* ./mdsobjects/
 	rsync -a ${srcdir}/deploy/platform/windows/winbld.bat ./deploy/
 	rsync -a ${MDSPLUS_DIR}/bin_* ./

--- a/deploy/platform/windows/windows_docker_build.sh
+++ b/deploy/platform/windows/windows_docker_build.sh
@@ -56,10 +56,10 @@ buildrelease() {
 	trap windows_cleanup EXIT
 	topsrcdir=${WINREMBLD}/${tmpdir}
 	cd ${tmpdir}
-	rsync -am --include="*/" --include="*.h*" --include="*.def" --exclude="*" /source/ ./
+	rsync -am --include="*/" --include="*.h*" --include="*.def" --exclude="*" ${srcdir}/ ./
 	rsync -am /workspace/64/include/config.h ./include/
-	rsync -a /source/mdsobjects/cpp /source/mdsobjects/MdsObjects* /source/mdsobjects/VS-* ./mdsobjects/
-	rsync -a /source/deploy/platform/windows/winbld.bat ./deploy/
+	rsync -a ${srcdir}/mdsobjects/cpp ${srcdir}/mdsobjects/MdsObjects* ${srcdir}/mdsobjects/VS-* ./mdsobjects/
+	rsync -a ${srcdir}/deploy/platform/windows/winbld.bat ./deploy/
 	rsync -a ${MDSPLUS_DIR}/bin_* ./
 	curl http://${WINHOST}:8080${topsrcdir}/deploy/winbld.bat
 	# see if files are there

--- a/deploy/platform/windows/windows_docker_build.sh
+++ b/deploy/platform/windows/windows_docker_build.sh
@@ -78,12 +78,12 @@ EOF
 	fi
 	vs="-DVisualStudio"
 	popd
-    fi
   fi
   if [ -z "$NOMAKE" ]; then
     ${srcdir}/deploy/packaging/windows/create_installer.sh ${MDSPLUS_DIR}
   fi # NOMAKE
 }
+
 publish() {
     major=$(echo ${RELEASE_VERSION} | cut -d. -f1)
     minor=$(echo ${RELEASE_VERSION} | cut -d. -f2)

--- a/deploy/platform/windows/windows_docker_build.sh
+++ b/deploy/platform/windows/windows_docker_build.sh
@@ -46,6 +46,40 @@ buildrelease() {
     ###
     ### pack installer
     ###
+    if [ ! -z "$WINHOST" -a -r /winbld -a ! -z "$WINREMBLD" ]
+    then
+	windows_cleanup() {
+	    rm -Rf /winbld/${tmpdir}
+	}
+	pushd /winbld
+	tmpdir=$(mktemp -d mdsplus-XXXXXXXXXX)
+	trap windows_cleanup EXIT
+	topsrcdir=${WINREMBLD}/${tmpdir}
+	cd ${tmpdir}
+	rsync -am --include="*/" --include="*.h*" --include="*.def" --exclude="*" /source/ ./
+	rsync -am /workspace/64/include/config.h ./include/
+	rsync -a /source/mdsobjects/cpp /source/mdsobjects/MdsObjects* /source/mdsobjects/VS-* ./mdsobjects/
+	rsync -a /source/deploy/platform/windows/winbld.bat ./deploy/
+	rsync -a ${MDSPLUS_DIR}/bin_* ./
+	curl http://${WINHOST}:8080${topsrcdir}/deploy/winbld.bat
+	# see if files are there
+	if ( ls /winbld/${tmpdir}/bin_x86*/*.lib /winbld/${tmpdir}/bin_x86*/MdsObjectsCppShr-VS.* > /dev/null )
+	then
+	    rsync -av --include="*/" --include="*.lib" --include="MdsObjectsCppShr-VS.dll" --exclude="*" /winbld/${tmpdir}/bin_x86* ${MDSPLUS_DIR}/
+	else
+	    RED $COLOR
+	    cat <<EOF >&2
+============================================
+Failure: Problem building Visual Studio dll
+============================================
+EOF
+	    NORMAL $COLOR
+	    exit 1
+	fi
+	vs="-DVisualStudio"
+	popd
+    fi
+  fi
   if [ -z "$NOMAKE" ]; then
     ${srcdir}/deploy/packaging/windows/create_installer.sh ${MDSPLUS_DIR}
   fi # NOMAKE

--- a/deploy/platform/windows/windows_docker_build.sh
+++ b/deploy/platform/windows/windows_docker_build.sh
@@ -57,7 +57,7 @@ buildrelease() {
 	topsrcdir=${WINREMBLD}/${tmpdir}
 	cd ${tmpdir}
 	rsync -am --include="*/" --include="*.h*" --include="*.def" --exclude="*" ${srcdir}/ ./
-	rsync -am /workspace/64/include/config.h ./include/
+	rsync -am /workspace/64/include ./
 	rsync -a ${srcdir}/mdsobjects/cpp ${srcdir}/mdsobjects/MdsObjects* ${srcdir}/mdsobjects/VS-* ./mdsobjects/
 	rsync -a ${srcdir}/deploy/platform/windows/winbld.bat ./deploy/
 	rsync -a ${MDSPLUS_DIR}/bin_* ./

--- a/include/mdsplus/mdsplus.h
+++ b/include/mdsplus/mdsplus.h
@@ -21,16 +21,17 @@
 #endif
 
 #if defined(_WIN32)
+
 #define MDS_API_IMPORT __declspec(dllimport)
 #define MDS_API_EXPORT __declspec(dllexport)
 #define MDS_API_HIDDEN
-#ifdef __GNUC__
-#if __GNUC__ >= 7
+
+#if defined (__GNUC__) && __GNUC__ >= 7
 #define MDS_ATTR_FALLTHROUGH __attribute__((fallthrough));
 #else
 #define MDS_ATTR_FALLTHROUGH
 #endif
-#endif
+
 #else
 #if __GNUC__ >= 4
 #define MDS_API_IMPORT __attribute__ ((visibility ("default")))


### PR DESCRIPTION
At some point the code which created the VS cppshr dll and the VS
compatible libs was removed from the build scripts. This attempts to
reenable the VS support.