### PR TITLE
Fix: reverting FC28 changes to this file as it broke MdsValue

### DIFF
--- a/mdslibidl/MdsLibIdl.c
+++ b/mdslibidl/MdsLibIdl.c
@@ -443,18 +443,12 @@ EXPORT int IdlMdsValue(int argc, void **argv)
 	char dims[512] = "(";
 	int i;
 	if (ptr->aflags.coeff)
-	  for (i = 0; i < ptr->dimct; i++) {
-	    char dim[16];
-	    sprintf(dim, "%d,", ptr->m[i] > 0 ? ptr->m[i] : 1);
-	    strcat(dims,dim);
-	  }
-	else {
-	  char dim[16];
-	  sprintf(dim, "%d,",
+	  for (i = 0; i < ptr->dimct; i++)
+	    sprintf(dims, "%s%d,", dims, ptr->m[i] > 0 ? ptr->m[i] : 1);
+	else
+	  sprintf(dims, "%s%d,", dims,
 		  ((ptr->arsize / ptr->length) > 0) ? (ptr->arsize / ptr->length) : 1);
-	  strcat(dims,dim);
-	}
-	strcat(dims,")");
+	dims[strlen(dims) - 1] = ')';
 	switch (mdsValueAnswer.pointer->dtype) {
 	case DTYPE_B:
 	  strcpy((char *)argv[2], "if max(answer) gt 127 then answer = fix(answer)-256");


### PR DESCRIPTION
This commit reverts MdsLibIld.c  - the changes to this file for
FC28 compiler warnings did not work.

Symptom -

in IDL
```
set_databse, 'logbook'
DSQL('select count(*) from entries', cnt)
```
produced the error:
```
answer = lonarr(1,)
                   ^
% Syntax error.
% Compiled module: EVALUATE.
```
This is a temporary rollback of the change so that new kits will work.