### PR TITLE
Build: Avoid potential gpg locking problems caused by aborted builds

### DIFF
--- a/deploy/platform/debian/debian_docker_build.sh
+++ b/deploy/platform/debian/debian_docker_build.sh
@@ -148,7 +148,7 @@ EOF
     if [ ! -z "$GPG_HOME" ]
     then
     	echo "SignWith: MDSplus" >> /release/repo/conf/distributions
-	rsync -a ${GPG_HOME}/.gnupg /workspace
+	rsync -a ${GPG_HOME}/.gnupg /tmp
     fi
     pushd /release/repo
     reprepro clearvanished
@@ -156,7 +156,7 @@ EOF
     do
         if [ -z "$abort" ] || [ "$abort" = "0" ]
         then
-            :&& HOME=/workspace reprepro -V -C ${BRANCH} includedeb MDSplus $deb
+            :&& HOME=/tmp reprepro -V -C ${BRANCH} includedeb MDSplus $deb
             checkstatus abort "Failure: Problem installing $deb into repository." $?
         fi
     done

--- a/deploy/platform/debian/debian_docker_build.sh
+++ b/deploy/platform/debian/debian_docker_build.sh
@@ -148,7 +148,8 @@ EOF
     if [ ! -z "$GPG_HOME" ]
     then
     	echo "SignWith: MDSplus" >> /release/repo/conf/distributions
-	export HOME="$GPG_HOME"
+	rsync -a ${GPG_HOME}/.gnupg /workspace
+	export GNUPGHOME="/workspace"
     fi
     pushd /release/repo
     reprepro clearvanished

--- a/deploy/platform/debian/debian_docker_build.sh
+++ b/deploy/platform/debian/debian_docker_build.sh
@@ -149,7 +149,6 @@ EOF
     then
     	echo "SignWith: MDSplus" >> /release/repo/conf/distributions
 	rsync -a ${GPG_HOME}/.gnupg /workspace
-	export GNUPGHOME="/workspace"
     fi
     pushd /release/repo
     reprepro clearvanished
@@ -157,7 +156,7 @@ EOF
     do
         if [ -z "$abort" ] || [ "$abort" = "0" ]
         then
-            :&& reprepro -V -C ${BRANCH} includedeb MDSplus $deb
+            :&& HOME=/workspace reprepro -V -C ${BRANCH} includedeb MDSplus $deb
             checkstatus abort "Failure: Problem installing $deb into repository." $?
         fi
     done

--- a/deploy/platform/redhat/redhat_build_rpms.py
+++ b/deploy/platform/redhat/redhat_build_rpms.py
@@ -223,7 +223,7 @@ Buildarch: noarch
     try:
         os.stat('/sign_keys/.gnupg')
         try:
-            cmd="/bin/sh -c 'HOME=/sign_keys rpmsign --addsign /release/%(branch)s/RPMS/*/*%(major)d.%(minor)d-%(release)d*.rpm'" % info
+            cmd="/bin/sh -c 'rsync -a /sign_keys/.gnupg /workspace; GNUPGHOME=/workspace rpmsign --addsign /release/%(branch)s/RPMS/*/*%(major)d.%(minor)d-%(release)d*.rpm'" % info
             child = pexpect.spawn(cmd,timeout=60,logfile=sys.stdout)
             child.expect("Enter pass phrase: ")
             child.sendline("")

--- a/deploy/platform/redhat/redhat_build_rpms.py
+++ b/deploy/platform/redhat/redhat_build_rpms.py
@@ -223,7 +223,7 @@ Buildarch: noarch
     try:
         os.stat('/sign_keys/.gnupg')
         try:
-            cmd="/bin/sh -c 'rsync -a /sign_keys/.gnupg /workspace; GNUPGHOME=/workspace rpmsign --addsign /release/%(branch)s/RPMS/*/*%(major)d.%(minor)d-%(release)d*.rpm'" % info
+            cmd="/bin/sh -c 'rsync -a /sign_keys/.gnupg /workspace; HOME=/workspace rpmsign --addsign /release/%(branch)s/RPMS/*/*%(major)d.%(minor)d-%(release)d*.rpm'" % info
             child = pexpect.spawn(cmd,timeout=60,logfile=sys.stdout)
             child.expect("Enter pass phrase: ")
             child.sendline("")

--- a/deploy/platform/redhat/redhat_build_rpms.py
+++ b/deploy/platform/redhat/redhat_build_rpms.py
@@ -223,7 +223,7 @@ Buildarch: noarch
     try:
         os.stat('/sign_keys/.gnupg')
         try:
-            cmd="/bin/sh -c 'rsync -a /sign_keys/.gnupg /workspace; HOME=/workspace rpmsign --addsign /release/%(branch)s/RPMS/*/*%(major)d.%(minor)d-%(release)d*.rpm'" % info
+            cmd="/bin/sh -c 'rsync -a /sign_keys/.gnupg /tmp; HOME=/tmp rpmsign --addsign /release/%(branch)s/RPMS/*/*%(major)d.%(minor)d-%(release)d*.rpm'" % info
             child = pexpect.spawn(cmd,timeout=60,logfile=sys.stdout)
             child.expect("Enter pass phrase: ")
             child.sendline("")


### PR DESCRIPTION
Under some circumstances file in the .gnupg directory used when signing
installers can become locked. This is rare but it can cause builds to hang indefinitely. This change makes a copy of the signing information and uses the copy for each installer creation.