### PR TITLE
Fix: Do not call TreeSwitchDbid with NULL

### DIFF
--- a/tdishr/TdiGetDbi.c
+++ b/tdishr/TdiGetDbi.c
@@ -284,7 +284,9 @@ int Tdi1Using(int opcode __attribute__ ((unused)),
                 *********************/
     if STATUS_OK {
       char *tree = MdsDescrToCstring((struct descriptor *)&expt);
-      ctx = TreeSwitchDbid(0);
+      void *newctx = NULL;
+      _TreeNewDbid(&newctx);
+      ctx = TreeSwitchDbid(newctx);
       reset_ctx = 1;
       status = TreeOpen(tree, shot, 1);
       MdsFree(tree);


### PR DESCRIPTION
Tdi1Using was calling TreeSwitchDbid with a NULL which caused a segfault later.