### PR TITLE
Fix: Use the new device module import method

### DIFF
--- a/pydevices/HtsDevices/acq435st.py
+++ b/pydevices/HtsDevices/acq435st.py
@@ -106,7 +106,7 @@ class ACQ435ST(MDSplus.Device):
         chan.setSegmentScale(MDSplus.ADD(MDSplus.MULTIPLY(chan.COEFFICIENT,MDSplus.dVALUE()),chan.OFFSET))
 
     def init(self):
-        import acq400_hapi
+        acq400_hapi=self.importPyDeviceModule('acq400_hapi')
         from threading import Thread
 
         uut = acq400_hapi.Acq400(self.node.data(), monitor=False)
@@ -155,7 +155,7 @@ class ACQ435ST(MDSplus.Device):
     STOP=stop
 
     def trig(self):
-        import acq400_hapi
+        acq400_hapi=self.importPyDeviceModule('acq400_hapi')
         uut = acq400_hapi.Acq400(self.node.data(), monitor=False)
         uut.so.set_knob('soft_trigger','1')
         return 1


### PR DESCRIPTION
This device uses the D-Tacq supplied acq400_hapi module which
is included under HtsDevices.

The device superclass now has a method:
  importPyDeviceModule
which can find this code even though it is not in PYTHONPATH

The imports become:
  acq400_hapi=self.importPyDeviceModule('acq400_hapi')