### PR TITLE
zack.vii playground

### DIFF
--- a/servershr/ServerSendMessage.c
+++ b/servershr/ServerSendMessage.c
@@ -539,8 +539,6 @@ static void ResetFdactive(int rep, SOCKET sock, fd_set* active){
   DBG("reset fdactive in ResetFdactive\n");
 }
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wclobbered"
 static void ReceiverThread(void *sockptr){
   atexit((void*)ReceiverExit);
   CONDITION_SET(&ReceiverRunning);
@@ -594,7 +592,6 @@ static void ReceiverThread(void *sockptr){
   fprintf(stderr,"Cannot recover from select errors in ServerSendMessage, exitting\n");
   pthread_exit(0);
 }
-#pragma GCC diagnostic pop
 
 int is_broken_socket(SOCKET socket)
 {

--- a/treeshr/TreeAddNode.c
+++ b/treeshr/TreeAddNode.c
@@ -482,8 +482,7 @@ static void get_add_rtn_c(void* in){
   free_if(&c->model);
   free_if(&c->image);
 }
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wclobbered"
+
 static inline int get_add_rtn(char const *congtype, int (**add)()){
   static int (*TdiExecute) () = NULL;
   int status = LibFindImageSymbol_C("TdiShr", "TdiExecute", &TdiExecute);
@@ -523,7 +522,6 @@ static inline int get_add_rtn(char const *congtype, int (**add)()){
   pthread_cleanup_pop(1);
   return status;
 }
-#pragma GCC diagnostic pop
 
 int _TreeAddConglom(void *dbid, char const *path, char const *congtype, int *nid){
   if (!IS_OPEN_FOR_EDIT(((PINO_DATABASE *)dbid))) return TreeNOEDIT;

--- a/treeshr/TreeSegments.c
+++ b/treeshr/TreeSegments.c
@@ -696,14 +696,9 @@ inline static int ReadProperty_safe(TREE_INFO *tinfo, const int64_t offset,char 
 //#define CLEANUP_NCI_PUSH
 //#define CLEANUP_NCI_POP  unlock_nci(vars)
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wclobbered"
-
-int _TreeMakeSegment(void *dbid, int nid,
-        struct descriptor *start, struct descriptor *end, struct descriptor *dimension,
-        struct descriptor_a *initValIn, int idx, int rows_filled){
+int _TreeMakeSegment(void *dbid, int nid, struct descriptor *start, struct descriptor *end, struct descriptor *dimension, struct descriptor_a *initValIn, int idx, int rows_filled){
   INIT_WRITE_VARS;
-  pthread_cleanup_push(unlock_nci,(void*)vars);
+  CLEANUP_NCI_PUSH;
   struct descriptor_a* initialValue = initValIn;
   GOTO_END_ON_ERROR(open_datafile_write0(vars));
   GOTO_END_ON_ERROR(check_input(&initialValue));
@@ -936,8 +931,6 @@ end: ;
   CLEANUP_NCI_POP;
   return status;
 }
-
-#pragma GCC diagnostic pop
 
 ///// GET SEGMENT TIMES /////
 


### PR DESCRIPTION
* length of integer to str conversion inconsistent
* tcl("dir/full") failed with tdi devices
* c/lib devices wont work without python
* running python code without python caused sigsegv
* added lib-device and tdi-device add-test to tditest treeshr test