### PR TITLE
Fix: svrgp overflows index for large arrays

### DIFF
--- a/math/svrgn.f
+++ b/math/svrgn.f
@@ -50,7 +50,7 @@
                   jstack = jstack-2
             Enddo
             ran = mod(ran*211+1663,7875)
-            i = l + (r-l+1)*ran/7875
+            i = l + int((int(r-l+1,8)*ran)/7875,4)
             If (perm) kperm = iperm(i)
             If (perm) iperm(i) = iperm(l)
             keep = rb(i)
@@ -140,7 +140,7 @@
                   jstack = jstack-2
             Enddo
             ran = mod(ran*211+1663,7875)
-            i = l + (r-l+1)*ran/7875
+            i = l + int((int(r-l+1,8)*ran)/7875,4)
             If (perm) kperm = iperm(i)
             If (perm) iperm(i) = iperm(l)
             keep = rb(i)


### PR DESCRIPTION
for arrays larger than (1<<31)/7875 SVRGP (used by e.g. csint) has the potential to overflow the signed int32.
the fix prevents this by casting to int64 for the critical math.

TdiCall reused opcode as return type. datatype dtype_t gives more useful prints in gdb
