### PR TITLE
Fix: Repair thick client create pulse

### DIFF
--- a/treeshr/RemoteAccess.c
+++ b/treeshr/RemoteAccess.c
@@ -368,10 +368,13 @@ int CreatePulseFileRemote(PINO_DATABASE * dblist, int shot, int *nids, int num)
   int status;
   char exp[8192];
   int i;
-  sprintf(exp, "TreeCreatePulseFile(%d,[", shot);
-  for (i = 0; i < num; i++)
-    sprintf(&exp[strlen(exp)], "%d,", nids[i]);
-  sprintf(&exp[strlen(exp) - 1], "],%d)", num);
+  sprintf(exp, "TreeShr->TreeCreatePulseFile(val(%d),val(%d),ref([", shot,num);
+  for (i = 0; i < num; i++) {
+    sprintf(&exp[strlen(exp)], "%d", nids[i]);
+    if (i<num-1)
+      strcat(exp,",");
+  }
+  strcat(exp,"]))");
   status = MdsValue0(dblist->tree_info->channel, exp, &ans);
   if (ans.ptr) {
     status = (ans.dtype == DTYPE_L) ? *(int *)ans.ptr : 0;


### PR DESCRIPTION
At some point the argument list of the tdi fun for
calling TreeShr->TreeCreatePulseFile were changed to
match the order of the arguments of the c library call. The
thick client implementation was still calling the tdi fun
with the old argument list order so doing a create pulse
of a tree with subtrees using thick client resulted in an error.

This change calls the TreeShr function directly instead of using
the tdi fun which should be more efficient and has the correct
argument order.