### PR TITLE
Fix: TreeFindNodeWild segfaults with empty string as input

### DIFF
--- a/treeshr/TreeFindNodeWild.l
+++ b/treeshr/TreeFindNodeWild.l
@@ -163,41 +163,42 @@ static char *strtrim(char *str)
 
 EXPORT int WildParse(char const *path, SEARCH_CTX *ctx, int *wild) 
 {
+  int status = TreeINVPATH;
+
 //  static pthread_mutex_t lock = PTHREAD_MUTEX_INITIALIZER;
-  char *wild_path = strdup(path);
-  char *p;
-  int status;
-  yyscan_t scanner;
-  wild_path = strtrim(wild_path);
-  while ((p = strstr(wild_path, "***"))) {
+  if (path && strlen(path)) {
+    char *wild_path = strdup(path);
+    char *p;
+    yyscan_t scanner;
+    wild_path = strtrim(wild_path);
+    while ((p = strstr(wild_path, "***"))) {
       *p++ = '~';
       *p++ = '~';
       *p++ = '~';
+    }
+
+    yytreepathlex_init_extra(ctx, &scanner);
+    ctx->wildcard = strdup(wild_path);
+
+    yytreepath_scan_string(wild_path, scanner);
+
+    while((status = yytreepathlex(scanner)) > 0) ;
+    if (status == 0) {
+      /* now merge in trailing search clauses */
+      ctx->terms=SquishSearches(ctx->terms);
+      /* check if any terms are wild */
+      *wild = strchr(wild_path, '*') || 
+              strchr(wild_path, '%') || 
+              strstr(wild_path, "~~~") || 
+              strstr(wild_path, "...") || 
+              strstr(wild_path, ":::") || 
+              strstr(wild_path, "^^^") ;
+    }
+    yytreepathlex_destroy(scanner);
+    free(wild_path);
   }
 
-  yytreepathlex_init_extra(ctx, &scanner);
-  ctx->wildcard = strdup(wild_path);
-
-  yytreepath_scan_string(wild_path, scanner);
-
-  while((status = yytreepathlex(scanner)) > 0) ;
-  if (status == 0) {
-    /* now merge in trailing search clauses */
-    ctx->terms=SquishSearches(ctx->terms);
-    /* check if any terms are wild */
-    *wild = strchr(wild_path, '*') || 
-            strchr(wild_path, '%') || 
-            strstr(wild_path, "~~~") || 
-            strstr(wild_path, "...") || 
-            strstr(wild_path, ":::") || 
-            strstr(wild_path, "^^^") ;
-  }
-  yytreepathlex_destroy(scanner);
-  free(wild_path);
-
-//  PrintCtx(ctx);
-
-  return(status ==0) ? TreeNORMAL : 0;
+  return(status ==0) ? TreeNORMAL : status;
 }
 
 STATIC_ROUTINE void addSearchTerm(yyscan_t scanner, int type, char *str)

--- a/treeshr/lex.yytreepath.c
+++ b/treeshr/lex.yytreepath.c
@@ -8,7 +8,7 @@
 #define FLEX_SCANNER
 #define YY_FLEX_MAJOR_VERSION 2
 #define YY_FLEX_MINOR_VERSION 6
-#define YY_FLEX_SUBMINOR_VERSION 1
+#define YY_FLEX_SUBMINOR_VERSION 0
 #if YY_FLEX_SUBMINOR_VERSION > 0
 #define FLEX_BETA
 #endif
@@ -87,13 +87,25 @@ typedef unsigned int flex_uint32_t;
 
 #endif /* ! FLEXINT_H */
 
-/* TODO: this is always defined, so inline it */
-#define yyconst const
+#ifdef __cplusplus
 
-#if defined(__GNUC__) && __GNUC__ >= 3
-#define yynoreturn __attribute__((__noreturn__))
+/* The "const" storage-class-modifier is valid. */
+#define YY_USE_CONST
+
+#else	/* ! __cplusplus */
+
+/* C99 requires __STDC__ to be defined as 1. */
+#if defined (__STDC__)
+
+#define YY_USE_CONST
+
+#endif	/* defined (__STDC__) */
+#endif	/* ! __cplusplus */
+
+#ifdef YY_USE_CONST
+#define yyconst const
 #else
-#define yynoreturn
+#define yyconst
 #endif
 
 /* Returned upon end-of-file. */
@@ -206,12 +218,12 @@ struct yy_buffer_state
 	/* Size of input buffer in bytes, not including room for EOB
 	 * characters.
 	 */
-	int yy_buf_size;
+	yy_size_t yy_buf_size;
 
 	/* Number of characters read into yy_ch_buf, not including EOB
 	 * characters.
 	 */
-	int yy_n_chars;
+	yy_size_t yy_n_chars;
 
 	/* Whether we "own" the buffer - i.e., we know we created it,
 	 * and can realloc() it to grow it, and should free() it to
@@ -290,7 +302,7 @@ static void yytreepath_init_buffer (YY_BUFFER_STATE b,FILE *file ,yyscan_t yysca
 
 YY_BUFFER_STATE yytreepath_scan_buffer (char *base,yy_size_t size ,yyscan_t yyscanner );
 YY_BUFFER_STATE yytreepath_scan_string (yyconst char *yy_str ,yyscan_t yyscanner );
-YY_BUFFER_STATE yytreepath_scan_bytes (yyconst char *bytes,int len ,yyscan_t yyscanner );
+YY_BUFFER_STATE yytreepath_scan_bytes (yyconst char *bytes,yy_size_t len ,yyscan_t yyscanner );
 
 void *yytreepathalloc (yy_size_t ,yyscan_t yyscanner );
 void *yytreepathrealloc (void *,yy_size_t ,yyscan_t yyscanner );
@@ -334,14 +346,17 @@ typedef int yy_state_type;
 static yy_state_type yy_get_previous_state (yyscan_t yyscanner );
 static yy_state_type yy_try_NUL_trans (yy_state_type current_state  ,yyscan_t yyscanner);
 static int yy_get_next_buffer (yyscan_t yyscanner );
-static void yynoreturn yy_fatal_error (yyconst char* msg ,yyscan_t yyscanner );
+#if defined(__GNUC__) && __GNUC__ >= 3
+__attribute__((__noreturn__))
+#endif
+static void yy_fatal_error (yyconst char msg[] ,yyscan_t yyscanner );
 
 /* Done after the current pattern has been matched and before the
  * corresponding action - sets up yytext.
  */
 #define YY_DO_BEFORE_ACTION \
 	yyg->yytext_ptr = yy_bp; \
-	yyleng = (int) (yy_cp - yy_bp); \
+	yyleng = (size_t) (yy_cp - yy_bp); \
 	yyg->yy_hold_char = *yy_cp; \
 	*yy_cp = '\0'; \
 	yyg->yy_c_buf_p = yy_cp;
@@ -548,7 +563,7 @@ STATIC_ROUTINE int isPunctuation(char c)
 }
 
 #define YY_NO_INPUT 1
-#line 552 "lex.yytreepath.c"
+#line 567 "lex.yytreepath.c"
 
 #define INITIAL 0
 
@@ -575,8 +590,8 @@ struct yyguts_t
     size_t yy_buffer_stack_max; /**< capacity of stack. */
     YY_BUFFER_STATE * yy_buffer_stack; /**< Stack as an array. */
     char yy_hold_char;
-    int yy_n_chars;
-    int yyleng_r;
+    yy_size_t yy_n_chars;
+    yy_size_t yyleng_r;
     char *yy_c_buf_p;
     int yy_init;
     int yy_start;
@@ -623,7 +638,7 @@ FILE *yytreepathget_out (yyscan_t yyscanner );
 
 void yytreepathset_out  (FILE * _out_str ,yyscan_t yyscanner );
 
-			int yytreepathget_leng (yyscan_t yyscanner );
+yy_size_t yytreepathget_leng (yyscan_t yyscanner );
 
 char *yytreepathget_text (yyscan_t yyscanner );
 
@@ -684,7 +699,7 @@ static int input (yyscan_t yyscanner );
 /* This used to be an fputs(), but since the string might contain NUL's,
  * we now use fwrite().
  */
-#define ECHO do { if (fwrite( yytext, (size_t) yyleng, 1, yyout )) {} } while (0)
+#define ECHO do { if (fwrite( yytext, yyleng, 1, yyout )) {} } while (0)
 #endif
 
 /* Gets input and stuffs it into "buf".  number of characters read, or YY_NULL,
@@ -695,7 +710,7 @@ static int input (yyscan_t yyscanner );
 	if ( YY_CURRENT_BUFFER_LVALUE->yy_is_interactive ) \
 		{ \
 		int c = '*'; \
-		int n; \
+		size_t n; \
 		for ( n = 0; n < max_size && \
 			     (c = getc( yyin )) != EOF && c != '\n'; ++n ) \
 			buf[n] = (char) c; \
@@ -708,7 +723,7 @@ static int input (yyscan_t yyscanner );
 	else \
 		{ \
 		errno=0; \
-		while ( (result = (int) fread(buf, 1, (yy_size_t) max_size, yyin)) == 0 && ferror(yyin)) \
+		while ( (result = fread(buf, 1, max_size, yyin))==0 && ferror(yyin)) \
 			{ \
 			if( errno != EINTR) \
 				{ \
@@ -810,7 +825,7 @@ YY_DECL
 	{
 #line 45 "TreeFindNodeWild.l"
 
-#line 814 "lex.yytreepath.c"
+#line 829 "lex.yytreepath.c"
 
 	while ( /*CONSTCOND*/1 )		/* loops until end-of-file is reached */
 		{
@@ -841,7 +856,7 @@ yy_match:
 				if ( yy_current_state >= 136 )
 					yy_c = yy_meta[(unsigned int) yy_c];
 				}
-			yy_current_state = yy_nxt[yy_base[yy_current_state] + (flex_int16_t) yy_c];
+			yy_current_state = yy_nxt[yy_base[yy_current_state] + (unsigned int) yy_c];
 			++yy_cp;
 			}
 		while ( yy_base[yy_current_state] != 163 );
@@ -971,7 +986,7 @@ YY_RULE_SETUP
 #line 88 "TreeFindNodeWild.l"
 ECHO;
 	YY_BREAK
-#line 975 "lex.yytreepath.c"
+#line 990 "lex.yytreepath.c"
 
 	case YY_END_OF_BUFFER:
 		{
@@ -1171,7 +1186,7 @@ static int yy_get_next_buffer (yyscan_t yyscanner)
 
 			if ( b->yy_is_our_buffer )
 				{
-				int new_size = b->yy_buf_size * 2;
+				yy_size_t new_size = b->yy_buf_size * 2;
 
 				if ( new_size <= 0 )
 					b->yy_buf_size += b->yy_buf_size / 8;
@@ -1180,11 +1195,11 @@ static int yy_get_next_buffer (yyscan_t yyscanner)
 
 				b->yy_ch_buf = (char *)
 					/* Include room in for 2 EOB chars. */
-					yytreepathrealloc((void *) b->yy_ch_buf,(yy_size_t) (b->yy_buf_size + 2) ,yyscanner );
+					yytreepathrealloc((void *) b->yy_ch_buf,b->yy_buf_size + 2 ,yyscanner );
 				}
 			else
 				/* Can't grow it, we don't own it. */
-				b->yy_ch_buf = NULL;
+				b->yy_ch_buf = 0;
 
 			if ( ! b->yy_ch_buf )
 				YY_FATAL_ERROR(
@@ -1226,10 +1241,10 @@ static int yy_get_next_buffer (yyscan_t yyscanner)
 	else
 		ret_val = EOB_ACT_CONTINUE_SCAN;
 
-	if ((int) (yyg->yy_n_chars + number_to_move) > YY_CURRENT_BUFFER_LVALUE->yy_buf_size) {
+	if ((yy_size_t) (yyg->yy_n_chars + number_to_move) > YY_CURRENT_BUFFER_LVALUE->yy_buf_size) {
 		/* Extend the array by 50%, plus the number we really need. */
-		int new_size = yyg->yy_n_chars + number_to_move + (yyg->yy_n_chars >> 1);
-		YY_CURRENT_BUFFER_LVALUE->yy_ch_buf = (char *) yytreepathrealloc((void *) YY_CURRENT_BUFFER_LVALUE->yy_ch_buf,(yy_size_t) new_size ,yyscanner );
+		yy_size_t new_size = yyg->yy_n_chars + number_to_move + (yyg->yy_n_chars >> 1);
+		YY_CURRENT_BUFFER_LVALUE->yy_ch_buf = (char *) yytreepathrealloc((void *) YY_CURRENT_BUFFER_LVALUE->yy_ch_buf,new_size ,yyscanner );
 		if ( ! YY_CURRENT_BUFFER_LVALUE->yy_ch_buf )
 			YY_FATAL_ERROR( "out of dynamic memory in yy_get_next_buffer()" );
 	}
@@ -1268,7 +1283,7 @@ static int yy_get_next_buffer (yyscan_t yyscanner)
 			if ( yy_current_state >= 136 )
 				yy_c = yy_meta[(unsigned int) yy_c];
 			}
-		yy_current_state = yy_nxt[yy_base[yy_current_state] + (flex_int16_t) yy_c];
+		yy_current_state = yy_nxt[yy_base[yy_current_state] + (unsigned int) yy_c];
 		}
 
 	return yy_current_state;
@@ -1297,7 +1312,7 @@ static int yy_get_next_buffer (yyscan_t yyscanner)
 		if ( yy_current_state >= 136 )
 			yy_c = yy_meta[(unsigned int) yy_c];
 		}
-	yy_current_state = yy_nxt[yy_base[yy_current_state] + (flex_int16_t) yy_c];
+	yy_current_state = yy_nxt[yy_base[yy_current_state] + (unsigned int) yy_c];
 	yy_is_jam = (yy_current_state == 135);
 
 	(void)yyg;
@@ -1333,7 +1348,7 @@ static int yy_get_next_buffer (yyscan_t yyscanner)
 
 		else
 			{ /* need more input */
-			int offset = yyg->yy_c_buf_p - yyg->yytext_ptr;
+			yy_size_t offset = yyg->yy_c_buf_p - yyg->yytext_ptr;
 			++yyg->yy_c_buf_p;
 
 			switch ( yy_get_next_buffer( yyscanner ) )
@@ -1357,7 +1372,7 @@ static int yy_get_next_buffer (yyscan_t yyscanner)
 				case EOB_ACT_END_OF_FILE:
 					{
 					if ( yytreepathwrap(yyscanner ) )
-						return 0;
+						return EOF;
 
 					if ( ! yyg->yy_did_buffer_switch_on_eof )
 						YY_NEW_FILE;
@@ -1463,12 +1478,12 @@ static void yytreepath_load_buffer_state  (yyscan_t yyscanner)
 	if ( ! b )
 		YY_FATAL_ERROR( "out of dynamic memory in yytreepath_create_buffer()" );
 
-	b->yy_buf_size = size;
+	b->yy_buf_size = (yy_size_t)size;
 
 	/* yy_ch_buf has to be 2 characters longer than the size given because
 	 * we need to put in 2 end-of-buffer characters.
 	 */
-	b->yy_ch_buf = (char *) yytreepathalloc((yy_size_t) (b->yy_buf_size + 2) ,yyscanner );
+	b->yy_ch_buf = (char *) yytreepathalloc(b->yy_buf_size + 2 ,yyscanner );
 	if ( ! b->yy_ch_buf )
 		YY_FATAL_ERROR( "out of dynamic memory in yytreepath_create_buffer()" );
 
@@ -1615,7 +1630,7 @@ void yytreepathpop_buffer_state (yyscan_t yyscanner)
  */
 static void yytreepathensure_buffer_stack (yyscan_t yyscanner)
 {
-	int num_to_alloc;
+	yy_size_t num_to_alloc;
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
 
 	if (!yyg->yy_buffer_stack) {
@@ -1671,16 +1686,16 @@ YY_BUFFER_STATE yytreepath_scan_buffer  (char * base, yy_size_t  size , yyscan_t
 	     base[size-2] != YY_END_OF_BUFFER_CHAR ||
 	     base[size-1] != YY_END_OF_BUFFER_CHAR )
 		/* They forgot to leave room for the EOB's. */
-		return NULL;
+		return 0;
 
 	b = (YY_BUFFER_STATE) yytreepathalloc(sizeof( struct yy_buffer_state ) ,yyscanner );
 	if ( ! b )
 		YY_FATAL_ERROR( "out of dynamic memory in yytreepath_scan_buffer()" );
 
-	b->yy_buf_size = (int) (size - 2);	/* "- 2" to take care of EOB's */
+	b->yy_buf_size = size - 2;	/* "- 2" to take care of EOB's */
 	b->yy_buf_pos = b->yy_ch_buf = base;
 	b->yy_is_our_buffer = 0;
-	b->yy_input_file = NULL;
+	b->yy_input_file = 0;
 	b->yy_n_chars = b->yy_buf_size;
 	b->yy_is_interactive = 0;
 	b->yy_at_bol = 1;
@@ -1703,7 +1718,7 @@ YY_BUFFER_STATE yytreepath_scan_buffer  (char * base, yy_size_t  size , yyscan_t
 YY_BUFFER_STATE yytreepath_scan_string (yyconst char * yystr , yyscan_t yyscanner)
 {
     
-	return yytreepath_scan_bytes(yystr,(int) strlen(yystr) ,yyscanner);
+	return yytreepath_scan_bytes(yystr,strlen(yystr) ,yyscanner);
 }
 
 /** Setup the input buffer state to scan the given bytes. The next call to yytreepathlex() will
@@ -1713,7 +1728,7 @@ YY_BUFFER_STATE yytreepath_scan_string (yyconst char * yystr , yyscan_t yyscanne
  * @param yyscanner The scanner object.
  * @return the newly allocated buffer state object.
  */
-YY_BUFFER_STATE yytreepath_scan_bytes  (yyconst char * yybytes, int  _yybytes_len , yyscan_t yyscanner)
+YY_BUFFER_STATE yytreepath_scan_bytes  (yyconst char * yybytes, yy_size_t  _yybytes_len , yyscan_t yyscanner)
 {
 	YY_BUFFER_STATE b;
 	char *buf;
@@ -1721,7 +1736,7 @@ YY_BUFFER_STATE yytreepath_scan_bytes  (yyconst char * yybytes, int  _yybytes_le
 	yy_size_t i;
     
 	/* Get memory for full buffer, including space for trailing EOB's. */
-	n = (yy_size_t) _yybytes_len + 2;
+	n = _yybytes_len + 2;
 	buf = (char *) yytreepathalloc(n ,yyscanner );
 	if ( ! buf )
 		YY_FATAL_ERROR( "out of dynamic memory in yytreepath_scan_bytes()" );
@@ -1747,7 +1762,7 @@ YY_BUFFER_STATE yytreepath_scan_bytes  (yyconst char * yybytes, int  _yybytes_le
 #define YY_EXIT_FAILURE 2
 #endif
 
-static void yynoreturn yy_fatal_error (yyconst char* msg , yyscan_t yyscanner)
+static void yy_fatal_error (yyconst char* msg , yyscan_t yyscanner)
 {
 	struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
 	(void)yyg;
@@ -1830,7 +1845,7 @@ FILE *yytreepathget_out  (yyscan_t yyscanner)
 /** Get the length of the current token.
  * @param yyscanner The scanner object.
  */
-int yytreepathget_leng  (yyscan_t yyscanner)
+yy_size_t yytreepathget_leng  (yyscan_t yyscanner)
 {
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
     return yyleng;
@@ -1989,10 +2004,10 @@ static int yy_init_globals (yyscan_t yyscanner)
      * This function is called from yytreepathlex_destroy(), so don't allocate here.
      */
 
-    yyg->yy_buffer_stack = NULL;
+    yyg->yy_buffer_stack = 0;
     yyg->yy_buffer_stack_top = 0;
     yyg->yy_buffer_stack_max = 0;
-    yyg->yy_c_buf_p = NULL;
+    yyg->yy_c_buf_p = (char *) 0;
     yyg->yy_init = 0;
     yyg->yy_start = 0;
 
@@ -2005,8 +2020,8 @@ static int yy_init_globals (yyscan_t yyscanner)
     yyin = stdin;
     yyout = stdout;
 #else
-    yyin = NULL;
-    yyout = NULL;
+    yyin = (FILE *) 0;
+    yyout = (FILE *) 0;
 #endif
 
     /* For future reference: Set errno on error, since we are called by
@@ -2076,7 +2091,7 @@ void *yytreepathalloc (yy_size_t  size , yyscan_t yyscanner)
 {
 	struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
 	(void)yyg;
-	return malloc(size);
+	return (void *) malloc( size );
 }
 
 void *yytreepathrealloc  (void * ptr, yy_size_t  size , yyscan_t yyscanner)
@@ -2091,7 +2106,7 @@ void *yytreepathrealloc  (void * ptr, yy_size_t  size , yyscan_t yyscanner)
 	 * any pointer type to void*, and deal with argument conversions
 	 * as though doing an assignment.
 	 */
-	return realloc(ptr, size);
+	return (void *) realloc( (char *) ptr, size );
 }
 
 void yytreepathfree (void * ptr , yyscan_t yyscanner)
@@ -2183,41 +2198,42 @@ static char *strtrim(char *str)
 
 EXPORT int WildParse(char const *path, SEARCH_CTX *ctx, int *wild) 
 {
+  int status = TreeINVPATH;
+
 //  static pthread_mutex_t lock = PTHREAD_MUTEX_INITIALIZER;
-  char *wild_path = strdup(path);
-  char *p;
-  int status;
-  yyscan_t scanner;
-  wild_path = strtrim(wild_path);
-  while ((p = strstr(wild_path, "***"))) {
+  if (path && strlen(path)) {
+    char *wild_path = strdup(path);
+    char *p;
+    yyscan_t scanner;
+    wild_path = strtrim(wild_path);
+    while ((p = strstr(wild_path, "***"))) {
       *p++ = '~';
       *p++ = '~';
       *p++ = '~';
+    }
+
+    yytreepathlex_init_extra(ctx, &scanner);
+    ctx->wildcard = strdup(wild_path);
+
+    yytreepath_scan_string(wild_path, scanner);
+
+    while((status = yytreepathlex(scanner)) > 0) ;
+    if (status == 0) {
+      /* now merge in trailing search clauses */
+      ctx->terms=SquishSearches(ctx->terms);
+      /* check if any terms are wild */
+      *wild = strchr(wild_path, '*') || 
+              strchr(wild_path, '%') || 
+              strstr(wild_path, "~~~") || 
+              strstr(wild_path, "...") || 
+              strstr(wild_path, ":::") || 
+              strstr(wild_path, "^^^") ;
+    }
+    yytreepathlex_destroy(scanner);
+    free(wild_path);
   }
 
-  yytreepathlex_init_extra(ctx, &scanner);
-  ctx->wildcard = strdup(wild_path);
-
-  yytreepath_scan_string(wild_path, scanner);
-
-  while((status = yytreepathlex(scanner)) > 0) ;
-  if (status == 0) {
-    /* now merge in trailing search clauses */
-    ctx->terms=SquishSearches(ctx->terms);
-    /* check if any terms are wild */
-    *wild = strchr(wild_path, '*') || 
-            strchr(wild_path, '%') || 
-            strstr(wild_path, "~~~") || 
-            strstr(wild_path, "...") || 
-            strstr(wild_path, ":::") || 
-            strstr(wild_path, "^^^") ;
-  }
-  yytreepathlex_destroy(scanner);
-  free(wild_path);
-
-//  PrintCtx(ctx);
-
-  return(status ==0) ? TreeNORMAL : 0;
+  return(status ==0) ? TreeNORMAL : status;
 }
 
 STATIC_ROUTINE void addSearchTerm(yyscan_t scanner, int type, char *str)


### PR DESCRIPTION
The parser WildParse in TreeFindNodeWild.l was allowing empty input
and the code which called it in TreeFindNode.c was not handling a
search context with no entries.

This change causes the parser to return 'invalid path' on empty input.

Fixes: https://github.com/MDSplus/mdsplus/issues/1408