### PR TITLE
Fix: reopen a tree in edit mode violates dbid stack

### DIFF
--- a/mdsobjects/python/tests/segmentsUnitTest.py
+++ b/mdsobjects/python/tests/segmentsUnitTest.py
@@ -258,8 +258,8 @@ class Tests(_UnitTest.TreeTests):
         self.assertEqual(Tree.getTimeContext(),(1,2,3))
         tdi('treeclose()')
         self.assertEqual(Tree.getTimeContext(),(2,3,4))
-        tdi('treeclose()',self.tree,self.shot+5)
-        self.assertEqual(Tree.getTimeContext(),(1,2,3))
+        tdi('treeclose()')
+        self.assertEqual(Tree.getTimeContext(),(2,3,4))
 
     def ScaledSegments(self):
         from MDSplus import Tree,Int64,Int64Array,Int16Array

--- a/tditest/testing/test-treeshr.ans
+++ b/tditest/testing/test-treeshr.ans
@@ -185,9 +185,11 @@ TreePutRecord(member,build_with_units(1:1000,'volts'))
 265389633
 member
 Build_With_Units(1 : 1000, "volts")
-TreeClose('main',_shot)
-265388041
 TreeOpen('main',-1,1)
+265388041
+TreeOpenEdit('main',_shot)
+265388041
+TreeClose('main',_shot)
 265388041
 TreeDeletePulseFile(_shot)
 265389633

--- a/tditest/testing/test-treeshr.tdi
+++ b/tditest/testing/test-treeshr.tdi
@@ -89,8 +89,11 @@ TreePutRecord(member,42)
 member
 TreePutRecord(member,build_with_units(1:1000,'volts'))
 member
-TreeClose('main',_shot)
 TreeOpen('main',-1,1)
+TreeOpenEdit('main',_shot)
+!should reopen _shot in edit mode
+TreeClose('main',_shot)
+!should leave model open and top tree
 TreeDeletePulseFile(_shot)
 TreeClose()
 TreeOpenNew('main',_shot)

--- a/treeshr/TreeOpen.c
+++ b/treeshr/TreeOpen.c
@@ -1166,7 +1166,7 @@ int _TreeOpenEdit(void **dbid, char const *tree_in, int shot_in)
 	    memset(info->edit, 0, sizeof(TREE_EDIT));
 	    info->root = info->node;
 	    status = TreeOpenNciW(info, 0);
-	    if (status & 1) {
+	    if STATUS_OK {
 	      (*dblist)->tree_info = info;
 	      (*dblist)->open = 1;
 	      (*dblist)->open_for_edit = 1;
@@ -1180,7 +1180,10 @@ int _TreeOpenEdit(void **dbid, char const *tree_in, int shot_in)
 	  free(info->treenam);
 	  free(info);
 	}
-      }
+      } else
+	status = TreeMEMERR;
+      if STATUS_NOT_OK
+	free_top_db(dblist);
     }
   }
   return status;
@@ -1277,6 +1280,8 @@ int _TreeOpenNew(void **dbid, char const *tree_in, int shot_in)
 	  free(tree);
       } else
 	status = TreeMEMERR;
+      if STATUS_NOT_OK
+	free_top_db(dblist);
     }
   }
   if STATUS_OK

--- a/treeshr/TreeOpen.c
+++ b/treeshr/TreeOpen.c
@@ -634,7 +634,7 @@ static int CreateDbSlot(PINO_DATABASE ** dblist, char *tree, int shot, int editt
 
   case CLOSE:
     move_to_top(prev_db, db);
-    _TreeClose((void **)dblist, 0, 0);
+    CloseTopTree(*dblist, 1);
     status = TreeNORMAL;
     break;
   case ERROR_DIRTY:
@@ -656,7 +656,7 @@ static int CreateDbSlot(PINO_DATABASE ** dblist, char *tree, int shot, int editt
       if (count >= stack_size) {
 	if (useable_db) {
 	  move_to_top(saved_prev_db, useable_db);
-	  _TreeClose((void **)dblist, 0, 0);
+	  CloseTopTree(*dblist, 1);
 	  move_to_top(saved_prev_db, useable_db);
 	  status = TreeNORMAL;
 	} else {

--- a/treeshr/treeshrp.h
+++ b/treeshr/treeshrp.h
@@ -235,6 +235,7 @@ typedef struct nid {
 #endif
 
 #define MAX_SUBTREES 256	/* since there are only 8 bits of tree number in a nid */
+#define DEFAULT_STACK_LIMIT 8
 
 /********************************************
    NODE


### PR DESCRIPTION
CreateDbSlot used _TreeClose to close the top most tree if it has to close a tree for any reason (edit<>normal, out of stack). But _TreeClose moves the slot to the end of the stack. Since CreateDbSlot assumes teh stack is untouched it overwrites the entries of the next slot which might contain valid data of a different tree. using CloseTopTree will leave the stack untouched.

* remove cap of stacklimit and free closed dbid slots instead of moving them to back.

This PR fixes issue #1546