### PR TITLE
Build: Fix promote.sh script

### DIFF
--- a/deploy/promote.sh
+++ b/deploy/promote.sh
@@ -5,16 +5,29 @@
 # Format: promote.sh git-source-dir 
 BRANCH=$1
 PROMOTE_TO=$2
-set -v
-set -e
-git checkout ${PROMOTE_TO}
-git pull
-git checkout ${BRANCH}
-git rebase -q -s ours ${PROMOTE_TO}
-set +e
-git pull -q -s recursive -X theirs 2>/dev/null
-set -e
-git status | grep "modified:" | awk '{system("git checkout '${PROMOTE_TO}' -- "$2)}'
-git status | grep "deleted by us:" | awk '{system("git rm "$4)}'
-git commit -m "Feature: Promote ${BRANCH} to ${PROMOTE_TO}"
-git push
+if ( echo $0 | grep /tmp > /dev/null )
+then
+  set -v
+  set -e
+  git checkout ${PROMOTE_TO}
+  git clean -x -f -d
+  git pull
+  git checkout ${BRANCH}
+  git pull
+  git branch -D $(whoami)-promote-${BRANCH}-${PROMOTE_TO} 2>/dev/null || :
+  git checkout ${BRANCH} -b $(whoami)-promote-${BRANCH}-${PROMOTE_TO}
+  git rebase -q -s ours ${PROMOTE_TO}
+  set +e
+  git merge stable -q -s recursive -X theirs 2>/dev/null
+  set -e
+  git status | grep "modified:" | awk '{system("git checkout '${PROMOTE_TO}' -- "$2)}'
+  git status | grep "deleted by us:" | awk '{system("git rm "$4)}'
+  git commit -a -m "Feature: Incorporate new features and fixes from ${PROMOTE_TO} branch into ${BRANCH}" 
+  git tag ${BRANCH}_release-$(git tag | grep ${PROMOTE_TO}_release\- | sort -Vr | awk -F \- '{print $2"-"$3"-"$4; exit}')
+  rm -f $0
+else
+    cp $0 /tmp/
+    /tmp/promote.sh ${BRANCH} ${PROMOTE_TO}
+fi
+
+


### PR DESCRIPTION
deploy/promote.sh script is used to create a new promotion branch
to create a pull request to essentially rebase one development branch
onto another (i.e. rebase alpha on top of stable). The script now
performs the required rebasing and merging and the end result should be
a branch with the same head as the promote to branch while retaining the
history of commits from both branches. The script needs to be copied
to /tmp and executed there to prevent the script itself being replaced
in the midst of the rebasing and merging.