### PR TITLE
Fix: remove fc28 temorarily

### DIFF
--- a/deploy/os/fc28.opts
+++ b/deploy/os/fc28.opts
@@ -1,1 +1,0 @@
---platform=redhat --valgrind=memcheck,helgrind --sanitize=address,undefined,thread --dockerimage=mdsplus/docker:fc28 --distname=fc28


### PR DESCRIPTION
need to build disregarding fc28 issues so mds idl interface can revert