### PR TITLE
Fix: Handling of segments which have expression dim

### DIFF
--- a/mdsobjects/python/descriptor.py
+++ b/mdsobjects/python/descriptor.py
@@ -192,6 +192,7 @@ class Descriptor_a(Descriptor):
     def _new_structure(self,arsize=0,**kwarg):
         super(Descriptor_a,self)._new_structure(**kwarg)
         self._structure.arsize = arsize
+        self._structure.aflags=48
     PTR = _C.POINTER(_structure_class)
     null= _C.cast(0,PTR)
     @property

--- a/treeshr/TreeSegments.c
+++ b/treeshr/TreeSegments.c
@@ -1087,7 +1087,7 @@ static int ReadSegment(TREE_INFO* tinfo, int nid, SEGMENT_HEADER* shead, SEGMENT
           MdsFree1Dx(&compressed_segment_xd, 0);
         }
       } else {
-        ans_ptr = ans.pointer = malloc(ans.arsize);
+        ans_ptr = ans.pointer = ans.a0 = malloc(ans.arsize);
         status = ReadProperty(tinfo,sinfo->data_offset, ans.pointer, (ssize_t)ans.arsize);
       }
       if (STATUS_OK && !compressed_segment)

--- a/xtreeshr/XTreeDefaultResample.c
+++ b/xtreeshr/XTreeDefaultResample.c
@@ -684,7 +684,7 @@ static int XTreeDefaultResampleMode(struct descriptor_signal *inSignalD, struct 
   //Build array descriptor for out data
   outDataArray.length = dataD->length;
   outDataArray.dtype = dataD->dtype;
-  outDataArray.pointer = outData;
+  outDataArray.pointer = outDataArray.a0 = outData;
   outDataArray.arsize = itemSize * outSamples;
   outDataArray.dimct = numDims;
   for (i = 0; i < numDims - 1; i++) {
@@ -699,14 +699,14 @@ static int XTreeDefaultResampleMode(struct descriptor_signal *inSignalD, struct 
     outDimArray.length = sizeof(double);
     outDimArray.arsize = sizeof(double) * outSamples;
     outDimArray.dtype = DTYPE_DOUBLE;
-    outDimArray.pointer = (char *)timebaseDouble;
+    outDimArray.pointer = outDataArray.a0 = (char *)timebaseDouble;
   }
 
   else {
     outDimArray.length = 8;
     outDimArray.arsize = 8 * outSamples;
     outDimArray.dtype = DTYPE_Q;
-    outDimArray.pointer = (char *)outDim;
+    outDimArray.pointer = outDataArray.a0 = (char *)outDim;
   }
 
   MdsCopyDxXd((struct descriptor *)&outSignalD, outSignalXd);

--- a/xtreeshr/XTreeDefaultSquish.c
+++ b/xtreeshr/XTreeDefaultSquish.c
@@ -324,6 +324,7 @@ EXPORT int XTreeDefaultSquish(struct descriptor_a *signalsApd,
     //Merge first dimension in outDim array. It is assumed that the first dimension has been evaluaed to a 1D array
 //              memcpy(&outDimD, dimensionsXd[0].pointer, sizeof(struct descriptor_a));
     memcpy(&outDimD, arraysD[0], sizeof(struct descriptor_a));
+    outDimD.aflags.coeff=0;
 
     outDimBuf = malloc(totSize);
     outDimD.pointer = outDimBuf;
@@ -389,7 +390,7 @@ EXPORT int XTreeDefaultSquish(struct descriptor_a *signalsApd,
     totSize += arrayD->arsize;
   }
   outDataBuf = malloc(totSize);
-  outDataD.pointer = outDataBuf;
+  outDataD.pointer = outDataD.a0 = outDataBuf;
   outDataD.arsize = totSize;
   currSignalD = ((struct descriptor_signal **)signalsApd->pointer)[0];
   arrayD = (struct descriptor_a *)currSignalD->data;

--- a/xtreeshr/XTreeGetTimedRecord.c
+++ b/xtreeshr/XTreeGetTimedRecord.c
@@ -312,6 +312,12 @@ EXPORT int _XTreeGetTimedRecord(void *dbid, int inNid, struct descriptor *startD
 		status = (dbid)?_TreeGetSegment(dbid, nid, currIdx, &dataXds[currSegIdx], &dimensionXds[currSegIdx]):TreeGetSegment(nid, currIdx, &dataXds[currSegIdx], &dimensionXds[currSegIdx]);
 
 //printf("Read Segment %d\n", currSegIdx);
+		if STATUS_OK
+		{
+		  if (dimensionXds[currSegIdx].pointer->dtype == DTYPE_FUNCTION) {
+		    status = TdiData(dimensionXds[currSegIdx].pointer,&dimensionXds[currSegIdx] MDS_END_ARG);
+		  }
+		}
 
 		if STATUS_NOT_OK
 		{

--- a/xtreeshr/XTreeGetTimedRecord.c
+++ b/xtreeshr/XTreeGetTimedRecord.c
@@ -312,12 +312,7 @@ EXPORT int _XTreeGetTimedRecord(void *dbid, int inNid, struct descriptor *startD
 		status = (dbid)?_TreeGetSegment(dbid, nid, currIdx, &dataXds[currSegIdx], &dimensionXds[currSegIdx]):TreeGetSegment(nid, currIdx, &dataXds[currSegIdx], &dimensionXds[currSegIdx]);
 
 //printf("Read Segment %d\n", currSegIdx);
-		if STATUS_OK
-		{
-		  if (dimensionXds[currSegIdx].pointer->dtype == DTYPE_FUNCTION) {
-		    status = TdiData(dimensionXds[currSegIdx].pointer,&dimensionXds[currSegIdx] MDS_END_ARG);
-		  }
-		}
+		if STATUS_OK status = TdiData(dimensionXds[currSegIdx].pointer,&dimensionXds[currSegIdx] MDS_END_ARG);
 
 		if STATUS_NOT_OK
 		{


### PR DESCRIPTION
The attempt to store segments which contain expressions for
the dimension of a segment uncovered problems in the handling
of segments. The existing code assumed that the dimensions of
segments were either ranges or arrays when combining multiple
segments into a single signal. This PR should fix some of the problems.
There is still further work needed to either support other such
features and/or restrict what can be stored in a segment to
prevent unexpected behaviors.

This should fix https://github.com/MDSplus/mdsplus/issues/1291