### PR TITLE
Fix: compile clobber warning false positive

### DIFF
--- a/treeshr/TreeAddNode.c
+++ b/treeshr/TreeAddNode.c
@@ -482,7 +482,8 @@ static void get_add_rtn_c(void* in){
   free_if(&c->model);
   free_if(&c->image);
 }
-
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wclobbered"
 static inline int get_add_rtn(char const *congtype, int (**add)()){
   static int (*TdiExecute) () = NULL;
   int status = LibFindImageSymbol_C("TdiShr", "TdiExecute", &TdiExecute);
@@ -522,7 +523,7 @@ static inline int get_add_rtn(char const *congtype, int (**add)()){
   pthread_cleanup_pop(1);
   return status;
 }
-
+#pragma GCC diagnostic pop
 int _TreeAddConglom(void *dbid, char const *path, char const *congtype, int *nid){
   if (!IS_OPEN_FOR_EDIT(((PINO_DATABASE *)dbid))) return TreeNOEDIT;
   static int (*_TdiExecute) () = NULL;


### PR DESCRIPTION
Invalid warning must be ignored.