### PR TITLE
Zck io tunnel cleanup

### DIFF
--- a/configure
+++ b/configure
@@ -13242,7 +13242,7 @@ ifeq ($(ENABLE_VALGRIND),yes)
 _print_valgrind_hello = \
   echo ""; \
   echo "---------------------------------------------------------------------------"; \
-  echo " vagrind $(VALGRIND_TOOL) "; \
+  echo " valgrind $(VALGRIND_TOOL) "; \
   echo " active tool options   :  $(valgrind_$(VALGRIND_TOOL)_flags) "; \
   echo " active valgrind flags : $(VALGRIND_FLAGS) "; \
   echo " active suppressions   : "; \

--- a/m4/m4_ax_valgrind_check.m4
+++ b/m4/m4_ax_valgrind_check.m4
@@ -250,7 +250,7 @@ ifeq ($(enable_valgrind),yes)
 _print_valgrind_hello = \
   echo ""; \
   echo "---------------------------------------------------------------------------"; \
-  echo " [vagrind $(VALGRIND_TOOL)] "; \
+  echo " [valgrind $(VALGRIND_TOOL)] "; \
   echo " active tool options   :  $(valgrind_$(VALGRIND_TOOL)_flags) "; \
   echo " active valgrind flags : $(VALGRIND_FLAGS) "; \
   echo " active suppressions   : "; \

--- a/mdstcpip/IoRoutinesThread.c
+++ b/mdstcpip/IoRoutinesThread.c
@@ -106,7 +106,7 @@ ssize_t thread_recv_to(Connection* c, void *buffer, size_t buflen, int to_msec){
   if (to_msec>=0) { // don't time out if to_msec < 0
     struct timeval timeout;
     timeout.tv_sec  = to_msec / 1000;
-    timeout.tv_usec = to_msec % 1000;
+    timeout.tv_usec =(to_msec % 1000) * 1000;
     fd_set set;
     FD_ZERO(&set); /* clear the set */
     FD_SET(p->out, &set); /* add our file descriptor to the set */

--- a/mdstcpip/IoRoutinesTunnel.c
+++ b/mdstcpip/IoRoutinesTunnel.c
@@ -125,7 +125,7 @@ static ssize_t tunnel_recv_to(Connection* c, void *buffer, size_t buflen, int to
   if (to_msec>=0) { // don't time out if to_msec < 0
     struct timeval timeout;
     timeout.tv_sec  = to_msec / 1000;
-    timeout.tv_usec = to_msec % 1000;
+    timeout.tv_usec =(to_msec % 1000) * 1000;
     fd_set set;
     FD_ZERO(&set); /* clear the set */
     FD_SET(p->in, &set); /* add our file descriptor to the set */

--- a/mdstcpip/ParseCommand.c
+++ b/mdstcpip/ParseCommand.c
@@ -27,6 +27,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <stdlib.h>
 #include <string.h>
 #include "mdsip_connections.h"
+#include <pthread_port.h>
 
 void PrintHelp(char *option)
 {
@@ -59,12 +60,11 @@ void PrintHelp(char *option)
 ///
 /// Parse standard input command options.
 ///
-void ParseCommand(int argc, char **argv, Options options[], int more, int *rem_argc,
-		  char ***rem_argv)
+void ParseCommand(int argc, char **argv, Options options[], int more, int *rem_argc, char ***rem_argv)
 {
+  INIT_AS_AND_FREE_ON_EXIT(char**,extra_argv,malloc(argc * sizeof(char *)));
   int i;
   int extra_argc = 1;
-  char **extra_argv = malloc(argc * sizeof(char *));
   extra_argv[0] = argv[0];
   for (i = 1; i < argc; i++) {
     char *arg = argv[i];
@@ -125,6 +125,7 @@ void ParseCommand(int argc, char **argv, Options options[], int more, int *rem_a
     *rem_argv = extra_argv;
   } else
      free(extra_argv);
+  FREE_CANCEL();
 }
 
 ///
@@ -132,7 +133,7 @@ void ParseCommand(int argc, char **argv, Options options[], int more, int *rem_a
 ///
 void ParseStdArgs(int argc, char **argv, int *extra_argc, char ***extra_argv)
 {
-  Options options[] = { 
+  Options options[] = {
       {"P", "protocol", 1, 0, 0},
       {"h", "hostfile", 1, 0, 0},
       {"s", "server", 0, 0, 0},

--- a/mdstcpip/mdsip-client-local
+++ b/mdstcpip/mdsip-client-local
@@ -1,2 +1,2 @@
 #!/bin/sh
-exec mdsip -P ssh 2>> ~/mdsip-local.log
+exec mdsip -P local 2>> ~/mdsip-local.log

--- a/mdstcpip/mdsip-client-local.bat
+++ b/mdstcpip/mdsip-client-local.bat
@@ -1,2 +1,2 @@
 @echo off
-mdsip -P ssh
+mdsip -P local

--- a/mdstcpip/mdsip.c
+++ b/mdstcpip/mdsip.c
@@ -26,19 +26,21 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <stdio.h>
 
 #include "mdsip_connections.h"
+#include <pthread_port.h>
 
-int main(int argc, char **argv)
-{
+int main(int argc, char **argv){
+  int errout;
+  INIT_AND_FREE_ON_EXIT(char**,extra_argv);
   IoRoutines *io;
   int extra_argc;
-  char **extra_argv;
   ParseStdArgs(argc, argv, &extra_argc, &extra_argv);
   io = LoadIo(GetProtocol());
   if (io && io->listen)
-    io->listen(extra_argc, extra_argv);
+    errout = io->listen(extra_argc, extra_argv);
   else {
     fprintf(stderr, "Protocol %s does not support servers\n", GetProtocol());
-    return 1;
+    errout = 1;
   }
-  return 0;
+  FREE_NOW();
+  return errout;
 }


### PR DESCRIPTION
* allows hopping tunnel connections and cleanup of all descendants

setenv('test_path=ssh://localhost::ssh://localhost::')
treefilename("test")
"ssh://localhost::ssh://localhost::/tmp/test_model.tree"