### PR TITLE
Fix: Use MDS_END_ARG in MdsLibIdl Treeshr calls

### DIFF
--- a/mdslibidl/MdsLibIdl.c
+++ b/mdslibidl/MdsLibIdl.c
@@ -69,7 +69,7 @@ EXPORT int IdlMdsClose(int argc, void **argv)
   int status;
   BlockSig(SIGALRM);
   if (argc > 1)
-    status = TreeClose((char *)argv[0], ((char *)argv[1] - (char *)0));
+    status = TreeClose((char *)argv[0], (int)(intptr_t)argv[1]);
   else {
     status = TreeClose(0, 0);
     while (TreeClose(0, 0) & 1) ;
@@ -83,7 +83,7 @@ EXPORT int IdlMdsOpen(int argc, void **argv)
   int status = 0;
   if (argc == 2) {
     BlockSig(SIGALRM);
-    status = TreeOpen((char *)argv[0], ((char *)argv[1] - (char *)0) MDS_END_ARG);
+    status = TreeOpen((char *)argv[0], (int)(intptr_t)argv[1], 0);
     UnBlockSig(SIGALRM);
   }
   return status;

--- a/mdslibidl/MdsLibIdl.c
+++ b/mdslibidl/MdsLibIdl.c
@@ -83,7 +83,7 @@ EXPORT int IdlMdsOpen(int argc, void **argv)
   int status = 0;
   if (argc == 2) {
     BlockSig(SIGALRM);
-    status = TreeOpen((char *)argv[0], ((char *)argv[1] - (char *)0), 0);
+    status = TreeOpen((char *)argv[0], ((char *)argv[1] - (char *)0) MDS_END_ARG);
     UnBlockSig(SIGALRM);
   }
   return status;
@@ -555,7 +555,7 @@ EXPORT int IdlMdsPut(int argc, void **argv)
     *(int *)&arglist[0] = argidx;
     status = (int)(intptr_t)LibCallg(arglist, TdiCompile);
     if (status & 1) {
-      status = TreePutRecord(nid, (struct descriptor *)&tmp, 0);
+      status = TreePutRecord(nid, (struct descriptor *)&tmp MDS_END_ARG);
       MdsFree1Dx(&tmp, NULL);
     }
     for (i = 0; i < 16; i++) {

--- a/mdslibidl/MdsLibIdl.c
+++ b/mdslibidl/MdsLibIdl.c
@@ -555,7 +555,7 @@ EXPORT int IdlMdsPut(int argc, void **argv)
     *(int *)&arglist[0] = argidx;
     status = (int)(intptr_t)LibCallg(arglist, TdiCompile);
     if (status & 1) {
-      status = TreePutRecord(nid, (struct descriptor *)&tmp MDS_END_ARG);
+      status = TreePutRecord(nid, (struct descriptor *)&tmp, 0);
       MdsFree1Dx(&tmp, NULL);
     }
     for (i = 0; i < 16; i++) {


### PR DESCRIPTION
The change from MDS_END_ARG=0 to MDS_END_ARG=1 made the non standard
(non macro) use of 0 to terminate argument lists wrong.

This caused MdsOpen, 'tree', shot  to segfault on some platforms.
Changed calls to TreeOpen and TreeClose to use the MDS_END_ARG macro