### PR TITLE
wave13: fixes getsegment trim toward rows_filled; includes typedef

### DIFF
--- a/include/treeshr.h
+++ b/include/treeshr.h
@@ -185,6 +185,8 @@ extern int TREE_BLOCKID;
 				     struct descriptor_a *initialData, int idx, int filled);
   extern EXPORT int TreePutSegment(int nid, const int rowidx, struct descriptor_a *data);
   extern EXPORT int _TreePutSegment(void *dbid, int nid, const int rowidx, struct descriptor_a *data);
+  extern EXPORT int TreeSetRowsFilled(int nid, int rows_filled);
+  extern EXPORT int _TreeSetRowsFilled(void *dbid, int nid, int rows_filled);
   extern EXPORT int TreeUpdateSegment(int nid, struct descriptor *start, struct descriptor *end,
 				      struct descriptor *dim, int idx);
   extern EXPORT int _TreeUpdateSegment(void *dbid, int nid, struct descriptor *start,

--- a/mdsobjects/python/tree.py
+++ b/mdsobjects/python/tree.py
@@ -2586,6 +2586,18 @@ class TreeNode(_dat.TreeRef,_dat.Data): # HINT: TreeNode begin  (maybe subclass 
         """
         self.write_once=flag
 
+    def setRowsFilled(self,rows_filled=-1):
+        """ updates the rows_filled value; influences the length of the last segment
+        @param rows_filled: length of last segment
+        @type rows_filled: int
+        @rtype: None
+        """
+        _exc.checkStatus(
+                _TreeShr._TreeSetRowsFilled(self.ctx,
+                                            self._nid,
+                                            _C.c_int32(int(rows_filled))))
+
+
     def updateSegment(self,start,end,dim,idx):
         """Update a segment
         @param start: index of first row of segment

--- a/treeshr/RemoteAccess.c
+++ b/treeshr/RemoteAccess.c
@@ -1096,9 +1096,11 @@ inline static off_t io_lseek_remote(int conid,int fd, off_t offset, int whence) 
   int info[] = { 0, fd, 0, 0, whence };
   *(off_t *) (&info[2]) = offset;
 #ifdef WORDS_BIGENDIAN
-  status = info[2];
-  info[2] = info[3];
-  info[3] = status;
+  {
+    int tmp = info[2];
+    info[2] = info[3];
+    info[3] = tmp;
+  }
 #endif
   int len;
   char *dout;

--- a/treeshr/TreeAddTag.c
+++ b/treeshr/TreeAddTag.c
@@ -135,7 +135,7 @@ the tag name specified does not already exist.
   if (tags > 0) {
     newtag_idx = 0;
     for (tidx = 0; tidx < tags; tidx++) {
-      int idx = swapint((char *)(old_tags_ptr + tidx));
+      int idx = swapint32((old_tags_ptr + tidx));
       char *defined_tag = (char *)(dblist->tree_info->tag_info + idx)->name;
       int cmp = strncmp(tag, defined_tag, sizeof(TAG_NAME));
       if (cmp == 0)
@@ -178,7 +178,7 @@ the tag name specified does not already exist.
     memcpy(new_tags_ptr, old_tags_ptr, (size_t)newtag_idx * sizeof(int));
     memcpy(new_tags_ptr + newtag_idx + 1, old_tags_ptr + newtag_idx,
 	   (size_t)(tags - newtag_idx) * sizeof(int));
-    *(new_tags_ptr + newtag_idx) = swapint((char *)&tags);
+    *(new_tags_ptr + newtag_idx) = swapint32(&tags);
     if (dblist->tree_info->edit->tags_pages > 0)
       free(old_tags_ptr);
     dblist->tree_info->tags = new_tags_ptr;
@@ -196,7 +196,7 @@ the tag name specified does not already exist.
 
     memmove(old_tags_ptr + newtag_idx + 1, old_tags_ptr + newtag_idx,
 	    (size_t)(tags - newtag_idx) * sizeof(int));
-    *(old_tags_ptr + newtag_idx) = swapint((char *)&tags);	/* Load new */
+    *(old_tags_ptr + newtag_idx) = swapint32(&tags);	/* Load new */
   }
 
 /*********************************************
@@ -206,7 +206,7 @@ the tag name specified does not already exist.
 
   memcpy(tag_info.name, tag, sizeof(tag));
   tmp = (int)(node_ptr - dblist->tree_info->node);
-  tag_info.node_idx = swapint((char *)&tmp);
+  tag_info.node_idx = swapint32(&tmp);
   tag_info.tag_link = node_ptr->tag_link;
 
 /*******************************************************
@@ -257,7 +257,7 @@ the tag name specified does not already exist.
 ******************************************/
 
   tags++;
-  node_ptr->tag_link = swapint((char *)&tags);
+  node_ptr->tag_link = swapint32(&tags);
   dblist->tree_info->header->tags = tags;
   dblist->modified = 1;
   return TreeNORMAL;

--- a/treeshr/TreeDeleteNode.c
+++ b/treeshr/TreeDeleteNode.c
@@ -142,14 +142,14 @@ STATIC_ROUTINE void check_nid(PINO_DATABASE * dblist, NID * nid, int *count)
       node_to_nid(dblist, descendent, (&nid));
       check_nid(dblist, &nid, count);
     }
-    if (swapshort((char *)&node->conglomerate_elt)) {
+    if (swapint16(&node->conglomerate_elt)) {
       NID elt_nid;
       NODE *elt_node;
       unsigned short elt_num = 1;
-      elt_nid.node = (unsigned)(nid->node - swapshort((char *)&node->conglomerate_elt) + 1)&0xFFFFFF;
+      elt_nid.node = (unsigned)(nid->node - swapint16(&node->conglomerate_elt) + 1)&0xFFFFFF;
       elt_nid.tree = nid->tree;
       elt_node = nid_to_node(dblist, &elt_nid);
-      for (; swapshort((char *)&elt_node->conglomerate_elt) == elt_num;
+      for (; swapint16(&elt_node->conglomerate_elt) == elt_num;
 	   elt_nid.node++, elt_num++, elt_node++)
 	check_nid(dblist, &elt_nid, count);
     }
@@ -255,7 +255,7 @@ extern void _TreeDeleteNodeExecute(void *dbid)
     else
       memset(edit->nci + nid.node - edit->first_in_mem, 0, sizeof(struct nci));
     memcpy(node->name, "deleted node", sizeof(node->name));
-    LoadShort(zero, &node->conglomerate_elt);
+    loadint16(&node->conglomerate_elt,&zero);
     node->member = 0;
     node->brother = 0;
     node->usage = 0;
@@ -283,20 +283,20 @@ void _TreeDeleteNodesWrite(void *dbid) {
     if (prevnode) {
       int tmp;
       prevnode->parent = node_offset(node, prevnode);
-      tmp = -swapint((char *)&prevnode->parent);
-      node->child = swapint((char *)&tmp);
+      tmp = -swapint32(&prevnode->parent);
+      node->child = swapint32(&tmp);
     } else {
       int tmp;
       tmp = node_offset(node, dblist->tree_info->node);
-      dblist->tree_info->header->free = swapint((char *)&tmp);
+      dblist->tree_info->header->free = swapint32(&tmp);
       node->child = 0;
     }
     prevnode = node;
     if (firstempty) {
       int tmp;
       node->parent = node_offset(firstempty, node);
-      tmp = -swapint((char *)&node->parent);
-      firstempty->child = swapint((char *)&tmp);
+      tmp = -swapint32(&node->parent);
+      firstempty->child = swapint32(&tmp);
     } else
       node->parent = 0;
     nidx = nid.node;

--- a/treeshr/TreeFindTag.c
+++ b/treeshr/TreeFindTag.c
@@ -106,7 +106,7 @@ EXPORT char *_TreeFindNodeTags(void *dbid, int nid_in, void **ctx_ptr)
 
     if (*ctx == 0) {
       node_ptr = nid_to_node(dblist, nid);
-      *ctx = swapint((char *)&node_ptr->tag_link);
+      loadint32(ctx,&node_ptr->tag_link);
     } else if (*ctx == -1) {
       *ctx = 0;
     }
@@ -116,7 +116,7 @@ EXPORT char *_TreeFindNodeTags(void *dbid, int nid_in, void **ctx_ptr)
       for (i = 0; i < sizeof(TAG_NAME) && name[i] != ' '; i++) ;
       char *answer = strncpy(malloc(i + 1), name, i);
       answer[i] = '\0';
-      *ctx = swapint((char *)&(info_ptr->tag_info + *ctx - 1)->tag_link);
+      loadint32(ctx,&(info_ptr->tag_info + *ctx - 1)->tag_link);
       if (*ctx == 0)
 	*ctx = -1;
       return answer;
@@ -190,7 +190,7 @@ EXPORT int _TreeFindTag(PINO_DATABASE * db, NODE * default_node, short treelen, 
       break;
     case 1:
       if (BsearchCompare((void *)&tsearch, (void *)tsearch.info->tags) == 0) {
-	*nodeptr = tsearch.info->node + swapint((char *)&tsearch.info->tag_info->node_idx);
+	*nodeptr = tsearch.info->node + swapint32(&tsearch.info->tag_info->node_idx);
 	*tagidx = 1;
 	return TreeNORMAL;
       } else
@@ -201,8 +201,8 @@ EXPORT int _TreeFindTag(PINO_DATABASE * db, NODE * default_node, short treelen, 
 			 (size_t)tsearch.info->header->tags, sizeof(int), BsearchCompare)) != 0) {
 	*nodeptr =
 	    tsearch.info->node +
-	    swapint((char *)&(tsearch.info->tag_info + swapint((char *)idx))->node_idx);
-	*tagidx = swapint((char *)idx) + 1;
+	    swapint32(&(tsearch.info->tag_info + swapint32(idx))->node_idx);
+	*tagidx = swapint32(idx) + 1;
 	return TreeNORMAL;
       } else
 	status = TreeTNF;
@@ -236,7 +236,7 @@ EXPORT int _TreeFindTag(PINO_DATABASE * db, NODE * default_node, short treelen, 
 STATIC_ROUTINE int BsearchCompare(const void *this_one, const void *compare_one)
 {
   struct tag_search *tsearch = (struct tag_search *)this_one;
-  char *tag = (tsearch->info->tag_info + swapint((char *)compare_one))->name;
+  char *tag = (tsearch->info->tag_info + swapint32(compare_one))->name;
 
 /******************************************
  This routine is called by bsearch during

--- a/treeshr/TreeFindTagWild.c
+++ b/treeshr/TreeFindTagWild.c
@@ -142,7 +142,7 @@ static int findtag(PINO_DATABASE *dblist, TAG_SEARCH **ctx) {
 	for (; !done && ((*ctx)->next_tag < (*ctx)->this_tree_info->header->tags);) {
 	  unsigned short len;
 	  s_tag_dsc.pointer = (char *)(*ctx)->this_tree_info->tag_info[
-			swapint((char *)&(*ctx)->this_tree_info->tags[(*ctx)->next_tag])
+			swapint32(&(*ctx)->this_tree_info->tags[(*ctx)->next_tag])
 			].name;
 	  StrTrim((struct descriptor *)&tag_dsc, (struct descriptor *)&s_tag_dsc, &len);
 	  if IS_OK(StrMatchWild((struct descriptor *)&tag_dsc,(struct descriptor *)&((*ctx)->search_tag))) {
@@ -201,12 +201,12 @@ char *_TreeFindTagWild(void *dbid, char *wild, int *nidout, void **ctx_inout)
       struct descriptor_s tag_name = { sizeof(TAG_NAME), DTYPE_T, CLASS_S, tagname };
       unsigned short len;
       s_tag_name.pointer = (char *)(*ctx)->this_tree_info->tag_info[
-		swapint((char *)&(*ctx)->this_tree_info->tags[(*ctx)->next_tag])
+		swapint32(&(*ctx)->this_tree_info->tags[(*ctx)->next_tag])
 		].name;
       StrTrim((struct descriptor *)&tag_name, (struct descriptor *)&s_tag_name, &len);
       tagname[len] = '\0';
-      nptr += swapint(&(*ctx)->this_tree_info->tag_info[
-		swapint((char *)&(*ctx)->this_tree_info->tags[(*ctx)->next_tag])
+      nptr += swapint32(&(*ctx)->this_tree_info->tag_info[
+		swapint32(&(*ctx)->this_tree_info->tags[(*ctx)->next_tag])
 		].node_idx);
     } else
       strcpy(tagname, "TOP");

--- a/treeshr/TreeGetRecord.c
+++ b/treeshr/TreeGetRecord.c
@@ -125,13 +125,13 @@ int TreeGetRecord(int nid_in, struct descriptor_xd *dsc){
 		  if (dptr->dtype != DTYPE_T) {
 		    switch (dptr->length) {
 		    case 2:
-		      *(short *)dptr->pointer = swapshort(dptr->pointer);
+		      *(int16_t*)dptr->pointer = swapint16(dptr->pointer);
 		      break;
 		    case 4:
-		      *(int *)dptr->pointer = swapint(dptr->pointer);
+		      *(int32_t*)dptr->pointer = swapint32(dptr->pointer);
 		      break;
 		    case 8:
-		      *(int64_t *) dptr->pointer = swapquad(dptr->pointer);
+		      *(int64_t*)dptr->pointer = swapint64(dptr->pointer);
 		      break;
 		    }
 		  }
@@ -321,8 +321,8 @@ EXPORT int TreeGetDatafile(TREE_INFO * info, unsigned char *rfa_in, int *buffer_
 	  status = TreeReopenDatafile(info);
       }
       if STATUS_OK {
-	unsigned int partlen = min(swapshort((char *)&hdr.rlength) - 10, buffer_space);
-	int nidx = swapint((char *)&hdr.node_number);
+	unsigned int partlen = min(swapint16(&hdr.rlength) - 10, buffer_space);
+	int nidx = swapint32(&hdr.node_number);
 	if (first)
 	  *nodenum = nidx;
 	else if (*nodenum != nidx) {
@@ -375,7 +375,7 @@ EXPORT int TreeGetDatafile(TREE_INFO * info, unsigned char *rfa_in, int *buffer_
 	if (STATUS_OK && deleted)
 	  status = TreeReopenDatafile(info);
       }
-      *nodenum = swapint((char *)&((RECORD_HEADER *) buffer)->node_number);
+      loadint32(nodenum,&((RECORD_HEADER *) buffer)->node_number);
       for (bptr_in = buffer, bptr = record + *buffer_size, bytes_remaining = *buffer_size;
 	   bytes_remaining;) {
 	int bytes_this_time = min(DATAF_C_MAX_RECORD_SIZE + 2, bytes_remaining);

--- a/treeshr/TreeOpen.c
+++ b/treeshr/TreeOpen.c
@@ -541,7 +541,7 @@ static int ConnectTree(PINO_DATABASE * dblist, char *tree, NODE * parent, char *
   }
   if (info) {
     for (i = 0; i < info->header->externals; i++) {
-      NODE *external_node = info->node + swapint((char *)&info->external[i]);
+      NODE *external_node = info->node + swapint32(&info->external[i]);
       char *subtree = strncpy(calloc(1,sizeof(NODE_NAME)+1), external_node->name, sizeof(NODE_NAME));
       subtree[sizeof(NODE_NAME)] = '\0';
       char *blank = strchr(subtree, ' ');

--- a/treeshr/TreePutRecord.c
+++ b/treeshr/TreePutRecord.c
@@ -466,7 +466,7 @@ static int PutDatafile(TREE_INFO * info, int nodenum, NCI * nci_ptr,
     } else {
       buffer = (char *)malloc(blen);
       bptr = buffer;
-      LoadInt(nodenum, (char *)&info->data_file->record_header->node_number);
+      loadint32(&info->data_file->record_header->node_number,&nodenum);
       bitassign_c(0, nci_ptr->flags2, NciM_NON_VMS);
       memset(&info->data_file->record_header->rfa, 0, sizeof(RFA));
       while (bytes_to_put && (status & 1)) {
@@ -486,7 +486,7 @@ static int PutDatafile(TREE_INFO * info, int nodenum, NCI * nci_ptr,
 	int bytes_this_time = min(DATAF_C_MAX_RECORD_SIZE + 2, bytes_to_put);
 	unsigned short rlength = bytes_this_time + 10;
 	bytes_to_put -= bytes_this_time;
-	LoadShort(rlength, (char *)&info->data_file->record_header->rlength);
+	loadint16(&info->data_file->record_header->rlength,&rlength);
 	memcpy(bptr, (void *)info->data_file->record_header, sizeof(RECORD_HEADER));
 	bptr += sizeof(RECORD_HEADER);
 	bptr += bytes_this_time;
@@ -540,7 +540,7 @@ static int PutDatafile(TREE_INFO * info, int nodenum, NCI * nci_ptr,
   int status = TreeNORMAL;
   int bytes_to_put = nci_ptr->DATA_INFO.DATA_LOCATION.record_length;
 
-  LoadInt(nodenum, (char *)&info->data_file->record_header->node_number);
+  loadint32(&info->data_file->record_header->node_number,&nodenum);
   memset(&info->data_file->record_header->rfa, 0, sizeof(RFA));
   while (bytes_to_put && (status & 1)) {
     int bytes_this_time = min(DATAF_C_MAX_RECORD_SIZE + 2, bytes_to_put);
@@ -551,7 +551,7 @@ static int PutDatafile(TREE_INFO * info, int nodenum, NCI * nci_ptr,
       unsigned short rlength = bytes_this_time + 10;
       eof = MDS_IO_LSEEK(info->data_file->put, 0, SEEK_END);
       bytes_to_put -= bytes_this_time;
-      LoadShort(rlength, (char *)&info->data_file->record_header->rlength);
+      loadint16(&info->data_file->record_header->rlength,&rlength);
       status =
 	  (MDS_IO_WRITE
 	   (info->data_file->put, (void *)info->data_file->record_header,
@@ -593,7 +593,7 @@ static int UpdateDatafile(TREE_INFO * info, int nodenum, NCI * nci_ptr,
 {
   int status = TreeNORMAL;
   unsigned int bytes_to_put = nci_ptr->DATA_INFO.DATA_LOCATION.record_length;
-  LoadInt(nodenum, (char *)&info->data_file->record_header->node_number);
+  loadint32(&info->data_file->record_header->node_number,&nodenum);
   memset(&info->data_file->record_header->rfa, 0, sizeof(RFA));
   while (bytes_to_put && (status & 1)) {
     int bytes_this_time = min(DATAF_C_MAX_RECORD_SIZE + 2, bytes_to_put);
@@ -601,9 +601,8 @@ static int UpdateDatafile(TREE_INFO * info, int nodenum, NCI * nci_ptr,
     status = TreeLockDatafile(info, 0, rfa_l);
     if (status & 1) {
       bytes_to_put -= bytes_this_time;
-      info->data_file->record_header->rlength = (unsigned short)(bytes_this_time + 10);
-      info->data_file->record_header->rlength =
-	  swapshort((char *)&info->data_file->record_header->rlength);
+      uint16_t tmp = bytes_this_time + 10;
+      loadint16(&info->data_file->record_header->rlength,&tmp);
       MDS_IO_LSEEK(info->data_file->put, rfa_l, SEEK_SET);
       status =
 	  (MDS_IO_WRITE

--- a/treeshr/TreeRemoveNodesTags.c
+++ b/treeshr/TreeRemoveNodesTags.c
@@ -87,8 +87,8 @@ int _TreeRemoveNodesTags(void *dbid, int nid)
 ***********************************/
 
   node = nid_to_node(dblist, nid_ptr);
-  for (tagidx = swapint((char *)&node->tag_link); tagidx != 0; tagidx = next_tag) {
-    next_tag = swapint((char *)&dblist->tree_info->tag_info[tagidx - 1].tag_link);
+  for (tagidx = swapint32(&node->tag_link); tagidx != 0; tagidx = next_tag) {
+    next_tag = swapint32(&dblist->tree_info->tag_info[tagidx - 1].tag_link);
     _RemoveTagIdx(dblist, tagidx);
   }
   return TreeNORMAL;
@@ -135,17 +135,17 @@ static void _RemoveTagIdx(PINO_DATABASE * dblist, int tagidx)
   *****************************************/
 
   remove_info_ptr = dblist->tree_info->tag_info + tagidx - 1;
-  node_ptr = dblist->tree_info->node + swapint((char *)&remove_info_ptr->node_idx);
-  if (swapint((char *)&node_ptr->tag_link) == tagidx)
+  node_ptr = dblist->tree_info->node + swapint32(&remove_info_ptr->node_idx);
+  if (swapint32(&node_ptr->tag_link) == tagidx)
     node_ptr->tag_link = remove_info_ptr->tag_link;
   else {
     int tag_link;
-    for (tag_link = swapint((char *)&node_ptr->tag_link), info_ptr =
+    for (tag_link = swapint32(&node_ptr->tag_link), info_ptr =
 	 dblist->tree_info->tag_info + tag_link - 1;
-	 (swapint((char *)&info_ptr->tag_link) != tagidx)
-	 && (swapint((char *)&info_ptr->tag_link) >= 0);
-	 info_ptr = dblist->tree_info->tag_info + swapint((char *)&info_ptr->tag_link) - 1) ;
-    if (swapint((char *)&info_ptr->tag_link) == tagidx)
+	 (swapint32(&info_ptr->tag_link) != tagidx)
+	 && (swapint32(&info_ptr->tag_link) >= 0);
+	 info_ptr = dblist->tree_info->tag_info + swapint32(&info_ptr->tag_link) - 1) ;
+    if (swapint32(&info_ptr->tag_link) == tagidx)
       info_ptr->tag_link = remove_info_ptr->tag_link;
   }
 
@@ -159,15 +159,15 @@ static void _RemoveTagIdx(PINO_DATABASE * dblist, int tagidx)
 
   for (info_ptr = dblist->tree_info->tag_info;
        info_ptr < dblist->tree_info->tag_info + dblist->tree_info->header->tags; info_ptr++)
-    if (swapint((char *)&info_ptr->tag_link) >= tagidx) {
-      int tmp = swapint((char *)&info_ptr->tag_link) - 1;
-      info_ptr->tag_link = swapint((char *)&tmp);
+    if (swapint32(&info_ptr->tag_link) >= tagidx) {
+      int tmp = swapint32(&info_ptr->tag_link) - 1;
+      info_ptr->tag_link = swapint32(&tmp);
     }
   for (node_ptr = dblist->tree_info->node;
        node_ptr < dblist->tree_info->node + dblist->tree_info->header->nodes; node_ptr++)
-    if (swapint((char *)&node_ptr->tag_link) >= tagidx) {
-      int tmp = swapint((char *)&node_ptr->tag_link) - 1;
-      node_ptr->tag_link = swapint((char *)&tmp);
+    if (swapint32(&node_ptr->tag_link) >= tagidx) {
+      int tmp = swapint32(&node_ptr->tag_link) - 1;
+      node_ptr->tag_link = swapint32(&tmp);
     }
 
   /*************************************************
@@ -177,12 +177,12 @@ static void _RemoveTagIdx(PINO_DATABASE * dblist, int tagidx)
 
   for (tags_ptr = dblist->tree_info->tags;
        tags_ptr < dblist->tree_info->tags + dblist->tree_info->header->tags; tags_ptr++) {
-    int tags = swapint((char *)tags_ptr);
+    int tags = swapint32(tags_ptr);
     if (tags == (tagidx - 1))
       this_tags_ptr = tags_ptr;
     if (tags >= tagidx) {
       tags--;
-      *tags_ptr = swapint((char *)&tags);
+      *tags_ptr = swapint32(&tags);
     }
   }
 

--- a/treeshr/TreeSegments.c
+++ b/treeshr/TreeSegments.c
@@ -2236,15 +2236,17 @@ int _TreeGetSegmentInfo(void *dbid, int nid, int idx, char *dtype, char *dimct, 
   RETURN_IF_NOT_OK(get_segment(vars));
   if (vars->sinfo->data_offset == -1)
     return TreeFAILURE;
-  *dtype = vars->shead.dtype;
-  *dimct = vars->shead.dimct;
-  memcpy(dims, vars->shead.dims, sizeof(vars->shead.dims));
-  if (vars->idx == vars->shead.idx)
-    *next_row = vars->shead.next_row;
-  else if (vars->sinfo->rows < 1)
-    return get_compressed_segment_rows(vars->tinfo, vars->sinfo->data_offset, next_row);
-  else
-    *next_row = vars->sinfo->rows;
+  if (dtype) *dtype = vars->shead.dtype;
+  if (dimct) *dimct = vars->shead.dimct;
+  if (dims)  memcpy(dims, vars->shead.dims, sizeof(vars->shead.dims));
+  if (next_row) {
+    if (vars->idx == vars->shead.idx)
+      *next_row = vars->shead.next_row;
+    else if (vars->sinfo->rows < 1)
+      return get_compressed_segment_rows(vars->tinfo, vars->sinfo->data_offset, next_row);
+    else
+      *next_row = vars->sinfo->rows;
+  }
   return status;
 }
 

--- a/treeshr/TreeSegments.c
+++ b/treeshr/TreeSegments.c
@@ -305,6 +305,7 @@ int TreeSetSegmentScale(int nid, struct descriptor *value) {
 #endif
 
 static int read_property(TREE_INFO * tinfo, const int64_t offset, char *buffer, const int length){
+  if (!tinfo->data_file) return MDSplusFATAL;
   INIT_TREESUCCESS;
   int deleted = B_TRUE;
   while STATUS_OK {
@@ -331,6 +332,7 @@ static void unlock_datafile(void* c) {
     TreeUnLockDatafile(s->tinfo, 0, s->offset);
 }
 static int write_property(TREE_INFO * tinfo, int64_t *offset, const char *buffer, const int length) {
+  if (!tinfo->data_file) return MDSplusFATAL;
   int status;
   write_cleanup_t c = {tinfo,-1};
   pthread_cleanup_push(unlock_datafile,&c);

--- a/treeshr/TreeSerializeNci.c
+++ b/treeshr/TreeSerializeNci.c
@@ -27,76 +27,55 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <ncidef.h>
 #include "treeshrp.h"
 
-void TreeSerializeNciOut(NCI * in, char *out)
-{
+void TreeSerializeNciOut(const NCI * in, char *out) {
   char *ptr = out;
   memset(out, 0, 42);
-  LoadInt(in->flags, ptr);
-  ptr += 4;
-  *ptr = in->flags2;
-  ptr += 1;
-  ptr += 1;
-  LoadQuad(in->time_inserted, ptr);
-  ptr += 8;
-  LoadInt(in->owner_identifier, ptr);
-  ptr += 4;
-  *ptr = in->class;
-  ptr += 1;
-  *ptr = in->dtype;
-  ptr += 1;
-  LoadInt(in->length, ptr);
-  ptr += 4;
-  ptr += 1;
-  LoadInt(in->status, ptr);
-  ptr += 4;
+  putint32(&ptr,&in->flags);
+  putint8 (&ptr,&in->flags2);
+  putint8 (&ptr,&in->spare);
+  putint64(&ptr,&in->time_inserted);
+  putint32(&ptr,&in->owner_identifier);
+  putint8 (&ptr,&in->class);
+  putint8 (&ptr,&in->dtype);
+  putint32(&ptr,&in->length);
+  putint8 (&ptr,&in->spare2);
+  putint32(&ptr,&in->status);
   if (in->flags2 & NciM_DATA_IN_ATT_BLOCK) {
-    *ptr = in->DATA_INFO.DATA_IN_RECORD.element_length;
-    ptr += 1;
-    memcpy(ptr, in->DATA_INFO.DATA_IN_RECORD.data, 11);
+    putint8 (&ptr,&in->DATA_INFO.DATA_IN_RECORD.element_length);
+    putchars(&ptr,&in->DATA_INFO.DATA_IN_RECORD.data, 11);
   } else if (in->flags2 & NciM_ERROR_ON_PUT) {
-    LoadInt(in->DATA_INFO.ERROR_INFO.error_status, ptr);
-    ptr += 4;
-    LoadInt(in->DATA_INFO.ERROR_INFO.stv, ptr);
+    putint32(&ptr,&in->DATA_INFO.ERROR_INFO.error_status);
+    putint32(&ptr,&in->DATA_INFO.ERROR_INFO.stv);
   } else {
-    *ptr = in->DATA_INFO.DATA_LOCATION.file_level;
-    ptr += 1;
-    *ptr = in->DATA_INFO.DATA_LOCATION.file_version;
-    ptr += 1;
-    memcpy(ptr, in->DATA_INFO.DATA_LOCATION.rfa, 6);
-    ptr += 6;
-    LoadInt(in->DATA_INFO.DATA_LOCATION.record_length, ptr);
+    putint8 (&ptr,&in->DATA_INFO.DATA_LOCATION.file_level);
+    putint8 (&ptr,&in->DATA_INFO.DATA_LOCATION.file_version);
+    putchars(&ptr,&in->DATA_INFO.DATA_LOCATION.rfa, 6);
+    putint32(&ptr,&in->DATA_INFO.DATA_LOCATION.record_length);
   }
 }
 
-void TreeSerializeNciIn(char *in, NCI * out)
-{
-  char *ptr = in;
-  out->flags = (unsigned)swapint(ptr);ptr += 4;
-  out->flags2 = (unsigned char)*ptr;ptr += 1;
-  ptr += 1;
-  out->time_inserted = swapquad(ptr);ptr += 8;
-  out->owner_identifier = swapint(ptr);ptr += 4;
-  out->class = (unsigned char)*ptr;ptr += 1;
-  out->dtype = (unsigned char)*ptr;ptr += 1;
-  out->length = swapint(ptr);ptr += 4;
-  ptr += 1;
-  out->status = swapint(ptr);ptr += 4;
+void TreeSerializeNciIn(const char *in, NCI * out) {
+  char *ptr = (char*)in;
+  getint32(&ptr,&out->flags);
+  getint8 (&ptr,&out->flags2);
+  getint8 (&ptr,&out->spare);
+  getint64(&ptr,&out->time_inserted);
+  getint32(&ptr,&out->owner_identifier);
+  getint8 (&ptr,&out->class);
+  getint8 (&ptr,&out->dtype);
+  getint32(&ptr,&out->length);
+  getint8 (&ptr,&out->spare2);
+  getint32(&ptr,&out->status);
   if (out->flags2 & NciM_DATA_IN_ATT_BLOCK) {
-    out->DATA_INFO.DATA_IN_RECORD.element_length = *ptr;
-    ptr += 1;
-    memcpy(out->DATA_INFO.DATA_IN_RECORD.data, ptr, 11);
+    getint8 (&ptr,&out->DATA_INFO.DATA_IN_RECORD.element_length);
+    getchars(&ptr,&out->DATA_INFO.DATA_IN_RECORD.data, 11);
   } else if (out->flags2 & NciM_ERROR_ON_PUT) {
-    out->DATA_INFO.ERROR_INFO.error_status = swapint(ptr);
-    ptr += 4;
-    out->DATA_INFO.ERROR_INFO.stv = swapint(ptr);
-    ptr += 4;
+    getint32(&ptr,&out->DATA_INFO.ERROR_INFO.error_status);
+    getint32(&ptr,&out->DATA_INFO.ERROR_INFO.stv);
   } else {
-    out->DATA_INFO.DATA_LOCATION.file_level = *ptr;
-    ptr += 1;
-    out->DATA_INFO.DATA_LOCATION.file_version = *ptr;
-    ptr += 1;
-    memcpy(out->DATA_INFO.DATA_LOCATION.rfa, ptr, 6);
-    ptr += 6;
-    out->DATA_INFO.DATA_LOCATION.record_length = swapint(ptr);
+    getint8 (&ptr,&out->DATA_INFO.DATA_LOCATION.file_level);
+    getint8 (&ptr,&out->DATA_INFO.DATA_LOCATION.file_version);
+    getchars(&ptr,&out->DATA_INFO.DATA_LOCATION.rfa, 6);
+    getint32(&ptr,&out->DATA_INFO.DATA_LOCATION.record_length);
   }
 }

--- a/treeshr/treeshrp.h
+++ b/treeshr/treeshrp.h
@@ -128,35 +128,42 @@ typedef struct named_attributes_index {
   NAMED_ATTRIBUTE attribute[NAMED_ATTRIBUTES_PER_INDEX];
 } NAMED_ATTRIBUTES_INDEX;
 
-#define SCI(out,in,O,I) ((char*)(out))[O] = ((char*)in)[I]
 // #define WORDS_BIGENDIAN // use for testing
 #ifdef WORDS_BIGENDIAN
+static inline void SWP(void* out, const void* in, const int a, const int b) {
+ char t=((char*)out)[O];	// in and out could be the same
+        ((char*)in )[O]=((char*)out)[I];
+                        ((char*)in )[I]=t;
+}
 static inline void loadint16(void* out, const void* in) {
- SCI(out,in,0,1);SCI(out,in,1,0);
+ SWP(out,in,0,1);
 }
 static inline void loadint32(void* out, const void* in) {
- SCI(out,in,0,3);SCI(out,in,1,2);
- SCI(out,in,2,1);SCI(out,in,3,0);
+ SWP(out,in,0,3);
+ SWP(out,in,2,1);
 }
 static inline void loadint64(void* out, const void* in) {
- SCI(out,in,0,7);SCI(out,in,1,6);
- SCI(out,in,2,5);SCI(out,in,3,4);
- SCI(out,in,4,3);SCI(out,in,5,2);
- SCI(out,in,6,1);SCI(out,in,7,0);
+ SWP(out,in,0,7);
+ SWP(out,in,2,5);
+ SWP(out,in,4,3);
+ SWP(out,in,6,1);
 }
 #else
+static inline void CPY(void* out, const void* in, const int idx) {
+  ((char*)out)[idx] = ((char*)in)[idx];
+}
 static inline void loadint16(void* out, const void* in) {
- SCI(out,in,0,0);SCI(out,in,1,1);
+ CPY(out,in,0);CPY(out,in,1);
 }
 static inline void loadint32(void* out, const void* in) {
- SCI(out,in,0,0);SCI(out,in,1,1);
- SCI(out,in,2,2);SCI(out,in,3,3);
+ CPY(out,in,0);CPY(out,in,1);
+ CPY(out,in,2);CPY(out,in,3);
 }
 static inline void loadint64(void* out, const void* in) {
- SCI(out,in,0,0);SCI(out,in,1,1);
- SCI(out,in,2,2);SCI(out,in,3,3);
- SCI(out,in,4,4);SCI(out,in,5,5);
- SCI(out,in,6,6);SCI(out,in,7,7);
+ CPY(out,in,0);CPY(out,in,1);
+ CPY(out,in,2);CPY(out,in,3);
+ CPY(out,in,4);CPY(out,in,5);
+ CPY(out,in,6);CPY(out,in,7);
 }
 #endif
 static inline int16_t swapint16(const void *buf) {

--- a/treeshr/treeshrp.h
+++ b/treeshr/treeshrp.h
@@ -82,10 +82,11 @@ SEGMENTED_RECORD_FACILITY =1,
 NAMED_ATTRIBUTES_FACILITY =2,
 };
 
+#define MAXDIM 8
 typedef struct segment_header {
   dtype_t dtype;
   char dimct;
-  int dims[8];
+  int dims[MAXDIM];
   length_t length;
   int idx;
   int next_row;
@@ -127,23 +128,33 @@ typedef struct named_attributes_index {
   NAMED_ATTRIBUTE attribute[NAMED_ATTRIBUTES_PER_INDEX];
 } NAMED_ATTRIBUTES_INDEX;
 
-#if defined(WORDS_BIGENDIAN)
+#define SCI(outp,in,O,I) ((char*)(outp))[O] = ((char*)&in)[I]
+// #define WORDS_BIGENDIAN // use for testing
+#ifdef WORDS_BIGENDIAN
+static inline int64_t swapquad(const void *buf) {
+  return (((int64_t)((uint8_t*)buf)[7]) << 56) | (((int64_t)((uint8_t*)buf)[6]) << 48) |
+	 (((int64_t)((uint8_t*)buf)[5]) << 40) | (((int64_t)((uint8_t*)buf)[4]) << 32) |
+	 (((int64_t)((uint8_t*)buf)[3]) << 24) | (((int64_t)((uint8_t*)buf)[2]) << 16) |
+	 (((int64_t)((uint8_t*)buf)[1]) <<  8) | (((int64_t)((uint8_t*)buf)[0])      ) ;
+}
+static inline int32_t swapint(const void *buf) {
+  return (((int32_t)((uint8_t*)buf)[3]) << 24) | (((int32_t)((uint8_t*)buf)[2]) << 16) |
+	 (((int32_t)((uint8_t*)buf)[1]) <<  8) | (((int32_t)((uint8_t*)buf)[0])      ) ;
+}
+static inline int16_t swapshort(const void *buf) {
+  return (int16_t) ( (((int32_t)((uint8_t*)buf)[1]) << 8)  | (((int32_t)((uint8_t*)buf)[0]) ) ) ;
+}
 
-#define swapquad(ptr) ( (((int64_t)((unsigned char *)ptr)[7]) << 56) | (((int64_t)((unsigned char *)ptr)[6]) << 48) | \
-                        (((int64_t)((unsigned char *)ptr)[5]) << 40) | (((int64_t)((unsigned char *)ptr)[4]) << 32) | \
-                        (((int64_t)((unsigned char *)ptr)[3]) << 24) | (((int64_t)((unsigned char *)ptr)[2]) << 16) | \
-                        (((int64_t)((unsigned char *)ptr)[1]) <<  8) | (((int64_t)((unsigned char *)ptr)[0]) ))
-#define swapint(ptr) ( (((int)((unsigned char *)(ptr))[3]) << 24) | (((int)((unsigned char *)(ptr))[2]) << 16) | \
-                       (((int)((unsigned char *)(ptr))[1]) <<  8) | (((int)((unsigned char *)(ptr))[0]) ))
-#define swapshort(ptr) ( (((int)((unsigned char *)ptr)[1]) << 8) | (((int)((unsigned char *)ptr)[0]) ))
-
-#define LoadShort(in,outp) ((char *)(outp))[0] = ((char *)&in)[1]; ((char *)(outp))[1] = ((char *)&in)[0]
-#define LoadInt(in,outp)   ((char *)(outp))[0] = ((char *)&in)[3]; ((char *)(outp))[1] = ((char *)&in)[2]; \
-                           ((char *)(outp))[2] = ((char *)&in)[1]; ((char *)(outp))[3] = ((char *)&in)[0]
-#define LoadQuad(in,outp)  (outp)[0] = ((char *)&in)[7]; (outp)[1] = ((char *)&in)[6]; \
-                           (outp)[2] = ((char *)&in)[5]; (outp)[3] = ((char *)&in)[4]; \
-                           (outp)[4] = ((char *)&in)[3]; (outp)[5] = ((char *)&in)[2]; \
-                           (outp)[6] = ((char *)&in)[1]; (outp)[7] = ((char *)&in)[0]
+#define LoadShort(in,outp) \
+ SCI(outp,in,0,1);SCI(outp,in,1,0);
+#define LoadInt(in,outp) \
+ SCI(outp,in,0,3);SCI(outp,in,1,2);\
+ SCI(outp,in,2,1);SCI(outp,in,3,0);
+#define LoadQuad(in,outp) \
+ SCI(outp,in,0,7);SCI(outp,in,1,6);\
+ SCI(outp,in,2,5);SCI(outp,in,3,4);\
+ SCI(outp,in,4,3);SCI(outp,in,5,2);\
+ SCI(outp,in,6,1);SCI(outp,in,7,0);
 #else
 
 static inline int64_t swapquad(const void *buf) {
@@ -161,14 +172,16 @@ static inline int16_t swapshort(const void *buf) {
   memcpy(&ans,buf,sizeof(ans));
   return ans;
 }
-
-#define LoadShort(in,outp) ((char *)(outp))[0] = ((char *)&in)[0]; ((char *)(outp))[1] = ((char *)&in)[1]
-#define LoadInt(in,outp)   ((char *)(outp))[0] = ((char *)&in)[0]; ((char *)(outp))[1] = ((char *)&in)[1]; \
-                           ((char *)(outp))[2] = ((char *)&in)[2]; ((char *)(outp))[3] = ((char *)&in)[3]
-#define LoadQuad(in,outp)  (outp)[0] = ((char *)&in)[0]; (outp)[1] = ((char *)&in)[1]; \
-                           (outp)[2] = ((char *)&in)[2]; (outp)[3] = ((char *)&in)[3]; \
-                           (outp)[4] = ((char *)&in)[4]; (outp)[5] = ((char *)&in)[5]; \
-                           (outp)[6] = ((char *)&in)[6]; (outp)[7] = ((char *)&in)[7]
+#define LoadShort(in,outp) \
+ SCI(outp,in,0,0);SCI(outp,in,1,1);
+#define LoadInt(in,outp) \
+ SCI(outp,in,0,0);SCI(outp,in,1,1);\
+ SCI(outp,in,2,2);SCI(outp,in,3,3);
+#define LoadQuad(in,outp) \
+ SCI(outp,in,0,0);SCI(outp,in,1,1);\
+ SCI(outp,in,2,2);SCI(outp,in,3,3);\
+ SCI(outp,in,4,4);SCI(outp,in,5,5);\
+ SCI(outp,in,6,6);SCI(outp,in,7,7);
 #endif
 
 #define bitassign(bool,value,mask)   value = (bool) ? (value) | (unsigned)(mask) : (value) & ~(unsigned)(mask)
@@ -722,8 +735,8 @@ extern int GetDefaultNidRemote(PINO_DATABASE * dblist, int *nid);
 #ifdef _WIN32
 #include <windows.h>
 #endif
-extern int64_t RfaToSeek(unsigned char *rfa);
-void SeekToRfa(int64_t seek, unsigned char *rfa);
+extern int64_t RfaToSeek(uint8_t*rfa);
+void SeekToRfa(int64_t seek, uint8_t*rfa);
 extern int SetParentState(PINO_DATABASE * db, NODE * node, unsigned int state);
 extern void TreeCallHookFun(char *hookType, char *hookName, ...);
 extern int TreeMakeNidsLocal(struct descriptor *dsc_ptr, int nid);
@@ -746,7 +759,7 @@ int _TreeFindTag(PINO_DATABASE * db, NODE * default_node, short treelen, const c
 extern int TreeCallHook(TreeshrHookType operation, TREE_INFO * info, int nid);
 extern void _TreeDeleteNodesWrite(void *dbid);
 extern void _TreeDeleteNodesDiscard(void *dbid);
-extern int TreeGetDatafile(TREE_INFO * info_ptr, unsigned char *rfa, int *buffer_size, char *record,
+extern int TreeGetDatafile(TREE_INFO * info_ptr, uint8_t*rfa, int *buffer_size, char *record,
 			   int *retsize, int *nodenum, unsigned char flags);
 extern int TreeEstablishRundownEvent(TREE_INFO * info);
 extern int TreeGetDsc(TREE_INFO * info, const int nid, const int64_t offset, const int length,


### PR DESCRIPTION
* added function _TreeSetRowsFilled which should replace the hacky NEXT_ROW_FIX environ impl
* properly trim dimensions with treeref (_Execute) and/or windows definitions (lbound)
* remove bad code and streamlined buffer to struct transfer using put/get-int methods
* fixed WORDS_BIGENDIAN branch (compiling errors)
* fixed all main code clobbered (no-more need for pragma ignored)
* fixed stdout interference with mdsip protocol for Tunnel
* added some tests


I browsed the code and made a lot of changes:
 basically croping code and sticking it into inline statics where possible.
 some minor usage of macros to handle the methods that convert between struct and buffer.
i added some helper functions to treeshrp.h inspired by java ByteBuffer.

The PR is base on #1502 which does not pass the test for some reason. It incorporates tyedefs that will help to debug and identify argument issues, missing cases in switch statements etc.