### PR TITLE
Zck context mdsip

### DIFF
--- a/include/treeshr.h
+++ b/include/treeshr.h
@@ -90,6 +90,7 @@ extern int TREE_BLOCKID;
   extern EXPORT int _TreeFlushReset(void *dbid, int nid);
   extern EXPORT void TreeFree(void *);
   extern EXPORT void TreeFreeDbid(void *);
+  extern EXPORT int _TreeNewDbid(void **dbid);
   extern EXPORT int TreeGetDbi(struct dbi_itm *itmlst);
   extern EXPORT int _TreeGetDbi(void *dbid, struct dbi_itm *itmlst);
   extern EXPORT int TreeGetNci(int nid, struct nci_itm *itmlst);

--- a/mdsobjects/cpp/testing/Makefile.am
+++ b/mdsobjects/cpp/testing/Makefile.am
@@ -7,8 +7,8 @@ AM_CFLAGS = $(TARGET_ARCH) $(WARNFLAGS) $(TEST_CFLAGS)
 AM_CXXFLAGS = $(TARGET_ARCH) $(WARNFLAGS) -fsigned-char -Wno-deprecated @CXXFLAGS@ $(TEST_CFLAGS)
 AM_LDFLAGS = -L@MAKESHLIBDIR@ $(RPATHLINK),@MAKESHLIBDIR@
 AM_LIBS = $(LIBS) $(TEST_LIBS) testutils/libMdsTestUtils.a
-LDADD = $(AM_LIBS) -lMdsShr -lTreeShr -lTdiShr -lMdsIpShr -lMdsObjectsCppShr
-
+LDADD = $(AM_LIBS) -lMdsShr -lTreeShr -lTdiShr -lMdsIpShr -lMdsObjectsCppShr \
+@MINGW_TRUE@	-lws2_32
 ## ////////////////////////////////////////////////////////////////////////// ##
 ## // TESTS  //////////////////////////////////////////////////////////////// ##
 ## ////////////////////////////////////////////////////////////////////////// ##

--- a/mdsobjects/cpp/testing/Makefile.in
+++ b/mdsobjects/cpp/testing/Makefile.in
@@ -916,7 +916,9 @@ AM_CFLAGS = $(TARGET_ARCH) $(WARNFLAGS) $(TEST_CFLAGS)
 AM_CXXFLAGS = $(TARGET_ARCH) $(WARNFLAGS) -fsigned-char -Wno-deprecated @CXXFLAGS@ $(TEST_CFLAGS)
 AM_LDFLAGS = -L@MAKESHLIBDIR@ $(RPATHLINK),@MAKESHLIBDIR@
 AM_LIBS = $(LIBS) $(TEST_LIBS) testutils/libMdsTestUtils.a
-LDADD = $(AM_LIBS) -lMdsShr -lTreeShr -lTdiShr -lMdsIpShr -lMdsObjectsCppShr
+LDADD = $(AM_LIBS) -lMdsShr -lTreeShr -lTdiShr -lMdsIpShr -lMdsObjectsCppShr \
+@MINGW_TRUE@	-lws2_32
+
 AM_DEFAULT_SOURCE_EXT = .cpp
 BUILD_FLAGS = @MAKEFLAG_J@
 # no parallel execution as this currently breaks the MdsConnectionTest "Connection local"

--- a/mdsobjects/cpp/testing/MdsConnectionTest.cpp
+++ b/mdsobjects/cpp/testing/MdsConnectionTest.cpp
@@ -22,30 +22,22 @@ CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
-// if windows skip this test .. //
-#ifdef _WIN32
-#include "testing.h"
-int main(int argc __attribute__ ((unused)), char *argv[] __attribute__ ((unused))){
- SKIP_TEST("Connection test requires fork")
-}
-#else
 
-
+#include "testutils/MdsIpInstancer.h"
 #include <unistd.h>
 #include <fstream>
 #include <sys/types.h>
 #include <signal.h>
 
-
-#include <sys/wait.h>
 #include <mdsobjects.h>
-
 
 #include "testutils/testutils.h"
 #include "testutils/unique_ptr.h"
-#include "testutils/MdsIpInstancer.h"
 #include "testing.h"
 
+#ifdef _WIN32
+#define setenv(name,val,extra) _putenv_s(name,val)
+#endif
 
 //
 // TODO: Finish tests with PutMany and GetMany ...
@@ -72,6 +64,12 @@ void test_tree_open(const char *prot, const unsigned short port)
     unique_ptr<Data> data = cnx.get("ZERO(10)");
     TEST1( AutoString(data->getString()).string
            == "[0.,0.,0.,0.,0.,0.,0.,0.,0.,0.]" );
+
+    data = cnx.get("TreeShr->TreeDbid()");
+    TEST0(data->getInt() == 0);
+
+    data = cnx.get("setTimeContext()");
+    TEST1(AutoString(data->getString()).string == "1");
 
     // test tree opening //
     cnx.openTree((char*)"t_connect",1);
@@ -112,26 +110,14 @@ int main(int argc UNUSED_ARGUMENT, char *argv[] UNUSED_ARGUMENT)
 
     // this makes the t_connect in a separate process so that all static
     // variables instanced are destroied when the child ends.
-    pid_t pid = fork();
-    if(pid == 0)
-    {
-        {
-            unique_ptr<Tree> tree = new Tree("t_connect",-1,"NEW");
-            unique_ptr<TreeNode>(tree->addNode("test_cnx","NUMERIC"));
-            tree->write();
-            tree->edit(false);
-            tree->createPulse(1);
-        }
-        exit(0);
-    }
-    else {
-        // wait for child to finish the tree generation //
-        int status;
-        while (-1 == waitpid(pid, &status, 0));
-        if (!WIFEXITED(status) || WEXITSTATUS(status) != 0) {
-            std::cerr << "Process " << " (pid " << pid << ") failed" << "\n";
-            exit(1);
-        }
+    try {
+      unique_ptr<Tree> tree = new Tree("t_connect",-1,"NEW");
+      unique_ptr<TreeNode>(tree->addNode("test_cnx","NUMERIC"));
+      tree->write();
+      tree->edit(false);
+      tree->createPulse(1);
+    } catch (...) {
+      std::cerr << "Error creating model tree";
     }
 
     ////////////////////////////////////////////////////////////////////////////////
@@ -198,5 +184,3 @@ int main(int argc UNUSED_ARGUMENT, char *argv[] UNUSED_ARGUMENT)
     END_TESTING;
 */
 }
-
-#endif

--- a/mdsobjects/cpp/testing/MdsTdiTest.cpp
+++ b/mdsobjects/cpp/testing/MdsTdiTest.cpp
@@ -36,8 +36,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 using namespace MDSplus;
 using namespace testing;
 
-#define NUM_THREADS 8
-#define NUM_REPEATS 8
+#define NUM_THREADS 4
+#define NUM_REPEATS 4
 #define MEM_ALLOC 1028
 
 static char** cmds;

--- a/mdsobjects/cpp/testing/testutils/MdsIpInstancer.h
+++ b/mdsobjects/cpp/testing/testutils/MdsIpInstancer.h
@@ -84,7 +84,7 @@ public:
            else
              argv[5] = NULL;
 #ifdef _WIN32
-	   if (!(m_pid = _spawnle(P_NOWAIT, *argv, *environ)))
+	   if (!(m_pid = _spawnvpe(P_NOWAIT, argv[0], &argv[1], environ)))
 #else
 	   if (posix_spawnp(&m_pid, "mdsip", NULL, NULL, argv, environ))
 #endif

--- a/mdsobjects/cpp/testing/testutils/MdsIpInstancer.h
+++ b/mdsobjects/cpp/testing/testutils/MdsIpInstancer.h
@@ -88,8 +88,10 @@ public:
 #else
 	   if (posix_spawnp(&m_pid, "mdsip", NULL, NULL, argv, environ))
 #endif
-             std::cerr << "Could not start mdsip server " << m_protocol.c_str() << " on port " << m_port << ".";
-           else
+	   {
+	     char msg[128];sprintf(msg,"Could not start mdsip server %s on port %d.",m_protocol.c_str(), m_port);
+             throw std::runtime_error(msg);
+           } else
              std::cout << "started mdsip server for " << m_protocol << " on port: " << m_port << " pid: " << m_pid << "\n" << std::flush;
         }
 

--- a/mdsobjects/cpp/testing/testutils/MdsIpInstancer.h
+++ b/mdsobjects/cpp/testing/testutils/MdsIpInstancer.h
@@ -87,7 +87,8 @@ public:
 	std::cout << "FORKING PROCESS!" << std::flush;
 	m_pid = fork();
 	if(m_pid==0) // child process
-	   exit(execvpe(argv[0], argv, environ));
+	//   exit(execvpe(argv[0], argv, environ));
+	   exit(execvp(argv[0], argv));
 	else if (m_pid<0) // spawn failed
 #else
 	if (posix_spawnp(&m_pid, "mdsip", NULL, NULL, argv, environ))

--- a/mdstcpip/Connections.c
+++ b/mdstcpip/Connections.c
@@ -175,6 +175,7 @@ void DisconnectConnectionC(Connection *c){
   FreeDescriptors(c);
   free(c->protocol);
   free(c->info_name);
+  TreeFreeDbid(c->DBID);
   pthread_cond_destroy(&c->cond);
   free(c);
 }
@@ -219,6 +220,7 @@ Connection* NewConnectionC(char *protocol){
     connection->protocol = strcpy(malloc(strlen(protocol) + 1), protocol);
     connection->id = INVALID_CONNECTION_ID;
     connection->state = CON_IDLE;
+    _TreeNewDbid(&connection->DBID);
     pthread_cond_init(&connection->cond,NULL);
     return connection;
   } else

--- a/mdstcpip/IoRoutinesTunnel.c
+++ b/mdstcpip/IoRoutinesTunnel.c
@@ -147,6 +147,8 @@ static ssize_t tunnel_recv_to(Connection* c, void *buffer, size_t buflen, int to
 #ifndef _WIN32
 static void ChildSignalHandler(int num __attribute__ ((unused)))
 {
+  // Ensure that the handler does not spoil errno.
+  int saved_errno = errno;
   sigset_t set, oldset;
   pid_t pid;
   int status;
@@ -175,6 +177,7 @@ static void ChildSignalHandler(int num __attribute__ ((unused)))
     sigaddset(&set, SIGCHLD);
     sigprocmask(SIG_UNBLOCK, &set, &oldset);
   }
+  errno = saved_errno;
 }
 #endif
 

--- a/mdstcpip/Makefile.in
+++ b/mdstcpip/Makefile.in
@@ -196,10 +196,10 @@ docs:
 
 
 @MAKEBINDIR@mdsiptest$(EXE): testing/mdsiptest.c $(MdsIpShr)
-	$(LINK.c) $< $(OUTPUT_OPTION) -L@MAKESHLIBDIR@ -lMdsIpShr -lMdsShr $(LIBS)
+	$(LINK.c) $< $(OUTPUT_OPTION) -L@MAKESHLIBDIR@ -lMdsIpShr -lMdsShr -lTreeShr $(LIBS)
 
 @MAKEBINDIR@mdsip_service.exe: mdsip_service.c $(MdsIpShr)
-	$(LINK.c) $< $(OUTPUT_OPTION) -L@MAKESHLIBDIR@ -lMdsIpShr -lMdsShr $(LIBS)
+	$(LINK.c) $< $(OUTPUT_OPTION) -L@MAKESHLIBDIR@ -lMdsIpShr -lMdsShr -lTreeShr $(LIBS)
 
 MDSIP_EXTRALIB = -lMdsIpSrvShr
 @MAKEBINDIR@mdsip$(EXE): $(MdsIpSrvShr)
@@ -223,7 +223,7 @@ $(MDSIP_UTIL) : mdsiputil.o mdsip_socket_io.o mdsip_parallel.o $(COMPRESSION_OBJ
 
 @MINGW_TRUE@ MAKE_IMPLIB_MdsIpShr=-Wl,--out-implib,$(IMPLIB_MdsIpShr)
 $(MdsIpShr): $(LIB_OBJECTS) $(COMPRESSION_OBJECTS) $(DEF)
-	$(LINK.c) $(OUTPUT_OPTION) $^ @LINKSHARED@ $(MDSIPSHR_EXTRALIBS) $(LIBS) $(MAKE_IMPLIB_MdsIpShr)
+	$(LINK.c) $(OUTPUT_OPTION) $^ @LINKSHARED@ $(MDSIPSHR_EXTRALIBS) -lTreeShr $(LIBS) $(MAKE_IMPLIB_MdsIpShr)
 
 LINK_MDSIPSHR = -L@MAKESHLIBDIR@ -lMdsIpShr
 @MINGW_TRUE@ MAKE_IMPLIB_MdsIpSrvShr=-Wl,--out-implib,$(IMPLIB_MdsIpSrvShr)

--- a/mdstcpip/ProcessMessage.c
+++ b/mdstcpip/ProcessMessage.c
@@ -174,12 +174,12 @@ ConvertFloat(int num, int in_type, char in_length, char *in_ptr,
 
 
 ///
-/// 
+///
 /// \param client_type
 /// \param message_id
 /// \param status
 /// \param d
-/// \return 
+/// \return
 ///
 static Message *BuildResponse(int client_type, unsigned char message_id,
 			      int status, struct descriptor *d)
@@ -582,15 +582,15 @@ static void ClientEventAst(MdsEventList * e, int data_len, char *data)
 /// Executes TDI expression held by a connecion instance. This first searches if
 /// connection message corresponds to AST or CAN requests, if no asyncronous ops
 /// are requested the TDI actual expression is parsed through tdishr library.
-/// In this case the current TDI context and tree is switched to the connection 
+/// In this case the current TDI context and tree is switched to the connection
 /// ones stored in the connection context field.
-/// 
+///
 /// ### AST and CAN
 /// AST and CAN stands for "Asynchronous System Trap" and "CANcel event request".
-/// This is an asyncronous message mechanism taken from the OpenVMS system. 
-/// The event handler is passed inside the message arguments and executed by the 
+/// This is an asyncronous message mechanism taken from the OpenVMS system.
+/// The event handler is passed inside the message arguments and executed by the
 /// MDSEventAst() function from mdslib.
-/// 
+///
 /// \param connection the Connection instance filled with proper descriptor arguments
 /// \return the execute message answer built using BuildAnswer()
 ///
@@ -676,13 +676,13 @@ static Message *ExecuteMessage(Connection * connection)
   }
   // NORMAL TDI COMMAND //
   else {
-    void *old_context;
+    void *old_dbid;
     void *tdi_context[6];
     EMPTYXD(ans_xd);
 
     int contextSwitch = GetContextSwitching();
     if (contextSwitch) {
-      old_context = TreeSwitchDbid(connection->context.tree);
+      old_dbid = TreeSwitchDbid(connection->DBID);
       TdiSaveContext(tdi_context);
       TdiRestoreContext(connection->tdicontext);
     }
@@ -711,7 +711,7 @@ static Message *ExecuteMessage(Connection * connection)
     if (contextSwitch) {
       TdiSaveContext(connection->tdicontext);
       TdiRestoreContext(tdi_context);
-      connection->context.tree = TreeSwitchDbid(old_context);
+      connection->DBID = TreeSwitchDbid(old_dbid);
     }
   }
   FreeDescriptors(connection);
@@ -723,7 +723,7 @@ static Message *ExecuteMessage(Connection * connection)
 /// with the message buffer size and the message memory is copyed inside. A proper
 /// conversion of memory structure is applied if neede for the type of client
 /// connected.
-/// 
+///
 /// \param connection the connection instance to handle
 /// \param message the message to process
 /// \return message answer
@@ -735,7 +735,7 @@ Message *ProcessMessage(Connection * connection, Message * message)
 
   // COMING NEW MESSAGE  //
   // reset connection id //
-  if (connection->message_id != message->h.message_id) {      
+  if (connection->message_id != message->h.message_id) {
     FreeDescriptors(connection);
     if (message->h.nargs < MDSIP_MAX_ARGS - 1) {
       connection->message_id = message->h.message_id;
@@ -758,8 +758,8 @@ Message *ProcessMessage(Connection * connection, Message * message)
     connection->client_type = message->h.client_type;
 
     // d -> reference to curent idx argument desctriptor  //
-    struct descriptor *d = connection->descrip[message->h.descriptor_idx];    
-    
+    struct descriptor *d = connection->descrip[message->h.descriptor_idx];
+
     if (!d) {
       // instance the connection descriptor field //
       static short lengths[] = { 0, 0, 1, 2, 4, 8, 1, 2, 4, 8, 4, 8, 8, 16, 0 };
@@ -818,7 +818,7 @@ Message *ProcessMessage(Connection * connection, Message * message)
     if (d) {
         // have valid connection descriptor instance     //
         // copy the message buffer into the descriptor   //
-        
+
       int dbytes = d->class == CLASS_S ? (int)d->length : (int)((ARRAY_7 *) d)->arsize;
       int num = dbytes / max(1, d->length);
 
@@ -933,9 +933,9 @@ Message *ProcessMessage(Connection * connection, Message * message)
   }
 
   // SPECIAL I/O MESSAGES //////////////////////////////////////////////////////
-  // idx >= nargs         ////////////////////////////////////////////////////// 
+  // idx >= nargs         //////////////////////////////////////////////////////
   else {
-      
+
     connection->client_type = message->h.client_type;
     switch (message->h.descriptor_idx) {
     case MDS_IO_OPEN_K:

--- a/mdstcpip/RemoveConnection.c
+++ b/mdstcpip/RemoveConnection.c
@@ -34,7 +34,7 @@ extern int MDSEventCan();
 ///
 /// \brief RemoveConnection
 /// \param conid
-/// \return 
+/// \return
 ///
 int RemoveConnection(int conid)
 {
@@ -51,12 +51,7 @@ int RemoveConnection(int conid)
 	free(e->info);
       free(e);
     }
-    if (c->context.tree) {
-      void *old_context;
-      old_context = TreeSwitchDbid(c->context.tree);
-      TreeClose(0, 0);
-      c->context.tree = TreeSwitchDbid(old_context);
-    }
+    while IS_OK(_TreeClose(&c->DBID,0, 0));
     TdiSaveContext(tdi_context);
     TdiDeleteContext(c->tdicontext);
     TdiRestoreContext(tdi_context);

--- a/mdstcpip/mdsip_connections.h
+++ b/mdstcpip/mdsip_connections.h
@@ -15,7 +15,6 @@
 #include <ipdesc.h>
 #include <mds_stdarg.h>
 #include <pthread.h>
-
 #define MDSIP_MAX_ARGS 256
 #define MDSIP_MAX_COMPRESS 9
 
@@ -32,7 +31,6 @@ enum _mdsip_client_types {
   CRAY_CLIENT = 8
 };
 
-typedef struct _treecontext { void *tree; } TreeContext;
 
 typedef struct _eventinfo {
   char data[12];
@@ -72,7 +70,7 @@ typedef struct _connection {
   char *info_name;
   void *info;
   size_t info_len;
-  TreeContext context;
+  void* DBID;
   unsigned char message_id;
   int client_type;
   int nargs;

--- a/mdstcpip/udt4/src/common.cpp
+++ b/mdstcpip/udt4/src/common.cpp
@@ -145,8 +145,8 @@ void CTimer::rdtsc(uint64_t &x)
       x = hval;
       x = (x << 32) | lval;
    #elif defined(WIN32)
-      //HANDLE hCurThread = ::GetCurrentThread(); 
-      //DWORD_PTR dwOldMask = ::SetThreadAffinityMask(hCurThread, 1); 
+      //HANDLE hCurThread = ::GetCurrentThread();
+      //DWORD_PTR dwOldMask = ::SetThreadAffinityMask(hCurThread, 1);
       BOOL ret = QueryPerformanceCounter((LARGE_INTEGER *)&x);
       //SetThreadAffinityMask(hCurThread, dwOldMask);
       if (!ret)
@@ -283,19 +283,19 @@ uint64_t CTimer::getTime()
       return t.tv_sec * 1000000ULL + t.tv_usec;
    #else
       LARGE_INTEGER ccf;
-      HANDLE hCurThread = ::GetCurrentThread(); 
+      HANDLE hCurThread = ::GetCurrentThread();
       DWORD_PTR dwOldMask = ::SetThreadAffinityMask(hCurThread, 1);
       if (QueryPerformanceFrequency(&ccf))
       {
          LARGE_INTEGER cc;
          if (QueryPerformanceCounter(&cc))
          {
-            SetThreadAffinityMask(hCurThread, dwOldMask); 
+            SetThreadAffinityMask(hCurThread, dwOldMask);
             return (cc.QuadPart * 1000000ULL / ccf.QuadPart);
          }
       }
 
-      SetThreadAffinityMask(hCurThread, dwOldMask); 
+      SetThreadAffinityMask(hCurThread, dwOldMask);
       return GetTickCount() * 1000ULL;
    #endif
 }
@@ -303,7 +303,9 @@ uint64_t CTimer::getTime()
 void CTimer::triggerEvent()
 {
    #if !defined WIN32 || defined __MINGW64__
+      pthread_mutex_lock(&m_EventLock);
       pthread_cond_signal(&m_EventCond);
+      pthread_mutex_unlock(&m_EventLock);
    #else
       SetEvent(m_EventCond);
    #endif
@@ -552,7 +554,7 @@ const char* CUDTException::getErrorMessage()
 
       case 5:
         m_strMsg = "Operation not supported";
- 
+
         switch (m_iMinor)
         {
         case 1:

--- a/treeshr/TreeOpen.c
+++ b/treeshr/TreeOpen.c
@@ -568,18 +568,18 @@ static int ConnectTree(PINO_DATABASE * dblist, char *tree, NODE * parent, char *
             *dblist = db;}
 
 
-int initPinoDb(PINO_DATABASE ** dblist){
-  PINO_DATABASE *db = *dblist;
+EXPORT int _TreeNewDbid(void** dblist){
+  PINO_DATABASE *db = *(PINO_DATABASE **)dblist;
   *dblist = calloc(1,sizeof(PINO_DATABASE));
   if (*dblist) {
-    (*dblist)->next = db;
-    (*dblist)->timecontext.start.dtype = DTYPE_DSC;
-    (*dblist)->timecontext.start.class = CLASS_XD;
-    (*dblist)->timecontext.end.dtype = DTYPE_DSC;
-    (*dblist)->timecontext.end.class = CLASS_XD;
-    (*dblist)->timecontext.delta.dtype = DTYPE_DSC;
-    (*dblist)->timecontext.delta.class = CLASS_XD;
-    (*dblist)->stack_size = 8;
+    (*(PINO_DATABASE **)dblist)->next = db;
+    (*(PINO_DATABASE **)dblist)->timecontext.start.dtype = DTYPE_DSC;
+    (*(PINO_DATABASE **)dblist)->timecontext.start.class = CLASS_XD;
+    (*(PINO_DATABASE **)dblist)->timecontext.end.dtype = DTYPE_DSC;
+    (*(PINO_DATABASE **)dblist)->timecontext.end.class = CLASS_XD;
+    (*(PINO_DATABASE **)dblist)->timecontext.delta.dtype = DTYPE_DSC;
+    (*(PINO_DATABASE **)dblist)->timecontext.delta.class = CLASS_XD;
+    (*(PINO_DATABASE **)dblist)->stack_size = 8;
     return TreeNORMAL;
   }
   return TreeFAILURE;
@@ -667,7 +667,7 @@ static int CreateDbSlot(PINO_DATABASE ** dblist, char *tree, int shot, int editt
 	  treeshr_errno = TreeMAXOPENEDIT;
 	}
       } else
-        status = initPinoDb(dblist);
+        status = _TreeNewDbid((void**)dblist);
     }
   }
   if (status == TreeNORMAL) {

--- a/treeshr/TreeThreadSafe.c
+++ b/treeshr/TreeThreadSafe.c
@@ -32,7 +32,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <strroutines.h>
 #include <string.h>
 
-extern int initPinoDb(PINO_DATABASE ** dblist);
+extern int _TreeNewDbid(void** dblist);
 extern int TreeFreeDbid(PINO_DATABASE *db);
 static pthread_rwlock_t treectx_lock = PTHREAD_RWLOCK_INITIALIZER;
 void *DBID = NULL;
@@ -50,7 +50,7 @@ STATIC_ROUTINE void buffer_destroy(void *buf){
 }
 STATIC_ROUTINE void buffer_key_alloc(){
   pthread_key_create(&buffer_key, buffer_destroy);
-  if (!DBID) initPinoDb((PINO_DATABASE**)&DBID);
+  if (!DBID) _TreeNewDbid(&DBID);
 }
 /* Return the thread-specific buffer */
 TreeThreadStatic *TreeGetThreadStatic(){
@@ -58,7 +58,7 @@ TreeThreadStatic *TreeGetThreadStatic(){
   TreeThreadStatic* p = (TreeThreadStatic*)pthread_getspecific(buffer_key);
   if (!p) {
     p = (TreeThreadStatic*)calloc(1,sizeof(TreeThreadStatic));
-    initPinoDb((PINO_DATABASE **)&p->DBID);
+    _TreeNewDbid(&p->DBID);
     pthread_setspecific(buffer_key, (void*)p);
   }
   return p;


### PR DESCRIPTION
enables MdsConnectionTest for Windows by dropping the use of fork
fixes issue regarding missing initial treecontext for mdsip with -m flag mentioned here #1240
replaces pr  #1241