### PR TITLE
Fix: use (int)(intptr_t) to cast from void* to int

### DIFF
--- a/include/mds_stdarg.h
+++ b/include/mds_stdarg.h
@@ -12,7 +12,9 @@
 #define MDS_STDARG
 
 #include <stdarg.h>
-#define MdsEND_ARG ((void *)0xffffffff)
+#include <stdint.h>
+
+#define MdsEND_ARG ((void *)(uintptr_t)0xffffffff)
 #ifdef va_count
 #define MDS_END_ARG
 #else

--- a/javamds/mdsobjects.c
+++ b/javamds/mdsobjects.c
@@ -1247,7 +1247,7 @@ JNIEXPORT jobject JNICALL Java_MDSplus_Data_compile
   arglist[varIdx++] = &outXd;
   arglist[varIdx++] = MdsEND_ARG;
   *(int *)&arglist[0] = varIdx - 1;
-  status = (char *)LibCallg(arglist, TdiCompile) - (char *)0;
+  status = (int)(intptr_t)LibCallg(arglist, TdiCompile);
   (*env)->ReleaseStringUTFChars(env, jexpr, expr);
   for (i = 0; i < numArgs; i++)
     FreeDescrip(arglist[2 + i]);
@@ -1341,7 +1341,7 @@ JNIEXPORT jobject JNICALL Java_MDSplus_Data_execute
   arglist[varIdx++] = &outXd;
   arglist[varIdx++] = MdsEND_ARG;
   *(int *)&arglist[0] = varIdx - 1;
-  status = (char *)LibCallg(arglist, TdiCompile) - (char *)0;
+  status = (int)(intptr_t)LibCallg(arglist, TdiCompile);
   (*env)->ReleaseStringUTFChars(env, jexpr, expr);
   for (i = 0; i < numArgs; i++)
     FreeDescrip(arglist[2 + i]);

--- a/mdslib/MdsLib.c
+++ b/mdslib/MdsLib.c
@@ -27,6 +27,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <pthread_port.h>
 #define MDSLIB_NO_PROTOS
 #include "mdslib.h"
+#include <stdint.h>
 static int MdsCONNECTION = -1;
 #define NDESCRIP_CACHE 1024
 #ifndef _CLIENT_ONLY
@@ -39,7 +40,7 @@ extern int TdiExecute();
 extern int TdiCompile();
 extern int TdiData();
 extern int TdiCvt();
-extern int LibCallg();
+extern void* LibCallg();
 extern int TreeFindNode();
 extern int TreePutRecord();
 extern int TreeWait();
@@ -538,7 +539,7 @@ static inline int MdsValueVargs(va_list incrmtr, int connection, char *expressio
     arglist[argidx++] = (void *)&xd1;
     arglist[argidx++] = MdsEND_ARG;
     *(int *)&arglist[0] = argidx - 1;
-    status = LibCallg(arglist, TdiExecute);
+    status = (int)(intptr_t)LibCallg(arglist, TdiExecute);
 
     if (status & 1) {
 
@@ -766,7 +767,7 @@ static inline int MdsValue2Vargs(va_list incrmtr, int connection, char *expressi
     arglist[argidx++] = (void *)&xd1;
     arglist[argidx++] = MdsEND_ARG;
     *(int *)&arglist[0] = argidx - 1;
-    status = LibCallg(arglist, TdiExecute);
+    status = (int)(intptr_t)LibCallg(arglist, TdiExecute);
 
     if (status & 1) {
 
@@ -909,7 +910,7 @@ static inline int MdsPutVargs(va_list incrmtr, int connection, char *pathname, c
       arglist[argidx++] = MdsEND_ARG;
       *(int *)&arglist[0] = argidx - 1;
 
-      status = LibCallg(arglist, TdiCompile);
+      status = (int)(intptr_t)LibCallg(arglist, TdiCompile);
 
       if (status & 1) {
 	if ((status = TreePutRecord(nid, (struct descriptor *)arglist[argidx - 2], 0)) & 1) {
@@ -1035,7 +1036,7 @@ EXPORT int MdsPut2Vargs(va_list incrmtr, int connection, char *pathname, char *e
       arglist[argidx++] = MdsEND_ARG;
       *(int *)&arglist[0] = argidx - 1;
 
-      status = LibCallg(arglist, TdiCompile);
+      status = (int)(intptr_t)LibCallg(arglist, TdiCompile);
 
       if (status & 1) {
 	if ((status = TreePutRecord(nid, (struct descriptor *)arglist[argidx - 2]), 0) & 1) {
@@ -1149,7 +1150,7 @@ extern EXPORT int *cdescr(int dtype, void *data, ...)
   }
   arglist[argidx++] = MdsEND_ARG;
   *(int *)&arglist[0] = argidx - 1;
-  status = LibCallg(arglist, descr);
+  status = (int)(intptr_t)LibCallg(arglist, descr);
   return (&status);
 }
 #endif

--- a/mdslibidl/MdsLibIdl.c
+++ b/mdslibidl/MdsLibIdl.c
@@ -352,7 +352,7 @@ EXPORT int IdlMdsValue(int argc, void **argv)
   arglist[argidx++] = (void *)&tmp;
   arglist[argidx++] = MdsEND_ARG;
   *(long *)&arglist[0] = argidx;
-  status = (char *)LibCallg(arglist, TdiExecute) - (char *)0;
+  status = (int)(intptr_t)LibCallg(arglist, TdiExecute);
   if (status & 1) {
     status = TdiData(tmp.pointer, &mdsValueAnswer MDS_END_ARG);
     MdsFree1Dx(&tmp, NULL);
@@ -553,7 +553,7 @@ EXPORT int IdlMdsPut(int argc, void **argv)
     arglist[argidx++] = (void *)&tmp;
     arglist[argidx++] = MdsEND_ARG;
     *(int *)&arglist[0] = argidx;
-    status = (char *)LibCallg(arglist, TdiCompile) - (char *)0;
+    status = (int)(intptr_t)LibCallg(arglist, TdiCompile);
     if (status & 1) {
       status = TreePutRecord(nid, (struct descriptor *)&tmp, 0);
       MdsFree1Dx(&tmp, NULL);

--- a/mdsobjects/cpp/mdsdata.c
+++ b/mdsobjects/cpp/mdsdata.c
@@ -267,7 +267,7 @@ void *convertFromDsc(void *ptr, void *tree)
   }
   dscPtr = (struct descriptor *)dscRPtr;
 
-//printf("CONVERTFROMDSC class %d  type %d\n", dscPtr->class, dscPtr->dtype);   
+//printf("CONVERTFROMDSC class %d  type %d\n", dscPtr->class, dscPtr->dtype);
 
   switch (dscPtr->class) {
   case CLASS_S:
@@ -372,7 +372,7 @@ void *convertFromDsc(void *ptr, void *tree)
 
 void freeDsc(void *dscPtr)
 {
-  
+
   struct descriptor_xd *xdPtr = (struct descriptor_xd *)dscPtr;
   if(!dscPtr) return;
   if (xdPtr->class != CLASS_XD) {
@@ -414,7 +414,7 @@ void *compileFromExprWithArgs(char *expr, int nArgs, void **args, void *tree, in
   EMPTYXD(xd);
   struct descriptor exprD = { 0, DTYPE_T, CLASS_S, 0 };
 
-  exprD.length = strlen(expr);
+  exprD.length = (uint16_t)strlen(expr);
   exprD.pointer = (char *)expr;
 
   arglist[1] = &exprD;
@@ -432,7 +432,7 @@ void *compileFromExprWithArgs(char *expr, int nArgs, void **args, void *tree, in
   arglist[varIdx++] = MdsEND_ARG;
   *(int *)&arglist[0] = varIdx - 1;
 
-  status = *retStatus = (char *)LibCallg(arglist, TdiCompile) - (char *)0;
+  status = *retStatus = (int)(intptr_t)LibCallg(arglist, TdiCompile);
   if (!(status & 1))
     return NULL;
 

--- a/mdsshr/librtl.c
+++ b/mdsshr/librtl.c
@@ -327,7 +327,7 @@ EXPORT int LibSpawn(struct descriptor *cmd, int waitFlag, int notifyFlag __attri
     }
   }
   arglist[numargs]=(void *)NULL;
-  status = (char *)LibCallg(arglist, (void *)_spawnlp) - (char *)NULL;
+  status = (int)(intptr_t)LibCallg(arglist, (void *)_spawnlp);
   free(cmd_c);
   return status;
 }

--- a/mdstcpip/ProcessMessage.c
+++ b/mdstcpip/ProcessMessage.c
@@ -694,7 +694,7 @@ static Message *ExecuteMessage(Connection * connection)
     connection->descrip[connection->nargs++] = MdsEND_ARG;
     ResetErrors();
     SetCompressionLevel(connection->compression_level);
-    status = (char *)LibCallg(&connection->nargs, TdiExecute) - (char *)0;
+    status = (int)(intptr_t)LibCallg(&connection->nargs, TdiExecute);
     if (status & 1)
       status = TdiData(xd, &ans_xd MDS_END_ARG);
     if (!(status & 1))

--- a/tcl/tcl_dispatch.c
+++ b/tcl/tcl_dispatch.c
@@ -80,7 +80,7 @@ static void *getDispatchTable() {
 static void setDispatchTable(void *dispatch_table) {
   DBI_ITM itmlst[] = {{sizeof(void *), DbiDISPATCH_TABLE, dispatch_table, 0},{0,0,0,0}};
   TreeSetDbi(itmlst);
-}  
+}
 
 /****************************************************************
  * TclDispatch_close:
@@ -318,9 +318,9 @@ EXPORT int TclDispatch_show_server(void *ctx, char **error __attribute__ ((unuse
       tclAppend(output, "\n");
       mdsdclFlushOutput(*output);
       FREE_ON_EXIT(info);
-      info = ServerGetInfo(full, ident); 
+      info = ServerGetInfo(full, ident);
       if (dooutput) {
-	tclAppend(output, info); 
+	tclAppend(output, info);
 	tclAppend(output, "\n");
       }
       FREE_NOW(info);
@@ -339,10 +339,10 @@ static void printIt(char *output){
  *****************************************************************/
 EXPORT int TclDispatch_phase(void *ctx, char **error, char **output __attribute__ ((unused))){
   int status;
-  void *dispatch_table = getDispatchTable();
   INIT_AND_FREE_ON_EXIT(char*,phase);
   INIT_AND_FREE_ON_EXIT(char*,synch_str);
   INIT_AND_FREE_ON_EXIT(char*,monitor);
+  void *dispatch_table = getDispatchTable();
   int synch;
   int noaction = IS_OK(cli_present(ctx, "NOACTION"));
   void (*output_rtn) () = IS_OK(cli_present(ctx, "LOG")) ? printIt : 0;

--- a/tcl/tcl_do_method.c
+++ b/tcl/tcl_do_method.c
@@ -109,7 +109,7 @@ EXPORT int TclDoMethod(void *ctx, char **error, char **output __attribute__ ((un
 	arglist[argc + 3] = &dometh_stat_d;
 	arglist[argc + 4] = MdsEND_ARG;
 	arglist[0] = (argc + 4) + (char *)0;
-	sts = (char *)LibCallg(arglist, TreeDoMethod) - (char *)0;
+	sts = (int)(intptr_t)LibCallg(arglist, TreeDoMethod);
 	if (sts & 1)
 	  sts = dometh_stat;
       }

--- a/tdishr/TdiDoTask.c
+++ b/tdishr/TdiDoTask.c
@@ -98,7 +98,7 @@ STATIC_ROUTINE int Doit(struct descriptor_routine *ptask, struct descriptor_xd *
       status = TdiData(pmethod->method, &method_d MDS_END_ARG);
       if STATUS_OK
 	status = TdiGetNid(pmethod->object, &nid);
-      status = (int)((char *)LibCallg(arglist, TreeDoMethod) - (char *)0);
+      status = (int)(intptr_t)LibCallg(arglist, TreeDoMethod);
       FREED_NOW(&method_d);
       status = TdiPutLong(&status, out_ptr);
       break;

--- a/treeshr/TreeAddNode.c
+++ b/treeshr/TreeAddNode.c
@@ -479,7 +479,6 @@ int _TreeAddConglom(void *dbid, char const *path, char const *congtype, int *nid
   PINO_DATABASE *dblist = (PINO_DATABASE *) dbid;
   struct descriptor expdsc = { 0, DTYPE_T, CLASS_S, 0 };
   char exp[256];
-  void *arglist[4] = { (void *)3 };
   DESCRIPTOR_LONG(statdsc, 0);
   statdsc.pointer = (char *)&addstatus;
   if (!IS_OPEN_FOR_EDIT(dblist))
@@ -493,13 +492,10 @@ int _TreeAddConglom(void *dbid, char const *path, char const *congtype, int *nid
   if STATUS_OK {
     expdsc.length = (unsigned short)strlen(exp);
     expdsc.pointer = exp;
-    arglist[1] = &expdsc;
-    arglist[2] = &statdsc;
-    arglist[3] = MdsEND_ARG;
     // switch to privateContext for thread safety
     int old_pc = TreeUsePrivateCtx(1);
     void* old_dbid = *TreeCtx();*TreeCtx() = dbid;
-    status = (int)((char *)LibCallg(arglist, TdiExecute) - (char *)0);
+    status = (*TdiExecute)(&expdsc,&statdsc MDS_END_ARG);
     *TreeCtx() = old_dbid;TreeUsePrivateCtx(old_pc);
     // old context restored
     if STATUS_OK {

--- a/treeshr/TreeDoMethod.c
+++ b/treeshr/TreeDoMethod.c
@@ -90,7 +90,7 @@ int TreeDoMethod(struct descriptor *nid_dsc, struct descriptor *method_ptr, ...)
     arglist[i + 1] = va_arg(incrmtr, struct descriptor *);
   va_end(incrmtr);
   arglist[nargs + 2] = MdsEND_ARG;
-  return (int)((char *)LibCallg(arglist, _TreeDoMethod) - (char *)0);
+  return (int)(intptr_t)LibCallg(arglist, _TreeDoMethod);
 }
 
 int do_fun(struct descriptor *funname, int nargs, struct descriptor **args, struct descriptor_xd *out_ptr){
@@ -106,7 +106,7 @@ int do_fun(struct descriptor *funname, int nargs, struct descriptor **args, stru
   int i;
   for (i = 0; i < nargs; i++)
     fun.arguments[2 + i] = args[i];
-  return (int)((char *)LibCallg(call_arglist, TdiEvaluate) - (char *)0);
+  return (int)(intptr_t)LibCallg(call_arglist, TdiEvaluate);
 }
 
 #pragma GCC diagnostic push
@@ -182,13 +182,13 @@ int _TreeDoMethod(void *dbid, struct descriptor *nid_dsc, struct descriptor *met
         static void* (*TdiExecute)  () = NULL;
         status = LibFindImageSymbol_C("TdiShr", "TdiExecute", &TdiExecute);
         if STATUS_OK {
+	  _nargs += 2;
 	  for (i = _nargs; i > 0; i--)
 	    arglist[i + 1] = arglist[i];
-	  _nargs += 2;
 	  arglist[0] = arglist_nargs(_nargs);
 	  arglist[1] = &exp;
 	  arglist[_nargs] = MdsEND_ARG;
-	  status = (int)((char *)LibCallg(arglist, TdiExecute) - (char *)0);
+	  status = (int)(intptr_t)LibCallg(arglist, TdiExecute);
         }
       }
       FREED_NOW(&exp);
@@ -205,7 +205,7 @@ int _TreeDoMethod(void *dbid, struct descriptor *nid_dsc, struct descriptor *met
     if STATUS_OK {
       void *old_dbid = *TreeCtx();
       *TreeCtx() = dbid;
-      status = (int)((char *)LibCallg(arglist, addr) - (char *)0);
+      status = (int)(intptr_t)LibCallg(arglist, addr);
       *TreeCtx() = old_dbid;
       if (arglist[nargs]) {
 	struct descriptor *ans = (struct descriptor *)arglist[nargs];

--- a/treeshr/TreeOpen.c
+++ b/treeshr/TreeOpen.c
@@ -730,7 +730,6 @@ static char *GetFname(char *tree, int shot)
   int status = 1;
   static char *ans = 0;
   struct descriptor_d fname = { 0, DTYPE_T, CLASS_D, 0 };
-  void *arglist[4];
   char expression[128];
   struct descriptor expression_d = { 0, DTYPE_T, CLASS_S, 0 };
   if (ans) {
@@ -739,14 +738,10 @@ static char *GetFname(char *tree, int shot)
   }
   expression_d.length = (unsigned short)sprintf(expression, "%s_tree_filename(%d)", tree, shot);
   expression_d.pointer = expression;
-  arglist[0] = (void *)3;
-  arglist[1] = &expression_d;
-  arglist[2] = &fname;
-  arglist[3] = MdsEND_ARG;
-  static void *TdiExecute = NULL; // LibFindImageSymbol_C is a NOP if TdiExecute is already set
+  static int (*TdiExecute)() = NULL; // LibFindImageSymbol_C is a NOP if TdiExecute is already set
   status = LibFindImageSymbol_C("TdiShr", "TdiExecute", &TdiExecute);
   if STATUS_OK
-    status = (int)((char *)LibCallg(arglist, TdiExecute) - (char *)0);
+    status = (*TdiExecute)(&expression_d,&fname MDS_END_ARG);
   if (status & 1) {
     ans = strncpy(malloc((size_t)fname.length + 2), fname.pointer, fname.length);
     ans[fname.length] = '+';

--- a/treeshr/TreeSegments.c
+++ b/treeshr/TreeSegments.c
@@ -1119,13 +1119,7 @@ static int ReadSegment(TREE_INFO* tinfo, int nid, SEGMENT_HEADER* shead, SEGMENT
 	    if STATUS_OK {
 		STATIC_CONSTANT DESCRIPTOR(expression, "data($)[0:($-1)]");
 		DESCRIPTOR_LONG(row_d, &shead->next_row);
-		void *arglist[6] = { (void *)5 };
-		arglist[1] = &expression;
-		arglist[2] = dim;
-		arglist[3] = &row_d;
-		arglist[4] = dim;
-		arglist[5] = MdsEND_ARG;
-		status = (int)((char *)LibCallg(arglist, TdiExecute) - (char *)0);
+		status = (*TdiExecute)(&expression,dim,&row_d,dim MDS_END_ARG);
 	      }
 	  }
 	}
@@ -2263,34 +2257,14 @@ static int isSegmentInRange(vars_t* vars,
       if STATUS_OK {
         if ((start && start->pointer) && (end && end->pointer)) {
           STATIC_CONSTANT DESCRIPTOR(expression, "($ <= $) && ($ >= $)");
-          void *arglist[8] = { (void *)7 };
-          arglist[1] = &expression;
-          arglist[2] = start;
-          arglist[3] = &segend;
-          arglist[4] = end;
-          arglist[5] = &segstart;
-          arglist[6] = &ans_d;
-          arglist[7] = MdsEND_ARG;
-          status = (int)((char *)LibCallg(arglist, TdiExecute) - (char *)0);
+          status = (*TdiExecute)(&expression,start,&segend,end,&segstart,&ans_d MDS_END_ARG);
         } else {
           if (start && start->pointer) {
             STATIC_CONSTANT DESCRIPTOR(expression, "($ <= $)");
-            void *arglist[6] = { (void *)5 };
-            arglist[1] = &expression;
-            arglist[2] = start;
-            arglist[3] = &segend;
-            arglist[4] = &ans_d;
-            arglist[5] = MdsEND_ARG;
-            status = (int)((char *)LibCallg(arglist, TdiExecute) - (char *)0);
+            status = (*TdiExecute)(&expression,start,&segend,&ans_d MDS_END_ARG);
           } else {
             STATIC_CONSTANT DESCRIPTOR(expression, "($ >= $)");
-            void *arglist[6] = { (void *)5 };
-            arglist[1] = &expression;
-            arglist[2] = end;
-            arglist[3] = &segstart;
-            arglist[4] = &ans_d;
-            arglist[5] = MdsEND_ARG;
-            status = (int)((char *)LibCallg(arglist, TdiExecute) - (char *)0);
+            status = (*TdiExecute)(&expression,end,&segstart,&ans_d MDS_END_ARG);
           }
         }
       }


### PR DESCRIPTION
LibCallg should not be used for imported functions with a fixed number of args.
Instead, initialize the function reference with
```c
static int (*TdiExecute)() = NULL;
```
(NULL and static important for load-only-first-time)
load it with
```
 int status = LibFindImageSymbol_C("TdiShr", "TdiExecute", TdiExecute);
```
(handles the load-only-first-time, loads if ref is NULL)
and make the call
```c
status = (*TdiExecute)(expr, arg1, arg2 MDS_END_ARG);
```
If LibCallg is required, convert void* to status via portable intptr_t cast. 
```c
extern void* LibCallg();
...
status = (int)(intptr_t)LibCallg(arglist,TdiExecute);
````