### PR TITLE
Gm jscope fix dtype f data

### DIFF
--- a/javascope/jScope/Signal.java
+++ b/javascope/jScope/Signal.java
@@ -1169,7 +1169,7 @@ public class Signal implements WaveDataListener
         curr_y_xz_plot = Float.NaN;
         curr_y_xz_idx = -1;
 
-        if( zY2D != null )
+        if( zY2D != null && idx < zY2D.length)
         {
             ymin = ymax = zY2D[idx];
             for (int j = 0; j < y2d.length; j++)
@@ -2098,20 +2098,23 @@ public class Signal implements WaveDataListener
                         this.xmax = curr_xmax = xMax;
                 }
 //Autoscale Y, ymin and ymax are possibly changed afterwards
-                this.ymin = this.ymax = y[0];
-                for(int i = 0; i < y.length; i++)
-                {
-                    if(y[i] < this.ymin)
-                        this.ymin = y[i];
-                    if(y[i] > this.ymax)
-                        this.ymax = y[i];
-                }
-                
-                if(data.isXLong())
-                {
-                    xLong = xyData.xLong;
-                }
-                resolutionManager.addRegion(new RegionDescriptor(xMin, xMax, xyData.resolution));
+		if(y.length > 0)
+		{
+		    this.ymin = this.ymax = y[0];
+		    for(int i = 0; i < y.length; i++)
+		    {
+			if(y[i] < this.ymin)
+			    this.ymin = y[i];
+			if(y[i] > this.ymax)
+			    this.ymax = y[i];
+		    }
+		    
+		    if(data.isXLong())
+		    {
+			xLong = xyData.xLong;
+		    }
+		    resolutionManager.addRegion(new RegionDescriptor(xMin, xMax, xyData.resolution));
+		}
             }
             if(up_errorData != null && upError == null)
             {

--- a/mdsmisc/ScopeUtilities.c
+++ b/mdsmisc/ScopeUtilities.c
@@ -816,6 +816,28 @@ EXPORT struct descriptor_xd *GetXYSignal(char *inY, char *inX, float *inXMin, fl
 	yXd = currXd;
 	yArrD = (struct descriptor_a *)yXd.pointer;
     }
+    if(xArrD->dtype == DTYPE_F)
+    {
+	char *expr = (char *)"FLOAT($)";
+	struct descriptor exprDsc = {strlen(expr), DTYPE_T, CLASS_S, expr};
+	EMPTYXD(currXd);
+	status = TdiCompile(&exprDsc, xArrD, &currXd MDS_END_ARG);
+	if(status & 1)
+	    status = TdiData((struct descriptor *)&currXd, &currXd MDS_END_ARG);
+	if(!(status & 1))
+	{
+	    err = "Cannot Convert X to IEEE Floating point";
+	    MdsFree1Dx(&xXd, 0);
+	    MdsFree1Dx(&yXd, 0);
+	    errD.length = strlen(err);
+	    errD.pointer = err;
+	    MdsCopyDxXd(&errD, &retXd);
+	    return &retXd;
+	}
+	MdsFree1Dx(&xXd, 0);
+	xXd = currXd;
+	xArrD = (struct descriptor_a *)xXd.pointer;
+    }
 	      
     if(yArrD->dtype == DTYPE_FLOAT)
 	y = (float *)yArrD->pointer;


### PR DESCRIPTION
Added management of DTYPE_F data items in mdsmisc/ScopeUtilities used by jScope MdsDataProvider

This fixes the issue reported by Antoine Merle