### PR TITLE
Zck stack copysegmentindex

### DIFF
--- a/deploy/platform/debian/debian_docker_build.sh
+++ b/deploy/platform/debian/debian_docker_build.sh
@@ -118,6 +118,7 @@ buildrelease() {
 	fi
     done
     checkstatus abort "Failure: Problem with contents of one or more debs. (see above)" $baddeb
+  if [ -z "$abort" ] || [ "$abort" = "0" ]
     echo "Building repo";
     mkdir -p /release/repo/conf
     mkdir -p /release/repo/db
@@ -158,9 +159,12 @@ EOF
         then
             :&& HOME=/tmp reprepro -V -C ${BRANCH} includedeb MDSplus $deb
             checkstatus abort "Failure: Problem installing $deb into repository." $?
+        else
+          break
         fi
     done
     popd
+  fi #abort
   fi #nomake
 }
 publish() {

--- a/deploy/platform/platform_docker_build.sh
+++ b/deploy/platform/platform_docker_build.sh
@@ -171,7 +171,7 @@ normaltest() {
     checkstatus tests_$1 "Failure testing $1-bit." $?
     if [ ! -z "$VALGRIND_TOOLS" ]
     then
-        ### Test with valgrind		
+        ### Test with valgrind
         to=$( gettimeout $VALGRIND_TOOLS )
 		:&& tio $to  $MAKE -k rebuild-tests VALGRIND_BUILD=yes 2>&1
 		checkstatus tests_${1}_val "Failure building tests $1-bit with valgrind." $?

--- a/mdsobjects/python/tests/segmentsUnitTest.py
+++ b/mdsobjects/python/tests/segmentsUnitTest.py
@@ -319,7 +319,7 @@ class Tests(TestCase):
         ptree.compressDatafile()
         te = DateToQuad("now")
         sampperseg = 50
-        data = ZERO(Int32Array([sampperseg]),Int32(0)).data()
+        data = ZERO(Int32Array([sampperseg]),Int32(0))
         for i in range(513):
             t0=te+1;te=t0+sampperseg-1
             node.makeSegment(t0,te,Int64Array(range(t0,te+1)),data+Int32(i))

--- a/mdsobjects/python/tree.py
+++ b/mdsobjects/python/tree.py
@@ -315,6 +315,12 @@ class Tree(object):
     tctx = None
     ctx  = None
 
+    def getDatafileSize(self):
+        """return data file size.
+        @rtype: long
+        """
+        _TreeShr._TreeGetDatafileSize.restype=_C.c_int64
+        return _TreeShr._TreeGetDatafileSize(self.ctx)
     @classmethodX
     def cleanDatafile(self,tree=None,shot=None):
         """Clean up data file.

--- a/treeshr/TreeSegments.c
+++ b/treeshr/TreeSegments.c
@@ -475,9 +475,10 @@ inline static int check_sinfo(vars_t*vars) {
   if (vars->idx < 0 || vars->idx > vars->shead.idx)
     return TreeFAILURE;
   for (vars->index_offset = vars->shead.index_offset;
-       STATUS_OK && vars->idx < vars->sindex.first_idx && vars->sindex.previous_offset > 0;
-       vars->index_offset = vars->sindex.previous_offset)
+       STATUS_OK && vars->idx < vars->sindex.first_idx && vars->sindex.previous_offset > 0;) {
+    vars->index_offset = vars->sindex.previous_offset;
     status = GetSegmentIndex(vars->tinfo, vars->sindex.previous_offset, &vars->sindex);
+  }
   if (STATUS_NOT_OK || (vars->idx < vars->sindex.first_idx))
     return TreeFAILURE;
   vars->sinfo = &vars->sindex.segment[vars->idx % SEGMENTS_PER_INDEX];


### PR DESCRIPTION
Fixes a problem with updateSegment that resulted in corrupted data.
avoid recursive stack-memory expensive CopySegmentIndex.
only read and store sindex offsets and process them in correct order
