### PR TITLE
Build: Perform Visual Studio build in docker

### DIFF
--- a/deploy/packaging/windows/create_installer.sh
+++ b/deploy/packaging/windows/create_installer.sh
@@ -8,29 +8,31 @@ if [ "${BRANCH}" = "stable" ]
 then bname=""
 else bname="-${BRANCH}"
 fi
-if [ ! -z "$WINHOST" -a -r /winbld -a ! -z "$WINREMBLD" ]
-then
-  windows_cleanup() {
-      rm -Rf /winbld/${tmpdir}
-  }
-  pushd /winbld
-  tmpdir=$(mktemp -d mdsplus-XXXXXXXXXX)
-  trap windows_cleanup EXIT
-  topsrcdir=${WINREMBLD}/${tmpdir}
-  cd ${tmpdir}
-  rsync -am --include="*/" --include="*.h" --include="*.hpp" --include="*.def" --exclude="*" ${srcdir}/ ./
-  rsync -am /workspace/releasebld/64/include/mdsplus/mdsconfig.h ./include/
-  rsync -a ${srcdir}/mdsobjects/cpp ${srcdir}/mdsobjects/MdsObjects* ${srcdir}/mdsobjects/VS-* ./mdsobjects/
-  rsync -a ${srcdir}/deploy/platform/windows/winbld.bat ./deploy/
-  rsync -a ${MDSPLUS_DIR}/bin_* ./
-  curl http://${WINHOST}:8080${topsrcdir}/deploy/winbld.bat
+
+#if [ ! -z "$WINHOST" -a -r /winbld -a ! -z "$WINREMBLD" ]
+#then
+#  windows_cleanup() {
+#      rm -Rf /winbld/${tmpdir}
+#  }
+#  pushd /winbld
+#  tmpdir=$(mktemp -d mdsplus-XXXXXXXXXX)
+#  trap windows_cleanup EXIT
+#  topsrcdir=${WINREMBLD}/${tmpdir}
+#  cd ${tmpdir}
+#  rsync -am --include="*/" --include="*.h" --include="*.hpp" --include="*.def" --exclude="*" ${srcdir}/ ./
+#  rsync -am /workspace/releasebld/64/include/mdsplus/mdsconfig.h ./include/
+#  rsync -a ${srcdir}/mdsobjects/cpp ${srcdir}/mdsobjects/MdsObjects* ${srcdir}/mdsobjects/VS-* ./mdsobjects/
+#  rsync -a ${srcdir}/deploy/platform/windows/winbld.bat ./deploy/
+#  rsync -a ${MDSPLUS_DIR}/bin_* ./
+#  curl http://${WINHOST}:8080${topsrcdir}/deploy/winbld.bat
   # see if files are there
-  :&& ls /winbld/${tmpdir}/bin_x86*/*.lib /winbld/${tmpdir}/bin_x86*/MdsObjectsCppShr-VS.* > /dev/null
-  checkstatus abort "Failure: Problem building Visual Studio dll." $?
-  rsync -av --include="*/" --include="*.lib" --include="MdsObjectsCppShr-VS.dll" --exclude="*" /winbld/${tmpdir}/bin_x86* ${MDSPLUS_DIR}/
-  vs="-DVisualStudio"
-  popd
-fi
+#  :&& ls /winbld/${tmpdir}/bin_x86*/*.lib /winbld/${tmpdir}/bin_x86*/MdsObjectsCppShr-VS.* > /dev/null
+#  checkstatus abort "Failure: Problem building Visual Studio dll." $?
+#  rsync -av --include="*/" --include="*.lib" --include="MdsObjectsCppShr-VS.dll" --exclude="*" /winbld/${tmpdir}/bin_x86* ${MDSPLUS_DIR}/
+#  vs="-DVisualStudio"
+#  popd
+#fi
+
 pushd ${MDSPLUS_DIR}
 makensis -DMAJOR=${major} -DMINOR=${minor} -DRELEASE=${release} -DFLAVOR=${bname} -NOCD -DBRANCH=${BRANCH} \
      -DOUTDIR=/release/${BRANCH} -Dsrcdir=${srcdir} ${vs} ${srcdir}/deploy/packaging/${PLATFORM}/mdsplus.nsi

--- a/deploy/packaging/windows/mdsplus.nsi
+++ b/deploy/packaging/windows/mdsplus.nsi
@@ -324,18 +324,16 @@ File "/oname=mdslib.lib" bin_x86_64/MdsLib.dll.a
 File "/oname=mdsobjectscppshr.lib" bin_x86_64/MdsObjectsCppShr.dll.a
 File "/oname=mdsservershr.lib" bin_x86_64/MdsServerShr.dll.a
 File "/oname=xtreeshr.lib" bin_x86_64/XTreeShr.dll.a
-!ifdef VisualStudio
 CreateDirectory "$INSTDIR\devtools\lib64\visual_studio"
 SetOutPath "$INSTDIR\devtools\lib64\visual_studio"
 File "/oname=mdsshr.lib" bin_x86_64/MdsShr.lib
 File "/oname=treeshr.lib" bin_x86_64/TreeShr.lib
 File "/oname=tdishr.lib" bin_x86_64/TdiShr.lib
-File "/oname=mdsdcl.lib" bin_x86_64/mdsdclshr.lib
-File "/oname=mdsipshr.lib" bin_x86_64/mdsipshr.lib
+File "/oname=mdsdcl.lib" bin_x86_64/MdsDcl.lib
+File "/oname=mdsipshr.lib" bin_x86_64/MdsIpShr.lib
 File "/oname=mdslib.lib" bin_x86_64/MdsLib.lib
 File "/oname=mdsobjectscppshr-vs.lib" bin_x86_64/MdsObjectsCppShr-VS.lib
-File "/oname=mdsservershr.lib" bin_x86_64/servershr.lib
-!endif
+File "/oname=mdsservershr.lib" bin_x86_64/MdsServerShr.lib
 ${EndIf}
 CreateDirectory "$INSTDIR\devtools\lib32\mingw"
 SetOutPath "$INSTDIR\devtools\lib32\mingw"
@@ -348,18 +346,15 @@ File "/oname=mdslib.lib" bin_x86/MdsLib.dll.a
 File "/oname=mdsobjectscppshr.lib" bin_x86/MdsObjectsCppShr.dll.a
 File "/oname=mdsservershr.lib" bin_x86/MdsServerShr.dll.a
 File "/oname=xtreeshr.lib" bin_x86/XTreeShr.dll.a
-!ifdef VisualStudio
-CreateDirectory "$INSTDIR\devtools\lib64\visual_studio"
+CreateDirectory "$INSTDIR\devtools\lib32\visual_studio"
 SetOutPath "$INSTDIR\devtools\lib32\visual_studio"
 File "/oname=mdsshr.lib" bin_x86/MdsShr.lib
 File "/oname=treeshr.lib" bin_x86/TreeShr.lib
 File "/oname=tdishr.lib" bin_x86/TdiShr.lib
-File "/oname=mdsdcl.lib" bin_x86/mdsdclshr.lib
+File "/oname=mdsdcl.lib" bin_x86/mdsdcl.lib
 File "/oname=mdsipshr.lib" bin_x86/mdsipshr.lib
 File "/oname=mdslib.lib" bin_x86/MdsLib.lib
-File "/oname=mdsobjectscppshr-vs.lib" bin_x86/MdsObjectsCppShr-VS.lib
-File "/oname=mdsservershr.lib" bin_x86/servershr.lib
-!endif
+File "/oname=mdsservershr.lib" bin_x86/MdsServerShr.lib
 SectionEnd
 
 

--- a/deploy/platform/windows/windows_docker_build.sh
+++ b/deploy/platform/windows/windows_docker_build.sh
@@ -42,6 +42,12 @@ buildrelease() {
       $MAKE
       $MAKE install
     fi
+    if [ -z "$NOMAKE" ]; then
+      HOME=$winebottle64 WINEARCH=win64 wine cmd /C ${srcdir}/mdsobjects/cpp/visual-studio-build.bat
+      cp /workspace/releasebld/64/bin_x86_64/MdsObjectsCppShr-VS.dll ${MDSPLUS_DIR}/bin_x86_64/
+      cp /workspace/releasebld/64/bin_x86_64/*.lib ${MDSPLUS_DIR}/bin_x86_64/
+      cp /workspace/releasebld/32/bin_x86/*.lib ${MDSPLUS_DIR}/bin_x86/
+    fi
     popd
     ###
     ### pack installer

--- a/mdsobjects/cpp/visual-studio-build.bat
+++ b/mdsobjects/cpp/visual-studio-build.bat
@@ -1,0 +1,58 @@
+@ECHO on
+set OLDDIR=%CD%
+cd %~dp0..\..
+set SRCDIR=%CD%
+cd %OLDDIR%
+set PATH=\vc\bin\x64;\vc\winsdk\bin\x64
+set INCLUDE=\vc\include;\vc\winsdk\include\shared;\vc\winsdk\include\ucrt;\vc\winsdk\include\um;
+set LIB=\vc\lib\x64;\vc\winsdk\lib\x64
+set TMP=Z:\tmp
+set TEMP=Z:\tmp
+set SystemRoot=C:\Windows
+set CPP=%SRCDIR%\mdsobjects\cpp
+set BUILD64=\workspace\releasebld\64
+set BUILD32=\workspace\releasebld\32
+
+set CL_OPTS=/c /GS /W3 /Zc:wchar_t /I"%SRCDIR%\include" /I"%SRCDIR%\tdishr" /Zi /Gm- /O2 ^
+ /Fd"\tmp\vc141.pdb" /Zc:inline /fp:precise /D "WIN32" /D "NDEBUG" /D "WINDOWS_H" ^
+ /D "_WINDOWS" /D "_USRDLL" /D "MDSOBJECTSCPPSHRVS_EXPORTS" /D "NOMINMAX" ^
+ /D "_CRT_SECURE_NO_WARNINGS" /D "_WINDLL" /errorReport:prompt /WX- /Zc:forScope ^
+ /Gd /MD /EHsc /nologo  /Fp"MdsObjectsCppShr-VS.pch" /diagnostics:classic
+
+cl %CL_OPTS% %CPP%\mdsdata.c
+cl %CL_OPTS% %CPP%\mdsdataobjects.cpp
+cl %CL_OPTS% %CPP%\mdseventobjects.cpp
+cl %CL_OPTS% %CPP%\mdsipobjects.cpp
+cl %CL_OPTS% %CPP%\mdstree.c
+cl %CL_OPTS% %CPP%\mdstreeobjects.cpp
+
+lib /def:%SRCDIR%\mdsshr\mdsshr.def /out:%BUILD64%\bin_x86_64\MdsShr.lib /machine:x64
+dir %BUILD64%\bin_x86_64\*
+lib /def:%SRCDIR%\treeshr\treeshr.def /out:%BUILD64%\bin_x86_64\TreeShr.lib /machine:x64
+lib /def:%SRCDIR%\tdishr\tdishr.def /out:%BUILD64%\bin_x86_64\TdiShr.lib /machine:x64
+lib /def:%SRCDIR%\mdstcpip\mdsipshr.def /out:%BUILD64%\bin_x86_64\MdsIpShr.lib /machine:x64
+lib /def:%SRCDIR%\mdsmisc\mdsmisc.def /out:%BUILD64%\bin_x86_64\MdsMisc.lib /machine:x64
+lib /def:%SRCDIR%\servershr\servershr.def /out:%BUILD64%\bin_x86_64\MdsServerShr.lib /machine:x64
+lib /def:%SRCDIR%\mdslib\MdsLib.def /out:%BUILD64%\bin_x86_64\MdsLib.lib /machine:x64
+lib /def:%SRCDIR%\mdsdcl\mdsdclshr.def /out:%BUILD64%\bin_x86_64\MdsDcl.lib /machine:x64
+lib /def:%SRCDIR%\math\MdsMath.def /out:%BUILD64%\bin_x86_64\MdsMath.lib /machine:x64
+
+lib /def:%SRCDIR%\mdsshr\mdsshr.def /out:%BUILD32%\bin_x86\MdsShr.lib /machine:x86
+lib /def:%SRCDIR%\treeshr\treeshr.def /out:%BUILD32%\bin_x86\TreeShr.lib /machine:x86
+lib /def:%SRCDIR%\tdishr\tdishr.def /out:%BUILD32%\bin_x86\TdiShr.lib /machine:x86
+lib /def:%SRCDIR%\mdstcpip\mdsipshr.def /out:%BUILD32%\bin_x86\MdsIpShr.lib /machine:x86
+lib /def:%SRCDIR%\mdsmisc\mdsmisc.def /out:%BUILD32%\bin_x86\MdsMisc.lib /machine:x86
+lib /def:%SRCDIR%\servershr\servershr.def /out:%BUILD32%\bin_x86\MdsServerShr.lib /machine:x86
+lib /def:%SRCDIR%\mdslib\MdsLib.def /out:%BUILD32%\bin_x86\MdsLib.lib /machine:x86
+lib /def:%SRCDIR%\mdsdcl\mdsdclshr.def /out:%BUILD32%\bin_x86\MdsDcl.lib /machine:x86
+lib /def:%SRCDIR%\math\MdsMath.def /out:%BUILD32%\bin_x86\MdsMath.lib /machine:x86
+
+set LINK_OPTS=/OUT:"%BUILD64%\bin_x86_64\MdsObjectsCppShr-VS.dll" /NXCOMPAT /PDB:"MdsObjectsCppShr-VS.pdb" ^
+ /DYNAMICBASE "MdsShr.lib" "TreeShr.lib" "TdiShr.lib" "MdsIpShr.lib" "kernel32.lib" "user32.lib" ^
+ "gdi32.lib" "winspool.lib" "comdlg32.lib" "advapi32.lib" "shell32.lib" "ole32.lib" "oleaut32.lib" ^
+ "uuid.lib" "odbc32.lib" "odbccp32.lib" /IMPLIB:"%BUILD64%\bin_x86_64\MdsObjectsCppShr-VS.lib" /DLL /MACHINE:X64 ^
+ /OPT:REF /INCREMENTAL:NO  /SUBSYSTEM:WINDOWS /MANIFEST /MANIFESTUAC:"level='asInvoker' uiAccess='false'" ^
+ /MANIFEST:embed /OPT:ICF /ERRORREPORT:PROMPT /NOLOGO ^
+ /LIBPATH:"%BUILD64%\bin_x86_64" /TLBID:1
+
+link %LINK_OPTS% mdsdata.obj mdsdataobjects.obj mdseventobjects.obj mdsipobjects.obj mdstree.obj mdstreeobjects.obj


### PR DESCRIPTION
This will enable the MdsObjectsCppShr-VS.dll library for windows
to be built inside the mdsplus/docker:windows container without the
need for a separate Windows VM.