### PR TITLE
Fix: actlog should flush after each line

### DIFF
--- a/actions/actlog.c
+++ b/actions/actlog.c
@@ -84,6 +84,7 @@ inline static void EventUpdate(LinkedEvent * event){
 
 static void PutLog(char *time, char *mode, char *status, char *server, char *path){
   fprintf(stdout, "%s %12d %-10.10s %-44.44s %-20.20s %s\n", time, current_shot, mode, status, server, path);
+  fflush(stdout);
 }
 
 static void PutError(char *time, char* mode, char *status, char *server, char *path){


### PR DESCRIPTION
flushes stdout after each line which is required if you want to have a useful output that you might wanna parse by a third party program.
