### PR TITLE
Feature: enable importing of other modules in MDS_PYDEVICE_PATH  …

### DIFF
--- a/mdsobjects/python/tree.py
+++ b/mdsobjects/python/tree.py
@@ -3406,11 +3406,21 @@ If you did intend to write to a subnode of the device you should check the prope
             for part in parts:
               w=os.walk(part)
               for dp,dn,fn in w:
-                for fname in fn:
-                  if fname.lower() == check_name:
+                devname=None
+                if name in dn:
+                    devname=name
+                    doimport=True
+                else:
+                    for fname in fn:
+                        if fname.lower() == check_name:
+                            devname=fname[:-3]
+                            doimport=True
+                            break
+                print("devname=%s\n" % devname)
+                if devname is not None:
                     sys.path.insert(0,dp)
                     try:
-                      device = __import__(fname[:-3])
+                      device = __import__(devname)
                       Device.__cached_py_device_modules[name] = device
                       return device
                     finally:

--- a/mdsobjects/python/tree.py
+++ b/mdsobjects/python/tree.py
@@ -3407,16 +3407,15 @@ If you did intend to write to a subnode of the device you should check the prope
               w=os.walk(part)
               for dp,dn,fn in w:
                 devname=None
-                if name in dn:
-                    devname=name
-                    doimport=True
-                else:
+                for d in dn:
+                    if name == d.lower():
+                        devname=name
+                        break
+                if devname is None:
                     for fname in fn:
                         if fname.lower() == check_name:
                             devname=fname[:-3]
-                            doimport=True
                             break
-                print("devname=%s\n" % devname)
                 if devname is not None:
                     sys.path.insert(0,dp)
                     try:

--- a/mdsobjects/python/tree.py
+++ b/mdsobjects/python/tree.py
@@ -3408,8 +3408,8 @@ If you did intend to write to a subnode of the device you should check the prope
               for dp,dn,fn in w:
                 devname=None
                 for d in dn:
-                    if name == d.lower():
-                        devname=name
+                    if d.lower() == name:
+                        devname=d
                         break
                 if devname is None:
                     for fname in fn:

--- a/pydevices/HtsDevices/acq2106_423st.py
+++ b/pydevices/HtsDevices/acq2106_423st.py
@@ -95,7 +95,7 @@ class Acq2106_423st(MDSplus.Device):
         return ans
 
     def init(self):
-        import acq400_hapi
+        acq400_hapi=self.importPyDeviceModule('acq400_hapi')
         uut = acq400_hapi.Acq400(self.node.data(), monitor=False)
         uut.s0.set_knob('set_abort', '1')
         if self.ext_clock.length > 0:
@@ -134,7 +134,7 @@ class Acq2106_423st(MDSplus.Device):
     STOP=stop
 
     def trig(self):
-        import acq400_hapi
+        acq400_hapi=self.importPyDeviceModule('acq400_hapi')
         uut = acq400_hapi.Acq400(self.node.data(), monitor=False)
         uut.so.set_knob('soft_trigger','1')
         return 1


### PR DESCRIPTION
The Device.importPyDeviceModule(name) class method is used to
import pydevice modules found in the MDS_PYDEVICE_PATH environment
variable. This originally only provided support for importing
name.py files. This adds the capability of importing packages
contained in the directory with that name.

This class method is case insensitive when searching for modules
with the specified name.

When a device implementation imports a module inside of a method
or imports a module which resides in a directory other than
the device module itself but inside the MDS_PYDEVICE_PATH
directory trees it should use the importPyDeviceModule() method
to import a module.

Once imported these modules are cached so future calls to
importPyDeviceModule() do not need to search the directory trees.
Similarly if a module is found but fails to import this failure
is also cached so subsequent attempts do not search for the module.
2b476d5
