### PR TITLE
Fix: Avoid segfault in FindNode with invalid nodename syntax

### DIFF
--- a/tditest/testing/test-treeshr.ans
+++ b/tditest/testing/test-treeshr.ans
@@ -18,6 +18,12 @@ getnci('?ember','fullpath')
 "\\MAIN::TOP:MEMBER"
 getnci('%ember','fullpath')
 ["\\MAIN::TOP:MEMBER"]
+getnci('\n','fullpath')
+%TREE-W-NNF, Node Not Found
+%TDI Error in GETNCI("\n", "fullpath")
+%TDI Error in EVALUATE(GETNCI("\n", "fullpath"))
+%TDI Error in EXECUTE("getnci('\\n','fullpath')")
+
 _tim=getnci(member,'time_inserted')
 49776423271761650QU
 date_time(_tim)

--- a/tditest/testing/test-treeshr.tdi
+++ b/tditest/testing/test-treeshr.tdi
@@ -9,6 +9,7 @@ getnci(member,'length')
 getnci(member,'on')
 getnci('?ember','fullpath')
 getnci('%ember','fullpath')
+getnci('\n','fullpath')
 _tim=getnci(member,'time_inserted')
 date_time(_tim)
 .subtree:a12:name

--- a/treeshr/TreeFindNode.c
+++ b/treeshr/TreeFindNode.c
@@ -142,7 +142,12 @@ EXPORT int _TreeFindNode(void *dbid, char const *path, int *outnid)
     return TreeNOT_OPEN;
   if (dblist->remote)
     return FindNodeRemote(dblist, path, outnid);
-  
+
+  if (path && (path[0] == '\n')) {
+      status = TreeNNF;
+      goto done;
+  }
+
   status = WildParse(path, &ctx, &wild);
   if STATUS_NOT_OK
     goto done;
@@ -183,7 +188,7 @@ STATIC_ROUTINE void FreeSearchCtx(SEARCH_CTX *ctx)
 }
 STATIC_ROUTINE NODELIST *Search(PINO_DATABASE *dblist, SEARCH_CTX *ctx, SEARCH_TERM *term, NODE *start, NODELIST **tail)
 {
-  NODELIST *nodes = Find(dblist, term, start, tail);
+  NODELIST *nodes = term ? Find(dblist, term, start, tail) : NULL;
   if (nodes) {
     NODELIST *more_nodes = NULL;
     NODELIST *more_tail = NULL;    

--- a/treeshr/TreeFindNodeWild.l
+++ b/treeshr/TreeFindNodeWild.l
@@ -153,11 +153,8 @@ EXPORT void FreeSearchTerms(SEARCH_TERM *terms)
 
 static char *strtrim(char *str)
 {
-  char *q = str;
-  while (* q) q++;
-  do { q--; } while (isspace(* q));
-  q++;
-  *q = '\0';
+  char *q;
+  for (q=str+strlen(str)-1; (q > str) && isspace(*q); q--) *q='\0';
   return str;
 }
 

--- a/treeshr/lex.yytreepath.c
+++ b/treeshr/lex.yytreepath.c
@@ -2173,11 +2173,8 @@ EXPORT void FreeSearchTerms(SEARCH_TERM *terms)
 
 static char *strtrim(char *str)
 {
-  char *q = str;
-  while (* q) q++;
-  do { q--; } while (isspace(* q));
-  q++;
-  *q = '\0';
+  char *q;
+  for (q=str+strlen(str)-1; (q > str) && isspace(*q); q--) *q='\0';
   return str;
 }
 


### PR DESCRIPTION
If a bad syntax is passed to FindNode or FindNodeWild a segfault
occurs. This should fix https://github.com/MDSplus/mdsplus/issues/1423