### PR TITLE
Fix: NULL treenode search term

### DIFF
--- a/mdsobjects/cpp/testing/MdsTreeTest.cpp
+++ b/mdsobjects/cpp/testing/MdsTreeTest.cpp
@@ -221,6 +221,9 @@ int main(int argc UNUSED_ARGUMENT, char *argv[] UNUSED_ARGUMENT)
         TEST1( AutoData<TreeNode>(tree->getNode("ANY")).get() != NULL );
         TEST1( AutoData<TreeNode>(tree->getNode(AutoData<String>(new String("ANY")))).get() != NULL );
         TEST1( AutoData<TreeNode>(tree->getNode(AutoData<TreePath>(new TreePath(std::string("ANY"), tree)))).get() != NULL );
+
+        // testing exception on null path
+        TEST_EXCEPTION( AutoData<TreeNode>(tree->getNode("")), MdsException );
     }
 
 

--- a/treeshr/TreeFindNode.c
+++ b/treeshr/TreeFindNode.c
@@ -111,7 +111,7 @@ EXPORT int _TreeFindNodeWild(void *dbid, char const *path, int *nid_out, void **
     NODELIST *tail=NULL;
     ctx->default_node = dblist->default_node;
     ctx->answers = Search(dblist, ctx, ctx->terms, dblist->default_node, &tail);
-    ctx->answers = Filter(ctx->answers, usage_mask); 
+    ctx->answers = Filter(ctx->answers, usage_mask);
     if (ctx->answers && (ctx->answers->node == ctx->default_node) && wild) {
       NODELIST *tmp = ctx->answers;
       ctx->answers = ctx->answers->next;
@@ -126,7 +126,7 @@ EXPORT int _TreeFindNodeWild(void *dbid, char const *path, int *nid_out, void **
     tmp = ctx->answers->next;
     *nid_out = node_to_nid(dblist, ctx->answers->node, (NID *)nid_out);
     free(ctx->answers);
-    ctx->answers = tmp;    
+    ctx->answers = tmp;
   }
   else {
     status = (not_first_time) ? TreeNMN : TreeNNF;
@@ -147,7 +147,7 @@ EXPORT int _TreeFindNode(void *dbid, char const *path, int *outnid)
     return TreeNOT_OPEN;
   if (dblist->remote)
     return FindNodeRemote(dblist, path, outnid);
-  
+
   status = WildParse(path, &ctx, &wild);
   if STATUS_NOT_OK
     goto done;
@@ -188,10 +188,16 @@ STATIC_ROUTINE void FreeSearchCtx(SEARCH_CTX *ctx)
 }
 STATIC_ROUTINE NODELIST *Search(PINO_DATABASE *dblist, SEARCH_CTX *ctx, SEARCH_TERM *term, NODE *start, NODELIST **tail)
 {
-  NODELIST *nodes = Find(dblist, term, start, tail);
+  NODELIST *nodes = NULL;
+  if (term) {
+      nodes = Find(dblist, term, start, tail);
+  }
+  else {
+      return NULL;
+  }
   if (nodes) {
     NODELIST *more_nodes = NULL;
-    NODELIST *more_tail = NULL;    
+    NODELIST *more_tail = NULL;
     if(term->next) {
       NODELIST *these_nodes = NULL;
       NODELIST *these_tail = NULL;
@@ -212,10 +218,10 @@ STATIC_ROUTINE NODELIST *Search(PINO_DATABASE *dblist, SEARCH_CTX *ctx, SEARCH_T
   }
   else{
     return NULL;
-  } 
+  }
 }
 
-STATIC_ROUTINE inline int Wild(char *term) 
+STATIC_ROUTINE inline int Wild(char *term)
 {
   return (strchr(term, '*') || strchr(term, '?') || strchr(term, '%'));
 }
@@ -223,6 +229,7 @@ STATIC_ROUTINE inline int Wild(char *term)
 STATIC_ROUTINE NODELIST *Find(PINO_DATABASE *dblist, SEARCH_TERM *term, NODE *start, NODELIST **tail)
 {
   NODELIST *answer = NULL;
+  if(term == NULL) return NULL;
   if (((term->search_type==CHILD) || (term->search_type==MEMBER)) && (! Wild(term->term))) {
     term->search_type = CHILD_OR_MEMBER;
   }
@@ -341,7 +348,7 @@ STATIC_ROUTINE NODELIST *FindTags(PINO_DATABASE *dblist, TREE_INFO *info, int tr
     }
     answer = AddNodeList(answer, tail, n);
   }
-  else { 
+  else {
     for (i=0; i<info->header->tags; i++) {
       char *trimmed = Trim(tptr[i].name, sizeof(TAG_NAME));
       if(match(tagname, trimmed)) {
@@ -374,7 +381,7 @@ STATIC_ROUTINE TREE_INFO *GetDefaultTreeInfo(PINO_DATABASE *dblist, int *treenum
   int  i = 0;
   NID nid;
   node_to_nid(dblist, dblist->default_node, &nid);
-  *treenum = nid.tree; 
+  *treenum = nid.tree;
   for (info=dblist->tree_info; i < *treenum; info = info->next_info, i++);
   return info;
 
@@ -397,7 +404,7 @@ STATIC_ROUTINE NODELIST *FindTagWild(PINO_DATABASE *dblist, SEARCH_TERM *term, N
       if(match(treename, tinfo->treenam)) {
         NODELIST *tag_tail = NULL;
         answer = ConcatenateNodeLists(answer, tail, FindTags(dblist, tinfo, treenum, tagname, &tag_tail), tag_tail);
-        if(! tree_wild) 
+        if(! tree_wild)
           break;
       }
     }
@@ -412,7 +419,7 @@ STATIC_ROUTINE NODELIST *FindTagWild(PINO_DATABASE *dblist, SEARCH_TERM *term, N
     if ((!answer) || tag_wild) {
       for (treenum=0, tinfo=dblist->tree_info; tinfo; tinfo = tinfo->next_info) {
         if (tinfo != default_tinfo) {
-          NODELIST *tag_tail = NULL; 
+          NODELIST *tag_tail = NULL;
           answer = ConcatenateNodeLists(answer, tail, FindTags(dblist, tinfo, treenum, tagname, &tag_tail), tag_tail);
 	  if(answer && (!tag_wild))
             break;
@@ -563,18 +570,18 @@ STATIC_ROUTINE int match(char *first, char *second)
     // If we reach at the end of both strings, we are done
     if (*first == '\0' && *second == '\0')
         return 1;
- 
+
     // Make sure that the characters after '*' are present
     // in second string. This function assumes that the first
     // string will not contain two consecutive '*'
     if (*first == '*' && *(first+1) != '\0' && *second == '\0')
         return 0;
- 
+
     // If the first string contains '?', or current characters
     // of both strings match
     if (*first == '?' || *first == '%' || *first == *second)
         return match(first+1, second+1);
- 
+
     // If there is *, then there are two possibilities
     // a) We consider current character of second string
     // b) We ignore current character of second string.


### PR DESCRIPTION
The pull request adds a test and a fix proposal for Tom based on where the debugger stopped.
The tree getNode caused a SEGFAULT if a NULL search term is passed from an empty string argument.
