### PR TITLE
Fix: Handle DTYPE_SLOPE in python

### DIFF
--- a/mdsobjects/python/compound.py
+++ b/mdsobjects/python/compound.py
@@ -409,6 +409,14 @@ class Routine(Compound):
     dtype_id=205
 _dsc.addDtypeToClass(Routine)
 
+class Slope(Compound):
+    """A Slope is a deprecated object. You should use Range instead."""
+    fields=('slope','begin','end')
+    dtype_id=198
+    def slice(self):
+        return slice(self.begin.data(),self.end.data(),self.slope.data())
+_dsc.addDtypeToClass(Slope)
+
 class Signal(Compound):
     """A Signal is used to describe a measurement, usually time dependent, and associated the data with its independent
     axis (Dimensions). When Signals are indexed using s[idx], the index is resolved using the dimension of the signal

--- a/mdsobjects/python/mdsscalar.py
+++ b/mdsobjects/python/mdsscalar.py
@@ -43,18 +43,20 @@ class Scalar(_dat.Data):
     def _setTree(self,*a,**kw): return self;
 
     def __new__(cls,*value):
-        if cls is not Scalar or len(value)==0:
+        if len(value)==0:
             return object.__new__(cls)
         value = value[0]
+        if isinstance(value,(_arr.Array,list,tuple,_ver.generator,_ver.mapclass,_ver.nparray)):
+            key = cls.__name__+'Array'
+            if key in _arr.__dict__:
+                cls = _arr.__dict__[key]
+                return cls(value)
+        if cls is not Scalar:
+            return object.__new__(cls)
         if isinstance(value,(Scalar,)):
             return value
         if isinstance(value,_dat.Data):
             value = value.data()
-        if (isinstance(value,_arr.Array)) or isinstance(value,list) or isinstance(value, _ver.nparray):
-            key = cls.__name__+'Array'
-            if key in _arr.__dict__:
-                cls = _arr.__dict__[key]
-                return cls.__new__(cls,value)
         if isinstance(value,(_ver.npbytes, _ver.npunicode,_ver.basestring)):
             cls = String
         elif isinstance(value,(_N.bool_,)):

--- a/mdsobjects/python/tests/dataUnitTest.py
+++ b/mdsobjects/python/tests/dataUnitTest.py
@@ -150,6 +150,7 @@ class Tests(TestCase):
         a.append(f) # a should keep tree of e
         self.assertEqual(a.tree,e.tree)
         self.assertEqual(a[1].tree,f.tree)
+        self._doUnaryArray(m.Int32(range(10)),m.Int32Array(range(10)),'Int32(range(10))')
 
     def scalars(self):
         def doTest(suffix,cl,scl,ucl,**kw):


### PR DESCRIPTION
This change restores proper handling of the DTYPE_SLOPE data type. It also restores the ability to create array data types in python using statements such as x=Int32(range(100)) which used to and will now return an Int32Array instance in python.