### PR TITLE
Feature: extended attr support for python

### DIFF
--- a/mdsobjects/python/tests/treeUnitTest.py
+++ b/mdsobjects/python/tests/treeUnitTest.py
@@ -155,6 +155,14 @@ class Tests(TestCase):
             ip.tag='MAG_IP'
             ip.tag='MAGNETICS_IP'
             ip.tag='IP'
+            ip.setExtendedAttribute('ATT1',100)
+            ip.setExtendedAttribute('ATT2',Range(1,200))
+            ip.setExtendedAttribute('ATT3','this is ip')
+            ip.setExtendedAttribute('ATT3','this is plasma current')
+            self.assertEqual(str(ip.getExtendedAttribute('ATT1')),'100')
+            self.assertEqual(str(ip.getExtendedAttribute('ATT2')),'1 : 200 : *')
+            self.assertEqual(str(ip.getExtendedAttribute('ATT3')),'this is plasma current')
+            self.assertEqual(str(ip.getExtendedAttributes()),"{'ATT3': 'this is plasma current', 'ATT2': 1 : 200 : *, 'ATT1': 100}")
             for i in range(10):
                 node=pytreesub_top.addNode('child%02d' % (i,),'structure')
                 node.addDevice('dt200_%02d' % (i,),'dt200').on=False
@@ -332,6 +340,10 @@ class Tests(TestCase):
         self.assertEqual(ip.versions,ip.containsVersions())
         self.assertEqual(ip.getNumSegments(),0)
         self.assertEqual(ip.getSegment(0),None)
+        self.assertEqual(str(ip.getExtendedAttribute('ATT1')),'100')
+        self.assertEqual(str(ip.getExtendedAttribute('ATT2')),'1 : 200 : *')
+        self.assertEqual(str(ip.getExtendedAttribute('ATT3')),'this is plasma current')
+        self.assertEqual(str(ip.getExtendedAttributes()),"{'ATT3': 'this is plasma current', 'ATT2': 1 : 200 : *, 'ATT1': 100}")
       test()
       self.cleanup()
 


### PR DESCRIPTION
This adds the capability to manipulate extended attributes of
nodes in MDSplus tree using the python MDSplus module.

A node attribute can be added or modified by using the
setExtendedAttribute(name,value) method of a TreeNode.
The value of an extended attribute can be fetched using
the getExtendedAttribute(name) method. A python dictionary
of all extended attributes of a node can be obtained using
the getExtendedAttributes() method. Some special node
property shortcuts can be used as well. A TreeNode
instances property whose name begins with two underscores
can be used to set or get an extended attribute.

The following demonstrates these new features:

`>>>` t=Tree('main',1)
`>>>` t.NUMERIC.setExtendedAttribute('att1',42)
`>>>` t.NUMERIC.setExtendedAttribute('att2',Range(1,100))
`>>>` t.NUMERIC.getExtendedAttribute('att1')
42
`>>>` t.NUMERIC.getExtendedAttribute('att2')
1 : 100 : *
`>>>` t.NUMERIC.getExtendedAttributes()
{'att2 ': 1 : 100 : *, 'att1 ': 42, 'special': 42}
`>>>` t.NUMERIC.__att3=100
`>>>` t.NUMERIC.__att2
1 : 100 : *
`>>>` t.NUMERIC.getExtendedAttributes()
{'special': 42, 'att3 ': 100, 'att1 ': 42, 'att2 ': 1 : 100 : *}
`>>>` t.NUMERIC.__special=None
`>>>` t.NUMERIC.getExtendedAttributes()
{'att3 ': 100, 'att1 ': 42, 'att2 ': 1 : 100 : *}