### PR TITLE
Feature: Speed up getting python treeNodeArray attributes

### DIFF
--- a/mdsobjects/python/tree.py
+++ b/mdsobjects/python/tree.py
@@ -3003,6 +3003,9 @@ class TreeNodeArray(_arr.Int32Array): # HINT: TreeNodeArray begin
         return self.usage
 
     def __getattr__(self,name):
+      try:
+          return self.tree.tdiExecute('getnci($,$)',self._value,name)
+      except:
         ans=[]
         for node in self:
             val = node.__getattribute__(name)


### PR DESCRIPTION
When you request node attributes for a TreeNodeArray instance the
existing code builds the answer by appending to a python list and
then converts the list to an array. This upgrade uses tdishr to
retrieve the attributes and return an array which is orders of
magnetude more efficient.