### PR TITLE
fix: On Macintosh - listening for multiple UDP Events

### DIFF
--- a/mdsshr/UdpEvents.c
+++ b/mdsshr/UdpEvents.c
@@ -280,6 +280,11 @@ int MDSUdpEventAst(char const *eventName, void (*astadr) (void *, int, char *), 
     print_error("Cannot set REUSEADDR option");
     return 0;
   }
+  if (setsockopt(udpSocket, SOL_SOCKET, SO_REUSEPORT, &flag, sizeof(flag)) == SOCKET_ERROR) {
+    print_error("Cannot set REUSEPORT option");
+    return 0;
+  }
+
 #ifdef _WIN32
   check_bind_in_directive = (bind(udpSocket, (SOCKADDR *) & serverAddr, sizeof(serverAddr)) != 0);
 #else

--- a/mdsshr/UdpEvents.c
+++ b/mdsshr/UdpEvents.c
@@ -280,11 +280,12 @@ int MDSUdpEventAst(char const *eventName, void (*astadr) (void *, int, char *), 
     print_error("Cannot set REUSEADDR option");
     return 0;
   }
+#ifdef SO_REUSEPORT
   if (setsockopt(udpSocket, SOL_SOCKET, SO_REUSEPORT, &flag, sizeof(flag)) == SOCKET_ERROR) {
     print_error("Cannot set REUSEPORT option");
     return 0;
   }
-
+#endif
 #ifdef _WIN32
   check_bind_in_directive = (bind(udpSocket, (SOCKADDR *) & serverAddr, sizeof(serverAddr)) != 0);
 #else


### PR DESCRIPTION
On Macintosh the second event created by a process errors out with

  Cannot bind socket
  : Address already in use

This is due to the MAC socket implimentation needing BOTH
  SO_REUSEADDR
  SO_REUSEPORT
options.

Using both does not appear to break things on Linux