### PR TITLE
Feature: Add "code in" pydevice support

### DIFF
--- a/deploy/packaging/debian/python.noarch
+++ b/deploy/packaging/debian/python.noarch
@@ -26,6 +26,7 @@
 ./usr/local/mdsplus/mdsobjects/python/tests/dataUnitTest.py
 ./usr/local/mdsplus/mdsobjects/python/tests/dclUnitTest.py
 ./usr/local/mdsplus/mdsobjects/python/tests/devices/TestDevice.py
+./usr/local/mdsplus/mdsobjects/python/tests/devices/TestDeviceCodeIn.py
 ./usr/local/mdsplus/mdsobjects/python/tests/devicesUnitTest.py
 ./usr/local/mdsplus/mdsobjects/python/tests/exceptionUnitTest.py
 ./usr/local/mdsplus/mdsobjects/python/tests/images/mdsplus_logo.jpg

--- a/deploy/packaging/redhat/python.noarch
+++ b/deploy/packaging/redhat/python.noarch
@@ -31,6 +31,7 @@
 ./usr/local/mdsplus/mdsobjects/python/tests/dclUnitTest.py
 ./usr/local/mdsplus/mdsobjects/python/tests/devices
 ./usr/local/mdsplus/mdsobjects/python/tests/devices/TestDevice.py
+./usr/local/mdsplus/mdsobjects/python/tests/devices/TestDeviceCodeIn.py
 ./usr/local/mdsplus/mdsobjects/python/tests/devicesUnitTest.py
 ./usr/local/mdsplus/mdsobjects/python/tests/exceptionUnitTest.py
 ./usr/local/mdsplus/mdsobjects/python/tests/images

--- a/mdsobjects/python/compound.py
+++ b/mdsobjects/python/compound.py
@@ -291,6 +291,11 @@ class Conglom(Compound):
             raise _exc.DevNOT_A_PYDEVICE
         model = str(self.model)
         safe_env = {}
+        try:
+            exec '\n'.join(map(str,self.name.data())) in globals()
+            return globals()[model](*args,**kwargs)
+        except:
+            pass
         qualifiers = self.qualifiers.data()
         if isinstance(qualifiers,_N.generic): qualifiers = qualifiers.tolist()
         if isinstance(qualifiers,list):       qualifiers = ';'.join(qualifiers)  # make it a list of statements

--- a/mdsobjects/python/compound.py
+++ b/mdsobjects/python/compound.py
@@ -292,7 +292,7 @@ class Conglom(Compound):
         model = str(self.model)
         safe_env = {}
         try:
-            exec '\n'.join(map(str,self.name.data())) in globals()
+            exec('\n'.join(map(str,self.name.data())),globals())
             return globals()[model](*args,**kwargs)
         except:
             pass

--- a/mdsobjects/python/tests/dclUnitTest.py
+++ b/mdsobjects/python/tests/dclUnitTest.py
@@ -65,6 +65,7 @@ class Tests(_UnitTest.TreeTests,_UnitTest.MdsIp):
     def interface(self):
         with Tree(self.tree,self.shot,'new') as pytree:
             Device.PyDevice('TestDevice').Add(pytree,'TESTDEVICE')
+            Device.PyDevice('TestDeviceCodeIn').Add(pytree,'CI_DEVICE')
             pytree.write()
         self.assertEqual(dcl('help set verify',1,1,0)[1],None)
         self.assertEqual(tcl('help set tree',1,1,0)[1],None)
@@ -80,9 +81,13 @@ class Tests(_UnitTest.TreeTests,_UnitTest.MdsIp):
         self._doTCLTest('edit PYTREE/shot=%d'%(self.shot,))
         self._doTCLTest('add node TCL_NUM/usage=numeric')
         self._doTCLTest('add node TCL_PY_DEV/model=TESTDEVICE')
+        self._doTCLTest('add node TCL_PY_DEV_2/model=TESTDEVICECODEIN')
         self._doTCLTest('do TESTDEVICE:TASK_TEST')
         self._doExceptionTest('do TESTDEVICE:TASK_ERROR1',Exc.DevUNKOWN_STATE)
         self._doExceptionTest('do TESTDEVICE:TASK_ERROR2',Exc.DevUNKOWN_STATE)
+        self._doTCLTest('do CI_DEVICE:TASK_TEST')
+        self._doExceptionTest('do CI_DEVICE:TASK_ERROR1',Exc.DevUNKOWN_STATE)
+        self._doExceptionTest('do CI_DEVICE:TASK_ERROR2',Exc.DevUNKOWN_STATE)
         self._doExceptionTest('close',Exc.TreeWRITEFIRST)
         self._doTCLTest('write')
         self._doTCLTest('close')
@@ -103,6 +108,7 @@ class Tests(_UnitTest.TreeTests,_UnitTest.MdsIp):
         shot = self.shot+1
         with Tree(self.tree,shot,'new') as pytree:
             Device.PyDevice('TestDevice').Add(pytree,'TESTDEVICE')
+            Device.PyDevice('TestDeviceCodeIn').Add(pytree,'CI_DEVICE')
             pytree.write()
         monitor,monitor_port = self._setup_mdsip('ACTION_MONITOR','MONITOR_PORT',7010+self.index,False)
         monitor_opt = "/monitor=%s"%monitor if monitor_port>0 else ""
@@ -111,6 +117,8 @@ class Tests(_UnitTest.TreeTests,_UnitTest.MdsIp):
         pytree.normal()
         pytree.TESTDEVICE.ACTIONSERVER.no_write_shot = False
         pytree.TESTDEVICE.ACTIONSERVER.record = server
+        pytree.CI_DEVICE.ACTIONSERVER.no_write_shot = False
+        pytree.CI_DEVICE.ACTIONSERVER.record = server
         """ using dispatcher """
         mon,mon_log,svr,svr_log = (None,None,None,None)
         try:
@@ -155,6 +163,7 @@ class Tests(_UnitTest.TreeTests,_UnitTest.MdsIp):
             self._doTCLTest('close/all')
         pytree.readonly()
         self.assertTrue(pytree.TESTDEVICE.INIT1_DONE.record <= pytree.TESTDEVICE.INIT2_DONE.record)
+        self.assertTrue(pytree.CI_DEVICE.INIT1_DONE.record <= pytree.CI_DEVICE.INIT2_DONE.record)
 
     def timeout(self,full=False):
         def test_timeout(c,expr,to):

--- a/mdsobjects/python/tests/devices/TestDeviceCodeIn.py
+++ b/mdsobjects/python/tests/devices/TestDeviceCodeIn.py
@@ -1,0 +1,69 @@
+# 
+# Copyright (c) 2017, Massachusetts Institute of Technology All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# Redistributions of source code must retain the above copyright notice, this
+# list of conditions and the following disclaimer.
+#
+# Redistributions in binary form must reproduce the above copyright notice, this
+# list of conditions and the following disclaimer in the documentation and/or
+# other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+from MDSplus import Device
+class TestDeviceCodeIn(Device):
+    parts=[
+        {'path': ':ACTIONSERVER',               'type': 'TEXT',    'options':('no_write_shot','write_once')},
+        {'path': ':ACTIONSERVER:INIT1',         'type': 'ACTION',  'options':('no_write_shot','write_once'), 'valueExpr':'Action(Dispatch(head.ACTIONSERVER,"INIT",10),Method(None,"init1",head))'},
+        {'path': ':ACTIONSERVER:INIT2',         'type': 'ACTION',  'options':('no_write_shot','write_once'), 'valueExpr':'Action(Dispatch(head.ACTIONSERVER,"INIT",head.ACTIONSERVER.INIT1),Method(None,"init2",head))'},
+        {'path': ':ACTIONSERVER:PULSE',         'type': 'ACTION',  'options':('no_write_shot','write_once'), 'valueExpr':'Action(node.DISPATCH,node.TASK)'},
+        {'path': ':ACTIONSERVER:PULSE:DISPATCH','type': 'DISPATCH','options':('no_write_shot','write_once'), 'valueExpr':'Dispatch(head.ACTIONSERVER,"PULSE",10)'},
+        {'path': ':ACTIONSERVER:PULSE:TASK',    'type': 'TASK',    'options':('no_write_shot','write_once'), 'valueExpr':'Method(None,"pulse",head)'},
+        {'path': ':ACTIONSERVER:STORE',         'type': 'ACTION',  'options':('no_write_shot','write_once'), 'valueExpr':'Action(node.DISPATCH,node.TASK)'},
+        {'path': ':ACTIONSERVER:STORE:DISPATCH','type': 'DISPATCH','options':('no_write_shot','write_once'), 'valueExpr':'Dispatch(head.ACTIONSERVER,"STORE",10)'},
+        {'path': ':ACTIONSERVER:STORE:TASK',    'type': 'TASK',    'options':('no_write_shot','write_once'), 'valueExpr':'Method(None,"store",head)'},
+        {'path': ':TASK_TEST',                  'type': 'TASK',    'options':('no_write_shot','write_once'), 'valueExpr':'Method(None,"test",head)'},
+        {'path': ':TASK_ERROR1',                'type': 'TASK',    'options':('no_write_shot','write_once'), 'valueExpr':'Method(None,"error",head)'},
+        {'path': ':TASK_TIMEOUT',               'type': 'TASK',    'options':('no_write_shot','write_once'), 'valueExpr':'Method(1.,"timeout",head)'},
+        {'path': ':TASK_ERROR2',                'type': 'TASK',    'options':('no_write_shot','write_once'), 'valueExpr':'Method(10.,"error",head)'},
+        {'path': ':INIT1_DONE',                 'type': 'NUMERIC', 'options':('no_write_model','write_once')},
+        {'path': ':INIT2_DONE',                 'type': 'NUMERIC', 'options':('no_write_model','write_once')},
+        {'path': ':PULSE_DONE',                 'type': 'NUMERIC', 'options':('no_write_model','write_once')},
+        {'path': ':STORE_DONE',                 'type': 'NUMERIC', 'options':('no_write_model','write_once')},
+    ]
+    devcode="""
+
+import time
+
+from MDSplus import Device,DevUNKOWN_STATE
+
+class TestDeviceCodeIn(Device):
+    parts=%s
+    def init1(self):
+        self.init1_done.record = time.time()
+    def init2(self):
+        self.init2_done.record = time.time()
+    def pulse(self):
+        self.pulse_done.record = time.time()
+    def store(self):
+        self.store_done.record = time.time()
+    def test(self):
+        return 'TEST'
+    def error(self):
+        raise DevUNKOWN_STATE
+    def timeout(self):
+        time.sleep(10)
+""" % str(parts)

--- a/mdsobjects/python/tree.py
+++ b/mdsobjects/python/tree.py
@@ -3114,7 +3114,10 @@ If you did intend to write to a subnode of the device you should check the prope
         if isinstance(name,_scr.Ident):
             name=name.data()
         head=parent.addNode(name,'DEVICE')
-        head.record=_cmp.Conglom('__python__',cls.__name__,None,cls.getImportString())
+        if hasattr(cls,'devcode'):
+            head.record=_cmp.Conglom('__python__',cls.__name__,cls.devcode.split('\n'),None)
+        else:
+            head.record=_cmp.Conglom('__python__',cls.__name__,None,cls.getImportString())
         head=TreeNode(head)
         head.write_once=True
         glob = _mimport('__init__').load({})


### PR DESCRIPTION
This enables the feature to develop pydevices in which the device
methods are stored in the tree. The only time the python module file
is referenced is to add the device to an MDSplus tree. From that point
on the methods executed on the device are implemented in code living
in the trees datafile.