### PR TITLE
Feature: Add local protocol to windows

### DIFF
--- a/mdstcpip/IoRoutinesTunnel.c
+++ b/mdstcpip/IoRoutinesTunnel.c
@@ -285,21 +285,23 @@ static int tunnel_connect(Connection* c, char *protocol, char *host){
 }
 
 static int tunnel_listen(int argc __attribute__ ((unused)), char **argv __attribute__ ((unused))){
-#ifdef _WIN32
-  return C_OK;
-#else
-  struct TUNNEL_PIPES p = { 1, 0, 0 };
   int id;
   char *username;
+#ifdef _WIN32
+  struct TUNNEL_PIPES p;
+  p.stdin_pipe = GetStdHandle(STD_OUTPUT_HANDLE);
+  p.stdout_pipe = GetStdHandle(STD_INPUT_HANDLE);
+#else
+  struct TUNNEL_PIPES p = { 1, 0, 0 };
   p.stdin_pipe = dup2(1, 10);
   p.stdout_pipe = dup2(0, 11);
   close(0);
   close(1);
   dup2(2, 1);
+#endif
   AcceptConnection(GetProtocol(), "tunnel", 0, &p, sizeof(p), &id, &username);
   if (username)
     free(username);
   while (DoMessage(id) != 0) ;
   return C_ERROR;
-#endif
 }

--- a/mdstcpip/Makefile.in
+++ b/mdstcpip/Makefile.in
@@ -90,6 +90,8 @@ ALL_SOURCES = $(LIB_SOURCES) $(TUNNEL_SOURCES) $(TCP_SOURCES) $(SERVER_LIB_SOURC
 bin_SCRIPTS =
 @MINGW_TRUE@bin_SCRIPTS += @MAKEBINDIR@mdsip_service.exe.manifest
 @MINGW_TRUE@bin_SCRIPTS += @MAKEBINDIR@mdsip-client-ssh.bat
+@MINGW_TRUE@bin_SCRIPTS += @MAKEBINDIR@mdsip-client-local.bat
+
 
 @MINGW_FALSE@bin_SCRIPTS += @MAKEBINDIR@mdsipd
 @MINGW_FALSE@bin_SCRIPTS += @MAKEBINDIR@mdsip_server

--- a/mdstcpip/mdsip-client-local.bat
+++ b/mdstcpip/mdsip-client-local.bat
@@ -1,0 +1,2 @@
+@echo off
+mdsip -P ssh


### PR DESCRIPTION
This should enable the use of the "local" protocol for mdsip on
the windows platform.

mdsconnect('local://xxx')
