### PR TITLE
Fix: Repair older python package removal when upgrading MDSplus

### DIFF
--- a/deploy/packaging/debian/kernel.noarch
+++ b/deploy/packaging/debian/kernel.noarch
@@ -16,6 +16,7 @@
 ./usr/local/mdsplus/rpm/mdsipsd.xinetd
 ./usr/local/mdsplus/rpm/post_install_script
 ./usr/local/mdsplus/rpm/post_uninstall_script
+./usr/local/mdsplus/rpm/removePythonModule.sh
 ./usr/local/mdsplus/setup.csh
 ./usr/local/mdsplus/setup.sh
 ./usr/local/mdsplus/share/man/man1/mdsplus.1

--- a/deploy/packaging/linux.xml
+++ b/deploy/packaging/linux.xml
@@ -84,15 +84,7 @@ fi
     <include dir="/usr/local/mdsplus/tdi/MitDevices"/>
     <include dir="/usr/local/mdsplus/pydevices/MitDevices"/>
     <preinst>
-if [ -d "%{python_sitelib}" ]
-then 
-  rm -Rf %{python_sitelib}/MitDevices*
-  rm -Rf %{python_sitelib}/*mitdevices*
-else
-  export PYTHONPATH=""
-  easy_install -q pip &gt;/dev/null 2&gt;&amp;1
-  while (/usr/bin/yes | pip uninstall -q MitDevices 2&gt;/dev/null);do :;done
-fi
+      __INSTALL_PREFIX__/mdsplus/rpm/removePythonModule.sh MitDevices
     </preinst>
     <postinst>
       
@@ -106,11 +98,7 @@ python -m compileall  __INSTALL_PREFIX__/mdsplus/pydevices/MitDevices &gt;/dev/n
       fi
     </postrm>
     <pre-install>
-
-export PYTHONPATH=""
-easy_install -q pip &gt;/dev/null 2&gt;&amp;1
-while (/usr/bin/yes | pip uninstall -q MitDevices 2&gt;/dev/null);do :;done
-
+      __INSTALL_PREFIX__/mdsplus/rpm/removePythonModule.sh MitDevices
     </pre-install>
     <post-install>
 
@@ -550,15 +538,7 @@ fi
     <include dir="/usr/local/mdsplus/pydevices/RfxDevices"/>
     <include file="/usr/local/mdsplus/java/classes/jDevices.jar"/>
     <preinst>
-if [ -d "%{python_sitelib}" ]
-then 
-  rm -Rf %{python_sitelib}/RfxDevices*
-  rm -Rf %{python_sitelib}/*mitdevices*
-else
-  export PYTHONPATH=""
-  easy_install -q pip &gt;/dev/null 2&gt;&amp;1
-  while (/usr/bin/yes | pip uninstall -q RfxDevices 2&gt;/dev/null);do :;done
-fi
+      __INSTALL_PREFIX__/mdsplus/rpm/removePythonModule.sh RfxDevices
     </preinst>
     <postinst>
       
@@ -572,11 +552,7 @@ python -m compileall  __INSTALL_PREFIX__/mdsplus/pydevices/RfxDevices &gt;/dev/n
       fi
     </postrm>
     <pre-install>
-
-export PYTHONPATH=""
-easy_install -q pip &gt;/dev/null 2&gt;&amp;1
-while (/usr/bin/yes | pip uninstall -q RfxDevices 2&gt;/dev/null);do :;done
-
+      __INSTALL_PREFIX__/mdsplus/rpm/removePythonModule.sh RfxDevices
     </pre-install>
     <post-install>
 
@@ -590,15 +566,7 @@ python -m compileall  __INSTALL_PREFIX__/mdsplus/pydevices/RfxDevices &gt;/dev/n
     <requires package="python"/>
     <include dir="/usr/local/mdsplus/pydevices/W7xDevices"/>
     <preinst>
-if [ -d "%{python_sitelib}" ]
-then 
-  rm -Rf %{python_sitelib}/W7xDevices*
-  rm -Rf %{python_sitelib}/*mitdevices*
-else
-  export PYTHONPATH=""
-  easy_install -q pip &gt;/dev/null 2&gt;&amp;1
-  while (/usr/bin/yes | pip uninstall -q W7xDevices 2&gt;/dev/null);do :;done
-fi
+      __INSTALL_PREFIX__/mdsplus/rpm/removePythonModule.sh W7xDevices
     </preinst>
     <postinst>
       
@@ -612,11 +580,7 @@ python -m compileall  __INSTALL_PREFIX__/mdsplus/pydevices/W7xDevices &gt;/dev/n
       fi
     </postrm>
     <pre-install>
-
-export PYTHONPATH=""
-easy_install -q pip &gt;/dev/null 2&gt;&amp;1
-while (/usr/bin/yes | pip uninstall -q W7xDevices 2&gt;/dev/null);do :;done
-
+      __INSTALL_PREFIX__/mdsplus/rpm/removePythonModule.sh W7xDevices
     </pre-install>
     <post-install>
 
@@ -642,11 +606,7 @@ python -m compileall  __INSTALL_PREFIX__/mdsplus/pydevices/W7xDevices &gt;/dev/n
     <requires external="true" package="numpy"/>
     <include dir="/usr/local/mdsplus/mdsobjects/python"/>
     <postinst>
-      if [ -d %{python_sitelib} ]
-      then
-        packages=$(find %{python_sitelib} -maxdepth 1 -name 'mdsplus*' | grep -iv devices)
-        rm -Rf $packages %{python_sitelib}/MDSplus
-      fi
+      __INSTALL_PREFIX__/mdsplus/rpm/removePythonModule.sh MDSplus
       pushd __INSTALL_PREFIX__/mdsplus/mdsobjects/python &gt;/dev/null 2&gt;&amp;1
       python setup.py -q install
       rm -Rf build dist *.egg-info
@@ -663,27 +623,14 @@ python -m compileall  __INSTALL_PREFIX__/mdsplus/pydevices/W7xDevices &gt;/dev/n
       cd "$oldpwd"
     </post-install>
     <pre-deinstall>
-      rm -Rf $(python -c $(python -c "import site; print(site.getsitepackages()[0])")/mdsplus*
+      /mdsplus/rpm/removePythonModule.sh MDSplus
     </pre-deinstall>
     <pre-upgrade>
-      rm -Rf $(python -c $(python -c "import site; print(site.getsitepackages()[0])")/mdsplus*
+      /mdsplus/rpm/removePythonModule.sh MDSplus
     </pre-upgrade>
       
     <prerm>
-
-      if [ -d %{python_sitelib} ]
-      then
-        if [ "$1" == "0" ]
-        then
-          packages=$(find %{python_sitelib} -maxdepth 1 -name 'mdsplus*' | grep -iv devices)
-          rm -Rf $packages %{python_sitelib}/MDSplus
-        fi
-      else
-	export PYTHONPATH=""
-        easy_install -q pip &gt;/dev/null 2&gt;&amp;1
-        while (/usr/bin/yes | pip uninstall -q MDSplus 2&gt;/dev/null);do :;done
-      fi
-
+      __INSTALL_PREFIX__/mdsplus/rpm/removePythonModule.sh MDSplus
     </prerm>
   </package>
 

--- a/deploy/packaging/redhat/kernel.noarch
+++ b/deploy/packaging/redhat/kernel.noarch
@@ -21,6 +21,7 @@
 ./usr/local/mdsplus/rpm/mdsipsd.xinetd
 ./usr/local/mdsplus/rpm/post_install_script
 ./usr/local/mdsplus/rpm/post_uninstall_script
+./usr/local/mdsplus/rpm/removePythonModule.sh
 ./usr/local/mdsplus/setup.csh
 ./usr/local/mdsplus/setup.sh
 ./usr/local/mdsplus/share

--- a/rpm/Makefile.am
+++ b/rpm/Makefile.am
@@ -4,7 +4,7 @@ dist_etc_DATA = mdsplus.conf.template
 
 rpmdir = $(exec_prefix)/rpm
 rpm_SCRIPTS = post_uninstall_script
-dist_rpm_SCRIPTS = post_install_script
+dist_rpm_SCRIPTS = post_install_script removePythonModule.sh
 
 if GLOBUSLICENSE
 dist_rpm_DATA = fusiongrid-mdsip.xinetd fusiongrid-mdsips.xinetd globus-gatekeeper.xinetd globus-gridftp.xinetd

--- a/rpm/Makefile.in
+++ b/rpm/Makefile.in
@@ -482,7 +482,7 @@ etc_DATA = envsyms
 dist_etc_DATA = mdsplus.conf.template
 rpmdir = $(exec_prefix)/rpm
 rpm_SCRIPTS = post_uninstall_script
-dist_rpm_SCRIPTS = post_install_script
+dist_rpm_SCRIPTS = post_install_script removePythonModule.sh
 @GLOBUSLICENSE_FALSE@dist_rpm_DATA = mdsipd.xinetd mdsipsd.xinetd
 @GLOBUSLICENSE_TRUE@dist_rpm_DATA = fusiongrid-mdsip.xinetd fusiongrid-mdsips.xinetd globus-gatekeeper.xinetd globus-gridftp.xinetd
 all: all-am

--- a/rpm/removePythonModule.sh
+++ b/rpm/removePythonModule.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+#
+getModDir() {
+    if ( python -s -c 'import site' 2>/dev/null )
+    then
+	opt='-s'
+    fi
+    mdir=$(dirname $(python -E $opt -c 'import '$1';print('$1'.__file__)' 2>/dev/null) 2>/dev/null)
+    if ( dirname $mdir 2>/dev/null | grep -i mdsplus > /dev/null )
+    then
+	mdir=$(dirname $mdir 2>/dev/null)
+    fi
+    echo $mdir
+}
+
+mdir=$(getModDir $1)
+while [ ! -z "$mdir" ]
+do
+    if ( echo $mdir | grep -i $1 >/dev/null )
+    then
+	if ( rm -Rf $mdir )
+	then
+	    mdir=$(getModDir $1)
+	else
+	    mdir=""
+	fi
+    fi
+done


### PR DESCRIPTION
The previous scripts for cleaning off MDSplus python packages used
pip remove in a loop but on some newer versions of pip the pip remove
command does not return a failure status if the package was not found.
This produced an infinite loop when remove or upgrading MDSplus python
installers particularly on debian based platforms. This should fix this
problem. Unfortunaly an upgrade on debian systems will cause this infinite
loop until the newer packages are installed. To prevent this infinite
looping the following files will need to be edited by hand before
removing the associated packages if the exist on the debian based system:

/var/lib/dpkg/info/mdsplus-alpha-python.prerm
/var/lib/dpkg/info/mdsplus-*devices.prerm

You need to insert an single line containing:

exit

right after the:

line at the top of the file.