### PR TITLE
Fix: Repair MDSplus sign key used in redhat stable repo installer

### DIFF
--- a/deploy/platform/redhat/redhat_docker_build.sh
+++ b/deploy/platform/redhat/redhat_docker_build.sh
@@ -65,6 +65,10 @@ buildrelease(){
         echo "WARNING: Signing Keys Unavailable. Building unsigned RPMS"
         GPGCHECK="0"
     fi
+    if [ -r /sign_keys/RPM-GPG-KEY-MDSplus ]
+    then
+        cp /sign_keys/RPM-GPG-KEY-MDSplus ${BUILDROOT}/etc/pki/rpm-gpg/;
+    fi
     cat - > ${BUILDROOT}/etc/yum.repos.d/mdsplus${BNAME}.repo <<EOF
 [MDSplus${BNAME}]
 name=MDSplus${BNAME}


### PR DESCRIPTION
The stable redhat repo rpm was still installing the older less secure
signing public key which does not match the key used to sign the rpms.