### PR TITLE
Zck tdiio

### DIFF
--- a/tditest/testing/test-tdishr.ans
+++ b/tditest/testing/test-tdishr.ans
@@ -6154,13 +6154,13 @@ TUPLE   OPC$TUPLE           457
 LIST   OPC$LIST           458
 *
 kind(_u=fopen('tditst.tmp','w'))
-14BU
+51BU
 write(_u,"This is a test")
 15
 fclose(_u)
 0
 kind(_u=fopen('tditst.tmp','r'))
-14BU
+51BU
 fseek(_u,5,0)
 0
 ftell(_u)


### PR DESCRIPTION
allows stdin stdout,stderr to be specified directly on tdi read and write.
fopen now returns a pointer