### PR TITLE
Feature: Enable manipulation of node extended atts in python

### DIFF
--- a/mdsobjects/python/tree.py
+++ b/mdsobjects/python/tree.py
@@ -1521,6 +1521,8 @@ class TreeNode(_dat.Data): # HINT: TreeNode begin  (maybe subclass of _scr.Int32
         """
         #if name=='tree':
         #    return Tree()
+        if name.startswith('__'):
+            return self.getExtendedAttribute(name[2:])
         try:   return _getNodeByAttr(self,name)
         except _exc.TreeNNF: pass
         try:   return super(TreeNode,self).__getattr__(name)
@@ -1530,6 +1532,17 @@ class TreeNode(_dat.Data): # HINT: TreeNode begin  (maybe subclass of _scr.Int32
         #if self.length>0:
         #    return self.record.__getattr__(name)
         raise AttributeError('No such attribute: '+name)
+
+    def __setattr__(self,name,value):
+        """ Enables the setting of node attributes using
+        then format:
+
+           node.__myattribute=value
+        """
+        if name.startswith('__'):
+          self.setExtendedAttribute(name[2:],value)
+        else:
+          super(TreeNode, self).__setattr__(name, value)
 
     def __str__(self):
       """Convert TreeNode to string."""
@@ -1830,6 +1843,43 @@ class TreeNode(_dat.Data): # HINT: TreeNode begin  (maybe subclass of _scr.Int32
         @rtype: String
         """
         return self.dtype_str
+
+    def getExtendedAttribute(self,name):
+        """Get extended attribute of node
+        @param name: Name of attribute
+        @type name: str
+        @return: value of attribute or
+                       None if no such attribute or
+                       attribute has no data
+        @rtype: MDSplus data type
+        """
+        xd=_dsc.Descriptor_xd()
+        status = _TreeShr._TreeGetXNci(self.ctx,
+                            self.nid, 
+                            _C.c_char_p(_ver.tobytes(str(name).rstrip())),
+                            xd.ref)
+        if (status & 1):
+            return xd._setTree(self.tree).value
+        else:
+            return None
+
+    def getExtendedAttributes(self):
+        """Get all extended attributes of a node
+        @return: Dictionary of attributes or None if no attributes
+        @rtype: dict
+        """
+        ans=dict()
+        attributes = self.getExtendedAttribute("attributenames")
+        if attributes is None:
+            return None
+        for attr in attributes:
+            val=self.getExtendedAttribute(str(attr))
+            if val is not None:
+                ans[attr]=val
+        if len(ans) > 0:
+            return ans
+        else:
+            return None
 
     def getFullPath(self):
         """Return full path of this node
@@ -2513,6 +2563,26 @@ class TreeNode(_dat.Data): # HINT: TreeNode begin  (maybe subclass of _scr.Int32
         @rtype: original type
         """
         self.essential=flag
+
+    def setExtendedAttribute(self,name,value):
+        """Set extended attribute of node
+        @param name: Name of attribute
+        @type name: str
+        @param value: value of attribute
+        @type value: MDSplus data type
+        """
+        if value is None:
+            ref = _C.c_void_p(0)
+        else:
+            data = _dat.Data(value)
+            if data.__hasBadTreeReferences__(self.tree):
+                data = data.__fixTreeReferences__(self.tree)
+            ref = _dat.Data.byref(data)
+        _exc.checkStatus(
+            _TreeShr._TreeSetXNci(self.ctx,
+                                  self.nid, 
+                                  _C.c_char_p(_ver.tobytes(name)),
+                                            ref))
 
     def setIncludeInPulse(self,flag):
         """Set include in pulse state of this node


### PR DESCRIPTION
This adds the capability to manipulate extended attributes of
nodes in MDSplus tree using the python MDSplus module.

A node attribute can be added or modified by using the
setExtendedAttribute(name,value) method of a TreeNode.
The value of an extended attribute can be fetched using
the getExtendedAttribute(name) method. A python dictionary
of all extended attributes of a node can be obtained using
the getExtendedAttributes() method. Some special node
property shortcuts can be used as well. A TreeNode
instances property whose name begins with two underscores
can be used to set or get an extended attribute.

The following demonstrates these new features:

`>>>` t=Tree('main',1)
`>>>` t.NUMERIC.setExtendedAttribute('att1',42)
`>>>` t.NUMERIC.setExtendedAttribute('att2',Range(1,100))
`>>>` t.NUMERIC.getExtendedAttribute('att1')
42
`>>>` t.NUMERIC.getExtendedAttribute('att2')
1 : 100 : *
`>>>` t.NUMERIC.getExtendedAttributes()
{'att2   ': 1 : 100 : *, 'att1   ': 42, 'special': 42}
`>>>` t.NUMERIC.__att3=100
`>>>` t.NUMERIC.__att2
1 : 100 : *
`>>>` t.NUMERIC.getExtendedAttributes()
{'special': 42, 'att3   ': 100, 'att1   ': 42, 'att2   ': 1 : 100 : *}
`>>>` t.NUMERIC.__special=None
`>>>` t.NUMERIC.getExtendedAttributes()
{'att3   ': 100, 'att1   ': 42, 'att2   ': 1 : 100 : *}