### PR TITLE
Build: Fix some more compiler warnings

### DIFF
--- a/mdstcpip/udt4/src/epoll.cpp
+++ b/mdstcpip/udt4/src/epoll.cpp
@@ -107,7 +107,7 @@ int CEPoll::add_usock(const int eid, const UDTSOCKET& u, const int* events)
    return 0;
 }
 
-int CEPoll::add_ssock(const int eid, const SYSSOCKET& s, const int* events)
+int CEPoll::add_ssock(const int eid, const SYSSOCKET& s, const int* events __attribute__ ((unused)))
 {
    CGuard pg(m_EPollLock);
 


### PR DESCRIPTION
This removes a few more clobber and unused parameter warnings.