### PR TITLE
Fix: Avoid loading numpy in matlab if not using python bridge

### DIFF
--- a/matlab/mdsFromMatlab.m
+++ b/matlab/mdsFromMatlab.m
@@ -25,13 +25,16 @@ function  result = mdsFromMatlab( thing )
         if isscalar(thing)
           f=str2func(strcat('py.numpy.',dtype));
           result=f(thing);
-        else
+	else
+	  py_numpy_array=str2func('py.numpy.array');  
           sz=size(thing);
-          result=py.numpy.array(reshape(thing,int32(1),prod(int32(size(thing)))),dtype);
+          result=py_numpy_array(reshape(thing,int32(1),prod(int32(size(thing)))),dtype);
           if not(numel(sz) == 2 && sz(2) == 1)
-            presult=py.numpy.resize(result,int32(sz));
-            result=py.numpy.resize(result,presult.transpose().shape);
-            result=py.numpy.ascontiguousarray(result);
+	    py_numpy_resize=str2func('py.numpy.resize');
+            py_numpy_ascontiguousarray=str2func('py.numpy.ascontiguousarray');
+            presult=py_numpy_resize(result,int32(sz));
+            result=py_numpy_resize(result,presult.transpose().shape);
+            result=py_numpy_ascontiguousarray(result);
           end
         end
     end

--- a/matlab/mdsInfo.m
+++ b/matlab/mdsInfo.m
@@ -46,7 +46,8 @@ function info = mdsInfo()
     end
     if usePython
       try
-        x=py.MDSplus.Int32(int32(1));
+        py_MDSplus_Int32=str2func('py.MDSplus.Int32');
+        x=py_MDSplus_Int32(int32(1));
       catch pythonerror
         disp('Unable to connect to MDSplus using either a java bridge or a python bridge')
         disp(strcat(' Java error: ',javaerror.message))

--- a/matlab/mdsToMatlab.m
+++ b/matlab/mdsToMatlab.m
@@ -45,8 +45,10 @@ function  result = mdsToMatlab( mdsthing )
         end
         f=str2func(dtype);
         if value.ndim > 1
-          shape=int32(py.array.array('i',py.numpy.transpose(value).shape));
-          val=py.numpy.asfortranarray(value);
+	  py_numpy_transpose=str2func('py.numpy.transpose');
+          py_numpy_asfortranarray=str2func('py.numpy.asfortranarray');
+          shape=int32(py.array.array('i',py_numpy_transpose(value).shape));
+          val=py_numpy_asfortranarray(value);
           pyarray=py.array.array(value.dtype.char,val.flat);
           result=reshape(f(py.array.array(value.dtype.char,pyarray)),shape);
         else

--- a/matlab/mdsUsePython.m
+++ b/matlab/mdsUsePython.m
@@ -14,7 +14,8 @@ function mdsUsePython( varargin )
    end
    if MDSINFO.usePython
      try
-       x=py.MDSplus.Int32(int32(1));
+       py_MDSplus_Int32=str2func('py.MDSplus.Int32');
+       x=py_MDSplus_Int32(int32(1));
      catch
          display('The python bridge to MDSplus is not available. Reverting to java brdige.')
          MDSINFO.usePython=false;

--- a/matlab/mdsconnect.m
+++ b/matlab/mdsconnect.m
@@ -22,7 +22,8 @@ function [ status ] = mdsconnect( host )
     else
       try
         if MDSINFO.usePython
-          MDSINFO.connection=py.MDSplus.Connection(host);
+	  py_MDSplus_Connection=str2func('py.MDSplus.Connection');
+          MDSINFO.connection=py_MDSplus_Connection(host);
         else
           MDSINFO.connection=javaObject('MDSplus.Connection',host);
         end

--- a/matlab/mdsvalue.m
+++ b/matlab/mdsvalue.m
@@ -42,7 +42,8 @@ function [ result, status ] = mdsvalue( expression, varargin)
       end
     else
       if info.usePython
-        result = py.MDSplus.EXECUTE(expression,args{:}).evaluate();
+        py_MDSplus_EXECUTE=str2func('py.MDSplus.EXECUTE');
+        result = py_MDSplus_EXECUTE(expression,args{:}).evaluate();
       else
         dobj=javaObject('MDSplus.Data');
         result = dobj.execute(expression, args);


### PR DESCRIPTION
On platforms such as Ubuntu18 there are incompatibilities between
the python numpy libraries and those used by matlab. This causes
memory issues and segfaults if the matlab scripts contain py functions
which loads the numpy module even if those py functions are not
executed. This fix uses str2func to reference those py functions
when defers the load until the users explicitly tries to use the
python bridge instead of the java bridge to access MDSplus.