### PR TITLE
Fix: Repair rpm installation scripts

### DIFF
--- a/deploy/packaging/linux.xml
+++ b/deploy/packaging/linux.xml
@@ -877,7 +877,12 @@ rm -f /etc/ld.so.conf.d/mdsplus.conf 2&gt;/dev/null
       find . -name '*\.pyc' -delete
       popd &gt;/dev/null 2&gt;&amp;1
     </post>
-    <preun>$RPM_INSTALL_PREFIX/mdsplus/rpm/removePythonModule.sh MDSplus</preun>
+    <preun>
+      if [ "$1" == "0" ]
+      then
+        $RPM_INSTALL_PREFIX/mdsplus/rpm/removePythonModule.sh MDSplus
+      fi
+    </preun>
     <!-- end rpm scripts -->
     
     <!-- deb scripts -->

--- a/deploy/platform/redhat/redhat_build_rpms.py
+++ b/deploy/platform/redhat/redhat_build_rpms.py
@@ -194,14 +194,10 @@ Buildarch: noarch
                 os.write(out,"%%exclude %s\n" % exclude)
         if package.find("exclude_staticlibs") is not None:
             os.write(out,"%%exclude /usr/local/mdsplus/lib??/*.a\n" % info)
-        for s in (("preinst","pre"),("postinst","post"),("prerm","preun"),("postrm","postun")):
-            script=package.find(s[0])
-            if script is not None and ("type" not in script.attrib or script.attrib["type"]=="rpm"):
-                os.write(out,"%%%s\n%s\n" % (s[1],script.text.replace("__INSTALL_PREFIX__","$RPM_INSTALL_PREFIX")))
-        triggerin=package.find("triggerin")
-        if triggerin is not None:
-            os.write(out,"%%triggerin -- %s\n%s\n" % (triggerin.attrib['trigger'],
-                                                       triggerin.text.replace("__INSTALL_PREFIX__","$RPM_INSTALL_PREFIX")))
+        for s in ("pre","post","preun","postun"):
+            script=package.find(s)
+            if script is not None:
+                os.write(out,"%%%s\n%s\n" % (s,script.text))
         os.close(out)
         info['specfilename']=specfilename
         print("Building rpm for mdsplus%(bname)s%(packagename)s.noarch" % info)


### PR DESCRIPTION
When splitting the debian and redhat installer scripts the build
script was inadvertently using the debian scripts for noarch packages
which led configuration changes to be removed during package updates.
On redhat the uninstall scripts of the installed package is invoked
after the updated package is installed and the redhat uninstall scripts
check an argument to determine if it is an update or a perminant package
deinstall so that it won't remove things if it is an update. The debian
packages don't have this problem. It will take a couple updates for the
fix to take effect though since the deinstall scripts of the installed
package will be invoked until the fixed scripts are added with new versions.