### PR TITLE
Fix: Remove all references to MdsRoutinePrefix in idl routines

### DIFF
--- a/idl/mdsdisconnect.pro
+++ b/idl/mdsdisconnect.pro
@@ -1,5 +1,5 @@
 pro mdsdisconnect,status=status,quiet=quiet, socket=socket
-  forward_function mds$socket, MdsIPImage, MdsRoutinePrefix
+  forward_function mds$socket, MdsIPImage
   image = MdsIPImage()
   status = 1
   if keyword_set(socket) then $
@@ -7,7 +7,7 @@ pro mdsdisconnect,status=status,quiet=quiet, socket=socket
   else $
     sock = mds$socket(status=status,quiet=quiet)
   if status then begin
-    status = call_external(image,MdsRoutinePrefix()+'DisconnectFromMds',sock,value=[1b])
+    status = call_external(image,'DisconnectFromMds',sock,value=[1b])
     if (status eq 0) then status = 1 else status = 0
     if not keyword_set(socket) then $
       !MDS_SOCKET = -1l

--- a/idl/mdslogin.pro
+++ b/idl/mdslogin.pro
@@ -29,14 +29,14 @@
 
 pro MdsLogin,user,password,quiet=quiet,status=status
 
-  forward_function mdsIsClient,mdsIdlImage,mds$socket,MdsRoutinePrefix,MdsIPImage,IsWindows
+  forward_function mdsIsClient,mdsIdlImage,mds$socket,MdsIPImage,IsWindows
 
   if (mdsIsClient()) then begin
 
     ON_ERROR,2                  ;RETURN TO CALLER IF ERROR
     sock = mds$socket(quiet=quiet,status=status)
     if not status then return
-    status = call_external(MdsIPImage(),MdsRoutinePrefix()+'MdsLogin',sock,string(user),string(password),value=[1b,byte([1,1] * (not IsWindows()))])
+    status = call_external(MdsIPImage(),'MdsLogin',sock,string(user),string(password),value=[1b,byte([1,1] * (not IsWindows()))])
     if not status then begin
       if keyword_set(quiet) then message,mdsgetmsg(status,quiet=quiet),/continue,/noprint $
                             else message,mdsgetmsg(status,quiet=quiet),/continue

--- a/idl/mdsvalue.pro
+++ b/idl/mdsvalue.pro
@@ -47,7 +47,7 @@
 
 function MdsValue,expression,arg1,arg2,arg3,arg4,arg5,arg6,arg7,arg8,arg9,arg10,arg11,arg12,arg13,arg14,arg15,arg16,quiet=quiet,status=status,socket=socket
 
-  forward_function mdsIsClient,mdsIdlImage,mds$socket,MdsRoutinePrefix,MdsIPImage,MdsGetAnsFN,evaluate
+  forward_function mdsIsClient,mdsIdlImage,mds$socket,MdsIPImage,MdsGetAnsFN,evaluate
   MdsCheckArg,expression,type="STRING",name="expression"
   ;; note that MdsIpShr version of MdsValue had 32 arguments in addition
   ;; to expression
@@ -78,7 +78,7 @@ function MdsValue,expression,arg1,arg2,arg3,arg4,arg5,arg6,arg7,arg8,arg9,arg10,
     ansptr = 0l
 ;Not sure here... hope Mac acts like others, if not maybe try OSF way
     if !version.memory_bits eq 64 then ansptr = 0ll 
-;;;;  status = call_external(MdsIPImage(),MdsRoutinePrefix()+'GetAnsInfo',sock,dtype,length,ndims,dims,numbytes,ansptr,value=[1,0,0,0,0,0,0])
+;;;;  status = call_external(MdsIPImage(),'GetAnsInfo',sock,dtype,length,ndims,dims,numbytes,ansptr,value=[1,0,0,0,0,0,0])
 ;;; temporary fix Jeff Schachte 98.05.13
     status = call_external(MdsIPImage(),'IdlGetAnsInfo',sock,dtype,length,ndims,dims,numbytes,ansptr,value=[1,0,0,0,0,0,0])
     if numbytes gt 0 then begin


### PR DESCRIPTION
The MdsRoutinePrefix fnuction was used for VMS compatibility and
was removed but references to the function was still present
in other functions. This removes those references.

This should fix https://github.com/MDSplus/mdsplus/issues/1378