### PR TITLE
Feature: Add ubuntu18 support

### DIFF
--- a/deploy/os/ubuntu18.opts
+++ b/deploy/os/ubuntu18.opts
@@ -1,0 +1,1 @@
+--platform=debian --valgrind=memcheck,helgrind --dockerimage=mdsplus/docker:ubuntu18-64 --distname=Ubuntu18 --arch=amd64


### PR DESCRIPTION
This initial change will provide 64-bit only MDSplus for
Ubuntu 18.