### PR TITLE
Fix: Fix class names for acq2106_423 devices

### DIFF
--- a/pydevices/HtsDevices/acq2106_423_2st.py
+++ b/pydevices/HtsDevices/acq2106_423_2st.py
@@ -23,7 +23,7 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 from acq2106_423st import Acq2106_423st
-class ACQ2106_423_1ST(Acq2106_423st):
+class ACQ2106_423_2ST(Acq2106_423st):
     """
     D-Tacq ACQ2106 with ACQ423 Digitizers (up to 6)  real time streaming support.
 

--- a/pydevices/HtsDevices/acq2106_423_3st.py
+++ b/pydevices/HtsDevices/acq2106_423_3st.py
@@ -23,7 +23,7 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 from acq2106_423st import Acq2106_423st
-class ACQ2106_423_1ST(Acq2106_423st):
+class ACQ2106_423_3ST(Acq2106_423st):
     """
     D-Tacq ACQ2106 with ACQ423 Digitizers (up to 6)  real time streaming support.
 

--- a/pydevices/HtsDevices/acq2106_423_4st.py
+++ b/pydevices/HtsDevices/acq2106_423_4st.py
@@ -23,7 +23,7 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 from acq2106_423st import Acq2106_423st
-class ACQ2106_423_1ST(Acq2106_423st):
+class ACQ2106_423_4ST(Acq2106_423st):
     """
     D-Tacq ACQ2106 with ACQ423 Digitizers (up to 6)  real time streaming support.
 

--- a/pydevices/HtsDevices/acq2106_423_5st.py
+++ b/pydevices/HtsDevices/acq2106_423_5st.py
@@ -23,7 +23,7 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 from acq2106_423st import Acq2106_423st
-class ACQ2106_423_1ST(Acq2106_423st):
+class ACQ2106_423_5ST(Acq2106_423st):
     """
     D-Tacq ACQ2106 with ACQ423 Digitizers (up to 6)  real time streaming support.
 

--- a/pydevices/HtsDevices/acq2106_423_6st.py
+++ b/pydevices/HtsDevices/acq2106_423_6st.py
@@ -23,7 +23,7 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 from acq2106_423st import Acq2106_423st
-class ACQ2106_423_1ST(Acq2106_423st):
+class ACQ2106_423_6ST(Acq2106_423st):
     """
     D-Tacq ACQ2106 with ACQ423 Digitizers (up to 6)  real time streaming support.
 


### PR DESCRIPTION
The class name for the ACQ2106_423_nST devices did not match the
filenames. They were copied from _1ST without modification.  This
PR updates them to the correct strings.