### PR TITLE
Feature: print traceback on PY-E-UNHANDLED_EXCEPTION

### DIFF
--- a/tdi/dev_support/PyDoMethod.py
+++ b/tdi/dev_support/PyDoMethod.py
@@ -60,5 +60,6 @@ def PyDoMethod(n,method,*args):
         raise
     except Exception as exc:
         stderr.write("Python error in %s.%s:\n%s\n\n" % (model,method,str(exc)))
+        import traceback
+        traceback.print_exc()
         raise PyUNHANDLED_EXCEPTION
-


### PR DESCRIPTION
PY-E-UNHANDLED_EXCEPTION advises to look in the log for details. This will print the details.