### PR TITLE
Fix: acq device getInteger method using node.record

### DIFF
--- a/mitdevices/mitdevices_messages.xml
+++ b/mitdevices/mitdevices_messages.xml
@@ -161,7 +161,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
         text="Pre trigger samples either not available or invalid"
         />
     <status name="BAD_POST_TRIG" value ="4142" severity="Error"
-        text="Clock source either not available or invalid"
+        text="Post trigger samples either not available or invalid"
         />
     <status name="BAD_CLOCK_FREQ" value ="4143" severity="Error"
         text="Clock frequency either not available or invalid"

--- a/pydevices/MitDevices/acq.py
+++ b/pydevices/MitDevices/acq.py
@@ -104,7 +104,7 @@ class Acq(MDSplus.Device):
 
     def getInteger(self, node, cls):
         try:
-            ans = int(node.record)
+            ans = int(node.data())
         except Exception as e:
             print("ACQ error reading %s erro is\n%s" %(node, e,))
             raise cls()
@@ -124,7 +124,7 @@ class Acq(MDSplus.Device):
         from MDSplus.mdsExceptions import DevNO_NAME_SPECIFIED
         from MDSplus.mdsExceptions import TreeNODATA
         try:
-            boardip=str(self.node.record)
+            boardip=str(self.node.data())
         except Exception as e:
             raise DevNO_NAME_SPECIFIED(str(e))
         if len(boardip) == 0 :
@@ -230,7 +230,7 @@ class Acq(MDSplus.Device):
 
     def storeStatusCommands(self):
         status = []
-        cmds = self.status_cmds.record
+        cmds = self.status_cmds.data()
         for cmd in cmds:
             cmd = cmd.strip()
             if self.debugging():


### PR DESCRIPTION
When an integer value is expected int(node.record) returns an
error instead of evaluating the contents of the record.

In addition the text of the error message for BAD_POST_TRIG was
wrong, copy and pasted from a clock error.