### PR TITLE
Feature: Allow MDS_DEVICES environment to identify device list

### DIFF
--- a/tdi/dev_support/MDSDEVICES.py
+++ b/tdi/dev_support/MDSDEVICES.py
@@ -5,7 +5,7 @@ lock = Lock() # locks the cache
 def MDSDEVICES():
   with lock:
    if cache[0] is None:
-    from MDSplus import Device,tdi,version
+    from MDSplus import Device,tdi,version,getenv
     from numpy import array
     def importDevices(name):
         bname = version.tobytes(name)
@@ -18,7 +18,12 @@ def MDSDEVICES():
         tdidev = [[k.rstrip(), v.rstrip()] for k,v in tdidev.value.reshape((int(tdidev.value.size/2),2)).tolist()]
         return tdidev+ans
     ans = [[version.tobytes(d),b'pydevice'] for d in Device.findPyDevices()]
-    for module in ["KbsiDevices","MitDevices","RfxDevices","W7xDevices"]:
+    mdsdevs=getenv('MDS_DEVICES')
+    if mdsdevs is not None:
+      modules=mdsdevs.split(':')
+    else:
+      modules=["KbsiDevices","MitDevices","RfxDevices","W7xDevices"]
+    for module in modules:
         ans += importDevices(module)
     ans = array(list(dict(ans).items()))
     ans.view('%s,%s'%(ans.dtype,ans.dtype)).sort(order=['f0'], axis=0)


### PR DESCRIPTION
MDS_DEVICES can now be used to add site specific devices. You
can specify a colon delimited list of tdi functions that will
return lists of devices. If there is no MDS_DEVICES environment
variable defined it will default to including only the default
MDSplus devices defined by KbsiDevices(), MitDevices(), RfxDevices()
and W7xDevices(). If you have a local device list you could
define MDS_DEVICES to something like "mydevices:MitDevices" and your
supported device list would include your devices and the devices
listed in the MITDEVICES.fun. All python device implementations
will still be found based on the MDS_PYDEVICE_PATH environment variable
which contains a semi-colon delimited list of directories containing
device support modules.