### PR TITLE
wave12: some more enum typedefs 

### DIFF
--- a/camshr/RemCamMulti.c
+++ b/camshr/RemCamMulti.c
@@ -26,18 +26,12 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
+#include <mdsdescrip.h>
 #include <mdsplus/mdsconfig.h>
 
 #ifndef min
 #define min(a,b) ((a) < (b)) ? (a) : (b)
 #endif
-
-struct descriptor {
-  unsigned short length;
-  char dtype;
-  char class;
-  void *pointer;
-};
 
 extern short RemCamLastIosb[4];
 extern int RemoteServerId();

--- a/camshr/RemCamSingle.c
+++ b/camshr/RemCamSingle.c
@@ -27,13 +27,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <stdio.h>
 #include <string.h>
 #include <mdsplus/mdsconfig.h>
-
-struct descriptor {
-  unsigned short length;
-  char dtype;
-  char class;
-  void *pointer;
-};
+#include <mdsdescrip.h>
 
 short RemCamLastIosb[4];
 

--- a/include/mds_gendevice.h
+++ b/include/mds_gendevice.h
@@ -208,7 +208,7 @@ int getmsg(int sts, char **facnam, char **msgnam, char **msgtext)
 
 #define ADD_NODE_EXPR(name, usage)\
     {   DESCRIPTOR(expr_d, expr);\
-	int curr_usage = usage;\
+	usage_t curr_usage = usage;\
 	struct descriptor_xd comp_expr_xd = {0, DTYPE_DSC, CLASS_XD, 0, 0};\
 	status = TdiCompile((struct descriptor *)&expr_d, &comp_expr_xd MDS_END_ARG);\
 	if(!(status & 1)) {TreeSetDefaultNid(old_nid); return status;}\

--- a/include/mdsobjects.h
+++ b/include/mdsobjects.h
@@ -57,70 +57,8 @@
 ///@{
 ///
 /// DESCRIPTORS CODE DEFINITIONS
-
-
-#define DTYPE_BU 2
-#define DTYPE_WU 3
-#define DTYPE_LU 4
-#define DTYPE_QU 5
-#define DTYPE_OU 25
-#define DTYPE_B 6
-#define DTYPE_W 7
-#define DTYPE_L 8
-#define DTYPE_Q 9
-#define DTYPE_O 26
-#define DTYPE_FLOAT 52
-#define DTYPE_DOUBLE 53
-#define DTYPE_F	10
-#define DTYPE_D	11
-#define DTYPE_G	27
-#define DTYPE_H	28
-#define DTYPE_FSC 54
-#define DTYPE_FTC 55
-#define DTYPE_T 14
-#define DTYPE_IDENT 191
-#define DTYPE_NID 192
-#define DTYPE_PATH 193
-#define DTYPE_PARAM 194
-#define DTYPE_SIGNAL 195
-#define DTYPE_DIMENSION 196
-#define DTYPE_WINDOW 197
-#define DTYPE_SLOPE 198
-#define DTYPE_FUNCTION 199
-#define DTYPE_CONGLOM 200
-#define DTYPE_RANGE 201
-#define DTYPE_ACTION 202
-#define DTYPE_DISPATCH 203
-#define DTYPE_PROGRAM 204
-#define DTYPE_ROUTINE 205
-#define DTYPE_PROCEDURE 206
-#define DTYPE_METHOD 207
-#define DTYPE_DEPENDENCY 208
-#define DTYPE_CONDITION 209
-#define DTYPE_EVENT 210
-#define DTYPE_WITH_UNITS 211
-#define DTYPE_CALL 212
-#define DTYPE_WITH_ERROR 213
-#define DTYPE_LIST 214
-#define DTYPE_TUPLE 215
-#define DTYPE_DICTIONARY 216
-#define DTYPE_POINTER 51
-#define DTYPE_DSC	24
-
+#include <mdsdescrip.h>
 ///@}
-
-
-#define TreeNEGATE_CONDITION 	7
-#define TreeIGNORE_UNDEFINED 	8
-#define TreeIGNORE_STATUS	9
-#define TreeDEPENDENCY_AND	10
-#define TreeDEPENDENCY_OR	11
-#define CLASS_S 1
-#define CLASS_D 2
-#define CLASS_A 4
-#define CLASS_R 194
-#define CLASS_APD 196
-#define MAX_DIMS 32
 
 extern "C" char *MdsGetMsg(int status);
 

--- a/include/tdishr.h
+++ b/include/tdishr.h
@@ -23,6 +23,6 @@
 extern int TdiGetLong(struct descriptor *indsc, int *out_int);
 extern int TdiGetFloat(struct descriptor *index, float *out_float);
 extern int TdiConvert();
-extern int TdiIntrinsic(int opcode, int narg, struct descriptor *list[], struct descriptor_xd *out_ptr);
-extern int _TdiIntrinsic(void** ctx, int opcode, int narg, struct descriptor *list[], struct descriptor_xd *out_ptr);
+extern int  TdiIntrinsic(            opcode_t opcode, int narg, struct descriptor *list[], struct descriptor_xd *out_ptr);
+extern int _TdiIntrinsic(void** ctx, opcode_t opcode, int narg, struct descriptor *list[], struct descriptor_xd *out_ptr);
 extern int CvtConvertFloat(void *invalue, uint32_t indtype, void *outvalue, uint32_t outdtype, uint32_t options);

--- a/include/treeshr.h
+++ b/include/treeshr.h
@@ -22,15 +22,7 @@ extern "C" {
 extern int treeshr_errno;
 extern int TREE_BLOCKID;
 
-
-
-
-#ifndef MDSDESCRIP_H_DEFINED
-  struct descriptor;
-  struct descriptor_a;
-  struct descriptor_r;
-  struct descriptor_xd;
-#endif
+#include <mdsdescrip.h>
 
 #ifndef DBIDEF_H
   struct dbi_itm;

--- a/mdsshr/MdsCompareXd.c
+++ b/mdsshr/MdsCompareXd.c
@@ -73,7 +73,7 @@ EXPORT int MdsCompareXd(const struct descriptor *dsc1_ptr, const struct descript
     if (d1->dtype == d2->dtype) {
       switch (d1->class) {
       default:
-	return 0;
+	return 0; // TODO: handle missing classes
       case CLASS_S:
       case CLASS_D:
 	if (((d2->class == CLASS_S) || (d2->class == CLASS_D)) && (d1->length == d2->length))
@@ -138,7 +138,7 @@ EXPORT int MdsCompareXd(const struct descriptor *dsc1_ptr, const struct descript
 	      else if (d1->class == CLASS_CA)
 		isequal = MdsCompareXd((struct descriptor *)a1->pointer,(struct descriptor *)a2->pointer);
 	      else {//d1->class == CLASS_APD
-		unsigned int i, nelts = a1->arsize / a1->length;
+		l_length_t i, nelts = a1->arsize / a1->length;
 		struct descriptor *ptr1 = (struct descriptor *)a1->pointer;
 		struct descriptor *ptr2 = (struct descriptor *)a2->pointer;
 		for (i = 0; isequal && (i < nelts);) {

--- a/mdsshr/MdsCompress.c
+++ b/mdsshr/MdsCompress.c
@@ -97,8 +97,7 @@ STATIC_CONSTANT EMPTYXD(EMPTY_XD);
 	The inner routine scans some classes and tries to compress arrays.
 	If successful returns 1, if unsuccessful returns NORMAL.
 */
-STATIC_ROUTINE int compress(const struct descriptor *pcimage,
-			    const struct descriptor *pcentry, int64_t delta, struct descriptor *pwork)
+STATIC_ROUTINE int compress(const struct descriptor *pcimage, const struct descriptor *pcentry, int64_t delta, struct descriptor *pwork)
 {
   int j, stat1, status = 1;
   unsigned int bit = 0;

--- a/mdsshr/MdsGet1DxA.c
+++ b/mdsshr/MdsGet1DxA.c
@@ -76,23 +76,21 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #define align(bytes,size) ((((bytes) + (size) - 1)/(size)) * (size))
 
-EXPORT int MdsGet1DxA(struct descriptor_a const *in_ptr, unsigned short const *length_ptr, dtype_t const *dtype_ptr,
-	       struct descriptor_xd *out_xd)
-{
+EXPORT int MdsGet1DxA(const struct descriptor_a *in_ptr, const length_t *length_ptr, const dtype_t *dtype_ptr, struct descriptor_xd *out_xd){
   array_coeff *in_dsc = (array_coeff *) in_ptr;
-  unsigned int new_arsize;
-  unsigned int dsc_size;
-  unsigned int new_size;
+  l_length_t new_arsize;
+  l_length_t dsc_size;
+  l_length_t new_size;
   int status;
   int i;
-  unsigned int align_size;
+  l_length_t align_size;
   array_coeff *out_dsc;
   dtype_t dsc_dtype = DTYPE_DSC;
   if ((in_dsc->length == 0) || (*length_ptr == 0))
     new_arsize = 0;
   else
     new_arsize = (in_dsc->arsize / in_dsc->length) * (*length_ptr);
-  dsc_size = (unsigned int)(sizeof(struct descriptor_a)
+  dsc_size = (l_length_t)(sizeof(struct descriptor_a)
            + ((in_dsc->aflags.coeff || (new_arsize == 0)) ? sizeof(void*) + sizeof(int) * in_dsc->dimct : 0)
            + ( in_dsc->aflags.bounds                      ? sizeof(int) * (size_t)(in_dsc->dimct * 2)   : 0));
   align_size = (*dtype_ptr == DTYPE_T) ? 1 : *length_ptr;

--- a/mdsshr/MdsGet1DxS.c
+++ b/mdsshr/MdsGet1DxS.c
@@ -71,15 +71,12 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #define align(bytes,size) ((((bytes) + (size) - 1)/(size)) * (size))
 
-EXPORT int MdsGet1DxS(length_t const *length_ptr, dtype_t const *dtype_ptr,
-	       struct descriptor_xd *out_dsc_ptr)
-{
-
+EXPORT int MdsGet1DxS(length_t const *length_ptr, dtype_t const *dtype_ptr, struct descriptor_xd *out_dsc_ptr){
   int status;
   unsigned int dsc_size = (unsigned int)sizeof(struct descriptor);
   unsigned int align_size = (*dtype_ptr == DTYPE_T) ? 1 : *length_ptr;
   unsigned int length;
-  STATIC_CONSTANT dtype_t dsc_dtype = DTYPE_DSC;
+  static dtype_t dsc_dtype = DTYPE_DSC;
   dsc_size = align(dsc_size, align_size);
   length = dsc_size + *length_ptr;
   status = MdsGet1Dx(&length, &dsc_dtype, out_dsc_ptr, NULL);

--- a/mdsshr/MdsSerialize.c
+++ b/mdsshr/MdsSerialize.c
@@ -103,11 +103,9 @@ union __bswap {
 
 #endif
 
-STATIC_ROUTINE int copy_rec_dx(char const *in_ptr, struct descriptor_xd *out_dsc_ptr,
-			       unsigned int *b_out, unsigned int *b_in)
-{
+STATIC_ROUTINE int copy_rec_dx(char const *in_ptr, struct descriptor_xd *out_dsc_ptr, l_length_t *b_out, l_length_t *b_in){
   int status = 1;
-  unsigned int bytes_out = 0, bytes_in = 0, i, j, size_out, size_in;
+  uint32_t bytes_out = 0, bytes_in = 0, i, j, size_out, size_in;
   if (in_ptr && (in_ptr[0] || in_ptr[1] || in_ptr[2] || in_ptr[3])) {
     switch (class()) {
     case CLASS_S:
@@ -461,13 +459,10 @@ STATIC_ROUTINE int copy_rec_dx(char const *in_ptr, struct descriptor_xd *out_dsc
   return status;
 }
 
-EXPORT int MdsSerializeDscIn(char const *in, struct descriptor_xd *out)
-{
-  unsigned int size_out;
-  unsigned int size_in;
-  int status;
-  STATIC_CONSTANT const dtype_t dsc_dtype = DTYPE_DSC;
-  status = copy_rec_dx(in, 0, &size_out, &size_in);
+EXPORT int MdsSerializeDscIn(char const *in, struct descriptor_xd *out){
+  l_length_t size_out, size_in;
+  static const dtype_t dsc_dtype = DTYPE_DSC;
+  int status = copy_rec_dx(in, 0, &size_out, &size_in);
   if (STATUS_OK && size_out) {
     status = MdsGet1Dx(&size_out, &dsc_dtype, out, 0);
     if STATUS_OK
@@ -477,9 +472,8 @@ EXPORT int MdsSerializeDscIn(char const *in, struct descriptor_xd *out)
   return status;
 }
 
-STATIC_ROUTINE int copy_dx_rec(struct descriptor *in_ptr, char *out_ptr, unsigned int *b_out,
-			       unsigned int *b_in)
-{ int status = MDSplusSUCCESS;
+STATIC_ROUTINE int copy_dx_rec(const struct descriptor *in_ptr, char *out_ptr, l_length_t *b_out, l_length_t *b_in){
+  int status = MDSplusSUCCESS;
   unsigned bytes_out = 0, bytes_in = 0, j, size_out, size_in, num_dsc;
   if (in_ptr)
     switch (in_ptr->class) {
@@ -802,33 +796,25 @@ STATIC_ROUTINE int copy_dx_rec(struct descriptor *in_ptr, char *out_ptr, unsigne
   return status;
 }
 
-STATIC_ROUTINE int Dsc2Rec(struct descriptor const *inp, struct descriptor_xd *out_dsc_ptr,
-			   unsigned int *reclen)
-{
-  unsigned int size_out;
-  unsigned int size_in;
-  int status;
-  STATIC_CONSTANT const dtype_t dsc_dtype = DTYPE_B;
-  status = copy_dx_rec((struct descriptor *)inp, 0, &size_out, &size_in);
+STATIC_ROUTINE int Dsc2Rec(const struct descriptor *inp, struct descriptor_xd *out_ptr, arsize_t *reclen){
+  arsize_t size_out, size_in;
+  static const dtype_t b_dtype = DTYPE_B;
+  int status = copy_dx_rec(inp, 0, &size_out, &size_in);
   if (status & 1 && size_out) {
     unsigned short nlen = 1;
     array out_template = { 1, DTYPE_B, CLASS_A, 0, 0, 0, {0, 1, 1, 0, 0}, 1, 0 };
     out_template.arsize = *reclen = size_out;
-    status =
-	MdsGet1DxA((struct descriptor_a *)&out_template, &nlen, &dsc_dtype,
-		   out_dsc_ptr);
+    status = MdsGet1DxA((struct descriptor_a*)&out_template, &nlen, &b_dtype, out_ptr);
     if (status & 1) {
-      memset(out_dsc_ptr->pointer->pointer, 0, size_out);
-      status =
-	  copy_dx_rec((struct descriptor *)inp, out_dsc_ptr->pointer->pointer, &size_out, &size_in);
+      memset(out_ptr->pointer->pointer, 0, size_out);
+      status = copy_dx_rec((struct descriptor *)inp, out_ptr->pointer->pointer, &size_out, &size_in);
     }
   } else
-    MdsFree1Dx(out_dsc_ptr, NULL);
+    MdsFree1Dx(out_ptr, NULL);
   return status;
 }
 
-STATIC_CONSTANT int PointerToOffset(struct descriptor *dsc_ptr, unsigned int *length)
-{
+STATIC_CONSTANT int PointerToOffset(struct descriptor *dsc_ptr, l_length_t *length){
   int status = 1;
   if ((dsc_ptr->dtype == DTYPE_DSC) && (dsc_ptr->class != CLASS_A) && (dsc_ptr->class != CLASS_APD))
     status = PointerToOffset((struct descriptor *)dsc_ptr->pointer, length);
@@ -837,12 +823,12 @@ STATIC_CONSTANT int PointerToOffset(struct descriptor *dsc_ptr, unsigned int *le
     case CLASS_S:
     case CLASS_D:
       *length += (unsigned int)sizeof(struct descriptor) + dsc_ptr->length;
-      dsc_ptr->pointer = dsc_ptr->pointer - ((char *)dsc_ptr - (char *)0);
+      dsc_ptr->pointer = dsc_ptr->pointer - (uintptr_t)dsc_ptr;
       break;
     case CLASS_XD:
     case CLASS_XS:
       *length += (unsigned int)sizeof(struct descriptor_xd) + ((struct descriptor_xd *)dsc_ptr)->l_length;
-      dsc_ptr->pointer = dsc_ptr->pointer - ((char *)dsc_ptr - (char *)0);
+      dsc_ptr->pointer = dsc_ptr->pointer - (uintptr_t)dsc_ptr;
       break;
     case CLASS_R:
       {
@@ -939,10 +925,10 @@ EXPORT int MdsSerializeDscOutZ(struct descriptor const *in,
   struct descriptor *out_ptr;
   struct descriptor_xd tempxd;
   int compressible = 0;
-  unsigned int length = 0;
-  unsigned int reclen = 0;
-  unsigned char dtype = 0;
-  unsigned char class = 0;
+  l_length_t length = 0;
+  l_length_t reclen = 0;
+  dtype_t dtype = 0;
+  class_t class = 0;
   int data_in_altbuf = 0;
   status = MdsCopyDxXdZ(in, out, 0, fixupNid, fixupNidArg, fixupPath, fixupPathArg);
   if (status == MdsCOMPRESSIBLE) {
@@ -960,7 +946,7 @@ EXPORT int MdsSerializeDscOutZ(struct descriptor const *in,
   if (status & 1) {
     if (out->pointer && out->dtype == DTYPE_DSC) {
       out_ptr = out->pointer;
-      dtype = out_ptr->dtype;
+      dtype = (dtype_t)out_ptr->dtype;
       if ((out_ptr->class == CLASS_S || out_ptr->class == CLASS_D) && out_ptr->length < altbuflen) {
 	data_in_altbuf = 1;
 	class = CLASS_S;

--- a/mdsshr/librtl.c
+++ b/mdsshr/librtl.c
@@ -687,8 +687,7 @@ EXPORT int StrPosition(struct descriptor *source, struct descriptor *substring, 
   return answer;
 }
 
-EXPORT int StrCopyR(struct descriptor *dest, const unsigned short *len, char *source)
-{
+EXPORT int StrCopyR(struct descriptor *dest, const length_t *len, char *source){
   const struct descriptor s = { *len, DTYPE_T, CLASS_S, source };
   return StrCopyDx(dest, &s);
 }
@@ -708,7 +707,7 @@ EXPORT int StrLenExtr(struct descriptor *dest, struct descriptor *source, int *s
   return status;
 }
 
-EXPORT int StrGet1Dx(const unsigned short *len, struct descriptor_d *out)
+EXPORT int StrGet1Dx(const length_t *len, struct descriptor_d *out)
 {
   if (out->class != CLASS_D)
     return LibINVSTRDES;
@@ -730,8 +729,7 @@ EXPORT int StrGet1Dx(const unsigned short *len, struct descriptor_d *out)
 //  return 1;
 //}
 
-int LibSFree1Dd(struct descriptor_d *out)
-{
+int LibSFree1Dd(struct descriptor_d *out){
   return StrFree1Dx(out);
 }
 
@@ -770,8 +768,7 @@ EXPORT int StrCopyDx(struct descriptor *out, const struct descriptor *in)
   return MDSplusSUCCESS;
 }
 
-EXPORT int StrCompare(struct descriptor *str1, struct descriptor *str2)
-{
+EXPORT int StrCompare(struct descriptor *str1, struct descriptor *str2){
   char *str1c = MdsDescrToCstring(str1);
   char *str2c = MdsDescrToCstring(str2);
   int ans;
@@ -781,8 +778,7 @@ EXPORT int StrCompare(struct descriptor *str1, struct descriptor *str2)
   return ans;
 }
 
-EXPORT int StrUpcase(struct descriptor *out, struct descriptor *in)
-{
+EXPORT int StrUpcase(struct descriptor *out, struct descriptor *in){
   unsigned int outlength,i;
   StrCopyDx(out, in);
   outlength = (out->class == CLASS_A) ? ((struct descriptor_a *)out)->arsize : out->length;
@@ -1622,9 +1618,9 @@ STATIC_ROUTINE int FindFileStart(struct descriptor *filespec, FindFileCtx ** ctx
   memset(*ctx, 0, sizeof(FindFileCtx));
   lctx = *ctx;
 
-  CSTRING_FROM_DESCRIPTOR(fspec, filespec)
+  CSTRING_FROM_DESCRIPTOR(fspec, filespec);
 
-      lctx->next_index = lctx->next_dir_index = 0;
+  lctx->next_index = lctx->next_dir_index = 0;
   colon = strchr(fspec, ':');
   if (colon == 0) {
     lctx->env = 0;
@@ -1706,12 +1702,11 @@ STATIC_ROUTINE char *_FindNextFile(FindFileCtx * ctx, int recursively, int caseB
     if (dp != NULL) {
       struct descriptor_d upname = { 0, DTYPE_T, CLASS_D, 0 };
       DESCRIPTOR_FROM_CSTRING(filename, dp->d_name);
-      if (caseBlind) {
-	    StrUpcase((struct descriptor *)&upname, &filename);
-      } else {
-	    StrCopyDx((struct descriptor *)&upname, &filename);
-      }
-      found = StrMatchWild((struct descriptor *)&upname, &ctx->wild_descr) & 1;
+      if (caseBlind)
+	StrUpcase((struct descriptor *)&upname, &filename);
+      else
+	StrCopyDx((struct descriptor *)&upname, &filename);
+      found = IS_OK(StrMatchWild((struct descriptor *)&upname, &ctx->wild_descr));
       StrFree1Dx(&upname);
       if (recursively) {
 	if ((strcmp(dp->d_name, ".") != 0) && (strcmp(dp->d_name, "..") != 0)) {

--- a/mdsshr/mds_dsc_string.c
+++ b/mdsshr/mds_dsc_string.c
@@ -22,11 +22,11 @@ CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
-#include        <stdio.h>
-#include        <mdsdescrip.h>
-#include        <usagedef.h>
-#include        <STATICdef.h>
-#include		<mdsshr.h>
+#include <stdio.h>
+#include <mdsdescrip.h>
+#include <usagedef.h>
+#include <STATICdef.h>
+#include <mdsshr.h>
 
 #define checkString(S)     case(S): return #S ;
 #define checkAltStr(A, S)  case(A): return #S ;

--- a/remcam/CamMulti.c
+++ b/remcam/CamMulti.c
@@ -27,17 +27,11 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <stdio.h>
 #include <string.h>
 #include <mdsplus/mdsconfig.h>
+#include <mdsdescrip.h>
 
 #ifndef min
 #define min(a,b) ((a) < (b)) ? (a) : (b)
 #endif
-
-struct descriptor {
-  unsigned short length;
-  char dtype;
-  char class;
-  void *pointer;
-};
 
 extern short RemCamLastIosb[4];
 extern int RemoteServerId();

--- a/remcam/CamSingle.c
+++ b/remcam/CamSingle.c
@@ -27,13 +27,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <stdio.h>
 #include <string.h>
 #include <mdsplus/mdsconfig.h>
-
-struct descriptor {
-  unsigned short length;
-  char dtype;
-  char class;
-  void *pointer;
-};
+#include <mdsdescrip.h>
 
 short RemCamLastIosb[4];
 

--- a/tdishr/TdiDecompile.c
+++ b/tdishr/TdiDecompile.c
@@ -377,7 +377,7 @@ int Tdi0Decompile(struct descriptor *in_ptr, int prec, struct descriptor_d *out_
   char c0[85], *cptr, *bptr;
   struct descriptor cdsc = { 11, DTYPE_T, CLASS_S, 0 };
   struct descriptor t2 = { 0, DTYPE_T, CLASS_S, 0 };
-  int status = MDSplusSUCCESS, j, dtype, n1, n2;
+  int status = MDSplusSUCCESS, j, n1, n2;
   char n1c;
   cdsc.pointer = c0;
 	/******************
@@ -386,7 +386,7 @@ int Tdi0Decompile(struct descriptor *in_ptr, int prec, struct descriptor_d *out_
   if (!in_ptr)
     return StrAppend(out_ptr, (struct descriptor *)&STAR);
 
-  dtype = in_ptr->dtype;
+  dtype_t dtype = (dtype_t)in_ptr->dtype;
   switch (in_ptr->class) {
   default:
     status = StrAppend(out_ptr, (struct descriptor *)&CLASS);

--- a/tdishr/TdiDecompileDependency.c
+++ b/tdishr/TdiDecompileDependency.c
@@ -89,7 +89,7 @@ STATIC_ROUTINE int DependencyGet(int prec, struct descriptor_r *pin, struct desc
     status = StrAppend(pout, (struct descriptor *)pin);
     break;
   case DTYPE_DEPENDENCY:
-    switch (*(short *)pin->pointer) {
+    switch (*(treedep_t*)pin->pointer) {
     case TreeDEPENDENCY_AND:
       now = P_AND;
       pwhich = (struct descriptor *)&AND;
@@ -114,7 +114,7 @@ STATIC_ROUTINE int DependencyGet(int prec, struct descriptor_r *pin, struct desc
       status = StrAppend(pout, (struct descriptor *)&RIGHT_PAREN);
     break;
   case DTYPE_CONDITION:
-    switch (*((short *)pin->pointer)) {
+    switch (*((treecond_t*)pin->pointer)) {
     case TreeNEGATE_CONDITION:
       pwhich = (struct descriptor *)&NEGATE;
       break;

--- a/tdishr/TdiDefCat.c
+++ b/tdishr/TdiDefCat.c
@@ -106,4 +106,4 @@ const struct TdiCatStruct_table TdiREF_CAT[] = {
   {"FTC", 0x9707, 16, 48, FT_SYM}	/*55 ieee double floating complex */
 };
 
-const unsigned char TdiCAT_MAX = sizeof(TdiREF_CAT) / sizeof(struct TdiCatStruct_table);
+const tdicat_t TdiCAT_MAX = sizeof(TdiREF_CAT) / sizeof(struct TdiCatStruct_table);

--- a/tdishr/TdiDefFunction.c
+++ b/tdishr/TdiDefFunction.c
@@ -34,8 +34,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <libroutines.h>
 #include <tdishr.h>
 
-extern int TdiIntrinsic();
-extern int _TdiIntrinsic();
 #define COM
 #define OPC(name,NAME, ...) \
 extern EXPORT int Tdi##name ( struct descriptor *first, ... ){\

--- a/tdishr/TdiExpt.c
+++ b/tdishr/TdiExpt.c
@@ -44,13 +44,12 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 int Tdi3MdsDefault(struct descriptor *in_ptr __attribute__ ((unused)), struct descriptor_xd *out_ptr)
 {
   char value[4096];
-  STATIC_CONSTANT dtype_t dtype = (unsigned char)DTYPE_T;
+  STATIC_CONSTANT dtype_t dtype = DTYPE_T;
   int retlen, status;
-  struct dbi_itm lst[] = { {sizeof(value), DbiDEFAULT, 0, 0}
-			   , {0, DbiEND_OF_LIST, 0, 0}
+  struct dbi_itm lst[] = { {sizeof(value), DbiDEFAULT, 0, 0} , {0, DbiEND_OF_LIST, 0, 0}
   };
   length_t len;
-  lst[0].pointer = (unsigned char *)value;
+  lst[0].pointer = (uint8_t *)value;
   lst[0].return_length_address = &retlen;
   status = TreeGetDbi(lst);
   if STATUS_OK {

--- a/tdishr/TdiHash.c
+++ b/tdishr/TdiHash.c
@@ -37,6 +37,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define TdiHASH_MAX 991
 
 STATIC_THREADSAFE short TdiREF_HASH[TdiHASH_MAX];
+#include "tdirefcat.h"
 #include "tdireffunction.h"
 #include <string.h>
 #include <stdio.h>

--- a/tdishr/TdiIntrinsic.c
+++ b/tdishr/TdiIntrinsic.c
@@ -200,7 +200,7 @@ void cleanup_list(void* fixed_in) {
 	free(fixed->a[fixed->n]);
 }
 
-EXPORT int TdiIntrinsic(int opcode, int narg, struct descriptor *list[], struct descriptor_xd *out_ptr)
+EXPORT int TdiIntrinsic(opcode_t opcode, int narg, struct descriptor *list[], struct descriptor_xd *out_ptr)
 {
   int status;
   struct TdiFunctionStruct *fun_ptr = (struct TdiFunctionStruct *)&TdiRefFunction[opcode];
@@ -338,7 +338,7 @@ EXPORT int TdiIntrinsic(int opcode, int narg, struct descriptor *list[], struct 
   FREE_CANCEL(out_ptr);
   return status;
 }
-EXPORT int _TdiIntrinsic(void** ctx, int opcode, int narg, struct descriptor *list[], struct descriptor_xd *out_ptr){
+EXPORT int _TdiIntrinsic(void** ctx, opcode_t opcode, int narg, struct descriptor *list[], struct descriptor_xd *out_ptr){
   int status;
   CTX_PUSH(ctx);
   status = TdiIntrinsic(opcode, narg, list, out_ptr);

--- a/tdishr/TdiVector.c
+++ b/tdishr/TdiVector.c
@@ -170,8 +170,7 @@ int Tdi1Vector(opcode_t opcode, int narg, struct descriptor *list[], struct desc
         ***************************/
   if STATUS_OK
     status =
-	MdsGet1DxA((struct descriptor_a *)&arr, &(*pcats)[narg].digits,
-		   &(*pcats)[narg].out_dtype, out_ptr);
+	MdsGet1DxA((struct descriptor_a *)&arr, &(*pcats)[narg].digits, &(*pcats)[narg].out_dtype, out_ptr);
 
 	/*********************************
         Accumulate all arrays and scalars.

--- a/tdishr/tdirefcat.h
+++ b/tdishr/tdirefcat.h
@@ -15,21 +15,21 @@
 #define TdiCAT_F		(0x8000 | TdiCAT_FLOAT | 3)
 #define TdiCAT_D		(0x8000 | TdiCAT_FLOAT | 7)
 #define TdiCAT_FC		(TdiCAT_COMPLEX | TdiCAT_F)
-
+typedef uint16_t tdicat_t;
 struct TdiCatStruct {
-  unsigned short in_cat;
+  tdicat_t in_cat;
   dtype_t in_dtype;
-  unsigned short out_cat;
+  tdicat_t out_cat;
   dtype_t out_dtype;
-  unsigned short digits;
+  length_t digits;
 };
 struct TdiCatStruct_table {
   char *name;			/*text for decompile */
-  unsigned short cat;		/*category code */
-  unsigned char length;		/*size in bytes */
+  tdicat_t cat;			/*category code */
+  length_t length;		/*size in bytes */
   unsigned char digits;		/*size of text conversion */
   char *fname;			/*exponent name for floating decompile */
 };
 #include <inttypes.h>
-extern const unsigned char TdiCAT_MAX;
+extern const tdicat_t TdiCAT_MAX;
 extern const struct TdiCatStruct_table TdiREF_CAT[];

--- a/tdishr/tdirefzone.h
+++ b/tdishr/tdirefzone.h
@@ -1,5 +1,6 @@
 #ifndef TDIREFZONE_H
 #define TDIREFZONE_H
+#include <mdsdescrip.h>
 /*	tdirefzone.h
 	References to zone used by Tdi1BUILD_FUNCTION, TdiYacc, and TdiLex_... .
 

--- a/tdishr/tdithreadsafe.h
+++ b/tdishr/tdithreadsafe.h
@@ -3,7 +3,6 @@
 #else
 #ifndef TDITHREADSAFE_H
 #define TDITHREADSAFE_H
-#include <mdsdescrip.h>
 #include <pthread_port.h>
 
 typedef struct _thread_static {

--- a/treeshr/TreeSegments.c
+++ b/treeshr/TreeSegments.c
@@ -1484,15 +1484,14 @@ int TreePutDsc(TREE_INFO * tinfo, int nid_in, struct descriptor *dsc, int64_t * 
 {
   EMPTYXD(xd);
   int compressible;
-  unsigned int dlen;
-  unsigned int reclen;
+  l_length_t ddlen, reclen;
   dtype_t dtype;
   class_t class;
   int data_in_altbuf;
   NID *nid = (NID *) & nid_in;
   unsigned char tree = nid->tree;
   int status = MdsSerializeDscOutZ(dsc, &xd, TreeFixupNid, &tree, 0, 0, compress,
-                                   &compressible, &dlen, &reclen, &dtype, &class, 0, 0,
+                                   &compressible, &ddlen, &reclen, &dtype, &class, 0, 0,
                                    &data_in_altbuf);
   if (STATUS_OK && xd.pointer && xd.pointer->class == CLASS_A && xd.pointer->pointer) {
     struct descriptor_a *ap = (struct descriptor_a *)xd.pointer;

--- a/treeshr/treeshrp.h
+++ b/treeshr/treeshrp.h
@@ -47,7 +47,7 @@ typedef struct nci {
   unsigned int owner_identifier;
   class_t class;
   dtype_t dtype;
-  unsigned int length;
+  l_length_t length;
   unsigned char spare2;
   unsigned int status;
   union {
@@ -83,10 +83,10 @@ NAMED_ATTRIBUTES_FACILITY =2,
 };
 
 typedef struct segment_header {
-  unsigned char dtype;
+  dtype_t dtype;
   char dimct;
   int dims[8];
-  short length;
+  length_t length;
   int idx;
   int next_row;
   int64_t index_offset;


### PR DESCRIPTION
* turn enums into packed typedef
* use opcode_t, dtype_t, class_tm, etc. when desired and fix switch statements.