### PR TITLE
Fix: translate python int to Int32/Int64 based on bit_length ..

### DIFF
--- a/mdsobjects/python/mdsscalar.py
+++ b/mdsobjects/python/mdsscalar.py
@@ -65,11 +65,14 @@ class Scalar(_dat.Data):
             cls = Float64
         elif isinstance(value,(_C.c_float,float)):
             cls = Float32
-        elif isinstance(value,(_C.c_int64,_ver.long)):
+        elif isinstance(value,(int,)):
+            if value.bit_length()>31: cls = Int64
+            else:                     cls = Int32
+        elif isinstance(value,(_C.c_int64,)) or (_ver.ispy2 and isinstance(value,(long,))):
             cls = Int64
         elif isinstance(value,(_C.c_uint64,)):
             cls = Uint64
-        elif isinstance(value,(_C.c_int32,int)):
+        elif isinstance(value,(_C.c_int32,)):
             cls = Int32
         elif isinstance(value,(_C.c_uint32,)):
             cls = Uint32

--- a/mdsobjects/python/mdsscalar.py
+++ b/mdsobjects/python/mdsscalar.py
@@ -66,8 +66,7 @@ class Scalar(_dat.Data):
         elif isinstance(value,(_C.c_float,float)):
             cls = Float32
         elif isinstance(value,(int,)):
-            if value.bit_length()>31: cls = Int64
-            else:                     cls = Int32
+            cls = Int64 if _ver.bit_length(value)>31 else Int32
         elif isinstance(value,(_C.c_int64,)) or (_ver.ispy2 and isinstance(value,(long,))):
             cls = Int64
         elif isinstance(value,(_C.c_uint64,)):

--- a/mdsobjects/python/tests/dataUnitTest.py
+++ b/mdsobjects/python/tests/dataUnitTest.py
@@ -131,7 +131,11 @@ class Tests(TestCase):
             test('_a<=_b',      a<=b,   res.pop())
 
     def data(self):
-        a = m.ADD(1,2);self.assertEqual(m.MULTIPLY(a,a).decompile(),"(1 + 2) * (1 + 2)")
+        self.assertEqual(m.Data(0x80000000).__class__,m.Int64)
+        self.assertEqual(m.Data(0x7fffffff).__class__,m.Int32)
+        if m.version.ispy2:
+            self.assertEqual(m.Data(long(1)).__class__,m.Int64)
+        a = m.ADD(m.Int32(1),m.Int32(2));self.assertEqual(m.MULTIPLY(a,a).decompile(),"(1 + 2) * (1 + 2)")
         self.assertEqual(m.Data(2).compare(2),True)
         self.assertEqual(m.Data(2).compare(1),False)
         self.assertEqual(m.Dictionary([1,'a',2,'b']).data().tolist(),{1: 'a', 2: 'b'})

--- a/mdsobjects/python/version.py
+++ b/mdsobjects/python/version.py
@@ -47,6 +47,13 @@ has_buffer    = 'buffer'     in __builtins__
 has_xrange    = 'xrange'     in __builtins__
 has_mapclass  = isinstance(map,(type,))
 
+if pyver<(2,7):
+    def bit_length(val):
+        return len(bin(val)) - (3 is val<0 else 2)
+else:
+    def bit_length(val):
+        return val.bit_length()
+
 def load_library(name):
     import ctypes as C
     if os.sys.platform.startswith('darwin') and not os.getenv('DYLD_LIBRARY_PATH'):


### PR DESCRIPTION
consistently for both py2 and py3:

```python
In >> MDSplus.Data(1504798074346117981)
Old>> 941071197
New>> 1504798074346117981Q
```