### PR TITLE
Fix: Repair redhat python installer

### DIFF
--- a/deploy/packaging/linux.xml
+++ b/deploy/packaging/linux.xml
@@ -630,7 +630,12 @@ python -m compileall  __INSTALL_PREFIX__/mdsplus/pydevices/W7xDevices &gt;/dev/n
     </pre-upgrade>
       
     <prerm>
+      if [ -d %{python_sitelib} -a "$1" -ne "0" ]
+      then
+      :
+      else
       __INSTALL_PREFIX__/mdsplus/rpm/removePythonModule.sh MDSplus
+      fi
     </prerm>
   </package>
 


### PR DESCRIPTION
The python package installer was removing the MDSplus module
after an update. This should fix this problem.

This should fix: https://github.com/MDSplus/mdsplus/issues/1303