### PR TITLE
Feature: Add tdi based treeshr hooks

### DIFF
--- a/deploy/packaging/debian/kernel.noarch
+++ b/deploy/packaging/debian/kernel.noarch
@@ -208,6 +208,7 @@
 ./usr/local/mdsplus/tdi/treeshr/TreeSetDbiItm.fun
 ./usr/local/mdsplus/tdi/treeshr/TreeSetDefault.fun
 ./usr/local/mdsplus/tdi/treeshr/TreeSetNciItm.fun
+./usr/local/mdsplus/tdi/treeshr/TreeShrHook.fun-template
 ./usr/local/mdsplus/tdi/treeshr/TreeTurnOff.fun
 ./usr/local/mdsplus/tdi/treeshr/TreeTurnOn.fun
 ./usr/local/mdsplus/tdi/treeshr/TreeWrite.fun

--- a/deploy/packaging/redhat/kernel.noarch
+++ b/deploy/packaging/redhat/kernel.noarch
@@ -238,6 +238,7 @@
 ./usr/local/mdsplus/tdi/treeshr/TreeSetDbiItm.fun
 ./usr/local/mdsplus/tdi/treeshr/TreeSetDefault.fun
 ./usr/local/mdsplus/tdi/treeshr/TreeSetNciItm.fun
+./usr/local/mdsplus/tdi/treeshr/TreeShrHook.fun-template
 ./usr/local/mdsplus/tdi/treeshr/TreeTurnOff.fun
 ./usr/local/mdsplus/tdi/treeshr/TreeTurnOn.fun
 ./usr/local/mdsplus/tdi/treeshr/TreeWrite.fun

--- a/tdi/treeshr/TreeShrHook.fun-template
+++ b/tdi/treeshr/TreeShrHook.fun-template
@@ -10,7 +10,11 @@ public fun TreeShrHook(in _action, in _treename, in _shot, in _nid) {
   */
   _actions=["OpenTree","OpenTreeEdit","RetrieveTree","WriteTree","CloseTree",
   "OpenNciFileWrite","OpenDataFileWrite","GetData","GetNci","PutData","PutNci"];
-  _actnam=trim(_actions[_action]);
-  write(*,"TreeShrHook called with action="//_actnam//", tree="//_treename//", shot="//trim(adjustl(_shot))//", nid="//trim(adjustl(_nid)));
+  if ( _action >= 0 && _action < size(_actions) ) {
+    _actnam=trim(_actions[_action]);
+    write(*,"TreeShrHook called with action="//_actnam//", tree="//_treename//", shot="//trim(adjustl(_shot))//", nid="//trim(adjustl(_nid)));
+  } else {
+    write(*,"TreeShrHook initialize called with action="//trim(adjustl(_action)));
+  }
   return(1);
 }

--- a/tdi/treeshr/TreeShrHook.fun-template
+++ b/tdi/treeshr/TreeShrHook.fun-template
@@ -1,0 +1,16 @@
+public fun TreeShrHook(in _action, in _treename, in _shot, in _nid) {
+  /* This is a sample hook for treeshr operations. These hooks can be used for various purposes
+   such as recording tree access in a relation database, retrieving trees from offline storage when they
+   are opened, etc...
+
+   This is just a template to demonstrate when these hooks are called. It is written as a tdi fun which
+   would have to be MDS_PATH with a name such as TreeShrHook.fun. It can also be implemented as a python
+   function by writing a TreeShrHook.py module with the same function name enclosed which would be called
+   with the same arguments.
+  */
+  _actions=["OpenTree","OpenTreeEdit","RetrieveTree","WriteTree","CloseTree",
+  "OpenNciFileWrite","OpenDataFileWrite","GetData","GetNci","PutData","PutNci"];
+  _actnam=trim(_actions[_action]);
+  write(*,"TreeShrHook called with action="//_actnam//", tree="//_treename//", shot="//trim(adjustl(_shot))//", nid="//trim(adjustl(_nid)));
+  return(1);
+}

--- a/treeshr/RemoteAccess.c
+++ b/treeshr/RemoteAccess.c
@@ -368,10 +368,10 @@ int ConnectTreeRemote(PINO_DATABASE * dblist, char *tree, char *subtree_list, ch
 	  info->flush = (dblist->shotid == -1);
 	  info->header = (TREE_HEADER *) & info[1];
 	  info->treenam = strcpy(malloc(strlen(tree) + 1), tree);
-	  TreeCallHook(OpenTree, info, 0);
-	  info->channel = socket;
 	  dblist->tree_info = info;
 	  dblist->remote = 1;
+	  TreeCallHook(dblist, OpenTree, 0);
+	  info->channel = socket;
 	  status = TreeNORMAL;
 	} else
 	  status = TreeFILE_NOT_FOUND;

--- a/treeshr/TreeAddNode.c
+++ b/treeshr/TreeAddNode.c
@@ -757,7 +757,7 @@ int _TreeWriteTree(void **dbid, char const *exp_ptr, int shotid)
                 MDS_IO_LOCK(info_ptr->channel, 1, 1, MDS_IO_LOCK_RD | MDS_IO_LOCK_NOWAIT, 0);
                 status = TreeNORMAL;
                 (*dblist)->modified = 0;
-                TreeCallHook(WriteTree, info_ptr, 0);
+                TreeCallHook(*dblist, WriteTree, 0);
             } else {
                 (*dblist)->modified = 0;
                 status = TreeFCREATE;

--- a/treeshr/TreeCallHook.c
+++ b/treeshr/TreeCallHook.c
@@ -29,6 +29,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <treeshr.h>
 #include <mdsshr.h>
 #include "treeshrp.h"
+#include <tdishr_messages.h>
 #include <mds_stdarg.h>
 static int (*tdiExecute)();
 static int (*Notify) (TreeshrHookType, char *, int, int);
@@ -64,7 +65,8 @@ int TreeCallHook(PINO_DATABASE *dbid, TreeshrHookType htype, int nid)
     int status = (*tdiExecute) (&expression_d, &ans_d,  MdsEND_ARG);
     MdsFree1Dx(&ans_d,NULL);
     old_dbid = TreeSwitchDbid(old_dbid);
-    return status;
+    if (status != TdiUNKNOWN_VAR)
+      return status;
   }
   return 1;
 }

--- a/treeshr/TreeCleanDatafile.c
+++ b/treeshr/TreeCleanDatafile.c
@@ -67,8 +67,10 @@ STATIC_ROUTINE int RewriteDatafile(char *tree, int shot, int compress)
     TREE_INFO *info1 = dblist1->tree_info;
     status = TreeOpenNciW(dblist1->tree_info, 0);
     if STATUS_OK {
+      TreeCallHook(dblist1, OpenNCIFileWrite, 0);
       status = TreeOpenDatafileW(dblist1->tree_info, &stv, 0);
       if STATUS_OK {
+	TreeCallHook(dblist1, OpenDataFileWrite, 0);
 	status = _TreeOpenEdit(&dbid2, tree, shot);
 	if STATUS_OK {
 	  pthread_cleanup_push(treeclose,&dbid2);

--- a/treeshr/TreeGetNci.c
+++ b/treeshr/TreeGetNci.c
@@ -50,7 +50,7 @@ static inline int minInt(int a, int b) { return a < b ? a : b; }
  if (nci_version != version)\
  {\
     nid_to_tree_nidx(dblist, (&nid), info, node_number);\
-    status = TreeCallHook(GetNci,info,nid_in);\
+    status = TreeCallHook(dblist, GetNci, nid_in);	\
     if (status && STATUS_NOT_OK) break;\
     status = TreeGetNciW(info, node_number, &nci,version);\
     if STATUS_OK nci_version = version;\

--- a/treeshr/TreeGetRecord.c
+++ b/treeshr/TreeGetRecord.c
@@ -66,7 +66,7 @@ int _TreeGetRecord(void *dbid, int nid_in, struct descriptor_xd *dsc)
     return GetRecordRemote(dblist, nid_in, dsc);
   nid_to_tree_nidx(dblist, nid, info, nidx);
   if (info) {
-    status = TreeCallHook(GetNci, info, nid_in);
+    status = TreeCallHook(dblist, GetNci, nid_in);
     if (status && STATUS_NOT_OK)
       return 0;
     status = TreeOpenDatafileR(info);
@@ -74,7 +74,7 @@ int _TreeGetRecord(void *dbid, int nid_in, struct descriptor_xd *dsc)
       status = TreeGetNciW(info, nidx, &nci, 0);
       if STATUS_OK {
 	if (nci.length) {
-	  status = TreeCallHook(GetData, info, nid_in);
+	  status = TreeCallHook(dblist, GetData, nid_in);
 	  if (status && STATUS_NOT_OK)
 	    return 0;
 	  switch (nci.class) {

--- a/treeshr/TreePutRecord.c
+++ b/treeshr/TreePutRecord.c
@@ -141,7 +141,7 @@ int _TreePutRecord(void *dbid, int nid, struct descriptor *descriptor_ptr, int u
     int stv;
     NCI local_nci, old_nci;
     int64_t saved_viewdate;
-    status = TreeCallHook(PutData, info_ptr, nid);
+    status = TreeCallHook(dblist, PutData, nid);
     if (status && !(status & 1))
       return status;
     TreeGetViewDate(&saved_viewdate);
@@ -150,8 +150,11 @@ int _TreePutRecord(void *dbid, int nid, struct descriptor *descriptor_ptr, int u
       unlock_nci_needed = 1;
     TreeSetViewDate(&saved_viewdate);
     memcpy(&old_nci, &local_nci, sizeof(local_nci));
-    if (info_ptr->data_file ? (!info_ptr->data_file->open_for_write) : 1)
+    if (info_ptr->data_file ? (!info_ptr->data_file->open_for_write) : 1) {
       open_status = TreeOpenDatafileW(info_ptr, &stv, 0);
+      if (open_status & 1)
+        TreeCallHook(dblist, OpenDataFileWrite, 0);
+    }
     else
       open_status = 1;
     if (local_nci.flags2 & NciM_EXTENDED_NCI) {
@@ -425,8 +428,6 @@ int _TreeOpenDatafileW(TREE_INFO * info, int *stv_ptr, int tmpfile)
     df_ptr = NULL;
   }
   info->data_file = df_ptr;
-  if (status & 1)
-    TreeCallHook(OpenDataFileWrite, info, 0);
   return status;
 }
 

--- a/treeshr/TreeSegments.c
+++ b/treeshr/TreeSegments.c
@@ -315,7 +315,7 @@ inline static int open_datafile_write0(vars_t* vars) {
   RETURN_IF_NOT_OK(load_node_ptr(vars));
   RETURN_IF_NOT_OK(check_segment_remote(vars));
   RETURN_IF_NOT_OK(load_info_ptr(vars));
-  status = TreeCallHook(PutData, vars->tinfo, *(int*)vars->nid_ptr);
+  status = TreeCallHook(vars->dblist, PutData, *(int*)vars->nid_ptr);
   if (status && STATUS_NOT_OK)
     return status;
   TreeGetViewDate(&vars->saved_viewdate);
@@ -338,8 +338,12 @@ inline static int open_datafile_write0(vars_t* vars) {
 }
 
 inline static int open_datafile_write1(vars_t* vars){
-  if (vars->tinfo->data_file ? (!vars->tinfo->data_file->open_for_write) : 1)
-     return TreeOpenDatafileW(vars->tinfo, &vars->stv, 0);
+  if (vars->tinfo->data_file ? (!vars->tinfo->data_file->open_for_write) : 1) {
+     int status = TreeOpenDatafileW(vars->tinfo, &vars->stv, 0);
+     if (STATUS_OK && (vars->dblist != NULL))
+       TreeCallHook(vars->dblist, OpenDataFileWrite, 0);
+     return status;
+  }
   return TreeSUCCESS;
 }
 

--- a/treeshr/TreeSetNci.c
+++ b/treeshr/TreeSetNci.c
@@ -126,7 +126,7 @@ int _TreeSetNci(void *dbid, int nid_in, NCI_ITM * nci_itm_ptr)
   nid_to_tree_nidx(dblist, nid_ptr, tree_info, node_number);
   if (!tree_info)
     return TreeNNF;
-  status = TreeCallHook(PutNci, tree_info, nid_in);
+  status = TreeCallHook(dblist, PutNci, nid_in);
   if (status && !(status & 1))
     return status;
   status = TreeGetNciLw(tree_info, node_number, &nci);
@@ -414,8 +414,6 @@ int _TreeOpenNciW(TREE_INFO * info, int tmpfile)
       info->edit->first_in_mem = (int)MDS_IO_LSEEK(info->nci_file->put, 0, SEEK_END) / 42;
     }
   }
-  if (status & 1)
-    TreeCallHook(OpenNCIFileWrite, info, 0);
   return status;
 }
 

--- a/treeshr/treeshrp.h
+++ b/treeshr/treeshrp.h
@@ -754,7 +754,7 @@ extern struct descriptor *TreeSectionName(TREE_INFO * info);
 extern int TreeFindTag(const char *tagnam, const char *treename, int *tagidx);
 int _TreeFindTag(PINO_DATABASE * db, NODE * default_node, short treelen, const char *tree,
 		 short taglen, const char *tagnam, NODE ** nodeptr, int *tagidx);
-extern int TreeCallHook(TreeshrHookType operation, TREE_INFO * info, int nid);
+extern int TreeCallHook(PINO_DATABASE *db, TreeshrHookType operation, int nid);
 extern void _TreeDeleteNodesWrite(void *dbid);
 extern void _TreeDeleteNodesDiscard(void *dbid);
 extern int TreeGetDatafile(TREE_INFO * info_ptr, unsigned char *rfa, int *buffer_size, char *record,


### PR DESCRIPTION
This change will enable the implementation of tdi based
treeshr hooks which could be implemented in either tdi
or python. Like the C based hooks the tdi TreeShrHook() function
would be called with a action id, a treename, a shot number and a
node number (nid). A TreeShrHook.fun-template is included to
demonstrate how it is called during various tree operations.

The code will first try to call the C based implementation and if
there is no hooks library it will try the tdi based hooks.

This should implement the feature request:

https://github.com/MDSplus/mdsplus/issues/1349