### PR TITLE
Zck scaled segments

### DIFF
--- a/deploy/packaging/debian/kernel.noarch
+++ b/deploy/packaging/debian/kernel.noarch
@@ -158,6 +158,7 @@
 ./usr/local/mdsplus/tdi/segments/GetSegmentInfo.fun
 ./usr/local/mdsplus/tdi/segments/GetSegmentLimits.fun
 ./usr/local/mdsplus/tdi/segments/GetSegmentList.fun
+./usr/local/mdsplus/tdi/segments/GetSegmentScale.fun
 ./usr/local/mdsplus/tdi/segments/GetSegmentTimes.fun
 ./usr/local/mdsplus/tdi/segments/GetTimeContext.fun
 ./usr/local/mdsplus/tdi/segments/MakeSegment.fun
@@ -165,6 +166,7 @@
 ./usr/local/mdsplus/tdi/segments/PutRow.fun
 ./usr/local/mdsplus/tdi/segments/PutSegment.fun
 ./usr/local/mdsplus/tdi/segments/PutTimestampedSegment.fun
+./usr/local/mdsplus/tdi/segments/SetSegmentScale.fun
 ./usr/local/mdsplus/tdi/segments/SetTimeContext.fun
 ./usr/local/mdsplus/tdi/segments/testsegments.fun
 ./usr/local/mdsplus/tdi/shot_date.fun

--- a/deploy/packaging/redhat/kernel.noarch
+++ b/deploy/packaging/redhat/kernel.noarch
@@ -185,6 +185,7 @@
 ./usr/local/mdsplus/tdi/segments/GetSegmentInfo.fun
 ./usr/local/mdsplus/tdi/segments/GetSegmentLimits.fun
 ./usr/local/mdsplus/tdi/segments/GetSegmentList.fun
+./usr/local/mdsplus/tdi/segments/GetSegmentScale.fun
 ./usr/local/mdsplus/tdi/segments/GetSegmentTimes.fun
 ./usr/local/mdsplus/tdi/segments/GetTimeContext.fun
 ./usr/local/mdsplus/tdi/segments/MakeSegment.fun
@@ -192,6 +193,7 @@
 ./usr/local/mdsplus/tdi/segments/PutRow.fun
 ./usr/local/mdsplus/tdi/segments/PutSegment.fun
 ./usr/local/mdsplus/tdi/segments/PutTimestampedSegment.fun
+./usr/local/mdsplus/tdi/segments/SetSegmentScale.fun
 ./usr/local/mdsplus/tdi/segments/SetTimeContext.fun
 ./usr/local/mdsplus/tdi/segments/testsegments.fun
 ./usr/local/mdsplus/tdi/shot_date.fun

--- a/include/mdsdescrip.h
+++ b/include/mdsdescrip.h
@@ -2,6 +2,7 @@
 #define MDSDESCRIP_H_DEFINED 1
 
 #include <mdsplus/mdsconfig.h>
+#define MAX_NDIMS 64
 
 #ifdef _WIN32
 #define __char_align__ char

--- a/include/mdsobjects.h
+++ b/include/mdsobjects.h
@@ -2918,7 +2918,7 @@ protected:
     virtual void *convertToDsc();
     virtual bool getFlag(int flagOfs);
     virtual void setFlag(int flagOfs, bool val);
-    
+
     virtual char getNciChar(int itm);
     virtual int getNciInt(int itm);
     virtual int64_t getNciInt64(int itm);
@@ -3086,9 +3086,6 @@ public:
     /// Get all the descendant (members + children)for this node
     virtual TreeNode **getDescendants(int *numChildren);
 
-
-
-
     /// Return Nci class name (NciCLASS) as c string
     virtual const char *getClass();
 
@@ -3097,9 +3094,6 @@ public:
 
     /// Return Nci node usage (NciUSAGE) as c string
     virtual const char *getUsage();
-
-
-
 
     /// Get index of the node in the corresponding conglomerate.
     /// Ref to \ref getNci() with code NciCONGLOMERATE_ELT
@@ -3157,6 +3151,12 @@ public:
 
     /// Get both segment and segment dimension
     virtual void getSegmentAndDimension(int segIdx, Array *&segment, Data *&dimension);
+
+    /// Set scale for segmented Node
+    virtual void setSegmentScale(Data* scale);
+
+    /// Get scale of segmented Node
+    virtual Data* getSegmentScale();
 
     /// Begin a timestamted segment
     virtual void beginTimestampedSegment(Array *initData);
@@ -3248,7 +3248,7 @@ class  EXPORT TreeNodeThinClient: public TreeNode
 protected:
 
     Connection *connection;
- 
+
     //From Data
     virtual bool isImmutable() {return false;}
     // virtual void *convertToDsc();  Use superclass implementation
@@ -3314,13 +3314,13 @@ public:
     virtual TreeNode *getNode(char const * relPath)
     {
 	(void)relPath;
-	throw MdsException("getNode() not supported for TreeNodeThinClient object"); return NULL; 
+	throw MdsException("getNode() not supported for TreeNodeThinClient object"); return NULL;
     }
     /// Retrieve node from this tree by its realPath string
     virtual TreeNode *getNode(String *relPathStr)
     {
         (void)relPathStr;
-	throw MdsException("getNode() not supported for TreeNodeThinClient object"); return NULL; 
+	throw MdsException("getNode() not supported for TreeNodeThinClient object"); return NULL;
     }
 
     virtual Data *getData();
@@ -3650,7 +3650,7 @@ public:
       (void)isSubtree;
       throw MdsException("edit operations not supported for TreeNodeThinClient object");
     }
-    
+
 };
 
 /////////////////End Class TreeNodeThinClient///////////////
@@ -3774,7 +3774,7 @@ public:
     /// to.
     ///
     Tree(char const * name, int shot);
-    Tree(char const * name, int shot, void *ctx); 
+    Tree(char const * name, int shot, void *ctx);
 
 
     /// Builds a new Tree object instance creating or attaching to the named
@@ -4243,9 +4243,9 @@ public:
     {
         return new GetMany(this);
     }
-// Get TreeNode instance for (a subset of) TreeNode functionality in thin client configuration 
+// Get TreeNode instance for (a subset of) TreeNode functionality in thin client configuration
     TreeNodeThinClient *getNode(char *path);
-//Streaming stuff     
+//Streaming stuff
     void registerStreamListener(DataStreamListener *listener, char *expr, char *tree, int shot);
     void unregisterStreamListener(DataStreamListener *listener);
     void startStreaming();

--- a/include/treeshr.h
+++ b/include/treeshr.h
@@ -260,6 +260,10 @@ extern int TREE_BLOCKID;
   extern EXPORT int TreeFindTagWildDsc(char *wild, int *nidout, void **ctx_inout,
 				       struct descriptor_xd *name);
 
+  extern EXPORT int _TreeGetSegmentScale(void *dbid, int nid, struct descriptor_xd *value);
+  extern EXPORT int TreeGetSegmentScale(int nid, struct descriptor_xd *value);
+  extern EXPORT int _TreeSetSegmentScale(void *dbid, int nid, struct descriptor *value);
+  extern EXPORT int TreeSetSegmentScale(int nid, struct descriptor *value);
 
 #ifdef __cplusplus
 }

--- a/mdsobjects/cpp/mdsdataobjects.cpp
+++ b/mdsobjects/cpp/mdsdataobjects.cpp
@@ -1,3 +1,4 @@
+
 /*
 Copyright (c) 2017, Massachusetts Institute of Technology All rights reserved.
 
@@ -56,16 +57,16 @@ extern "C" {
 	char * serializeData(void *dsc, int *retSize, void **retDsc);
 	void *deserializeData(char const * serialized);
 
-	void * convertToByte(void *dsc); 
-	void * convertToShort(void *dsc); 
-	void * convertToInt(void *dsc); 
-	void * convertToLong(void *dsc); 
-	void * convertToByteUnsigned(void *dsc); 
-	void * convertToShortUnsigned(void *dsc); 
-	void * convertToIntUnsigned(void *dsc); 
-	void * convertToLongUnsigned(void *dsc); 
-	void * convertToFloat(void *dsc); 
-	void * convertToDouble(void *dsc); 
+	void * convertToByte(void *dsc);
+	void * convertToShort(void *dsc);
+	void * convertToInt(void *dsc);
+	void * convertToLong(void *dsc);
+	void * convertToByteUnsigned(void *dsc);
+	void * convertToShortUnsigned(void *dsc);
+	void * convertToIntUnsigned(void *dsc);
+	void * convertToLongUnsigned(void *dsc);
+	void * convertToFloat(void *dsc);
+	void * convertToDouble(void *dsc);
 	void * convertToShape(void *dcs);
 	void * convertToParameter(void *dsc, void *helpDsc, void *validationDsc);
 	void * convertToUnits(void *dsc, void *unitsDsc);
@@ -82,7 +83,7 @@ extern "C"  void *convertDataToDsc(void *data)
 	return ((Data *)data)->convertToDsc();
 }
 
-extern "C"  void *createScalarData(int dtype, int length, char *ptr, Data *unitsData, Data *errorData, 
+extern "C"  void *createScalarData(int dtype, int length, char *ptr, Data *unitsData, Data *errorData,
 								  Data *helpData, Data *validationData, Tree *tree)
 {
 	switch(dtype) {
@@ -95,13 +96,13 @@ extern "C"  void *createScalarData(int dtype, int length, char *ptr, Data *units
 		case DTYPE_Q: return new Int64(*(int64_t *)ptr, unitsData, errorData, helpData, validationData);
 		case DTYPE_QU: return new Uint64(*(int64_t *)ptr, unitsData, errorData, helpData, validationData);
 		case DTYPE_FLOAT: return new Float32(*(float *)ptr, unitsData, errorData, helpData, validationData);
-		case DTYPE_F: 
-			convertToIEEEFloat(dtype, length, ptr); 
+		case DTYPE_F:
+			convertToIEEEFloat(dtype, length, ptr);
 			return new Float32(*(float *)ptr, unitsData, errorData, helpData, validationData);
 		case DTYPE_DOUBLE: return new Float64(*(double *)ptr, unitsData, errorData, helpData, validationData);
 		case DTYPE_G:
 		case DTYPE_D:
-			convertToIEEEFloat(dtype, length, ptr); 
+			convertToIEEEFloat(dtype, length, ptr);
 			return new Float64(*(double *)ptr, unitsData, errorData, helpData, validationData);
 		case DTYPE_FSC: return new Complex32(((float *)ptr)[0], ((float *)ptr)[1], unitsData, errorData, helpData, validationData);
 		case DTYPE_FTC: return new Complex64(((double *)ptr)[0], ((double *)ptr)[1], unitsData, errorData, helpData, validationData);
@@ -113,7 +114,7 @@ extern "C"  void *createScalarData(int dtype, int length, char *ptr, Data *units
 	return 0;
 }
 
-extern "C"  void *createArrayData(int dtype, int length, int nDims, int *dims, char *ptr, 
+extern "C"  void *createArrayData(int dtype, int length, int nDims, int *dims, char *ptr,
 								 Data *unitsData, Data *errorData, Data *helpData, Data *validationData)
 {
 	int revDims[MAX_ARGS];
@@ -129,7 +130,7 @@ extern "C"  void *createArrayData(int dtype, int length, int nDims, int *dims, c
 		case DTYPE_Q: return new Int64Array((int64_t *)ptr, nDims, revDims, unitsData, errorData, helpData, validationData);
 		case DTYPE_QU: return new Uint64Array((uint64_t *)ptr, nDims, revDims, unitsData, errorData, helpData, validationData);
 		case DTYPE_FLOAT: return new Float32Array((float *)ptr, nDims, revDims, unitsData, errorData, helpData, validationData);
-		case DTYPE_F: 
+		case DTYPE_F:
 			convertToIEEEFloatArray(dtype, length, nDims, dims, ptr);
 			return new Float32Array((float *)ptr, nDims, revDims, unitsData, errorData, helpData, validationData);
 		case DTYPE_DOUBLE: return new Float64Array((double *)ptr, nDims, revDims, unitsData, errorData, helpData, validationData);
@@ -144,7 +145,7 @@ extern "C"  void *createArrayData(int dtype, int length, int nDims, int *dims, c
 	return 0;
 }
 
-extern "C"  void *createCompoundData(int dtype, int length, char *ptr, int nDescs, char **descs, 
+extern "C"  void *createCompoundData(int dtype, int length, char *ptr, int nDescs, char **descs,
 									Data *unitsData, Data *errorData, Data *helpData, Data *validationData)
 {
 //printf("CREATE COMPOUND DATA nDescs = %d ptr= %x\n", nDescs, ptr);
@@ -169,17 +170,17 @@ extern "C"  void *createCompoundData(int dtype, int length, char *ptr, int nDesc
 	return 0;
 }
 
-extern "C"  void *createApdData(int nData, char **dataPtrs, Data *unitsData, 
+extern "C"  void *createApdData(int nData, char **dataPtrs, Data *unitsData,
 							   Data *errorData, Data *helpData, Data *validationData)
 {
 	return new Apd(nData, (Data **) dataPtrs, unitsData, errorData, helpData, validationData);
 }
-extern "C"  void *createListData(int nData, char **dataPtrs, Data *unitsData, 
+extern "C"  void *createListData(int nData, char **dataPtrs, Data *unitsData,
 							   Data *errorData, Data *helpData, Data *validationData)
 {
 	return new List(nData, (Data **) dataPtrs, unitsData, errorData, helpData, validationData);
 }
-extern "C"  void *createDictionaryData(int nData, char **dataPtrs, Data *unitsData, 
+extern "C"  void *createDictionaryData(int nData, char **dataPtrs, Data *unitsData,
 							   Data *errorData, Data *helpData, Data *validationData)
 {
 	return new Dictionary(nData, (Data **) dataPtrs, unitsData, errorData, helpData, validationData);
@@ -353,7 +354,7 @@ int * Data::getShape(int *numDim)
 		throw MdsException("Cannot compute shape");
 	freeDsc(dscPtr);
 	freeDsc(retDsc);
-	
+
 	int *res = retData->getIntArray(numDim);
 	deleteData(retData);
 	return res;
@@ -364,16 +365,16 @@ int * Data::getShape(int *numDim)
 Data * Data::getData(int classType, int dataType) {
 	void *dscPtr = convertToDsc();
 	void *retDsc = NULL;
-	switch(dataType)  
+	switch(dataType)
 	{
-	  case DTYPE_B: 
-	    retDsc = convertToByte(dscPtr); 
+	  case DTYPE_B:
+	    retDsc = convertToByte(dscPtr);
 	    break;
 	  case DTYPE_BU:
-	    retDsc = convertToByteUnsigned(dscPtr); 
+	    retDsc = convertToByteUnsigned(dscPtr);
 	    break;
 	  case DTYPE_W:
-	    retDsc = convertToShort(dscPtr); 
+	    retDsc = convertToShort(dscPtr);
 	    break;
 	  case DTYPE_WU:
 	    retDsc = convertToShortUnsigned(dscPtr);
@@ -667,7 +668,7 @@ Data * Data::getDimensionAt(int dimIdx UNUSED_ARGUMENT) {
 
 ///
 /// \return new instanced Data representing compiled script
-/// 
+///
 /// ref to \ref MDSplus::compileWithArgs
 Data * MDSplus::compile(const char *expr) {
 	return compileWithArgs(expr, 0);
@@ -754,7 +755,7 @@ Data * MDSplus::executeWithArgs(const char *expr, int nArgs ...) {
 
 		va_list v;
 		va_start(v, nArgs);
-		
+
 		for(int i = 0; i < nArgs; i++)
 		{
 			Data *currArg = va_arg(v, Data *);
@@ -853,7 +854,7 @@ void * Data::completeConversionToDsc(void *dsc) {
 		if(validationDsc) freeDsc(validationDsc);
 		if(oldDsc) freeDsc(oldDsc);
 	}
-		 
+
 	if(error)
 	{
 		void *errorDsc = error->convertToDsc();
@@ -862,7 +863,7 @@ void * Data::completeConversionToDsc(void *dsc) {
 		if(errorDsc) freeDsc(errorDsc);
 		if(oldDsc) freeDsc(oldDsc);
 	}
-		
+
 	if(units)
 	{
 		void *unitsDsc = units->convertToDsc();
@@ -1014,7 +1015,7 @@ void Array::setElementAt(int *getDims, int getNumDims, Data *data)
 		scalarData = (Scalar *)data;
         //Propagate the passed scalar to all the remaining dimensions
 		for(i = 0; i < rowDims[getNumDims - 1]; i++)
-			memcpy(ptr + ((startIdx + i) * length), scalarData->ptr, length); 
+			memcpy(ptr + ((startIdx + i) * length), scalarData->ptr, length);
 	}
 	delete [] rowDims;
 
@@ -1279,7 +1280,7 @@ std::complex<double> *Array::getComplexArray(int *numElements)
 		switch(dtype) {
 			case DTYPE_FSC:
 				retArr[i] = std::complex<double>(((float *)ptr)[2*i], ((float *)ptr)[2*i+1]); break;
-			case DTYPE_FTC: 
+			case DTYPE_FTC:
 				retArr[i] = std::complex<double>(((double *)ptr)[2*i], ((double *)ptr)[2*i+1]); break;
             default:
             delete [] retArr;
@@ -1296,7 +1297,7 @@ char **Array::getStringArray(int *numElements)
 	char **retArr = new char*[size];
 	for(int i = 0; i < size; i++)
 		switch(dtype) {
-			case DTYPE_T: 
+			case DTYPE_T:
 				retArr[i] = new char[length+1];
 				memcpy(retArr[i], &ptr[i*length], length);
 				retArr[i][length] = 0;

--- a/mdsobjects/cpp/mdstree.c
+++ b/mdsobjects/cpp/mdstree.c
@@ -239,14 +239,15 @@ int getTreeSegmentInfo(void *dbid, int nid, int segIdx, char *dtype, char *dimct
 int getTreeSegment(void *dbid, int nid, int segIdx, void **dataDsc, void **timeDsc)
 {
   EMPTYXD(emptyXd);
-  struct descriptor_xd *dataXd = (struct descriptor_xd *)malloc(sizeof(struct descriptor_xd));
   struct descriptor_xd *timeXd = (struct descriptor_xd *)malloc(sizeof(struct descriptor_xd));
-
-  *dataXd = emptyXd;
-  *dataDsc = dataXd;
   *timeXd = emptyXd;
   *timeDsc = timeXd;
-
+  struct descriptor_xd *dataXd;
+  if (dataDsc) {
+    dataXd = (struct descriptor_xd *)malloc(sizeof(struct descriptor_xd));
+    *dataXd = emptyXd;
+    *dataDsc = dataXd;
+  } else dataXd = NULL;
   return _TreeGetSegment(dbid, nid, segIdx, dataXd, timeXd);
 }
 
@@ -311,4 +312,18 @@ int setTreeXNci(void *dbid, int nid, const char *name, void *dataDsc)
   return status;
 }
 
-
+int getTreeSegmentScale(void *dbid, int nid, void **sclDsc)
+{
+  EMPTYXD(emptyXd);
+  struct descriptor_xd *sclXd = (struct descriptor_xd *)malloc(sizeof(struct descriptor_xd));
+  *sclXd  = emptyXd;
+  *sclDsc = sclXd;
+  return _TreeGetSegmentScale(dbid, nid, sclXd);
+}
+int setTreeSegmentScale(void *dbid, int nid, void *sclDsc)
+{
+  struct descriptor_xd *sclXd = (struct descriptor_xd *)sclDsc;
+  int status = _TreeSetSegmentScale(dbid, nid, sclXd->pointer);
+  freeDsc(sclXd);
+  return status;
+}

--- a/mdsobjects/cpp/mdstreeobjects.cpp
+++ b/mdsobjects/cpp/mdstreeobjects.cpp
@@ -63,12 +63,12 @@ extern "C" {
 	void * convertToArrayDsc(int clazz, int dtype, int length, int l_length, int nDims, int *dims, void *ptr);
 	void * convertToCompoundDsc(int clazz, int dtype, int length, void *ptr, int ndescs, void **descs);
 	void * convertToApdDsc(int ndescs, void **ptr);
-	void * convertToByte(void *dsc); 
-	void * convertToShort(void *dsc); 
-	void * convertToInt(void *dsc); 
-	void * convertToLong(void *dsc); 
-	void * convertToFloat(void *dsc); 
-	void * convertToDouble(void *dsc); 
+	void * convertToByte(void *dsc);
+	void * convertToShort(void *dsc);
+	void * convertToInt(void *dsc);
+	void * convertToLong(void *dsc);
+	void * convertToFloat(void *dsc);
+	void * convertToDouble(void *dsc);
 	void * convertToShape(void *dcs);
 
 	// From mdstree.c
@@ -85,6 +85,8 @@ extern "C" {
 	int updateTreeSegment(void *dbid, int nid, int segIdx, void *startDsc, void *endDsc,
 									void *timeDsc);
 	int getTreeNumSegments(void *dbid, int nid, int *numSegments);
+	int getTreeSegmentScale(void *dbid, int nid, void* scale);
+	int setTreeSegmentScale(void *dbid, int nid, void* scale);
 	int getTreeSegmentLimits(void *dbid, int nid, int idx, void **startDsc, void **endDsc);
 	int getTreeSegment(void *dbid, int nid, int segIdx, void **dataDsc, void **timeDsc);
 	int setTreeTimeContext(void *dbid, void *startDsc, void *endDsc, void *deltaDsc);
@@ -538,7 +540,7 @@ TreeNode::TreeNode(int nid, Tree *tree, Data *units, Data *error, Data *help, Da
 	this->tree = 0;
 	if(!tree && nid != 0)
 		this->tree = getActiveTree();
-	if(!tree && nid != 0) //exclude the case in which this constructor has been called in a TreePath instantiation 
+	if(!tree && nid != 0) //exclude the case in which this constructor has been called in a TreePath instantiation
 		throw MdsException("A Tree instance must be defined when ceating TreeNode instances");
 	this->nid = nid;
 	this->tree = tree;
@@ -565,7 +567,7 @@ char TreeNode::getNciChar(int itm)
 {
     return getNci<char>(tree->getCtx(), nid, itm);
 }
-   
+
 int TreeNode::getNciInt(int itm)
 {
     return getNci<int>(tree->getCtx(), nid, itm);
@@ -1001,7 +1003,7 @@ void TreeNode::makeSegment(Data *start, Data *end, Data *time, Array *initialDat
 	int numDims;
 	int *shape = initialData->getShape(&numDims);
 	//if(tree) tree->lock();
-	int status = makeTreeSegment(tree->getCtx(), getNid(), initialData->convertToDsc(), start->convertToDsc(), 
+	int status = makeTreeSegment(tree->getCtx(), getNid(), initialData->convertToDsc(), start->convertToDsc(),
 		end->convertToDsc(), time->convertToDsc(), shape[0]);
 	deleteNativeArray(shape);
 	//if(tree) tree->unlock();
@@ -1056,7 +1058,7 @@ void TreeNode::makeSegmentResampled(Data *start, Data *end, Data *time, Array *i
 	//Resampled aray always converted to float, Assumed 1D array
 	int numRows;
 	float *arrSamples = initialData->getFloatArray(&numRows);
-	float *resSamples = new float[numRows/RES_FACTOR]; 
+	float *resSamples = new float[numRows/RES_FACTOR];
 	for(int i = 0; i < numRows; i+= RES_FACTOR)
 	{
 		float avgVal = arrSamples[i];
@@ -1091,7 +1093,7 @@ void TreeNode::beginSegment(Data *start, Data *end, Data *time, Array *initialDa
 {
 	resolveNid();
 	//if(tree) tree->lock();
-	int status = beginTreeSegment(tree->getCtx(), getNid(), initialData->convertToDsc(), start->convertToDsc(), 
+	int status = beginTreeSegment(tree->getCtx(), getNid(), initialData->convertToDsc(), start->convertToDsc(),
 		end->convertToDsc(), time->convertToDsc());
 	//if(tree) tree->unlock();
 	if(!(status & 1))
@@ -1112,7 +1114,7 @@ void TreeNode::updateSegment(Data *start, Data *end, Data *time)
 {
 	resolveNid();
 	//if(tree) tree->lock();
-	int status = updateTreeSegment(tree->getCtx(), getNid(), -1, start->convertToDsc(), 
+	int status = updateTreeSegment(tree->getCtx(), getNid(), -1, start->convertToDsc(),
 		end->convertToDsc(), time->convertToDsc());
 	//if(tree) tree->unlock();
 	if(!(status & 1))
@@ -1123,7 +1125,7 @@ void TreeNode::updateSegment(int segIdx, Data *start, Data *end, Data *time)
 {
 	resolveNid();
 	//if(tree) tree->lock();
-	int status = updateTreeSegment(tree->getCtx(), getNid(), segIdx, start->convertToDsc(), 
+	int status = updateTreeSegment(tree->getCtx(), getNid(), segIdx, start->convertToDsc(),
 		end->convertToDsc(), time->convertToDsc());
 	//if(tree) tree->unlock();
 	if(!(status & 1))
@@ -1175,8 +1177,7 @@ Array *TreeNode::getSegment(int segIdx)
 	//if(tree) tree->lock();
 	int status = getTreeSegment(tree->getCtx(), getNid(), segIdx, &dataDsc, &timeDsc);
 	//if(tree) tree->unlock();
-	if(!(status & 1))
-	{
+	if(!(status & 1)) {
 		freeDsc(dataDsc);
 		freeDsc(timeDsc);
 		throw MdsException(status);
@@ -1189,28 +1190,63 @@ Array *TreeNode::getSegment(int segIdx)
 
 Data *TreeNode::getSegmentDim(int segIdx)
 {
-	void *dataDsc;
 	void *timeDsc;
 	resolveNid();
 	//if(tree) tree->lock();
-	int status = getTreeSegment(tree->getCtx(), getNid(), segIdx, &dataDsc, &timeDsc);
+	int status = getTreeSegment(tree->getCtx(), getNid(), segIdx, NULL, &timeDsc);
 	//if(tree) tree->unlock();
-	if(!(status & 1))
-	{
-		freeDsc(dataDsc);
+	if(!(status & 1)) {
 		freeDsc(timeDsc);
 		throw MdsException(status);
 	}
 	Data *retDim = (Data *)convertFromDsc(timeDsc, tree);
-	freeDsc(dataDsc);
 	freeDsc(timeDsc);
     return retDim;
 }
 
 void TreeNode::getSegmentAndDimension(int segIdx, Array *&segment, Data *&dimension)
 {
-    segment = getSegment(segIdx);
-    dimension = getSegmentDim(segIdx);
+	void *dataDsc;
+	void *timeDsc;
+	resolveNid();
+	//if(tree) tree->lock();
+	int status = getTreeSegment(tree->getCtx(), getNid(), segIdx, &dataDsc, &timeDsc);
+	//if(tree) tree->unlock();
+	if(!(status & 1)) {
+		freeDsc(dataDsc);
+		freeDsc(timeDsc);
+		throw MdsException(status);
+	}
+	segment   = (Array *)convertFromDsc(dataDsc, tree);
+	dimension = (Data *)convertFromDsc(dataDsc, tree);
+        freeDsc(dataDsc);
+        freeDsc(timeDsc);
+}
+
+Data *TreeNode::getSegmentScale()
+{
+	void *sclDsc;
+	resolveNid();
+	//if(tree) tree->lock();
+	int status = getTreeSegmentScale(tree->getCtx(), getNid(), &sclDsc);
+	//if(tree) tree->unlock();
+        if(!(status & 1)) {
+                freeDsc(sclDsc);
+                sclDsc = NULL;
+        }
+	Data *retScl = (Data *)convertFromDsc(sclDsc, tree);
+	freeDsc(sclDsc);
+	return retScl;
+}
+
+void TreeNode::setSegmentScale(Data *scale)
+{
+        resolveNid();
+        //if(tree) tree->lock();
+        int status = setTreeSegmentScale(tree->getCtx(), getNid(), scale->convertToDsc());
+        //if(tree) tree->unlock();
+        if(!(status & 1))
+                throw MdsException(status);
 }
 
 void TreeNode::beginTimestampedSegment(Array *initData)
@@ -1510,7 +1546,7 @@ out of scope, this triggering multiple deallocation of the same C string and cra
 
 StringArray *TreeNodeArray::getFullPath()
 {
-/* Same as before  
+/* Same as before
 	std::vector<AutoArray<char> > paths;
 	for(int i = 0; i < numNodes; ++i)
 		paths.push_back(nodes[i]->getFullPath());
@@ -1680,7 +1716,7 @@ static const char *convertNciItm(int nciItm)
 {
     switch(nciItm) {
       case NciTIME_INSERTED: 		return "\'TIME_INSERTED\'";
-      case NciOWNER_ID: 		return "\'OWNER_ID\'"; 
+      case NciOWNER_ID: 		return "\'OWNER_ID\'";
       case NciCLASS:			return "\'CLASS\'";
       case NciDTYPE:			return "\'DTYPE\'";
       case NciLENGTH:			return "\'LENGTH\'";
@@ -1727,7 +1763,7 @@ std::string  TreeNodeThinClient::getNciString(int itm)
     AutoData<Data> retStringData(connection->get(expr));
     if(!retStringData.get())
 	throw MdsException("Error in Remote evaluation of getnci");
-    
+
     AutoString as(retStringData->getString());
     return as.string;
 }
@@ -1742,7 +1778,7 @@ char TreeNodeThinClient::getNciChar(int itm)
      char retChar = retData->getByte();
      return retChar;
 }
-   
+
 int TreeNodeThinClient::getNciInt(int itm)
 {
     char expr[64];
@@ -1772,7 +1808,7 @@ char *TreeNodeThinClient::getPath()
 	throw MdsException("Error in Remote evaluation of getnci(path)");
     return retData->getString();
 }
-    
+
 EXPORT Data *TreeNodeThinClient::getData()
 {
     char expr[64];
@@ -1782,7 +1818,7 @@ EXPORT Data *TreeNodeThinClient::getData()
 	throw MdsException("Error in Remote evaluation of getnci(record)");
     return retData;
 }
-  
+
 EXPORT void TreeNodeThinClient::putData(Data *data)
 {
     AutoArray<char> path(getPath());
@@ -1805,7 +1841,7 @@ EXPORT bool TreeNodeThinClient::isOn()
     AutoData<Data> retData(connection->get(expr));
     if(!retData.get())
 	throw MdsException("Error in Remote evaluation of getnci(state)");
-    
+
     char onData = retData->getByte();
     return (onData)?false:true;
 }
@@ -1824,7 +1860,7 @@ EXPORT void TreeNodeThinClient::beginSegment(Data *start, Data *end, Data *time,
 {
     char expr[256];
     AutoData<Data> argsD[] = { start->data(), end->data(), time->data(), initialData->data()};
-    Data *args[] = {argsD[0].get(), argsD[1].get(), argsD[2].get(), argsD[3].get()}; 
+    Data *args[] = {argsD[0].get(), argsD[1].get(), argsD[2].get(), argsD[3].get()};
     sprintf(expr, "BeginSegment(%d, $1, $2, $3, $4, -1)", nid);
     AutoData<Data> retData(connection->get(expr, args, 4));
 }
@@ -1833,7 +1869,7 @@ EXPORT void TreeNodeThinClient::makeSegment(Data *start, Data *end, Data *time, 
 {
     char expr[256];
     AutoData<Data> argsD[] = { start->data(), end->data(), time->data(), initialData->data()};
-    Data *args[] = {argsD[0].get(), argsD[1].get(), argsD[2].get(), argsD[3].get()}; 
+    Data *args[] = {argsD[0].get(), argsD[1].get(), argsD[2].get(), argsD[3].get()};
     sprintf(expr, "MakeSegment(%d, $1, $2, $3, $4, -1, size($4))", nid);
     AutoData<Data> retData(connection->get(expr, args, 4));
 }
@@ -1878,7 +1914,7 @@ EXPORT Array *TreeNodeThinClient::getSegment(int segIdx)
 	throw MdsException("Error in Remote evaluation of GetSegment");
     return retSegment;
 }
-  
+
 EXPORT Data *TreeNodeThinClient::getSegmentDim(int segIdx)
 {
     char expr[64];
@@ -1888,7 +1924,7 @@ EXPORT Data *TreeNodeThinClient::getSegmentDim(int segIdx)
 	throw MdsException("Error in Remote evaluation of dim_of(GetSegment)");
     return retDim;
 }
-    
+
 EXPORT void TreeNodeThinClient::getSegmentAndDimension(int segIdx, Array *&segment, Data *&dimension)
 {
     char expr[64];
@@ -1919,7 +1955,7 @@ EXPORT void TreeNodeThinClient::putTimestampedSegment(Array *data, int64_t *time
     sprintf(expr, "PutTimestampedSegment(%d, $1, $2)", nid);
     AutoData<Data> retData(connection->get(expr, args, 2));
 }
-   
+
 EXPORT void TreeNodeThinClient::makeTimestampedSegment(Array *data, int64_t *times)
 {
     beginTimestampedSegment(data);

--- a/mdsobjects/cpp/testing/MdsTreeSegments.cpp
+++ b/mdsobjects/cpp/testing/MdsTreeSegments.cpp
@@ -88,6 +88,7 @@ void putSegment(){
 void BlockAndRows(){
   unique_ptr<Tree>     t = new MDSplus::Tree("t_treeseg",1,"NEW");
   unique_ptr<TreeNode> n = t->addNode("BAR","SIGNAL");
+  t->write();
   {
     int d[2] = {0,7};  unique_ptr<Int32Array> s = new Int32Array(d,2);
     n->beginTimestampedSegment(s);
@@ -111,6 +112,12 @@ void BlockAndRows(){
   }
   TEST1(AutoString(unique_ptr<Data>(n->getData()    )->decompile()).string == "Build_Signal(0, [1,7], *, [-1Q,0Q])");
   TEST1(AutoString(unique_ptr<Data>(n->getSegment(0))->decompile()).string == "[1,7]");
+  n->setSegmentScale(unique_ptr<Data>(compile("$VALUE*2")));
+  TEST1(AutoString(unique_ptr<Data>(n->getSegmentScale())->decompile()).string == "$VALUE * 2");
+  TEST1(AutoString(unique_ptr<Data>(n->getData()    )->decompile()).string == "Build_Signal(0, $VALUE * 2, [1,7], [-1Q,0Q])");
+  std::vector<int> data = n->getIntArray();
+  TEST1(data[0]==2);
+  TEST1(data[1]==14);
 }
 
 

--- a/mdsobjects/python/tests/segmentsUnitTest.py
+++ b/mdsobjects/python/tests/segmentsUnitTest.py
@@ -308,6 +308,26 @@ class Tests(TestCase):
       test()
       self.cleanup()
 
+    def ScaledSegments(self):
+      def test():
+        from MDSplus import Tree,Int64,Int64Array,Int16Array
+        with Tree(self.tree,self.shot,'NEW') as ptree:
+            node = ptree.addNode('S')
+            ptree.write()
+        node.tree = Tree(self.tree,self.shot)
+        srt,end,dt=-10000,10000,1000
+        d = Int64Array(range(srt,end,dt))
+        v = Int16Array(range(srt,end,dt))
+        node.beginSegment(srt,end,d,v)
+        self.assertEqual(True,(node.getSegment(0).data()==v.data()).all())
+        node.setSegmentScale(2)
+        self.assertEqual(True,(node.record.data()==v.data()*2).all())
+        node.setSegmentScale(Int16Array([1,2]))
+        self.assertEqual(True,(node.record.data()==v.data()*2+1).all())
+        self.assertEqual(True,(node.getSegment(0)==v*2+1).all())
+      test()
+      self.cleanup()
+
     def CompressSegments(self):
       def test():
         from MDSplus import Tree,DateToQuad,ZERO,Int32,Int32Array,Int64Array,Range
@@ -347,7 +367,7 @@ class Tests(TestCase):
             self.__getattribute__(test)()
     @staticmethod
     def getTests():
-        return ['ArrayDimensionOrder','BlockAndRows','WriteSegments','WriteOpaque','UpdateSegments','TimeContext','CompressSegments']
+        return ['ArrayDimensionOrder','BlockAndRows','WriteSegments','WriteOpaque','UpdateSegments','TimeContext','ScaledSegments','CompressSegments']
     @classmethod
     def getTestCases(cls,tests=None):
         if tests is None: tests = cls.getTests()

--- a/mdsobjects/python/tree.py
+++ b/mdsobjects/python/tree.py
@@ -2041,16 +2041,17 @@ class TreeNode(_dat.Data): # HINT: TreeNode begin  (maybe subclass of _scr.Int32
         @return: Data segment
         @rtype: Signal | None
         """
-        num=self.getNumSegments()
-        if num <= 0 or idx >= num: return
         val=_dsc.Descriptor_xd()._setTree(self.tree)
         dim=_dsc.Descriptor_xd()._setTree(self.tree)
-        _exc.checkStatus(
-            _TreeShr._TreeGetSegment(self.ctx,
-                                     self._nid,
-                                     _C.c_int32(int(idx)),
-                                     val.ref,
-                                     dim.ref))
+        try:
+            _exc.checkStatus(
+                _TreeShr._TreeGetSegment(self.ctx,
+                                         self._nid,
+                                         _C.c_int32(int(idx)),
+                                         val.ref,
+                                         dim.ref))
+        except _exc.TreeNOSEGMENTS:
+            return None
         return _cmp.Signal(val.value,None,dim.value)
 
     def getSegmentDim(self,idx):
@@ -2060,11 +2061,17 @@ class TreeNode(_dat.Data): # HINT: TreeNode begin  (maybe subclass of _scr.Int32
         @return: Segment dimension
         @rtype: Dimension
         """
-        num=self.getNumSegments()
-        if num > 0 and idx < num:
-            return self.getSegment(idx).getDimensionAt(0)
-        else:
+        dim=_dsc.Descriptor_xd()._setTree(self.tree)
+        try:
+            _exc.checkStatus(
+                _TreeShr._TreeGetSegment(self.ctx,
+                                         self._nid,
+                                         _C.c_int32(int(idx)),
+                                         None,
+                                         dim.ref))
+        except _exc.TreeNOSEGMENTS:
             return None
+        return dim.value
 
     def getSegmentLimits(self,idx):
         start=_dsc.Descriptor_xd()._setTree(self.tree)

--- a/mdsobjects/python/tree.py
+++ b/mdsobjects/python/tree.py
@@ -2086,7 +2086,7 @@ class TreeNode(_dat.Data): # HINT: TreeNode begin  (maybe subclass of _scr.Int32
                                            _C.c_int32(int(idx)),
                                            start.ref,
                                            end.ref))
-        start,end = start.value,end.value
+        start,end = start.value,end.value;_gc.collect()
         if start is not None or end is not None:
             return (start,end)
 

--- a/tdi/segments/GetSegment.fun
+++ b/tdi/segments/GetSegment.fun
@@ -1,10 +1,15 @@
 public fun GetSegment(as_is _node, in _idx) {
   _nid=getnci(_node,"NID_NUMBER");
-  _data=0;
-  _dim=0;
+  _data=*;
+  _dim=*;
   _status=TreeShr->TreeGetSegment(val(_nid),val(_idx),xd(_data),xd(_dim));
   if (_status & 1) {
-    return(make_signal(_data,*,_dim));
+    _scl=*;
+    if(TreeShr->TreeGetSegmentScale(val(_nid),xd(_scl))&1 && KIND(_scl)!=0) {
+      return(make_signal(_scl,_data,_dim));
+    } else {
+      return(make_signal(_data,*,_dim));
+    }
   } else {
     return(*);
   }

--- a/tdi/segments/GetSegmentScale.fun
+++ b/tdi/segments/GetSegmentScale.fun
@@ -1,0 +1,8 @@
+public fun GetSegmentScale(as_is _node) {
+  _nid=getnci(_node,"nid_number");
+  _scale=*;
+  _status=TreeShr->TreeGetSegmentScale(val(_nid),xd(_scale));
+  if (_status & 1) {
+     return(_scale);
+  } else return(*);
+}

--- a/tdi/segments/SetSegmentScale.fun
+++ b/tdi/segments/SetSegmentScale.fun
@@ -1,0 +1,6 @@
+public fun SetSegmentScale(as_is _node, as_is _scale) {
+  _nid=getnci(_node,"nid_number");
+  return(TreeShr->TreeSetSegmentScale(val(_nid),xd(_scale)));
+}
+
+    

--- a/treeshr/TreeSegments.c
+++ b/treeshr/TreeSegments.c
@@ -274,6 +274,15 @@ int TreePutTimestampedSegment(int nid, int64_t * timestamp, struct descriptor_a 
   return _TreePutTimestampedSegment(*TreeCtx(), nid, timestamp, data);
 }
 
+int _TreeGetSegmentScale(void *dbid, int nid, struct descriptor_xd *value);
+int TreeGetSegmentScale(int nid, struct descriptor_xd *value) {
+  return _TreeGetSegmentScale(*TreeCtx(), nid, value);
+}
+
+int _TreeSetSegmentScale(void *dbid, int nid, struct descriptor *value);
+int TreeSetSegmentScale(int nid, struct descriptor *value) {
+  return _TreeSetSegmentScale(*TreeCtx(), nid, value);
+}
 
 inline static int load_node_ptr(vars_t* vars) {
   vars->node_ptr = nid_to_node(vars->dblist, vars->nid_ptr);
@@ -2345,4 +2354,12 @@ int _TreeGetSegments(void *dbid, int nid, struct descriptor *start, struct descr
   if (apd.pointer)
     free(apd.pointer);
   return status;
+}
+
+#define SEGMENT_SCALE_NAME "SegmentScale"
+int _TreeSetSegmentScale(void *dbid, int nid, struct descriptor *value) {
+  return _TreeSetXNci(dbid, nid, SEGMENT_SCALE_NAME, value);
+}
+int _TreeGetSegmentScale(void *dbid, int nid, struct descriptor_xd *value) {
+  return _TreeGetXNci(dbid, nid, SEGMENT_SCALE_NAME, value);
 }

--- a/treeshr/TreeSegments.c
+++ b/treeshr/TreeSegments.c
@@ -183,55 +183,30 @@ static int GetSegmentHeader(TREE_INFO * tinfo, int64_t offset, SEGMENT_HEADER * 
 static int GetSegmentIndex(TREE_INFO * tinfo, int64_t offset, SEGMENT_INDEX * idx);
 static int GetNamedAttributesIndex(TREE_INFO * tinfo, int64_t offset, NAMED_ATTRIBUTES_INDEX * index);
 
-static int __TreeBeginSegment(void *dbid, int nid, struct descriptor *start, struct descriptor *end,
-                              struct descriptor *dimension,
-                              struct descriptor_a *initialValue, int idx, int rows_filled);
-int _TreeBeginSegment(void *dbid, int nid, struct descriptor *start, struct descriptor *end,
-                      struct descriptor *dimension, struct descriptor_a *initialValue, int idx){
-  return __TreeBeginSegment(dbid, nid, start, end, dimension, initialValue, idx, 0);
+int _TreeMakeSegment(void *dbid, int nid, struct descriptor *start, struct descriptor *end, struct descriptor *dimension, struct descriptor_a *initialValue, int idx, int rows_filled);
+int TreeMakeSegment(int nid, struct descriptor *start, struct descriptor *end, struct descriptor *dimension, struct descriptor_a *initialValue, int idx, int rows_filled){
+  return _TreeMakeSegment(*TreeCtx(), nid, start, end, dimension, initialValue, idx, rows_filled);
 }
-
-int TreeBeginSegment(int nid, struct descriptor *start, struct descriptor *end,
-                     struct descriptor *dimension, struct descriptor_a *initialValue, int idx){
+int _TreeBeginSegment(void *dbid, int nid, struct descriptor *start, struct descriptor *end, struct descriptor *dimension, struct descriptor_a *initialValue, int idx){
+  return _TreeMakeSegment(dbid, nid, start, end, dimension, initialValue, idx, 0);
+}
+int TreeBeginSegment(int nid, struct descriptor *start, struct descriptor *end, struct descriptor *dimension, struct descriptor_a *initialValue, int idx){
   return _TreeBeginSegment(*TreeCtx(), nid, start, end, dimension, initialValue, idx);
 }
 
-int _TreeMakeSegment(void *dbid, int nid, struct descriptor *start, struct descriptor *end,
-                     struct descriptor *dimension,
-                     struct descriptor_a *initialValue, int idx, int rows_filled){
-  return __TreeBeginSegment(dbid, nid, start, end, dimension, initialValue, idx, rows_filled);
+int _TreeMakeTimestampedSegment(void *dbid, int nid, int64_t * timestamps, struct descriptor_a *initialValue, int idx, int rows_filled);
+int TreeMakeTimestampedSegment(int nid, int64_t * timestamps, struct descriptor_a *initialValue, int idx, int rows_filled){
+  return _TreeMakeTimestampedSegment(*TreeCtx(), nid, timestamps, initialValue, idx, rows_filled);
 }
-
-int TreeMakeSegment(int nid, struct descriptor *start, struct descriptor *end,
-                    struct descriptor *dimension,
-                    struct descriptor_a *initialValue, int idx, int rows_filled){
-  return _TreeMakeSegment(*TreeCtx(), nid, start, end, dimension, initialValue, idx, rows_filled);
-}
-
-static int __TreeBeginTimestampedSegment(void *dbid, int nid, int64_t * timestamps,
-                                         struct descriptor_a *initialValue, int idx,
-                                         int rows_filled);
 int _TreeBeginTimestampedSegment(void *dbid, int nid, struct descriptor_a *initialValue, int idx){
-  return __TreeBeginTimestampedSegment(dbid, nid, 0, initialValue, idx, 0);
+  return _TreeMakeTimestampedSegment(dbid, nid, 0, initialValue, idx, 0);
 }
-
 int TreeBeginTimestampedSegment(int nid, struct descriptor_a *initialValue, int idx){
   return _TreeBeginTimestampedSegment(*TreeCtx(), nid, initialValue, idx);
 }
 
-int _TreeMakeTimestampedSegment(void *dbid, int nid, int64_t * timestamps,
-                                struct descriptor_a *initialValue, int idx, int rows_filled){
-  return __TreeBeginTimestampedSegment(dbid, nid, timestamps, initialValue, idx, rows_filled);
-}
-
-int TreeMakeTimestampedSegment(int nid, int64_t * timestamps, struct descriptor_a *initialValue,
-                               int idx, int rows_filled){
-  return _TreeMakeTimestampedSegment(*TreeCtx(), nid, timestamps, initialValue, idx, rows_filled);
-}
-
 int _TreeUpdateSegment(void *dbid, int nid, struct descriptor *start, struct descriptor *end,
                        struct descriptor *dimension, int idx);
-
 int TreeUpdateSegment(int nid, struct descriptor *start, struct descriptor *end,
                       struct descriptor *dimension, int idx){
   return _TreeUpdateSegment(*TreeCtx(), nid, start, end, dimension, idx);
@@ -261,34 +236,27 @@ int TreeGetSegment(int nid, int idx, struct descriptor_xd *segment, struct descr
   return _TreeGetSegment(*TreeCtx(), nid, idx, segment, dim);
 }
 
-int _TreeGetSegmentLimits(void *dbid, int nid, int idx, struct descriptor_xd *retStart,
-                          struct descriptor_xd *retEnd);
-int TreeGetSegmentLimits(int nid, int idx, struct descriptor_xd *retStart,
-                         struct descriptor_xd *retEnd){
+int _TreeGetSegmentLimits(void *dbid, int nid, int idx, struct descriptor_xd *retStart, struct descriptor_xd *retEnd);
+int TreeGetSegmentLimits(int nid, int idx, struct descriptor_xd *retStart, struct descriptor_xd *retEnd){
   return _TreeGetSegmentLimits(*TreeCtx(), nid, idx, retStart, retEnd);
 }
 
-int _TreeGetSegmentInfo(void *dbid, int nid, int idx, char *dtype, char *dimct, int *dims,
-                        int *next_row);
-
+int _TreeGetSegmentInfo(void *dbid, int nid, int idx, char *dtype, char *dimct, int *dims, int *next_row);
 int TreeGetSegmentInfo(int nid, int idx, char *dtype, char *dimct, int *dims, int *next_row){
   return _TreeGetSegmentInfo(*TreeCtx(), nid, idx, dtype, dimct, dims, next_row);
 }
 
 int _TreeSetXNci(void *dbid, int nid, const char *xnciname, struct descriptor *value);
-
 int TreeSetXNci(int nid, const char *xnciname, struct descriptor *value){
   return _TreeSetXNci(*TreeCtx(), nid, xnciname, value);
 }
 
 int _TreeGetXNci(void *dbid, int nid, const char *xnciname, struct descriptor_xd *value);
-
 int TreeGetXNci(int nid, const char *xnciname, struct descriptor_xd *value){
   return _TreeGetXNci(*TreeCtx(), nid, xnciname, value);
 }
 
-int TreeGetSegments(int nid, struct descriptor *start, struct descriptor *end,
-                    struct descriptor_xd *out){
+int TreeGetSegments(int nid, struct descriptor *start, struct descriptor *end, struct descriptor_xd *out){
   return _TreeGetSegments(*TreeCtx(), nid, start, end, out);
 }
 
@@ -297,13 +265,11 @@ int TreeGetSegmentedRecord(int nid, struct descriptor_xd *data){
 }
 
 int _TreePutRow(void *dbid, int nid, int bufsize, int64_t * timestamp, struct descriptor_a *data);
-
 int TreePutRow(int nid, int bufsize, int64_t * timestamp, struct descriptor_a *data){
   return _TreePutRow(*TreeCtx(), nid, bufsize, timestamp, data);
 }
 
 int _TreePutTimestampedSegment(void *dbid, int nid, int64_t * timestamp, struct descriptor_a *data);
-
 int TreePutTimestampedSegment(int nid, int64_t * timestamp, struct descriptor_a *data){
   return _TreePutTimestampedSegment(*TreeCtx(), nid, timestamp, data);
 }
@@ -720,7 +686,7 @@ inline static int ReadProperty_safe(TREE_INFO *tinfo, const int64_t offset,char 
 //#define CLEANUP_NCI_PUSH
 //#define CLEANUP_NCI_POP  unlock_nci(vars)
 
-static int __TreeBeginSegment(void *dbid, int nid,
+int _TreeMakeSegment(void *dbid, int nid,
         struct descriptor *start, struct descriptor *end, struct descriptor *dimension,
         struct descriptor_a *initValIn, int idx, int rows_filled){
   INIT_WRITE_VARS;
@@ -743,7 +709,7 @@ end: ;
   return status;
 }
 
-static int __TreeBeginTimestampedSegment(void *dbid, int nid,
+int _TreeMakeTimestampedSegment(void *dbid, int nid,
         int64_t * timestamps,
         struct descriptor_a *initValIn, int idx, int rows_filled){
   INIT_WRITE_VARS;

--- a/xtreeshr/XTreeDefaultSquish.c
+++ b/xtreeshr/XTreeDefaultSquish.c
@@ -57,7 +57,7 @@ static void printDecompiled(struct descriptor *inD)
 static int getShape(struct descriptor *dataD, int *dims, int *numDims)
 {
     int i;
-    ARRAY_COEFF(char *, 64) *arrPtr;
+    ARRAY_COEFF(char *, MAX_NDIMS) *arrPtr;
     if(dataD->class != CLASS_A)
     {
 //	printf("Internal error!!!! Class: %d\n", dataD->class);
@@ -104,11 +104,11 @@ EXPORT int XTreeDefaultSquish(struct descriptor_a *signalsApd,
   //struct descriptor shapeExprD = { strlen(shapeExpr), DTYPE_T, CLASS_S, shapeExpr };
   //char setRangeExpr[512];	//Safe dimension, to avoid useless mallocs
   //struct descriptor setRangeExprD = { 0, DTYPE_T, CLASS_S, setRangeExpr };
-  DESCRIPTOR_SIGNAL(outSignalD, 64, 0, 0);
+  DESCRIPTOR_SIGNAL(outSignalD, MAX_NDIMS, 0, 0);
   DESCRIPTOR_A(outDimD, 0, 0, 0, 0);
   //DESCRIPTOR_A(outDataD, 0, 0, 0, 0);
-  DESCRIPTOR_A_COEFF(outDataD, 0, 0, 0, 64, 0) ;
-  
+  DESCRIPTOR_A_COEFF(outDataD, 0, 0, 0, MAX_NDIMS, 0) ;
+
   DESCRIPTOR_A(beginArrD, 0, 0, 0, 0);
   DESCRIPTOR_A(endingArrD, 0, 0, 0, 0);
   DESCRIPTOR_A(deltavalArrD, 0, 0, 0, 0);
@@ -119,10 +119,10 @@ EXPORT int XTreeDefaultSquish(struct descriptor_a *signalsApd,
   int numSignals, numDimensions;
   int allDimensionsAreRanges;
   struct descriptor_range *rangeD, *prevRangeD;
-  
+
   int **shapes, *numShapes;
   int totShapes;
-  
+
   extern int TdiCompile(), TdiData();
 
   if (signalsApd->class == CLASS_XD)
@@ -133,7 +133,7 @@ EXPORT int XTreeDefaultSquish(struct descriptor_a *signalsApd,
     MdsCopyDxXd((struct descriptor *)&emptyXd, outXd);
     return 1;
   }
-//Check shapes. If n-multidimensional arrays, the first n-1 dimensions must fit 
+//Check shapes. If n-multidimensional arrays, the first n-1 dimensions must fit
 
 /*
 
@@ -180,8 +180,8 @@ EXPORT int XTreeDefaultSquish(struct descriptor_a *signalsApd,
     free((char *)shapesXd);
     return status;
   }
-*/  
-  
+*/
+
 //Get the shape of all segments
   numShapes = (int *)malloc(numSignals * sizeof(int));
   shapes = (int **)malloc(numSignals * sizeof(int *));
@@ -189,7 +189,7 @@ EXPORT int XTreeDefaultSquish(struct descriptor_a *signalsApd,
     currSignalD = ((struct descriptor_signal **)signalsApd->pointer)[i];
     shapes[i] = (int *)malloc(54 * sizeof(int));
     getShape((struct descriptor *)(currSignalD->data), shapes[i], &numShapes[i]);
-    
+
     if(i == 0)
       minNumShapes = maxNumShapes = numShapes[i];
     else  {
@@ -218,7 +218,7 @@ EXPORT int XTreeDefaultSquish(struct descriptor_a *signalsApd,
   if (!(status & 1)) {
     return status;
   }
-  
+
 //Shapes Ok, build definitive shapes array for this signal;
   for (i = 0; i < minNumShapes; i++)
     outShape[i] = shapes[0][i];
@@ -240,8 +240,8 @@ EXPORT int XTreeDefaultSquish(struct descriptor_a *signalsApd,
     free((char *)shapes[i]);
   free((char *)shapes);
   free((char *)numShapes);
-  
-  
+
+
 //Check that the number of dimensions in signals is the same
   currSignalD = ((struct descriptor_signal **)signalsApd->pointer)[0];
   numDimensions = currSignalD->ndesc - 2;
@@ -254,7 +254,7 @@ EXPORT int XTreeDefaultSquish(struct descriptor_a *signalsApd,
   if (!(status & 1))
     return status;
 
-//Check whether all dimensions are axpressed as a range. In this case a global range is built instead 
+//Check whether all dimensions are axpressed as a range. In this case a global range is built instead
 //of merging dimension arrays
   allDimensionsAreRanges = 1;
   for (i = 0; i < numSignals && allDimensionsAreRanges; i++) {
@@ -405,11 +405,11 @@ EXPORT int XTreeDefaultSquish(struct descriptor_a *signalsApd,
   outDataD.dimct = totShapes;
   for(i = 0; i < totShapes; i++)
     outDataD.m[i] = outShape[i];
-  
+
   outSignalD.data = (struct descriptor *)&outDataD;
- 
- 
- 
+
+
+
 //Input signals merged now to outSignalD, Copy result back
   status = MdsCopyDxXd((struct descriptor *)&outSignalD, outXd);
 

--- a/xtreeshr/XTreeGetTimedRecord.c
+++ b/xtreeshr/XTreeGetTimedRecord.c
@@ -42,7 +42,6 @@ extern unsigned short OpcExtFunction;
 
 static int timedAccessFlag = 0;
 
-#define MAX_DIMENSION_SIGNAL 16
 #define MAX_FUN_NAMELEN 512
 
 #ifdef _WIN32
@@ -186,13 +185,13 @@ EXPORT int _XTreeGetTimedRecord(void *dbid, int inNid, struct descriptor *startD
   struct descriptor_xd *dataXds;
   struct descriptor_xd *dimensionXds;
 
-  DESCRIPTOR_SIGNAL(currSignalD, MAX_DIMENSION_SIGNAL, 0, 0);
+  DESCRIPTOR_SIGNAL(currSignalD, MAX_NDIMS, 0, 0);
   DESCRIPTOR_APD(signalsApd, DTYPE_SIGNAL, 0, 0);
   struct descriptor_signal **signals;
 
 //printf("GET TIMED RECORD\n");
 
-//Chheck for possible resampled versions
+  //Check for possible resampled versions
   nid = checkResampledVersion(dbid, inNid, minDeltaD);
 
   timedAccessFlag = 1;

--- a/xtreeshr/XTreeGetTimedRecord.c
+++ b/xtreeshr/XTreeGetTimedRecord.c
@@ -432,6 +432,13 @@ EXPORT int _XTreeGetTimedRecord(void *dbid, int inNid, struct descriptor *startD
   free((char *)resampledXds);
   free((char *)dataXds);
   free((char *)dimensionXds);
+  if (outSignal->pointer && (_TreeGetSegmentScale(dbid, inNid, &xd)&1)){
+    struct descriptor_signal* sig = (struct descriptor_signal*)outSignal->pointer;
+    if (xd.pointer) {
+      sig->raw  = sig->data;
+      sig->data = xd.pointer;
+    }
+  }
   return status;
 }
 

--- a/xtreeshr/XTreeGetTimedRecord.c
+++ b/xtreeshr/XTreeGetTimedRecord.c
@@ -427,16 +427,21 @@ EXPORT int _XTreeGetTimedRecord(void *dbid, int inNid, struct descriptor *startD
 //Free stuff
   free((char *)signals);
   for (i = 0; i < actNumSegments; i++) {
-    MdsFree1Dx(&resampledXds[i], 0);
+    MdsFree1Dx(&resampledXds[i], NULL);
   }
   free((char *)resampledXds);
   free((char *)dataXds);
   free((char *)dimensionXds);
   if (outSignal->pointer && (_TreeGetSegmentScale(dbid, inNid, &xd)&1)){
-    struct descriptor_signal* sig = (struct descriptor_signal*)outSignal->pointer;
     if (xd.pointer) {
+      struct descriptor_signal* sig = (struct descriptor_signal*)outSignal->pointer;
+      emptyXd = *outSignal;
+      outSignal->pointer = NULL;
       sig->raw  = sig->data;
       sig->data = xd.pointer;
+      MdsCopyDxXd((struct descriptor*)sig,outSignal);
+      MdsFree1Dx(&xd,NULL);
+      MdsFree1Dx(&emptyXd,NULL);
     }
   }
   return status;


### PR DESCRIPTION
adds a new feature of scaled segmentsyou can add the value expression for a node using
```
TreeSetSegmentScale(nid, expr)
```
methods like getSegment(nid,idx) and getRecord() will look for the SegmentScale xnci and return:
```
Signal(expr, segment_data, segment_dim)
```
if the xnci exists and is not NULL. otherwise it will return:
```
Signal(segment_data, *, segment_dim)

```
, the original result.
