### PR TITLE
Fix: Allow the use of MdsException(string) in python

### DIFF
--- a/deploy/build.sh
+++ b/deploy/build.sh
@@ -23,7 +23,7 @@ SYNOPSIS
                [--distname=name] [--updatepkg] [--eventport=number]
                [--arch=name] [--color] [--winhost=hostname]
                [--winbld=dir] [--winrembld=dir] [--gitcommit=commit]
-               [--jars-dir=dir] [--make-jars] [--docker-srcdir=dir]
+               [--jars] [--make-jars] [--docker-srcdir=dir]
 
 DESCRIPTION
     The build.sh script is used for building, testing and deploy MDSplus
@@ -193,7 +193,7 @@ OPTIONS
     --gitcommit=commit
        Set by trigger jenkins job representing the commit hash of the sources.
 
-    --jars-dir=dir
+    --jars
        Set by trigger job to indicate that build job should get the java jar
        files from the trigger source directory instead of building them.
 
@@ -382,8 +382,8 @@ parsecmd() {
 	    --gitcommit=*)
 		GIT_COMMIT="${i#*=}"
 		;;
-	    --jars-dir=*)
-		JARS_DIR="$(realpath ${i#*=})"
+	    --jars)
+		JARS_DIR="$(realpath $(dirname ${0})/../jars)"
 		;;
 	    --make-jars)
 		MAKE_JARS="yes"

--- a/deploy/trigger.sh
+++ b/deploy/trigger.sh
@@ -42,7 +42,7 @@ OPTIONS
        This will make the directory if necessary, cd to that directory and run
        configure --enable-java_only and build the java jars in that directory
        tree. This is used to build the jar files once and then trigger the
-       platform builds with a --jars_dir=directory option so platform builds
+       platform builds with a --jars option so platform builds
        can just cp the jar files from the trigger directory location.
 
    --make_epydocs
@@ -153,7 +153,7 @@ parsecmd() {
 		;;
 	    --make_jars=*)
 		MAKE_JARS=${i#*=}
-		opts="${opts} --jars-dir=${SRCDIR}/jars"
+		opts="${opts} --jars"
 		;;
 	    --make_epydocs)
 		MAKE_EPYDOCS=yes

--- a/mdsobjects/python/mdsExceptions.py
+++ b/mdsobjects/python/mdsExceptions.py
@@ -32,7 +32,10 @@
 #     python gen_devices.py
 ########################################################
 
-class MDSplusException(Exception):
+class MdsException(Exception):
+  pass
+
+class MDSplusException(MdsException):
   fac="MDSplus"
   statusDict={}
   severities=["W", "S", "E", "I", "F", "?", "?", "?"]

--- a/mdsobjects/python/mdsdata.py
+++ b/mdsobjects/python/mdsdata.py
@@ -36,7 +36,6 @@ _dsc=_mimport('descriptor')
 _exc=_mimport('mdsExceptions')
 
 MDSplusException = _exc.MDSplusException
-MdsException = MDSplusException
 #### Load Shared Libraries Referenced #######
 #
 _MdsShr=_ver.load_library('MdsShr')

--- a/mdsshr/gen_messages.py
+++ b/mdsshr/gen_messages.py
@@ -138,7 +138,10 @@ f_py.write("""#
 #     python gen_devices.py
 ########################################################
 
-class MDSplusException(Exception):
+class MdsException(Exception):
+  pass
+
+class MDSplusException(MdsException):
   fac="MDSplus"
   statusDict={}
   severities=["W", "S", "E", "I", "F", "?", "?", "?"]


### PR DESCRIPTION
The definition of the MdsException class in python was changed
to be equivalent to the MDSplusException class which is used to
create exceptions from numeric status codes which are returned by
MDSplus C functions. This prevents the ability for applications
to create MdsExceptions using a string argument. This change
makes MdsException a subclass of Exception and the MDSplusException
class be a subclass of MdsException.

This should fix: https://github.com/MDSplus/mdsplus/issues/1388