### PR TITLE
Fix: Truncate last segment if not filled

### DIFF
--- a/mdsobjects/python/tests/segmentsUnitTest.py
+++ b/mdsobjects/python/tests/segmentsUnitTest.py
@@ -278,7 +278,7 @@ class Tests(TestCase):
         for i in range(-9,9,3):
             d = Int64Array(range(3))*10+i*10
             v = Int32Array(range(3))+i
-            node.beginSegment(d[0],d[2],d,v)
+            node.makeSegment(d[0],d[2],d,v)
         self.assertEqual(node.getSegmentList(20,59).dim_of(0).tolist(),[0,30])
         self.assertEqual(node.getSegmentList(20,60).dim_of(0).tolist(),[0,30,60])
         self.assertEqual(node.getSegmentList(21,60).dim_of(0).tolist(),[30,60])
@@ -318,7 +318,7 @@ class Tests(TestCase):
         srt,end,dt=-1000,1000,1000
         d = Int64Array(range(srt,end+1,dt))
         v = Int16Array(range(srt,end+1,dt))
-        node.beginSegment(srt,end,d,v)
+        node.makeSegment(srt,end,d,v)
         self.assertEqual(True,(node.getSegment(0).data()==v.data()).all())
         node.setSegmentScale(Int64(2))
         self.assertEqual(node.getSegmentScale().decompile(),"$VALUE * 2Q")

--- a/tditest/testing/test-treeshr.ans
+++ b/tditest/testing/test-treeshr.ans
@@ -214,6 +214,8 @@ TreeAddNode('numeric',_nid,5)
 265388041
 getnci(_nid,'usage')
 5BU
+TreeAddNode('segs',_nid,6)
+265388041
 TreeAddNode('signal',_nid,6)
 265388041
 getnci(_nid,'usage')
@@ -239,7 +241,7 @@ TreeAddNode('.subtree',_nid,11)
 getnci(_nid,'usage')
 11BU
 _nid
-11
+12
 getnci(0,"child")
 .CHILD
 getnci(0,"children_nids")
@@ -312,8 +314,8 @@ getnci(\child_tag5,'nid_number')
 1
 TreeShr->TreeVerify()
 Node summary:
-  Allocated = 12/14
-  Free      = 1/14
+  Allocated = 13/14
+  Free      = 0/14
   Other     = 1/14
 265388041
 TreePutRecord(action,Build_Action(Build_Dispatch(2, "CAMAC_SERVER", "INIT", *, *), Build_Method(*, "INIT", ACTION), *, *, *))
@@ -364,6 +366,14 @@ TreePutRecord(axis,1E-4 : 20E-4 : 1E-4)
 265388041
 axis
 .0001 : .002 : .0001
+BeginSegment(segs,0.,99.,0.:99.,data(0:99))
+265388041
+putsegment(segs,-1,data(0:9))
+265389633
+getsegment(segs,0)
+Build_Signal([0,1,2,3,4,5,6,7,8,9], *, [0.,1.,2.,3.,4.,5.,6.,7.,8.,9.])
+segs
+Build_Signal([0,1,2,3,4,5,6,7,8,9], *, [0.,1.,2.,3.,4.,5.,6.,7.,8.,9.])
 TreeWrite('main',_shot)
 265388041
 TreeClose()

--- a/tditest/testing/test-treeshr.tdi
+++ b/tditest/testing/test-treeshr.tdi
@@ -104,6 +104,7 @@ TreeAddNode('dispatch',_nid,4)
 getnci(_nid,'usage')
 TreeAddNode('numeric',_nid,5)
 getnci(_nid,'usage')
+TreeAddNode('segs',_nid,6)
 TreeAddNode('signal',_nid,6)
 getnci(_nid,'usage')
 TreeAddNode('task',_nid,7)
@@ -175,6 +176,10 @@ TreePutRecord(window,build_window(1,40,-4.))
 window
 TreePutRecord(axis,1E-4 : 20E-4 : 1E-4)
 axis
+BeginSegment(segs,0.,99.,0.:99.,data(0:99))
+putsegment(segs,-1,data(0:9))
+getsegment(segs,0)
+segs
 TreeWrite('main',_shot)
 TreeClose()
 TreeShr->TreeCompressDatafile(ref('main'),val(_shot))


### PR DESCRIPTION
If the last segment of a node containing regular (not timestamped)
segments is only partially filled a call to getSegment for the last
segment returned the contents of the whole segment instead of only
the filled portion. This PR should truncate the data and dimension
to return only the filled portion of the segment.