### PR TITLE
Build: Enable the -werror option

### DIFF
--- a/camshr/verbs.c
+++ b/camshr/verbs.c
@@ -265,16 +265,17 @@ EXPORT int Autoconfig(void *ctx __attribute__ ((unused)), char **error, char **o
 
   // loop thru list
   for (i = 0; i < numOfEntries; ++i) {
-    fscanf(fp, "%s", line);	// get a crate.db entry
-    sprintf(pHighwayName, "%.6s", line);	// trim it
+    if ( fscanf(fp, "%s", line) == 1) {	// get a crate.db entry
+      sprintf(pHighwayName, "%.6s", line);	// trim it
 
-    // NB! this is a work-around -- seems necessary for the moment
-    for (j = 0; j < 2; j++) {
-      if (map_scsi_device(pHighwayName) != SUCCESS) {	// map it if possible
-	  *error = malloc(strlen(pHighwayName)+100);
-	  sprintf(*error, "Error: problem mapping scsi device '%s'\n", pHighwayName);
-	  status = FILE_ERROR;
-	  goto AutoConfig_Exit;
+      // NB! this is a work-around -- seems necessary for the moment
+      for (j = 0; j < 2; j++) {
+        if (map_scsi_device(pHighwayName) != SUCCESS) {	// map it if possible
+	    *error = malloc(strlen(pHighwayName)+100);
+	    sprintf(*error, "Error: problem mapping scsi device '%s'\n", pHighwayName);
+	    status = FILE_ERROR;
+	    goto AutoConfig_Exit;
+        }
       }
     }
 

--- a/deploy/platform/platform_docker_build.sh
+++ b/deploy/platform/platform_docker_build.sh
@@ -48,6 +48,7 @@ config() {
         --libdir=${MDSPLUS_DIR}/$4 \
         ${CONFIGURE_PARAMS} \
         ${JAVA_OPTS} \
+	--enable-werror \
         $5 $6 $7 $8 $9;
     status=$?
 }

--- a/dwscope/dwscope.c
+++ b/dwscope/dwscope.c
@@ -460,8 +460,10 @@ int main(int argc, String * argv)
 static void DoPrint(char *filename)
 {
   char cmd[512];
-  sprintf(cmd, "dwscopePrint %s %s", filename, ScopePrinter);
-  system(cmd);
+  int num = snprintf(cmd, sizeof(cmd), "dwscopePrint %s %s", filename, ScopePrinter);
+  if (num > 0 && num <= (int)sizeof(cmd))
+    if (system(cmd) != 0)
+      printf("Error invoking dwscopePrint\n");
 }
 
 static char *GetPrinterList()

--- a/dwscope/evaluate.c
+++ b/dwscope/evaluate.c
@@ -361,7 +361,8 @@ static void EventAst(void *astparam, int dlen __attribute__ ((unused)), char *da
   pthread_mutex_lock(&event_mutex);
   *received = 1;
   pthread_mutex_unlock(&event_mutex);
-  write(event_pipe[1], buf, 1);
+  if (write(event_pipe[1], buf, 1) == -1)
+    perror("Error writing to event pipe\n");
 }
 
 void SetupEvent(String event, Boolean * received, int *id)
@@ -380,13 +381,15 @@ void SetupEvent(String event, Boolean * received, int *id)
 static void DoEventUpdate(XtPointer client_data, int *source, XtInputId * id)
 {
   char buf[1];
-  read(event_pipe[0], buf, 1);
+  if (read(event_pipe[0], buf, 1) == -1)
+    perror("Error reading from event pipe\n");
   EventUpdate(client_data, source, id);
 }
 
 void SetupEventInput(XtAppContext app_context, Widget w __attribute__ ((unused)))
 {
-  pipe(event_pipe);
+  if (pipe(event_pipe) == -1)
+    perror("Error creating event pipes");
   XtAppAddInput(app_context, event_pipe[0], (XtPointer) XtInputReadMask, DoEventUpdate, 0);
 
 }

--- a/idlmdsevent/mdsevent.c
+++ b/idlmdsevent/mdsevent.c
@@ -160,7 +160,8 @@ static void DoEventUpdate(XtPointer client_data __attribute__ ((unused)), int *s
   char *base_rec;
   EventStruct *e;
   IDL_WidgetStubLock(TRUE);
-  read(event_pipe[0], &e, sizeof(EventStruct *));
+  if (read(event_pipe[0], &e, sizeof(EventStruct *)) == -1)
+    perror("Error reading from event pipe\n");
   if ((stub_rec = IDL_WidgetStubLookup(e->stub_id))
       && (base_rec = IDL_WidgetStubLookup(e->base_id))) {
 #ifdef WIN32
@@ -195,7 +196,8 @@ static void EventAst(void * e_in, int len, char *data)
   EventStruct *e = (EventStruct *)e_in;
   if (len > 0)
     memcpy(e->value, data, len > 12 ? 12 : len);
-  write(event_pipe[1], &e, sizeof(EventStruct *));
+  if (write(event_pipe[1], &e, sizeof(EventStruct *)) == -1)
+    perror("Error writing to event pipe\n");
 }
 #endif
 EXPORT int IDLMdsEvent(int argc, void * *argv)
@@ -230,7 +232,8 @@ EXPORT int IDLMdsEvent(int argc, void * *argv)
 	    XtAppAddInput(XtWidgetToApplicationContext(w1), sock, (XtPointer) XtInputExceptMask,
 			  MdsDispatchEvent, (char *)0+sock);
 	  }
-	  pipe(event_pipe);
+	  if (pipe(event_pipe) == -1)
+	    perror("Error creating event pipes\n");
 	  XTINPUTID =
 	    XtAppAddInput(XtWidgetToApplicationContext(w1), event_pipe[0],
 			  (XtPointer) XtInputReadMask, DoEventUpdate, 0);

--- a/javamds/mdsobjects.c
+++ b/javamds/mdsobjects.c
@@ -2254,7 +2254,7 @@ JNIEXPORT void JNICALL Java_MDSplus_TreeNode_putData
  * Signature: (IIILjava/lang/String;)LMDSplus/Data;
  */
 JNIEXPORT jobject JNICALL Java_MDSplus_TreeNode_getExtendedAttribute
-  (JNIEnv *env, jclass class, jint nid, jint ctx1, jint ctx2, jstring jname)
+  (JNIEnv *env, jclass class __attribute__ ((unused)), jint nid, jint ctx1, jint ctx2, jstring jname)
 {
   int status;
   EMPTYXD(xd);
@@ -2279,7 +2279,7 @@ JNIEXPORT jobject JNICALL Java_MDSplus_TreeNode_getExtendedAttribute
  * Signature: (IIILjava/lang/String;LMDSplus/Data;)V
  */
 JNIEXPORT void JNICALL Java_MDSplus_TreeNode_setExtendedAttribute
-  (JNIEnv *env, jclass class, jint nid, jint ctx1, jint ctx2, jstring jname, jobject jdata)
+  (JNIEnv *env, jclass class __attribute__ ((unused)), jint nid, jint ctx1, jint ctx2, jstring jname, jobject jdata)
 {
   struct descriptor *dataD;
   int status;

--- a/mdsmisc/bessel.c
+++ b/mdsmisc/bessel.c
@@ -355,8 +355,7 @@ EXPORT void BessRoots()
   double curr_root, curr_x;
 
   printf("\nComputation of Roots for Bessel functions\n\nOut File (0 for screen):");
-  scanf("%s", filename);
-  if (strcmp(filename, "0")) {
+  if ((scanf("%s", filename) != 1) && strcmp(filename, "0")) {
     if ((fil_ptr = fopen(filename, "w")) == 0) {
       printf("\nCannot open file %s\n", filename);
       return;

--- a/mdsshr/MdsEvents.c
+++ b/mdsshr/MdsEvents.c
@@ -367,6 +367,8 @@ STATIC_ROUTINE void handleRemoteEvent(int sock)
 }
 
 #else// GLOBUS
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-result"
 
 STATIC_CONSTANT void KillHandler()
 {
@@ -420,6 +422,8 @@ STATIC_ROUTINE void handleRemoteAst()
     }
   }
 }
+#pragma GCC diagnostic pop
+
 #endif//GLOBUS
 
 /*

--- a/mdstcpip/IoRoutinesGsi.c
+++ b/mdstcpip/IoRoutinesGsi.c
@@ -202,7 +202,8 @@ static int gsi_authorize(Connection* c, char *username)
 	int fd = mkstemp(cred_file_name);
 	if (fd != -1) {
 	  fchmod(fd, 00600);
-	  write(fd, buffer_desc.value, buffer_desc.length);
+	  if (write(fd, buffer_desc.value, buffer_desc.length) == -1)
+	    perror("Error in gsi_authorize writing to temporary file\n");
 	  fchmod(fd, 00400);
 	  close(fd);
 	  setenv("X509_USER_PROXY", cred_file_name, 1);

--- a/mdstcpip/IoRoutinesTunnel.c
+++ b/mdstcpip/IoRoutinesTunnel.c
@@ -243,8 +243,10 @@ static int tunnel_connect(Connection* c, char *protocol, char *host){
 #else
   pid_t pid;
   int pipe_fd1[2], pipe_fd2[2];
-  pipe(pipe_fd1);
-  pipe(pipe_fd2);
+  if (pipe(pipe_fd1) == -1)
+    perror("Error in mdsip tunnel_connect creating pipes\n");
+  if (pipe(pipe_fd2) == -1)
+    perror("Error in mdsip tunnel_connect creating pipes\n");
   pid = fork();
   if (!pid) {
     char *localcmd =

--- a/mdstcpip/ProcessMessage.c
+++ b/mdstcpip/ProcessMessage.c
@@ -967,8 +967,12 @@ Message *ProcessMessage(Connection * connection, Message * message)
 #ifndef _WIN32
 	if ((fd != -1) && ((fopts & O_CREAT) != 0)) {
 	  char *cmd = (char *)malloc(64 + strlen(filename));
-	  sprintf(cmd, "SetMdsplusFileProtection %s 2> /dev/null", filename);
-	  system(cmd);
+	  int num = snprintf(cmd, 64 + strlen(filename), "SetMdsplusFileProtection %s 2> /dev/null", filename);
+	  if (num > 0)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-result"
+	    system(cmd);
+#pragma GCC diagnostic pop
 	  free(cmd);
 	}
 #endif

--- a/mitdevices/u_of_m_spect.c
+++ b/mitdevices/u_of_m_spect.c
@@ -60,6 +60,9 @@ int u_of_m_spect___init(struct descriptor *niddsc_ptr __attribute__ ((unused)), 
   return status;
 }
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-result"
+
 int u_of_m_spect___store(struct descriptor *niddsc_ptr __attribute__ ((unused)), InStoreStruct * setup)
 {
   int status;
@@ -127,6 +130,7 @@ int u_of_m_spect___store(struct descriptor *niddsc_ptr __attribute__ ((unused)),
   }
   return status;
 }
+#pragma GCC diagnostic pop
 
 static int StoreSpectra(int head_nid, int np, int num_frames, int *buffer, int p1, float dt)
 {

--- a/servershr/ServerSendMessage.c
+++ b/servershr/ServerSendMessage.c
@@ -689,6 +689,9 @@ static void DoMessage(Client * c, fd_set * fdactive)
     free(msg);
 }
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wclobbered"
+
 static void RemoveClient(Client * c, fd_set * fdactive)
 {
   int client_found = 0;
@@ -730,6 +733,8 @@ static void RemoveClient(Client * c, fd_set * fdactive)
     } else break;
   }
 }
+
+#pragma GCC diagnostic pop
 
 static int GetHostAddr(char *name)
 {

--- a/tdic/tdic.c
+++ b/tdic/tdic.c
@@ -95,6 +95,8 @@ void *dlsymget(void *handle, char *sym)
   return (ret);
 }
 
+#pragma GCC diagnostic ignored "-Wunused-result"
+
 int main(int argc, char **argv)
 {
   FILE *in = stdin;

--- a/tdishr/TdiVar.c
+++ b/tdishr/TdiVar.c
@@ -603,19 +603,21 @@ int compile_fun(struct descriptor *entry)
     StrAppend(&file, (struct descriptor *)&dnul);
     FILE *unit = fopen(file.pointer, "rb");
     if (unit) {
-	long flen;
-	fseek(unit, 0, SEEK_END);
-	flen = ftell(unit);
-	flen = (flen > 0xffff) ? 0xffff : flen;
-	fseek(unit, 0, SEEK_SET);
-	dcs.pointer = (char *)malloc(flen);
-	dcs.length = (unsigned short)flen;
-	fread(dcs.pointer, (size_t) flen, 1, unit);
-	fclose(unit);
-	status = TdiCompile(&dcs, &tmp MDS_END_ARG);
-	free(dcs.pointer);
+      long flen,readlen;
+      fseek(unit, 0, SEEK_END);
+      flen = ftell(unit);
+      flen = (flen > 0xffff) ? 0xffff : flen;
+      fseek(unit, 0, SEEK_SET);
+      dcs.pointer = (char *)malloc(flen);
+      dcs.length = (unsigned short)flen;
+      readlen = (long)fread(dcs.pointer, 1, (size_t) flen, unit);
+      if (readlen < flen)
+	perror("Error reading tdi function\n");
+      fclose(unit);
+      status = TdiCompile(&dcs, &tmp MDS_END_ARG);
+      free(dcs.pointer);
     } else
-	status = TdiUNKNOWN_VAR;
+      status = TdiUNKNOWN_VAR;
   }
   FREED_NOW(&file);
   if STATUS_OK {

--- a/testing/check_backend.c
+++ b/testing/check_backend.c
@@ -102,9 +102,10 @@ static FILE *switchStdout(const char *newStream)
     fflush(stdout);
     fgetpos(stdout, &out_pos);
     out_fd = dup(fileno(stdout));
-    if(newStream)
-        freopen(newStream, "w", stdout);
-    else
+    if(newStream) {
+      if (freopen(newStream, "w", stdout) == NULL)
+	perror("Error redirecting stdout\n");
+    } else
         fclose(stdout);
     return fdopen(out_fd, "w");
 }

--- a/traverser/CallbacksUil.c
+++ b/traverser/CallbacksUil.c
@@ -518,7 +518,7 @@ static void Init(Widget tree)
 
 static void CommandLineOpen(Display * display __attribute__ ((unused)), Widget tree)
 {
-  char chars[132];
+  char chars[132] = {0};
   //int status;
   typedef struct {
     int shot;
@@ -549,8 +549,7 @@ static void CommandLineOpen(Display * display __attribute__ ((unused)), Widget t
 	status = TreeOpenEdit(options.tree, options.shot);
 	if (status == TreeFILE_NOT_FOUND || status == TreeFOPENW) {
 	  printf("Tree /%s/ shot /%d/ does not exist.  Create?(Y/N) ", options.tree, options.shot);
-	  scanf("%s", chars);
-	  if ((chars[0] == 'y') || (chars[0] == 'Y')) {
+	  if ((scanf("%1s",chars) > 0) && ((chars[0] == 'y') || (chars[0] == 'Y'))) {
 	    status = TreeOpenNew(options.tree, options.shot);
 	  }
 	}

--- a/treeshr/TreeDoMethod.c
+++ b/treeshr/TreeDoMethod.c
@@ -115,6 +115,9 @@ int TreeDoFun(struct descriptor *funname, int nargs, struct descriptor **args,
   return status;
 }
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wclobbered"
+
 int _TreeDoMethod(void *dbid, struct descriptor *nid_dsc, struct descriptor *method_ptr, ...)
 {
   INIT_STATUS;
@@ -239,4 +242,5 @@ end: ;
   FREEXD_NOW(xd);
   return status;
 }
+#pragma GCC diagnostic pop
 

--- a/treeshr/TreeSegments.c
+++ b/treeshr/TreeSegments.c
@@ -696,6 +696,9 @@ inline static int ReadProperty_safe(TREE_INFO *tinfo, const int64_t offset,char 
 //#define CLEANUP_NCI_PUSH
 //#define CLEANUP_NCI_POP  unlock_nci(vars)
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wclobbered"
+
 int _TreeMakeSegment(void *dbid, int nid,
         struct descriptor *start, struct descriptor *end, struct descriptor *dimension,
         struct descriptor_a *initValIn, int idx, int rows_filled){
@@ -742,6 +745,7 @@ end: ;
   unlock_nci(vars);
   return status;
 }
+
 int _TreeUpdateSegment(void *dbid, int nid, struct descriptor *start, struct descriptor *end,
                        struct descriptor *dimension, int idx)
 {
@@ -905,6 +909,7 @@ end: ;
   return status;
 }
 
+#pragma GCC diagnostic pop
 
 ///// GET SEGMENT TIMES /////
 


### PR DESCRIPTION
This change fixes compiler warnings in several module and
ignores some warnings which are either unpreventable or have
been judged to be functionally ok.

Once this takes affect any modifications or additions to the code
base will fail if they produce new compiler warnings.