### PR TITLE
Build: rpmsign not prompting for pass phrase

### DIFF
--- a/deploy/platform/redhat/redhat_build_rpms.py
+++ b/deploy/platform/redhat/redhat_build_rpms.py
@@ -227,9 +227,10 @@ Buildarch: noarch
         try:
             cmd="/bin/sh -c 'rsync -a /sign_keys /tmp/; HOME=/tmp/sign_keys rpmsign --addsign /release/%(branch)s/RPMS/*/*%(major)d.%(minor)d-%(release)d*.rpm'" % info
             child = pexpect.spawn(cmd,timeout=60,logfile=sys.stdout)
-            child.expect("Enter pass phrase: ")
-            child.sendline("")
-            child.expect(pexpect.EOF)
+            index = child.expect(["Enter pass phrase: ",pexpect.EOF])
+            if index == 0:
+                child.sendline("")
+                child.expect(pexpect.EOF)
             child.close()
             if child.status != 0:
                 sys.stdout.flush()


### PR DESCRIPTION
On more recent fedora releases, the rpmsign command no longer
prompts for a pass phrase if the sign key does not require a pass phrase.
The build process used to expect the prompt and provide an empty line
response but with the new rpmsign the packages are being signed but there
are misleading error messages generated. The builds were completing ok
with signed packages but this change should prevent those error messages.