### PR TITLE
Feature: Allow MDS_DEVICES environment to identify device list

### DIFF
--- a/tdi/dev_support/MDSDEVICES.py
+++ b/tdi/dev_support/MDSDEVICES.py
@@ -1,26 +1,64 @@
 from threading import Lock
-from time import time
-cache = [None]  
-lock = Lock() # locks the cache
+from os import getenv
+
+cache = [None]
+lock = Lock()  # locks the cache
+
+
 def MDSDEVICES():
-  with lock:
-   if cache[0] is None:
-    from MDSplus import Device,tdi,version
-    from numpy import array
-    def importDevices(name):
-        bname = version.tobytes(name)
-        try:
-            module = __import__(name)
-            ans = [[version.tobytes(k),bname] for k,v in module.__dict__.items() if isinstance(v,int.__class__) and issubclass(v,Device)]
-        except (ImportError, ImportWarning): ans = []
-        tdidev = tdi("if_error(%s(),*)"%name)
-        if tdidev is None: return ans
-        tdidev = [[k.rstrip(), v.rstrip()] for k,v in tdidev.value.reshape((int(tdidev.value.size/2),2)).tolist()]
-        return tdidev+ans
-    ans = [[version.tobytes(d),b'pydevice'] for d in Device.findPyDevices()]
-    for module in ["KbsiDevices","MitDevices","RfxDevices","W7xDevices"]:
-        ans += importDevices(module)
-    ans = array(list(dict(ans).items()))
-    ans.view('%s,%s'%(ans.dtype,ans.dtype)).sort(order=['f0'], axis=0)
-    cache[0] = ans
-   return cache[0]
+    # let "with" statement do the aquire() and release() methods on lock
+    with lock:
+        if cache[0] is None:
+            from MDSplus import Device, tdi, version
+            from numpy import array
+
+            def importDevices(name):
+                bname = version.tobytes(name)
+                # import Python module and search for Device classes
+                try:
+                    module = __import__(name)
+                    # go through components of module to find Devices
+                    ans = [[version.tobytes(k), bname]
+                           for k, v in module.__dict__.items()
+                           if isinstance(v, int.__class__)
+                           and issubclass(v, Device)]
+                except (ImportError, ImportWarning):
+                    ans = []
+                # call TDI device function
+                tdidev = tdi("if_error(%s(), *)" % name)
+                # if TDI device function fails, return ans
+                if tdidev is None:
+                    return ans
+                # parse TDI devices from function call (stripping right spaces)
+                tdidev = [[k.rstrip(), v.rstrip()]
+                          for k, v in
+                          tdidev.value.reshape((int(tdidev.value.size/2),
+                                               2)).tolist()]
+                # concatenate TDI and Python Devices
+                return tdidev + ans
+
+            # start with Python Devices from Device class
+            ans = [[version.tobytes(d), b'pydevice']
+                   for d in Device.findPyDevices()]
+
+            # go through the TDI functions for all devices
+            # if MDS_DEVICES environment name is defined containing
+            # colon delimited device directories look in those directories
+            # for devices.
+            try:
+                modules=getenv('MDS_DEVICES').split(':')
+            except AttributeError:
+                modules=["KbsiDevices","MitDevices","RfxDevices","W7xDevices"]
+            for module in modules:
+                ans += importDevices(module)
+
+            # clean up ans, sort, and return
+            ans = array(list(dict(ans).items()))
+            ans.view('%s, %s' % (ans.dtype, ans.dtype)).sort(order=['f0'],
+                                                             axis=0)
+            cache[0] = ans
+        return cache[0]
+
+
+if __name__ == "__main__":
+    print(MDSDEVICES())


### PR DESCRIPTION
MDS_DEVICES can now be used to add site specific devices. You
can specify a colon delimited list of tdi functions that will
return lists of devices. If there is no MDS_DEVICES environment
variable defined it will default to including only the default
MDSplus devices defined by KbsiDevices(), MitDevices(), RfxDevices()
and W7xDevices(). If you have a local device list you could
define MDS_DEVICES to something like "mydevices:MitDevices" and your
supported device list would include your devices and the devices
listed in the MITDEVICES.fun. All python device implementations
will still be found based on the MDS_PYDEVICE_PATH environment variable
which contains a semi-colon delimited list of directories containing
device support modules.