### PR TITLE
Fix: Repair compilation of paths referencing nodes not yet added.

### DIFF
--- a/treeshr/TreeFindNode.c
+++ b/treeshr/TreeFindNode.c
@@ -702,7 +702,7 @@ STATIC_ROUTINE char *AbsPath(void *dbid, char const *inpath, int nid_in)
     }
     else {
       char *treename = Treename(dblist, nid_in);
-      char *answer = (char *)malloc(strlen(treename) + strlen(pathptr) + 2 + 1);
+      answer = (char *)malloc(strlen(treename) + strlen(pathptr) + 2 + 1);
       strcpy(answer, "\\");
       strcat(answer, treename);
       strcat(answer, "::");


### PR DESCRIPTION
This fixes a problem that occurs when an expression is compiled
that references a node that does not yet exist. A change to the code
prevented the code from returning a TREE_PATH data type for the referenced
node.