### PR TITLE
Feature: Add tdi based treeshr hooks

### DIFF
--- a/treeshr/RemoteAccess.c
+++ b/treeshr/RemoteAccess.c
@@ -321,6 +321,7 @@ int ConnectTreeRemote(PINO_DATABASE * dblist, char *tree, char *subtree_list, ch
 	  info->flush = (dblist->shotid == -1);
 	  info->header = (TREE_HEADER *) & info[1];
 	  info->treenam = strcpy(malloc(strlen(tree) + 1), tree);
+	  TreeCallHookFun("TreeHook","OpenTree",tree,dblist->shotid, NULL);
 	  TreeCallHook(OpenTree, info, 0);
 	  info->channel = conid;
 	  dblist->tree_info = info;

--- a/treeshr/TreeAddNode.c
+++ b/treeshr/TreeAddNode.c
@@ -748,6 +748,7 @@ int _TreeWriteTree(void **dbid, char const *exp_ptr, int shotid)
                 MDS_IO_LOCK(info_ptr->channel, 1, 1, MDS_IO_LOCK_RD | MDS_IO_LOCK_NOWAIT, 0);
                 status = TreeNORMAL;
                 (*dblist)->modified = 0;
+		TreeCallHookFun("TreeHook","WriteTree",info_ptr->treenam, (*dblist)->shotid, NULL);
                 TreeCallHook(WriteTree, info_ptr, 0);
             } else {
                 (*dblist)->modified = 0;

--- a/treeshr/TreeCallHook.c
+++ b/treeshr/TreeCallHook.c
@@ -28,6 +28,11 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <ncidef.h>
 #include "treeshrp.h"
 #include <mds_stdarg.h>
+#include <stdarg.h>
+#include <mdsshr.h>
+#include <stdlib.h>
+#include <string.h>
+#include <ctype.h>
 
 static int (*Notify) (TreeshrHookType, char *, int, int) = NULL;
 static void load_Notify() {
@@ -40,4 +45,101 @@ int TreeCallHook(TreeshrHookType htype, TREE_INFO * info, int nid)
   if (Notify)
     return (*Notify) (htype, info->treenam, info->shot, nid);
   return 1;
+}
+
+static char *_strcasestr(char *s1_in, char *s2_in) {
+  /* This is needed because strcasestr() is no available on all platforms */
+  char *s1=strdup(s1_in);
+  char *s2=strdup(s2_in);
+  char *s;
+  for (s=s1; *s; s++) *s=toupper((unsigned char) *s);
+  for (s=s2; *s; s++) *s=toupper((unsigned char) *s);
+  s=strstr(s1,s2);
+  if (s)
+    s=s1_in + (s-s1);
+  return s;
+}
+
+static int isEnabled(char *hookName) {
+  char *enabledHooks=getenv("TreeHooks");
+  if (enabledHooks==NULL) return 0;
+  enabledHooks=strdup(enabledHooks);
+  if (strcasecmp(enabledHooks,"all")==0) return 1;
+  char *p=enabledHooks;
+  while (p) {
+    p=_strcasestr(p,hookName);
+    if (p) {
+      if (p==enabledHooks || p[-1]==',') {
+	size_t len=strlen(hookName);
+	if (p[len]==',' || p[len]=='\0')
+	  return 1;
+	else
+	  p=p+len;
+      } else return 0;
+    }
+  }
+  free(enabledHooks);
+  return 0;
+}
+
+void TreeCallHookFun(char *hookType, char *hookName, ...) {
+  if (!isEnabled(hookName)) return;
+  static DESCRIPTOR(hooktype_key_d,"type");
+  DESCRIPTOR_FROM_CSTRING(hooktype_d,hookName);
+  static DESCRIPTOR(tree_key_d,"tree");
+  static DESCRIPTOR(shot_key_d,"shot");
+  static DESCRIPTOR(nid_key_d,"nid");
+  EMPTYXD(defaultAns);
+  struct descriptor_xd *ans=&defaultAns;
+  struct descriptor *dict=NULL;
+  if (strcmp(hookType,"TreeHook")==0) {
+    va_list ap;
+    va_start(ap, hookName);
+    char *tree = va_arg(ap, char *);
+    int shot = va_arg(ap, int);
+    struct descriptor_xd *this_ans = va_arg(ap, struct descriptor_xd *);
+    DESCRIPTOR_FROM_CSTRING(tree_d,tree);
+    DESCRIPTOR_LONG(shot_d,&shot);
+    va_end(ap);
+    ans=this_ans ? this_ans : &defaultAns;
+    struct descriptor *hook_dscs[] = {(struct descriptor *)&hooktype_key_d,
+				      (struct descriptor *)&hooktype_d,
+				      (struct descriptor *)&tree_key_d,
+				      (struct descriptor *)&tree_d,
+				      (struct descriptor *)&shot_key_d,
+				      (struct descriptor *)&shot_d};
+    DESCRIPTOR_APD(hook_d, DTYPE_DICTIONARY, &hook_dscs, 6);
+    dict = (struct descriptor *)&hook_d;
+  } else if (strcmp(hookType,"TreeNidHook")==0) {
+    va_list ap;
+    va_start(ap, hookName);
+    char *tree = va_arg(ap, char *);
+    int shot = va_arg(ap, int);
+    int nid = va_arg(ap, int);
+    struct descriptor_xd *this_ans = va_arg(ap, struct descriptor_xd *);
+    DESCRIPTOR_FROM_CSTRING(tree_d,tree);
+    DESCRIPTOR_LONG(shot_d,&shot);
+    DESCRIPTOR_NID(nid_d,&nid);
+    va_end(ap);
+    ans=this_ans ? this_ans : &defaultAns;
+    struct descriptor *hook_dscs[] = {(struct descriptor *)&hooktype_key_d,
+				      (struct descriptor *)&hooktype_d,
+				      (struct descriptor *)&tree_key_d,
+				      (struct descriptor *)&tree_d,
+				      (struct descriptor *)&shot_key_d,
+				      (struct descriptor *)&shot_d,
+                                      (struct descriptor *)&nid_key_d,
+                                      (struct descriptor *)&nid_d};
+    DESCRIPTOR_APD(hook_d, DTYPE_DICTIONARY, &hook_dscs, 8);
+    dict = (struct descriptor *)&hook_d;
+  } else {
+    return;
+  }
+  static int (*TdiExecute)() = NULL; // LibFindImageSymbol_C is a NOP if TdiExecute is already set
+  int status;
+  status = LibFindImageSymbol_C("TdiShr", "TdiExecute", &TdiExecute);
+  DESCRIPTOR(expression_d,"TreeShrHook($)");
+  if STATUS_OK
+      (*TdiExecute)(&expression_d,dict,ans MDS_END_ARG);
+  MdsFree1Dx(&defaultAns,0);
 }

--- a/treeshr/TreeCallHook.c
+++ b/treeshr/TreeCallHook.c
@@ -57,6 +57,8 @@ static char *_strcasestr(char *s1_in, char *s2_in) {
   s=strstr(s1,s2);
   if (s)
     s=s1_in + (s-s1);
+  free(s1);
+  free(s2);
   return s;
 }
 

--- a/treeshr/TreeGetNci.c
+++ b/treeshr/TreeGetNci.c
@@ -50,6 +50,7 @@ static inline int minInt(int a, int b) { return a < b ? a : b; }
  if (nci_version != version)\
  {\
     nid_to_tree_nidx(dblist, (&nid), info, node_number);\
+    TreeCallHookFun("TreeNidHook","GetNci",info->treenam, info->shot, nid, NULL); \
     status = TreeCallHook(GetNci,info,nid_in);\
     if (status && STATUS_NOT_OK) break;\
     status = TreeGetNciW(info, node_number, &nci,version);\

--- a/treeshr/TreeGetRecord.c
+++ b/treeshr/TreeGetRecord.c
@@ -66,6 +66,7 @@ int _TreeGetRecord(void *dbid, int nid_in, struct descriptor_xd *dsc)
     return GetRecordRemote(dblist, nid_in, dsc);
   nid_to_tree_nidx(dblist, nid, info, nidx);
   if (info) {
+    TreeCallHookFun("TreeNidHook","GetNci",info->treenam, info->shot, nid, NULL);
     status = TreeCallHook(GetNci, info, nid_in);
     if (status && STATUS_NOT_OK)
       return 0;
@@ -74,6 +75,7 @@ int _TreeGetRecord(void *dbid, int nid_in, struct descriptor_xd *dsc)
       status = TreeGetNciW(info, nidx, &nci, 0);
       if STATUS_OK {
 	if (nci.length) {
+	  TreeCallHookFun("TreeNidHook","GetData", info->treenam, info->shot, nid, NULL);
 	  status = TreeCallHook(GetData, info, nid_in);
 	  if (status && STATUS_NOT_OK)
 	    return 0;

--- a/treeshr/TreePutRecord.c
+++ b/treeshr/TreePutRecord.c
@@ -142,6 +142,8 @@ int _TreePutRecord(void *dbid, int nid, struct descriptor *descriptor_ptr, int u
     NCI local_nci, old_nci;
     int64_t saved_viewdate;
     TreeCallHookFun("TreeNidHook","PutData",info_ptr->treenam, info_ptr->shot, nid, NULL);
+    TreeCallHookFun("TreeNidDataHook","PutData",info_ptr->treenam,
+		    info_ptr->shot, nid, descriptor_ptr, NULL);
     status = TreeCallHook(PutData, info_ptr, nid);
     if (status && !(status & 1))
       return status;

--- a/treeshr/TreePutRecord.c
+++ b/treeshr/TreePutRecord.c
@@ -141,6 +141,7 @@ int _TreePutRecord(void *dbid, int nid, struct descriptor *descriptor_ptr, int u
     int stv;
     NCI local_nci, old_nci;
     int64_t saved_viewdate;
+    TreeCallHookFun("TreeNidHook","PutData",info_ptr->treenam, info_ptr->shot, nid, NULL);
     status = TreeCallHook(PutData, info_ptr, nid);
     if (status && !(status & 1))
       return status;
@@ -425,8 +426,10 @@ int _TreeOpenDatafileW(TREE_INFO * info, int *stv_ptr, int tmpfile)
     df_ptr = NULL;
   }
   info->data_file = df_ptr;
-  if (status & 1)
+  if (status & 1) {
+    TreeCallHookFun("TreeHook","OpenDataFileWrite", info->treenam, info->shot, NULL);
     TreeCallHook(OpenDataFileWrite, info, 0);
+  }
   return status;
 }
 

--- a/treeshr/TreePutRecord.c
+++ b/treeshr/TreePutRecord.c
@@ -142,7 +142,7 @@ int _TreePutRecord(void *dbid, int nid, struct descriptor *descriptor_ptr, int u
     NCI local_nci, old_nci;
     int64_t saved_viewdate;
     TreeCallHookFun("TreeNidHook","PutData",info_ptr->treenam, info_ptr->shot, nid, NULL);
-    TreeCallHookFun("TreeNidDataHook","PutData",info_ptr->treenam,
+    TreeCallHookFun("TreeNidDataHook","PutDataFull",info_ptr->treenam,
 		    info_ptr->shot, nid, descriptor_ptr, NULL);
     status = TreeCallHook(PutData, info_ptr, nid);
     if (status && !(status & 1))

--- a/treeshr/TreeSegments.c
+++ b/treeshr/TreeSegments.c
@@ -315,6 +315,7 @@ inline static int open_datafile_write0(vars_t* vars) {
   RETURN_IF_NOT_OK(load_node_ptr(vars));
   RETURN_IF_NOT_OK(check_segment_remote(vars));
   RETURN_IF_NOT_OK(load_info_ptr(vars));
+  TreeCallHookFun("TreeNidHook","PutData",vars->tinfo->treenam,vars->tinfo->shot,*vars->nid_ptr,NULL);
   status = TreeCallHook(PutData, vars->tinfo, *(int*)vars->nid_ptr);
   if (status && STATUS_NOT_OK)
     return status;
@@ -716,6 +717,7 @@ int _TreeMakeSegment(void *dbid, int nid,
   GOTO_END_ON_ERROR(begin_sinfo(vars,initialValue,check_compress_dim));
   GOTO_END_ON_ERROR(putdata_initialvalue(vars,initialValue));
   GOTO_END_ON_ERROR(putdim_dim(vars,start,end,dimension));
+  TreeCallHookFun("TreeNidHook","MakeSegment",vars->tinfo->treenam,vars->tinfo->shot,*vars->nid_ptr,NULL);
   status = begin_finish(vars);
 end: ;
   pthread_cleanup_pop(vars->nci_locked);
@@ -739,6 +741,7 @@ int _TreeMakeTimestampedSegment(void *dbid, int nid,
   GOTO_END_ON_ERROR(begin_sinfo(vars,initialValue,check_compress_ts));
   GOTO_END_ON_ERROR(putdata_initialvalue(vars,initialValue));
   GOTO_END_ON_ERROR(putdim_ts(vars,timestamps,initialValue));
+  TreeCallHookFun("TreeNidHook","MakeTimestampedSegment",vars->tinfo->treenam,vars->tinfo->shot,*vars->nid_ptr,NULL);
   status = begin_finish(vars);
 end: ;
   CLEANUP_NCI_POP;
@@ -759,6 +762,7 @@ int _TreeUpdateSegment(void *dbid, int nid, struct descriptor *start, struct des
   IF_NO_SEGMENT_INDEX  {status = TreeFAILURE;goto end;}
   GOTO_END_ON_ERROR(check_sinfo(vars));
   GOTO_END_ON_ERROR(putdim_dim(vars,start,end,dimension));
+  TreeCallHookFun("TreeNidHook","UpdateSegment",vars->tinfo->treenam,vars->tinfo->shot,*vars->nid_ptr,NULL);
   status = PutSegmentIndex(vars->tinfo, &vars->sindex, &vars->index_offset);
 end: ;
   CLEANUP_NCI_POP;
@@ -827,8 +831,10 @@ int _TreePutSegment(void *dbid, int nid, const int startIdx, struct descriptor_a
   }
   if (start_idx == vars->shead.next_row)
     vars->shead.next_row += bytes_to_insert / bytes_per_row;
-  if STATUS_OK
+  if STATUS_OK {
     status = PutSegmentHeader(vars->tinfo, &vars->shead, &vars->attr.facility_offset[SEGMENTED_RECORD_FACILITY]);
+    TreeCallHookFun("TreeNidHook","PutSegment",vars->tinfo->treenam,vars->tinfo->shot,*vars->nid_ptr,NULL);
+    }
 end: ;
   CLEANUP_NCI_POP;
   return status;
@@ -902,8 +908,10 @@ int _TreePutTimestampedSegment(void *dbid, int nid, int64_t * timestamp, struct 
   FREE_BUFFER(times);
   TreeUnLockDatafile(vars->tinfo, 0, offset);
   vars->shead.next_row = start_idx + bytes_to_insert / bytes_per_row;
-  if STATUS_OK
+  if STATUS_OK {
     status = PutSegmentHeader(vars->tinfo, &vars->shead, &vars->attr.facility_offset[SEGMENTED_RECORD_FACILITY]);
+    TreeCallHookFun("TreeNidHook","PutTimestampedSegment",vars->tinfo->treenam,vars->tinfo->shot,*vars->nid_ptr,NULL);
+    }
 end: ;
   CLEANUP_NCI_POP;
   return status;

--- a/treeshr/TreeSegments.c
+++ b/treeshr/TreeSegments.c
@@ -717,7 +717,12 @@ int _TreeMakeSegment(void *dbid, int nid,
   GOTO_END_ON_ERROR(begin_sinfo(vars,initialValue,check_compress_dim));
   GOTO_END_ON_ERROR(putdata_initialvalue(vars,initialValue));
   GOTO_END_ON_ERROR(putdim_dim(vars,start,end,dimension));
-  TreeCallHookFun("TreeNidHook","MakeSegment",vars->tinfo->treenam,vars->tinfo->shot,*vars->nid_ptr,NULL);
+  TreeCallHookFun("TreeNidHook","MakeSegment",vars->tinfo->treenam,
+		  vars->tinfo->shot,*vars->nid_ptr,NULL);
+  SIGNAL(1) signal = {0, DTYPE_SIGNAL, CLASS_R, 0, 3, __fill_value__ \
+		      (struct descriptor *)initValIn, NULL, {dimension}};
+  TreeCallHookFun("TreeNidDataHook","MakeSegmentFull",vars->tinfo->treenam,
+		  vars->tinfo->shot,*vars->nid_ptr,&signal,NULL);
   status = begin_finish(vars);
 end: ;
   pthread_cleanup_pop(vars->nci_locked);
@@ -741,7 +746,13 @@ int _TreeMakeTimestampedSegment(void *dbid, int nid,
   GOTO_END_ON_ERROR(begin_sinfo(vars,initialValue,check_compress_ts));
   GOTO_END_ON_ERROR(putdata_initialvalue(vars,initialValue));
   GOTO_END_ON_ERROR(putdim_ts(vars,timestamps,initialValue));
-  TreeCallHookFun("TreeNidHook","MakeTimestampedSegment",vars->tinfo->treenam,vars->tinfo->shot,*vars->nid_ptr,NULL);
+  TreeCallHookFun("TreeNidHook","MakeTimestampedSegment",vars->tinfo->treenam,
+		  vars->tinfo->shot,*vars->nid_ptr,NULL);
+  DESCRIPTOR_A(dimension, sizeof(int64_t), DTYPE_Q, timestamps, rows_filled * sizeof(int64_t));
+  SIGNAL(1) signal = {0, DTYPE_SIGNAL, CLASS_R, 0, 3, __fill_value__ \
+		      (struct descriptor *)initValIn, NULL, {(struct descriptor *)&dimension}};
+  TreeCallHookFun("TreeNidDataHook","MakeTimestampedSegmentFull",vars->tinfo->treenam,
+		  vars->tinfo->shot,*vars->nid_ptr,&signal,NULL);
   status = begin_finish(vars);
 end: ;
   CLEANUP_NCI_POP;
@@ -762,7 +773,8 @@ int _TreeUpdateSegment(void *dbid, int nid, struct descriptor *start, struct des
   IF_NO_SEGMENT_INDEX  {status = TreeFAILURE;goto end;}
   GOTO_END_ON_ERROR(check_sinfo(vars));
   GOTO_END_ON_ERROR(putdim_dim(vars,start,end,dimension));
-  TreeCallHookFun("TreeNidHook","UpdateSegment",vars->tinfo->treenam,vars->tinfo->shot,*vars->nid_ptr,NULL);
+  TreeCallHookFun("TreeNidHook","UpdateSegment",vars->tinfo->treenam,
+		  vars->tinfo->shot,*vars->nid_ptr,NULL);
   status = PutSegmentIndex(vars->tinfo, &vars->sindex, &vars->index_offset);
 end: ;
   CLEANUP_NCI_POP;
@@ -833,7 +845,10 @@ int _TreePutSegment(void *dbid, int nid, const int startIdx, struct descriptor_a
     vars->shead.next_row += bytes_to_insert / bytes_per_row;
   if STATUS_OK {
     status = PutSegmentHeader(vars->tinfo, &vars->shead, &vars->attr.facility_offset[SEGMENTED_RECORD_FACILITY]);
-    TreeCallHookFun("TreeNidHook","PutSegment",vars->tinfo->treenam,vars->tinfo->shot,*vars->nid_ptr,NULL);
+    TreeCallHookFun("TreeNidHook","PutSegment",vars->tinfo->treenam,
+		    vars->tinfo->shot,*vars->nid_ptr,NULL);
+    TreeCallHookFun("TreeNidDataHook","PutSegmentFull",vars->tinfo->treenam,
+		    vars->tinfo->shot,*vars->nid_ptr,data,NULL);
     }
 end: ;
   CLEANUP_NCI_POP;
@@ -910,7 +925,13 @@ int _TreePutTimestampedSegment(void *dbid, int nid, int64_t * timestamp, struct 
   vars->shead.next_row = start_idx + bytes_to_insert / bytes_per_row;
   if STATUS_OK {
     status = PutSegmentHeader(vars->tinfo, &vars->shead, &vars->attr.facility_offset[SEGMENTED_RECORD_FACILITY]);
-    TreeCallHookFun("TreeNidHook","PutTimestampedSegment",vars->tinfo->treenam,vars->tinfo->shot,*vars->nid_ptr,NULL);
+    TreeCallHookFun("TreeNidHook","PutTimestampedSegment",vars->tinfo->treenam,
+		    vars->tinfo->shot,*vars->nid_ptr,NULL);
+    DESCRIPTOR_A(dimension, sizeof(int64_t), DTYPE_Q, timestamp, rows_to_insert * sizeof(int64_t)); 
+    SIGNAL(1) signal = {0, DTYPE_SIGNAL, CLASS_R, 0, 3, __fill_value__ \
+			(struct descriptor *)data_in, NULL, {(struct descriptor *)&dimension}};
+    TreeCallHookFun("TreeNidDataHook","PutTimestampedSegmentFull",vars->tinfo->treenam,
+		    vars->tinfo->shot,*vars->nid_ptr,&signal,NULL);
     }
 end: ;
   CLEANUP_NCI_POP;

--- a/treeshr/treeshrp.h
+++ b/treeshr/treeshrp.h
@@ -738,6 +738,7 @@ extern int GetDefaultNidRemote(PINO_DATABASE * dblist, int *nid);
 extern int64_t RfaToSeek(unsigned char *rfa);
 void SeekToRfa(int64_t seek, unsigned char *rfa);
 extern int SetParentState(PINO_DATABASE * db, NODE * node, unsigned int state);
+extern void TreeCallHookFun(char *hookType, char *hookName, ...);
 extern int TreeMakeNidsLocal(struct descriptor *dsc_ptr, int nid);
 extern int TreeCloseFiles(TREE_INFO * info, int nci, int data);
 extern int TreeCopyExtended(PINO_DATABASE * dbid1, PINO_DATABASE * dbid2, int nid, NCI * nci, int compress);


### PR DESCRIPTION
Add various treeshr hooks which will call a TreeShrHook fun with
one argument which is a Dictionary. Depending on the hook the
Dictionary could contain fields such as:

  "type" - the name of the type of hook
  "tree" - the name of the tree
  "shot" - the shot number of the tree
  "nid"  - the node being operated on
  "data" - the data being written to the tree

The type of hooks currently provided are:

  "OpenTree"     - Tree being opened
  "WriteTree"    - Save of edited tree
  "GetNci"       - Getting node characteristics
  "GetData"      - Retrieving data stored in a node
  "CloseTree"    - Closing an opened tree
  "RetrieveTree" - Tree not found so hook to retrieve from storage
  "OpenTreeEdit" - Opening a tree for edit
  "OpenDatafileWrite" - Open tree datafile for write
  "MakeSegment"  - Store a segment in a node
  "MakeSegmentFull" - Store a segment in a node (data passed to hook)
  "MakeTimestampedSegment" - Store timestamped segment
  "MakeTimestampedSegmentFull" - Store segment (data passed)
  "PutSegment"      - Store segment
  "PutTimestampedSegment" - Store timestamped segment
  "PutTimestampedSegmentFull" - (data passed)

Hook selection is determined by the TreeHooks environment variable.
You can select particular hooks by listing the hook types in a
comma delimited list (i.e. export TreeHooks=OpenTree,GetNci,CloseTree)
or you can use the keywords allhooks and fullhooks. If the string,
"allhooks", is found in the TreeHooks environment variable all of the
hooks which do not have full in their type name will be called. If
the string, "fullhooks", is found all the hooks with full in their type
will be called. If you include allhooks and fullhooks in the TreeHooks
environment variable all the hooks will be called. The names included
in the TreeHooks environment variable will be case insensitive.
