### PR TITLE
Fix: ssh for Windows add username if not specified; passwd and ppk auth

### DIFF
--- a/mdstcpip/mdsip-client-ssh.bat
+++ b/mdstcpip/mdsip-client-ssh.bat
@@ -1,9 +1,37 @@
-echo off
-ssh /? >nul 2>&1
-if %errorlevel% == 9009 goto use_plink
-  ssh %1 %2
+@ECHO OFF
+REM GOTO:use_plink
+
+REM test if OpenSSH is available
+ssh 1>NUL 2>NUL
+IF %ERRORLEVEL% == 9009 GOTO:use_plink
+
+:use_ssh
+ssh %1 "/bin/sh -l -c %2"
+GOTO:done
+
 :use_plink
-  plink --help >nul 2>&1
-  if %errorlevel% == 9009 goto done
-    plink -agent -batch %1 "/bin/sh -l -c  %2"
+REM add current user if not specified in %1
+SETLOCAL EnableDelayedExpansion
+SET SERVER=%1
+IF "%SERVER:@=%" == "%SERVER%" SET SERVER=%USERNAME%@%SERVER%
+
+REM if the server does not support publickey define PASSWD
+IF DEFINED PASSWD  GOTO:use_plink_pw
+REM allows the specification of a key file (*.ppk) for authentication
+IF DEFINED SSH2RSA GOTO:use_plink_ssh2rsa
+REM otherwise, use agent
+GOTO:use_plink_agent
+
+:use_plink_pw
+plink -pw %PASSWD% -batch %SERVER% "/bin/sh -l -c %2"
+GOTO:done
+
+:use_plink_ssh2rsa
+plink -i %SSH2RSA% -batch %SERVER% "/bin/sh -l -c %2"
+GOTO:done
+
+:use_plink_agent
+plink -agent -A -batch %SERVER% "/bin/sh -l -c %2"
+GOTO:done
+
 :done


### PR DESCRIPTION
add a few more options to the windows mdsip-client-ssh

* ssh /h is not syntax of OpenSSH
* ssh was missing "/bin/sh -l -c"
* plink does not automatically choose username and we cannot use prompt
* plink can use env:SSH2RSA *.ppk file to authenticate
* plink can use env:PASSWD to authenticate
* plink agent should try to forward agent