### PR TITLE
Fix: removed unnecessary decompression in ReadSegment

### DIFF
--- a/treeshr/TreeSegments.c
+++ b/treeshr/TreeSegments.c
@@ -1079,13 +1079,8 @@ static int ReadSegment(TREE_INFO* tinfo, int nid, SEGMENT_HEADER* shead, SEGMENT
       for (i = 0; i < ans.dimct; i++)
         ans.arsize *= ans.m[i];
       if (compressed_segment) {
-        EMPTYXD(compressed_segment_xd);
         int data_length = sinfo->rows & 0x7fffffff;
-        status = TreeGetDsc(tinfo, nid, sinfo->data_offset, data_length, &compressed_segment_xd);
-        if STATUS_OK {
-          status = MdsDecompress((struct descriptor_r *)compressed_segment_xd.pointer, segment);
-          MdsFree1Dx(&compressed_segment_xd, 0);
-        }
+        status = TreeGetDsc(tinfo, nid, sinfo->data_offset, data_length, segment);
       } else {
         ans_ptr = ans.pointer = ans.a0 = malloc(ans.arsize);
         status = ReadProperty(tinfo,sinfo->data_offset, ans.pointer, (ssize_t)ans.arsize);

--- a/treeshr/TreeSegments.c
+++ b/treeshr/TreeSegments.c
@@ -2066,15 +2066,20 @@ int TreeGetTimeContext(struct descriptor_xd *start, struct descriptor_xd *end, s
 }
 
 static int getOpaqueList(void *dbid, int nid, struct descriptor_xd *out) {
+  {
+    unsigned char data_type;
+    NCI_ITM itmlst[] = { {1, NciDTYPE, &data_type, 0},{0, NciEND_OF_LIST, 0, 0}};
+    int status = _TreeGetNci(dbid, nid, itmlst);
+    if STATUS_NOT_OK return status;
+    if (data_type != DTYPE_OPAQUE) return 0;
+  }
   INIT_VARS;
-  int isOpList=0;
   EMPTYXD(segdata);
   EMPTYXD(segdim);
   status = _TreeGetSegment(dbid, nid, 0, &segdata, &segdim);
-  isOpList = segdata.pointer && (segdata.pointer->dtype == DTYPE_OPAQUE);
   MdsFree1Dx(&segdata, 0);
   MdsFree1Dx(&segdim, 0);
-  if (isOpList) {
+  if STATUS_OK {
     RETURN_IF_NOT_OK(open_header_read(vars));
     int numsegs = vars->shead.idx + 1;
     int apd_idx = 0;
@@ -2114,18 +2119,14 @@ static int getOpaqueList(void *dbid, int nid, struct descriptor_xd *out) {
     }
     if (apd.pointer)
       free(apd.pointer);
-  } else if STATUS_OK {
-    status = 0;
   }
   return status;
 }
 
 int _TreeGetSegmentedRecord(void *dbid, int nid, struct descriptor_xd *data)
 {
-  INIT_TREESUCCESS;
-  int opstatus = getOpaqueList(dbid, nid, data );
-  if IS_OK(opstatus)
-    return opstatus;
+  int status = getOpaqueList(dbid, nid, data );
+  if (status) return status; // 0: data is not Opaque
   static int activated = 0;
   static int (*addr) (void *, int, struct descriptor *, struct descriptor *, struct descriptor *, struct descriptor_xd *);
   if (!activated) {

--- a/xtreeshr/XTreeGetTimedRecord.c
+++ b/xtreeshr/XTreeGetTimedRecord.c
@@ -308,11 +308,14 @@ EXPORT int _XTreeGetTimedRecord(void *dbid, int inNid, struct descriptor *startD
 	for(currIdx = startIdx, currSegIdx = 0; currIdx <= endIdx; currIdx++, currSegIdx++)
 	{
 		status = (dbid)?_TreeGetSegment(dbid, nid, currIdx, &dataXds[currSegIdx], &dimensionXds[currSegIdx]):TreeGetSegment(nid, currIdx, &dataXds[currSegIdx], &dimensionXds[currSegIdx]);
-
-//printf("Read Segment %d\n", currSegIdx);
-
-		if STATUS_NOT_OK
-		{
+		// decompress if compressed
+		if (STATUS_OK && dataXds[currSegIdx].pointer->class == CLASS_CA) {
+                  struct descriptor_xd compressed = dataXds[currSegIdx];
+                  dataXds[currSegIdx] = emptyXd;
+		  status = MdsDecompress((struct descriptor_r *)compressed.pointer, &dataXds[currSegIdx]);
+		  MdsFree1Dx(&compressed, 0);
+		}
+		if STATUS_NOT_OK {
 			free((char *)signals);
 			for(i = 0; i < actNumSegments; i++)
 			{


### PR DESCRIPTION
Descriptro will decompress automatically when needed.
This allows a much faster remote access when reading compressed segmetns via mdsip using

_v=*;_d=*;_s=TreeShr->TreeGetSegment(val(_nid),val(_seg),xd(_v),xd(_d));serializeout(`List(*,_s,_v,_d))

e.g. by upcomming and maybe current jTraverser2