### PR TITLE
Fix: enable data(build_slope(...)) in tdi

### DIFF
--- a/tditest/testing/test-tdishr.ans
+++ b/tditest/testing/test-tdishr.ans
@@ -6179,6 +6179,8 @@ X_TO_I(BUILD_DIM(BUILD_WINDOW(2,5,1.1),BUILD_RANGE(,,3)))
 Set_Range(2:5,[2,3,4,5])
 X_TO_I(BUILD_DIM(BUILD_WINDOW(2,7,1.1),BUILD_RANGE(,,3)),[4.1,7.1,10.1,13.1])
 [1.,2.,3.,4.]
+data(BUILD_SLOPE(.1,0.,1.,.2,1.2,2.))
+[0.,.1,.2,.3,.4,.5,.6,.7,.8,.9,1.,1.2,1.4,1.6,1.8,2.]
 _x=build_signal(10*$VALUE,1:10,*)
 Build_Signal(10 * $VALUE, 1 : 10, *)
 long(_x)

--- a/tditest/testing/test-tdishr.tdi
+++ b/tditest/testing/test-tdishr.tdi
@@ -3022,6 +3022,10 @@ I_TO_X(BUILD_DIM(BUILD_WINDOW(2,7,1.1),BUILD_RANGE(,,3)),1:4)
 X_TO_I(BUILD_DIM(BUILD_WINDOW(2,5,1.1),BUILD_RANGE(,,3)))
 X_TO_I(BUILD_DIM(BUILD_WINDOW(2,7,1.1),BUILD_RANGE(,,3)),[4.1,7.1,10.1,13.1])
 !
+! Functions implemented in TdiGetData.c
+!
+data(BUILD_SLOPE(.1,0.,1.,.2,1.2,2.))
+!
 ! Miscellaneous
 !
 _x=build_signal(10*$VALUE,1:10,*)


### PR DESCRIPTION
Although the DTYPE_SLOPE data type has been deprecated for years they can
still be encountered in tree datafiles. It was discovered that attempting
to convert a DTYPE_SLOPE into an array of values by doing operations
such as: data(build_slope(.1,0.,1.))
caused a segfault in tditest. This fix should prevent this segfault
and return an array of values if the DTYPE_SLOPE contains values for the
increment, begin and end arguments for all of the slope segments.