### PR TITLE
Feature: Allow array of commands passed to tcl function

### DIFF
--- a/tdi/tcl/Tcl.fun
+++ b/tdi/tcl/Tcl.fun
@@ -2,19 +2,31 @@ public fun Tcl(in _command, optional out _output, optional out _error)
 {
   _outp = present(_output);
   _errp = present(_error);
-  _cmd = "set command tcl";
-  if (_outp) {
+  _cmd = ["set command tcl",_command];
+  if (_outp || _errp) {
     _output="";
     _error="";
-    _status = Mdsdcl->mdsdcl_do_command_dsc(_cmd, xd(_error), xd(_output));
-    if (_status & 1)
-      _status =  Mdsdcl->mdsdcl_do_command_dsc(_command, xd(_error),  xd(_output));
-    if (!_errp)
-      _output=_output//_error;
-  } else {
-    _status = Mdsdcl->mdsdcl_do_command_dsc(_cmd, val(0), val(0));
-    if (_status & 1)
-      _status =  Mdsdcl->mdsdcl_do_command_dsc(_command, val(0),  val(0));
-  }  
+    _append=0;
+  }
+  for (_line=0; _line < size(_cmd); _line++) {
+    if (_outp) {
+      _out="";
+      _err="";
+      _status =  Mdsdcl->mdsdcl_do_command_dsc(_cmd[_line], xd(_err),  xd(_out));
+      if (!_errp)
+      	 _out=_out//_err;
+      if (_append == 0)
+         _output=_out;
+      else
+         _output=[_output, _out];
+      if (_append == 0)
+         _error=_err;
+      else
+         _error=[_error,_err];
+      _append=1;
+    } else {
+      _status = Mdsdcl->mdsdcl_do_command_dsc(_cmd[_line], val(0), val(0));
+    }
+  }
   return(_status);
 }

--- a/tdi/tcl/Tcl.fun
+++ b/tdi/tcl/Tcl.fun
@@ -15,11 +15,11 @@ public fun Tcl(in _command, optional out _output, optional out _error)
       _status =  Mdsdcl->mdsdcl_do_command_dsc(_cmd[_line], xd(_err),  xd(_out));
       if (!_errp)
       	 _out=_out//_err;
-      if (_append == 0)
+      if (_append == 0 || size(_command) == 1)
          _output=_out;
       else
          _output=[_output, _out];
-      if (_append == 0)
+      if (_append == 0 || size(_command) == 1)
          _error=_err;
       else
          _error=[_error,_err];

--- a/tditest/testing/test-tcl.ans
+++ b/tditest/testing/test-tcl.ans
@@ -272,9 +272,28 @@ This tree has been modified. Either use the WRITE
 command before closing to save modifications or
 use CLOSE/CONFIRM to discard changes.
 
-mdsdcl: --> failed on line 'close'
+mdsdcl: --> failed on line 'close          '
 265388378
 Tcl('set tree main')
 265388041
 Tcl('delete pulse 1')
 1
+_status=Tcl(['set tree main','dir','close'],_out,_err)
+265388041
+write(*,"output=",_out,"error=",_err),_status 
+output=
+                                                                                                                       
+                                                                                                                       
+
+\MAIN::TOP
+
+ :MEMBER       :NUMERIC      :SIGNAL       :TEXT        
+
+  CHILD         SUBTREE     
+
+Total of 6 nodes.
+
+                                                                                                                       
+error=
+
+265388041

--- a/tditest/testing/test-tcl.tdi
+++ b/tditest/testing/test-tcl.tdi
@@ -80,3 +80,5 @@ Tcl('quit')
 Tcl('close')
 Tcl('set tree main')
 Tcl('delete pulse 1')
+_status=Tcl(['set tree main','dir','close'],_out,_err)
+write(*,"output=",_out,"error=",_err),_status 


### PR DESCRIPTION
In addition to passing a single command to the TDI function called Tcl
you can now pass a string array of commands to execute in a single
call to the function. For example:

    tcl(['set tree mytree','put mynode 42','close tree mytree'])