### PR TITLE
Fix: Repair installer signing

### DIFF
--- a/deploy/platform/debian/debian_docker_build.sh
+++ b/deploy/platform/debian/debian_docker_build.sh
@@ -119,6 +119,7 @@ buildrelease() {
     done
     checkstatus abort "Failure: Problem with contents of one or more debs. (see above)" $baddeb
   if [ -z "$abort" ] || [ "$abort" = "0" ]
+  then
     echo "Building repo";
     mkdir -p /release/repo/conf
     mkdir -p /release/repo/db

--- a/deploy/platform/redhat/redhat_build_rpms.py
+++ b/deploy/platform/redhat/redhat_build_rpms.py
@@ -223,7 +223,7 @@ Buildarch: noarch
     try:
         os.stat('/sign_keys/.gnupg')
         try:
-            cmd="/bin/sh -c 'rsync -a /sign_keys/.gnupg /tmp; HOME=/tmp rpmsign --addsign /release/%(branch)s/RPMS/*/*%(major)d.%(minor)d-%(release)d*.rpm'" % info
+            cmd="/bin/sh -c 'rsync -a /sign_keys /tmp/; HOME=/tmp/sign_keys rpmsign --addsign /release/%(branch)s/RPMS/*/*%(major)d.%(minor)d-%(release)d*.rpm'" % info
             child = pexpect.spawn(cmd,timeout=60,logfile=sys.stdout)
             child.expect("Enter pass phrase: ")
             child.sendline("")


### PR DESCRIPTION
Previous attempt to prevent signing interference between concurrent builds
introduced some other errors preventing the installers from being signed. This should fix this problem.