### PR TITLE
Fix: the file lookup implementation is very slow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,3 +94,6 @@ autom4te.cache
 # python version module
 _version.py
 *.log
+
+testing/MDSplus/
+testing/*Devices/

--- a/camshr/common.h
+++ b/camshr/common.h
@@ -40,7 +40,8 @@ enum { ALWAYS = 1,		// ... well, almost always -- for debug printout
 #define	DETAILS		 	 9
 #endif
 
-enum { FALSE = 0, TRUE };
+#define FALSE 0
+#define TRUE 1
 enum { TO_CAMAC, FROM_CAMAC };	// ie WRITE and READ
 enum { STATUS_BAD, STATUS_GOOD };
 enum { CTS_DB, CRATE_DB };

--- a/conf/valgrind-python.supp
+++ b/conf/valgrind-python.supp
@@ -601,3 +601,10 @@
    ...
    fun:_PyMethodDef_RawFastCallKeywords
 }
+
+{
+   debian python 2.7
+   Memcheck:Addr4
+   fun:long_dealloc.lto_priv.328
+   fun:frame_dealloc
+}

--- a/deploy/os/fc23.opts
+++ b/deploy/os/fc23.opts
@@ -1,1 +1,1 @@
---platform=redhat --valgrind=memcheck,helgrind --sanitize=address,undefined,thread --dockerimage=mdsplus/docker:fc23 --distname=fc23
+--platform=redhat --valgrind=memcheck,helgrind --sanitize=address,thread --dockerimage=mdsplus/docker:fc23 --distname=fc23

--- a/include/libroutines.h
+++ b/include/libroutines.h
@@ -24,10 +24,10 @@ extern int LibConvertDateString(const char *asc_time, int64_t * qtime);
 extern int LibCreateVmZone(ZoneList ** zone);
 extern time_t LibCvtTim(int *time_in, double *t);
 extern int LibDeleteVmZone(ZoneList ** zone);
-extern int LibFindFile(struct descriptor *filespec, struct descriptor *result, void **ctx);
+extern int LibFindFile(mdsdsc_t *filespec, mdsdsc_t *result, void **ctx);
+extern int LibFindFileCaseBlind(mdsdsc_t *filespec, mdsdsc_t *result, void **ctx);
 extern int LibFindFileEnd(void **ctx);
-extern int LibFindFileRecurseCaseBlind(struct descriptor *filespec,
-				       struct descriptor *result, void **ctx);
+extern int LibFindFileRecurseCaseBlind(mdsdsc_t *filespec, mdsdsc_t *result, void **ctx);
 extern int LibFindImageSymbol();
 extern int LibFindImageSymbol_C();
 extern char *LibFindImageSymbolErrString();

--- a/include/libroutines.h
+++ b/include/libroutines.h
@@ -8,7 +8,6 @@
 #ifndef LIBRTL_SRC
 #define ZoneList void
 #define LibTreeNode void
-#define FindFileCtx void
 #endif
 
 #include <inttypes.h>
@@ -25,10 +24,10 @@ extern int LibConvertDateString(const char *asc_time, int64_t * qtime);
 extern int LibCreateVmZone(ZoneList ** zone);
 extern time_t LibCvtTim(int *time_in, double *t);
 extern int LibDeleteVmZone(ZoneList ** zone);
-extern int LibFindFile(struct descriptor *filespec, struct descriptor *result, FindFileCtx **ctx);
-extern int LibFindFileEnd(FindFileCtx **ctx);
+extern int LibFindFile(struct descriptor *filespec, struct descriptor *result, void **ctx);
+extern int LibFindFileEnd(void **ctx);
 extern int LibFindFileRecurseCaseBlind(struct descriptor *filespec,
-				       struct descriptor *result, FindFileCtx **ctx);
+				       struct descriptor *result, void **ctx);
 extern int LibFindImageSymbol();
 extern int LibFindImageSymbol_C();
 extern char *LibFindImageSymbolErrString();

--- a/include/status.h
+++ b/include/status.h
@@ -1,7 +1,9 @@
 #pragma once
 #include <mdsshr_messages.h>
-#define B_TRUE  1
-#define B_FALSE 0
+#define FALSE 0
+#define TRUE  1
+#define B_TRUE  TRUE
+#define B_FALSE FALSE
 #define C_OK    0
 #define C_ERROR -1
 #define IS_OK(status)     ((status) & 1)

--- a/mdsobjects/python/mdsExceptions.py
+++ b/mdsobjects/python/mdsExceptions.py
@@ -1,4 +1,4 @@
-# 
+#
 # Copyright (c) 2017, Massachusetts Institute of Technology All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -49,16 +49,21 @@ class MDSplusException(MdsException):
       else:
           cls = MDSplusUnknown
       return cls.__new__(cls,*argv)
-  def __init__(self,status=None):
+  def __init__(self,status=None,message=None):
     if isinstance(status,int):
-      self.status=status
-    if not hasattr(self,'status'):
-      self.status=PyUNHANDLED_EXCEPTION.status
-      self.msgnam='Unknown'
-      self.message='Unknown exception'
-      self.fac='MDSplus'
-    if isinstance(status,str):
-      self.message = status
+      self.status = status
+    else:
+      if isinstance(status,str):
+          message = status
+      if not hasattr(self,'status'):
+        self.status=PyUNHANDLED_EXCEPTION.status
+        self.msgnam='Unknown'
+        self.message='Unknown exception'
+        self.fac='MDSplus'
+    if message is not None:
+        message = str(message)
+        if len(message)>0:
+            self.message = "%s:\n%s"%(self.message,message)
     self.severity=self.severities[self.status & 7]
     super(Exception,self).__init__(self.message)
 
@@ -81,13 +86,13 @@ class MDSplusUnknown(MDSplusException):
 def statusToException(status):
     return MDSplusException(status)
 
-def checkStatus(status,ignore=tuple()):
+def checkStatus(status,ignore=tuple(),message=None):
     if (status & 1)==0:
-        exception = MDSplusException(status)
+        exception = MDSplusException(status,message)
         if isinstance(exception, ignore):
             print(exception.message)
         else:
-            raise MDSplusException(status)
+            raise exception
 
 ########################### generated from mitdevices_messages.xml ########################
 

--- a/mdsobjects/python/mdsdcl.py
+++ b/mdsobjects/python/mdsdcl.py
@@ -69,7 +69,7 @@ else:
     else:
         status = _mdsdcl.mdsdcl_do_command_dsc(_ver.tobytes(command), error_p, out_p)
     if (return_out or return_error) and raise_exception:
-        if raise_exception: _exc.checkStatus(status)
+        if raise_exception: _exc.checkStatus(status,message=xd_error.value)
     if return_out and return_error:
         return (xd_output.value,xd_error.value)
     elif return_out:

--- a/mdsshr/MdsShr.def
+++ b/mdsshr/MdsShr.def
@@ -12,6 +12,7 @@ LibCreateVmZone
 LibCvtTim
 LibDeleteVmZone
 LibFindFile
+LibFindFileCaseBlind
 LibFindFileEnd
 LibFindFileRecurseCaseBlind
 LibFindImageSymbol

--- a/mdsshr/MdsShr.exports
+++ b/mdsshr/MdsShr.exports
@@ -3,6 +3,7 @@ LibCallg
 LibConvertDateString
 LibCreateVmZone
 LibFindFile
+LibFindFileCaseBlind
 LibFindFileEnd
 LibFindFileRecurseCaseBlind
 LibFindImageSymbol

--- a/mdsshr/gen_messages.py
+++ b/mdsshr/gen_messages.py
@@ -1,4 +1,4 @@
-# 
+#
 # Copyright (c) 2017, Massachusetts Institute of Technology All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -104,7 +104,7 @@ MDSplusException.statusDict[%(msgn_nosev)d] = %(fac)s%(msgnam)s
     f_inc.close()
 
 f_py=open("%s/mdsobjects/python/mdsExceptions.py"%sourcedir,'w')
-f_py.write("""# 
+f_py.write("""#
 # Copyright (c) 2017, Massachusetts Institute of Technology All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -155,16 +155,21 @@ class MDSplusException(MdsException):
       else:
           cls = MDSplusUnknown
       return cls.__new__(cls,*argv)
-  def __init__(self,status=None):
+  def __init__(self,status=None,message=None):
     if isinstance(status,int):
-      self.status=status
-    if not hasattr(self,'status'):
-      self.status=PyUNHANDLED_EXCEPTION.status
-      self.msgnam='Unknown'
-      self.message='Unknown exception'
-      self.fac='MDSplus'
-    if isinstance(status,str):
-      self.message = status
+      self.status = status
+    else:
+      if isinstance(status,str):
+          message = status
+      if not hasattr(self,'status'):
+        self.status=PyUNHANDLED_EXCEPTION.status
+        self.msgnam='Unknown'
+        self.message='Unknown exception'
+        self.fac='MDSplus'
+    if message is not None:
+        message = str(message)
+        if len(message)>0:
+            self.message = "%s:\n%s"%(self.message,message)
     self.severity=self.severities[self.status & 7]
     super(Exception,self).__init__(self.message)
 
@@ -187,13 +192,13 @@ class MDSplusUnknown(MDSplusException):
 def statusToException(status):
     return MDSplusException(status)
 
-def checkStatus(status,ignore=tuple()):
+def checkStatus(status,ignore=tuple(),message=None):
     if (status & 1)==0:
-        exception = MDSplusException(status)
+        exception = MDSplusException(status,message)
         if isinstance(exception, ignore):
             print(exception.message)
         else:
-            raise MDSplusException(status)
+            raise exception
 """)
 
 xmllist = {}

--- a/mdsshr/librtl.c
+++ b/mdsshr/librtl.c
@@ -1776,11 +1776,17 @@ EXPORT extern int LibFindFileEnd(void **ctx){
 
 static int find_file(struct descriptor *filespec, struct descriptor *result, void **ctx,
 			    int recursively, int case_blind){
+#ifdef DEBUG
+  clock_t start = clock();
+#endif
   int status;
   if (*ctx == 0) {
     char* fspec = malloc(filespec->length+1);
     memcpy(fspec,filespec->pointer,filespec->length);fspec[filespec->length] = '\0';
     *ctx = (void*)findfilestart(fspec,recursively,case_blind);
+#ifdef DEBUG
+  fprintf(stderr, "locking for %s: ", fspec);
+#endif
     free(fspec);
     if (!*ctx) return MDSplusERROR;
   }
@@ -1793,6 +1799,9 @@ static int find_file(struct descriptor *filespec, struct descriptor *result, voi
     status = MDSplusERROR;
     LibFindFileEnd(ctx);
   }
+#ifdef DEBUG
+  fprintf(stderr, "took %fs\n", ((double)(clock()-start))/CLOCKS_PER_SEC);
+#endif
   return status;
 }
 

--- a/mdsshr/librtl.c
+++ b/mdsshr/librtl.c
@@ -331,12 +331,12 @@ EXPORT uint32_t LibGetHostAddr(char *name){
   INIT_AND_FREE_ON_EXIT(void*,hp_mem);
   for ( memlen=1024, hp_mem=malloc(memlen);
 	hp_mem && (gethostbyname_r(name,&hostbuf,hp_mem,memlen,&hp,&herr) == ERANGE);
-	memlen *= 2, hp_mem = realloc(hp_mem, memlen));
+	memlen *= 2, free(hp_mem), hp_mem = malloc(memlen)); // free + malloc = realloc - memcpy
   if (!hp) {
     addr = (int)inet_addr(name);
     if (addr != -1) for (;
         hp_mem && (gethostbyaddr_r(((void*)&addr),sizeof(int),AF_INET,&hostbuf,hp_mem,memlen,&hp,&herr) == ERANGE);
-	memlen *= 2, hp_mem = realloc(hp_mem, memlen));
+	memlen *= 2, free(hp_mem), hp_mem = malloc(memlen));
   }
   if (hp) addr = *(int*)hp->h_addr_list[0];
   FREE_NOW(hp_mem);

--- a/mdsshr/librtl.c
+++ b/mdsshr/librtl.c
@@ -1813,6 +1813,10 @@ EXPORT int LibFindFileRecurseCaseBlind(struct descriptor *filespec, struct descr
   return find_file(filespec, result, ctx, 1, 1);
 }
 
+EXPORT int LibFindFileCaseBlind(struct descriptor *filespec, struct descriptor *result, void **ctx){
+  return find_file(filespec, result, ctx, 0, 1);
+}
+
 EXPORT void TranslateLogicalFree(char *value)
 {
   free(value);

--- a/mdsshr/librtl.c
+++ b/mdsshr/librtl.c
@@ -50,7 +50,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <errno.h>
 #include <signal.h>
 
-//#define DEBUG
+// #define DEBUG
 #ifdef DEBUG
 # define DBG(...) fprintf(stderr,__VA_ARGS__)
 #else
@@ -1388,32 +1388,23 @@ EXPORT int StrCaseBlindCompare(struct descriptor *one, struct descriptor *two)
   return ans;
 }
 
-EXPORT unsigned int StrMatchWild(struct descriptor *candidate, struct descriptor *pattern)
-{
+static int match_wild(const char*cand_ptr, const int cand_len, const char *pat_ptr, const int pat_len){
   struct descr {
+    const char *ptr;
     int length;
-    char *ptr;
   };
-  struct descr cand;
-  struct descr scand;
-  struct descr pat;
-  struct descr spat;
+  struct descr cand  = {cand_ptr,cand_len};
+  struct descr scand = {cand_ptr,0     };
+  struct descr pat   = {pat_ptr,pat_len};
+  struct descr spat  = pat;
   char pc;
-  cand.length = candidate->length;
-  cand.ptr = candidate->pointer;
-  scand = cand;
-  pat.length = pattern->length;
-  pat.ptr = pattern->pointer;
-  spat = pat;
-  scand.length = 0;
-
-  while (1) {
+  for (;;) {
     if (--pat.length < 0) {
       if (cand.length == 0)
-	return StrMATCH;
+	return TRUE;
       else {
 	if (--scand.length < 0)
-	  return StrNOMATCH;
+	  return FALSE;
 	else {
 	  scand.ptr++;
 	  cand = scand;
@@ -1423,16 +1414,16 @@ EXPORT unsigned int StrMatchWild(struct descriptor *candidate, struct descriptor
     } else {
       if ((pc = *pat.ptr++) == '*') {
 	if (pat.length == 0)
-	  return StrMATCH;
+	  return TRUE;
 	scand = cand;
 	spat = pat;
       } else {
 	if (--cand.length < 0)
-	  return StrNOMATCH;
+	  return FALSE;
 	if (*cand.ptr++ != pc) {
 	  if (pc != '%') {
 	    if (--scand.length < 0)
-	      return StrNOMATCH;
+	      return FALSE;
 	    else {
 	      scand.ptr++;
 	      cand = scand;
@@ -1443,17 +1434,14 @@ EXPORT unsigned int StrMatchWild(struct descriptor *candidate, struct descriptor
       }
     }
   }
-  return StrNOMATCH;
+  return FALSE;
 }
 
-#ifdef MAX
-#undef MAX
-#endif
-#define MAX(a,b) (a) > (b) ? (a) : (b)
-#ifdef MIN
-#undef MIN
-#endif
-#define MIN(a,b) (a) < (b) ? (a) : (b)
+EXPORT unsigned int StrMatchWild(struct descriptor *candidate, struct descriptor *pattern){
+  if (match_wild(candidate->pointer,candidate->length,pattern->pointer,pattern->length))
+    return StrMATCH;
+  return StrNOMATCH;
+}
 
 EXPORT int StrElement(struct descriptor *dest, int *num, struct descriptor *delim, struct descriptor *src)
 {
@@ -1479,8 +1467,7 @@ EXPORT int StrElement(struct descriptor *dest, int *num, struct descriptor *deli
 }
 
 EXPORT int StrTranslate(struct descriptor *dest, struct descriptor *src, struct descriptor *tran,
-		 struct descriptor *match)
-{
+		 struct descriptor *match){
   int status = 0;
   if (src->class == CLASS_S || src->class == CLASS_D) {
     char *dst = (char *)malloc(src->length);
@@ -1512,8 +1499,7 @@ EXPORT int StrTranslate(struct descriptor *dest, struct descriptor *src, struct 
   return status;
 }
 
-EXPORT int StrReplace(struct descriptor *dest, struct descriptor *src, int *start_idx, int *end_idx,
-	       struct descriptor *rep)
+EXPORT int StrReplace(struct descriptor *dest, struct descriptor *src, int *start_idx, int *end_idx, struct descriptor *rep)
 {
   int status;
   int start;
@@ -1522,8 +1508,9 @@ EXPORT int StrReplace(struct descriptor *dest, struct descriptor *src, int *star
   char *dst;
   char *sptr;
   char *dptr;
-  start = MAX(1, MIN(*start_idx, src->length));
-  end = MAX(1, MIN(*end_idx, src->length));
+#define minmax(l,x,u) (  ((x)<(l)) ? (l) : ( ((x)>(u)) ? (u) : (x) )  )
+  start = minmax(1, *start_idx, src->length);
+  end   = minmax(1, *end_idx,   src->length);
   dstlen = (unsigned short)(start - 1 + rep->length + src->length - end + 1);
   dst = (char *)malloc(dstlen);
   for (sptr = src->pointer, dptr = dst; (dptr - dst) < (start - 1); *dptr++ = *sptr++) ;
@@ -1534,39 +1521,273 @@ EXPORT int StrReplace(struct descriptor *dest, struct descriptor *src, int *star
   return status;
 }
 
-STATIC_ROUTINE int FindFile(struct descriptor *filespec, struct descriptor *result, FindFileCtx **ctx,
-			    int recursively, int caseBlind);
-STATIC_ROUTINE int FindFileStart(struct descriptor *filespec, FindFileCtx ** ctx, int caseBlind);
-STATIC_ROUTINE int FindFileEnd(FindFileCtx * ctx);
-STATIC_ROUTINE char *_FindNextFile(FindFileCtx * ctx, int recursively, int caseBlind);
+////////////////////////////////////////////////////////////////////////////////
+/////FIND FILE//////////////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////////
 
-EXPORT int LibFindFile(struct descriptor *filespec, struct descriptor *result, FindFileCtx **ctx)
-{
-  return FindFile(filespec, result, ctx, 0, 0);
+#ifdef _WIN32
+#define DIR_HND   HANDLE
+#define FILE_INFO WIN32_FIND_DATAA
+#else
+#define DIR_HND DIR
+#define FILE_INFO struct dirent *
+#endif
+
+typedef struct {
+  DIR_HND *h;
+  size_t wlen;
+} findstack_t;
+typedef struct {
+  findstack_t *stack;
+  int cur_stack;
+  int max_stack;
+  const char *cptr;
+  const char *ptr;
+  const char *folders;
+  const char *filename;
+  const size_t flen;
+  char *buffer;
+#ifndef _WIN32
+  size_t buflen;
+#endif
+  int recursive;
+  int case_blind;
+  FILE_INFO fd; // hold the file information
+} ctx_t;
+
+#ifdef _WIN32
+
+#define SEP    '\\'
+#define FILENAME(ctx) ctx->fd.cFileName
+#define ISDIRECTORY(ctx) (ctx->fd.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY)
+#define REALLOCBUF(ctx,extra)
+static inline void FINDFILECLOSE_OS(ctx_t* ctx){
+    FindClose(ctx->stack[ctx->cur_stack].h);
+}
+static inline int FINDFILENEXT_OS(ctx_t* ctx){
+    return FindNextFile(ctx->stack[ctx->cur_stack].h, &ctx->fd);
+}
+static inline int FINDFILEFIRST_OS(ctx_t* ctx){
+  ctx->stack[ctx->cur_stack].h = FindFirstFile(ctx->buffer, &ctx->fd);
+  return ctx->stack[ctx->cur_stack].h != INVALID_HANDLE_VALUE;
 }
 
-EXPORT int LibFindFileRecurseCaseBlind(struct descriptor *filespec, struct descriptor *result,
-				       FindFileCtx **ctx)
-{
-  return FindFile(filespec, result, ctx, 1, 1);
-}
+#else
 
-STATIC_ROUTINE int FindFile(struct descriptor *filespec, struct descriptor *result, FindFileCtx **ctx,
-			    int recursively, int caseBlind)
-{
-  int status;
-  char *ans;
-  if (*ctx == 0) {
-    status = FindFileStart(filespec, (FindFileCtx **) ctx, caseBlind);
-    if STATUS_NOT_OK  return status;
+#define SEP    '/'
+#define INVALID_HANDLE_VALUE NULL
+#define MAX_PATH 0
+#define FILENAME(ctx) ctx->fd->d_name
+static inline void REALLOCBUF(ctx_t *const ctx, const size_t extra) {
+  const size_t required = ctx->stack[ctx->cur_stack].wlen + extra;
+  if (ctx->buflen>=required) return;
+  char *newbuf = realloc(ctx->buffer, required);
+  if (newbuf) {
+    ctx->buffer = newbuf;
+    ctx->buflen = required;
   }
-  ans = _FindNextFile((FindFileCtx *) * ctx, recursively, caseBlind);
+}
+#include <sys/stat.h>
+static inline int ISDIRECTORY(ctx_t *ctx){
+   struct stat statbuf;
+   if (stat(ctx->buffer, &statbuf) != 0)
+       return FALSE;
+   return S_ISDIR(statbuf.st_mode);
+}
+static inline void FINDFILECLOSE_OS(ctx_t* ctx){
+  closedir(ctx->stack[ctx->cur_stack].h);
+}
+static inline int FINDFILENEXT_OS(ctx_t* ctx){
+    return (ctx->fd = readdir(ctx->stack[ctx->cur_stack].h)) != NULL;
+}
+static inline int FINDFILEFIRST_OS(ctx_t* ctx){
+    ctx->stack[ctx->cur_stack].h = opendir(ctx->buffer);
+    if (!ctx->stack[ctx->cur_stack].h) return FALSE;
+    if (!FINDFILENEXT_OS(ctx)) {
+      FINDFILECLOSE_OS(ctx);
+      return FALSE;
+    }
+    return TRUE;
+}
+
+#endif
+
+static int findfileloopstart(ctx_t *ctx) {
+  ctx->buffer[ctx->stack[ctx->cur_stack].wlen++] = SEP;
+#ifdef _WIN32
+  // after this wlen will mark the last SEP so we can simply attach the filename
+  if (ctx->recursive) { // append "\\*\0"
+    ctx->buffer[ctx->stack[ctx->cur_stack].wlen] = '*';
+    ctx->buffer[ctx->stack[ctx->cur_stack].wlen + 1] = '\0';
+  } else { // append "/<pattern>\0"
+    // Windows will find he file much faster
+    char* p;
+    memcpy(p = ctx->buffer + ctx->stack[ctx->cur_stack].wlen, ctx->filename, ctx->flen + 1);
+    // replace single char wildcard '%' with '?'
+    for (; *p; p++) if (*p == '%') *p = '?';
+  }
+#else
+  ctx->buffer[ctx->stack[ctx->cur_stack].wlen] = '\0';
+#endif
+  return FINDFILEFIRST_OS(ctx);
+}
+
+static size_t findfileloop(ctx_t *ctx) {
+  if (ctx->stack[ctx->cur_stack].h == INVALID_HANDLE_VALUE) {
+    if (!findfileloopstart(ctx)) {
+      ctx->cur_stack--;
+      return 0;
+    }
+  } else if (!FINDFILENEXT_OS(ctx))
+    goto close;
+  do {
+    if (strcmp(FILENAME(ctx), ".") == 0 || strcmp(FILENAME(ctx), "..") == 0)
+      continue;
+    size_t flen = strlen(FILENAME(ctx));
+    REALLOCBUF(ctx, flen + 2); // +2 for "/\0" - would be +3 for win but MAX_PATH
+    memcpy(ctx->buffer + ctx->stack[ctx->cur_stack].wlen, FILENAME(ctx), flen + 1);
+    if (ctx->case_blind) {
+      char* p;
+      for (p = FILENAME(ctx); *p; p++) *p = toupper(*p);
+    }
+    if (match_wild(FILENAME(ctx),flen, ctx->filename,ctx->flen))
+      return ctx->stack[ctx->cur_stack].wlen + flen;
+    if (ctx->recursive && ISDIRECTORY(ctx)) {
+      //DBG("path = %s\n", ctx->buffer);
+      if (++ctx->cur_stack == ctx->max_stack) {
+        DBG("max_stack increased = %d\n", ctx->max_stack);
+        findstack_t* old = ctx->stack;
+        ctx->max_stack *= 2;
+        ctx->stack = malloc(sizeof(findstack_t)*ctx->max_stack);
+        memcpy(ctx->stack, old, sizeof(findstack_t)*ctx->cur_stack);
+        free(old);
+      }
+      ctx->stack[ctx->cur_stack].h = INVALID_HANDLE_VALUE; // reset handle
+      ctx->stack[ctx->cur_stack].wlen = ctx->stack[ctx->cur_stack-1].wlen + flen;
+      const size_t len = findfileloop(ctx);
+      if (len > 0) return len;
+    }
+  } while (FINDFILENEXT_OS(ctx));
+close:
+  FINDFILECLOSE_OS(ctx);
+        ctx->cur_stack--;
+  return 0;
+}
+
+static inline void* _findfilestart(const char *envname, const char *filename, int recursive, int case_blind) {
+  DBG("looking for '%s' in '%s'\n", filename, envname);
+  ctx_t*ctx = (ctx_t*)malloc(sizeof(ctx_t));
+  ctx->max_stack = recursive ? 8 : 1;
+  ctx->stack = malloc(ctx->max_stack * sizeof(findstack_t));
+  ctx->cur_stack = -1;
+  char *folders;
+  if (envname && (folders = getenv(envname)))
+    ctx->folders = strdup(folders);
+  else
+    ctx->folders = calloc(1,1);
+  *(size_t*)&ctx->flen = strlen(filename);
+  ctx->filename = memcpy(malloc(ctx->flen+1),filename,ctx->flen+1);
+  ctx->buffer = malloc(MAX_PATH);
+#ifndef _WIN32
+  ctx->buflen = MAX_PATH;
+#endif
+  ctx->recursive = recursive;
+  ctx->case_blind = case_blind;
+  ctx->cptr = ctx->ptr = ctx->folders;
+  if (ctx->case_blind) {
+    char* p;
+    for (p = (char*)ctx->filename; *p; p++) *p = toupper(*p);
+  }
+  return ctx;
+}
+
+static inline void* findfilestart(const char *filename, int recursive, int case_blind) {
+  char* env;
+  const char* colon = strchr(filename, ':');
+  if (colon) {
+    size_t envlen = (colon++ - filename);
+    env = memcpy(malloc(envlen+1), filename, envlen); env[envlen] = '\0';
+  } else {
+    env = NULL;
+    colon = filename;
+  }
+  void* ctx;
+  if (strlen(colon) == 0)
+    ctx = NULL;
+  else
+      ctx = _findfilestart(env, colon, recursive, case_blind);
+  if (env) free(env);
+  return ctx;
+}
+
+static inline char* findfilenext(ctx_t *ctx) {
+  size_t len = 0; // length of valid data if fullpath, i.e. the result
+  if (ctx->cur_stack >= 0) do {
+    len = findfileloop(ctx);
+  } while (len == 0 && ctx->cur_stack >= 0);
+  if (ctx->cur_stack != -1) abort();
+  for (; len == 0 && ctx->cptr; ctx->ptr = ctx->cptr + 1) {
+    const size_t wlen = ((ctx->cptr = strchr(ctx->ptr, ';')) == NULL) ? (int)strlen(ctx->ptr) : (int)(ctx->cptr - ctx->ptr);
+    if (wlen == 0 && ctx->recursive) continue; // if path empty and recursive, skip
+    // start search in first folder
+    ctx->stack[ctx->cur_stack = 0].h = INVALID_HANDLE_VALUE;
+    ctx->stack[ctx->cur_stack].wlen = wlen;
+    REALLOCBUF(ctx,3); // +3 for "./\0" - would be 4 for win but MAX_PATH
+    memcpy(ctx->buffer, ctx->ptr, wlen);
+#ifdef _WIN32
+    char* sep;    // replace '/' with '\\'
+    for (sep = ctx->buffer+wlen; sep-- > ctx->buffer; ) if (*sep == '/') *sep = '\\';
+#endif
+    // allow current path , i.e. wlen = 0
+    if (ctx->stack[ctx->cur_stack].wlen==0)
+        ctx->buffer[ctx->stack[ctx->cur_stack].wlen++] = '.';
+    else {
+      // ensure buffer is not terminated by SEP
+      while (ctx->stack[ctx->cur_stack].wlen>0 && ctx->buffer[ctx->stack[ctx->cur_stack].wlen-1] == SEP)
+        ctx->stack[ctx->cur_stack].wlen--;
+    }
+     // ctx->buffer can enter findfileloop w/o \0 termination
+    len = findfileloop(ctx);
+  }
+  if (len) return ctx->buffer;
+  ctx->buffer[0] = '\0';
+  return NULL;
+}
+
+static inline void findfileend(void* ctx_i) {
+  if (!ctx_i) return;
+  ctx_t* ctx = (ctx_t*)ctx_i;
+  while (ctx->cur_stack >= 0) {
+    FINDFILECLOSE_OS(ctx);
+    ctx->cur_stack--;
+  }
+  free((void*)ctx->filename);
+  free((void*)ctx->folders);
+  free(ctx->stack);
+  free(ctx->buffer);
+  free(ctx);
+}
+
+EXPORT extern int LibFindFileEnd(void **ctx){
+  findfileend(*ctx);
+  *ctx = NULL;
+  return MDSplusSUCCESS;
+}
+
+static int find_file(struct descriptor *filespec, struct descriptor *result, void **ctx,
+			    int recursively, int case_blind){
+  int status;
+  if (*ctx == 0) {
+    char* fspec = malloc(filespec->length+1);
+    memcpy(fspec,filespec->pointer,filespec->length);fspec[filespec->length] = '\0';
+    *ctx = (void*)findfilestart(fspec,recursively,case_blind);
+    free(fspec);
+    if (!*ctx) return MDSplusERROR;
+  }
+  char* ans = findfilenext(*(ctx_t**)ctx);
   if (ans) {
-    struct descriptor ansd = { 0, DTYPE_T, CLASS_S, 0 };
-    ansd.length = (unsigned short)strlen(ans);
-    ansd.pointer = ans;
+    mdsdsc_t ansd = { strlen(ans), DTYPE_T, CLASS_S, ans };
     StrCopyDx(result, &ansd);
-    free(ans);
     status = MDSplusSUCCESS;
   } else {
     status = MDSplusERROR;
@@ -1575,171 +1796,12 @@ STATIC_ROUTINE int FindFile(struct descriptor *filespec, struct descriptor *resu
   return status;
 }
 
-EXPORT extern int LibFindFileEnd(FindFileCtx **ctx)
-{
-  int status = FindFileEnd((FindFileCtx *) * ctx);
-  if STATUS_OK
-    *ctx = NULL;
-  return status;
+EXPORT int LibFindFile(struct descriptor *filespec, struct descriptor *result, void **ctx){
+  return find_file(filespec, result, ctx, 0, 0);
 }
 
-STATIC_ROUTINE int FindFileEnd(FindFileCtx * ctx)
-{
-  int i;
-  if (ctx != NULL) {
-    if (ctx->dir_ptr) {
-      closedir(ctx->dir_ptr);
-      ctx->dir_ptr = 0;
-    }
-    if (ctx->env != 0)
-      free(ctx->env);
-    if (ctx->file != 0)
-      free(ctx->file);
-    for (i = 0; i < ctx->num_env; i++)
-      if (ctx->env_strs[i] != 0)
-	free(ctx->env_strs[i]);
-    if (ctx->env_strs != 0)
-      free(ctx->env_strs);
-    free(ctx);
-  }
-  return MDSplusSUCCESS;
-}
-
-#define CSTRING_FROM_DESCRIPTOR(cstring, descr)\
-  cstring=strncpy(malloc((size_t)(descr->length+1)),descr->pointer,descr->length);\
-  cstring[descr->length] = '\0';
-
-STATIC_ROUTINE int FindFileStart(struct descriptor *filespec, FindFileCtx ** ctx, int caseBlind)
-{
-  FindFileCtx *lctx;
-  char *fspec;
-  char *colon;
-  *ctx = (FindFileCtx *) malloc(sizeof(FindFileCtx));
-  memset(*ctx, 0, sizeof(FindFileCtx));
-  lctx = *ctx;
-
-  CSTRING_FROM_DESCRIPTOR(fspec, filespec);
-
-  lctx->next_index = lctx->next_dir_index = 0;
-  colon = strchr(fspec, ':');
-  if (colon == 0) {
-    lctx->env = 0;
-    colon = fspec - 1;
-  } else {
-    lctx->env = strncpy(malloc((size_t)(colon - fspec + 1)), fspec, (size_t)(colon - fspec));
-    lctx->env[colon - fspec] = '\0';
-  }
-  if (strlen(colon + 1) == 0) {
-    if (lctx->env)
-      free(lctx->env);
-    free(fspec);
-    return 0;
-  } else {
-    lctx->file = malloc(strlen(colon + 1) + 1);
-    strcpy(lctx->file, colon + 1);
-    lctx->wild_descr.length = (unsigned short)strlen(colon + 1);
-    lctx->wild_descr.pointer = lctx->file;
-    lctx->wild_descr.dtype = DTYPE_T;
-    lctx->wild_descr.class = CLASS_S;
-    if (caseBlind)
-      StrUpcase(&lctx->wild_descr, &lctx->wild_descr);
-    free(fspec);
-  }
-  if (lctx->env != 0) {
-    int num = 0;
-    char *env;
-    char *semi;
-    char *env_sav;
-    env = env_sav = TranslateLogical(lctx->env);
-    if (env != 0) {
-      if (env[strlen(env) - 1] != ';') {
-	char *tmp = malloc(strlen(env) + 2);
-	strcpy(tmp, env);
-	strcat(tmp, ";");
-	env = tmp;
-      } else {
-	char *tmp = malloc(strlen(env) + 1);
-	strcpy(tmp, env);
-	env = tmp;
-      }
-      free(env_sav);
-      for (semi = strchr(env, ';'); semi != 0; num++, semi = strchr(semi + 1, ';')) ;
-      if (num > 0) {
-	char *ptr;
-	int i;
-	lctx->num_env = num;
-	lctx->env_strs = (char **)malloc((size_t)num * sizeof(char *));
-	for (ptr = env, i = 0; i < num; i++) {
-	  char *cptr;
-	  int len = ((cptr = strchr(ptr, ';')) == (char *)0) ? (int)strlen(ptr) : (int)(cptr - ptr);
-	  lctx->env_strs[i] = strncpy(malloc((size_t)len + 1), ptr, (size_t)len);
-	  lctx->env_strs[i][len] = '\0';
-	  ptr = cptr + 1;
-	}
-      }
-      free(env);
-    }
-  }
-  lctx->dir_ptr = 0;
-  return 1;
-}
-
-STATIC_ROUTINE char *_FindNextFile(FindFileCtx * ctx, int recursively, int caseBlind)
-{
-  char *ans;
-  struct dirent *dp;
-
-  int found = 0;
-  while (!found) {
-    while (ctx->dir_ptr == 0) {
-      if (ctx->next_index < ctx->num_env) {
-	ctx->dir_ptr = opendir(ctx->env_strs[ctx->next_index++]);
-	ctx->next_dir_index = ctx->next_index;
-      } else
-	return 0;
-    }
-    dp = readdir(ctx->dir_ptr);
-    if (dp != NULL) {
-      struct descriptor_d upname = { 0, DTYPE_T, CLASS_D, 0 };
-      DESCRIPTOR_FROM_CSTRING(filename, dp->d_name);
-      if (caseBlind)
-	StrUpcase((struct descriptor *)&upname, &filename);
-      else
-	StrCopyDx((struct descriptor *)&upname, &filename);
-      found = IS_OK(StrMatchWild((struct descriptor *)&upname, &ctx->wild_descr));
-      StrFree1Dx(&upname);
-      if (recursively) {
-	if ((strcmp(dp->d_name, ".") != 0) && (strcmp(dp->d_name, "..") != 0)) {
-	  char *tmp_dirname;
-	  DIR *tmp_dir;
-	  tmp_dirname = malloc(strlen(ctx->env_strs[ctx->next_index - 1]) + 2 + strlen(dp->d_name));
-	  strcpy(tmp_dirname, ctx->env_strs[ctx->next_index - 1]);
-	  strcat(tmp_dirname, "/");
-	  strcat(tmp_dirname, dp->d_name);
-	  tmp_dir = opendir(tmp_dirname);
-	  if (tmp_dir != NULL) {
-	    int i;
-	    closedir(tmp_dir);
-	    ctx->env_strs = realloc(ctx->env_strs, sizeof(char *) * (size_t)(ctx->num_env + 1));
-	    for (i = ctx->num_env - 1; i >= ctx->next_dir_index; i--)
-	      ctx->env_strs[i + 1] = ctx->env_strs[i];
-	    ctx->env_strs[ctx->next_dir_index] = tmp_dirname;
-	    ctx->num_env++;
-	    ctx->next_dir_index++;
-	  } else
-	    free(tmp_dirname);
-	}
-      }
-    } else {
-      closedir(ctx->dir_ptr);
-      ctx->dir_ptr = NULL;
-    }
-  }
-  ans = malloc(strlen(ctx->env_strs[ctx->next_index - 1]) + 1 + strlen(dp->d_name) + 1);
-  strcpy(ans, ctx->env_strs[ctx->next_index - 1]);
-  strcat(ans, "/");
-  strcat(ans, dp->d_name);
-  return ans;
+EXPORT int LibFindFileRecurseCaseBlind(struct descriptor *filespec, struct descriptor *result, void **ctx){
+  return find_file(filespec, result, ctx, 1, 1);
 }
 
 EXPORT void TranslateLogicalFree(char *value)

--- a/tdishr/TdiVar.c
+++ b/tdishr/TdiVar.c
@@ -74,6 +74,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <stdlib.h>
 #include <mdsshr.h>
 #include <string.h>
+#include <ctype.h>
 #include <inttypes.h>
 #include <mdsshr_messages.h>
 
@@ -125,28 +126,6 @@ STATIC_CONSTANT struct descriptor_xd NULL_XD = { 0, 0, 0, 0, 0 };
 
 STATIC_CONSTANT unsigned char true = 1;
 STATIC_CONSTANT struct descriptor true_dsc = { sizeof(true), DTYPE_BU, CLASS_S, (char *)&true };
-
-int findfile_ext_env(mdsdsc_t *entry, const char*const ext, const char*const env, char**file) {
-  int status;
-  INIT_AND_FREED_ON_EXIT(bufd,DTYPE_T);
-  {
-    size_t extlen = strlen(ext),envlen = strlen(env);
-    bufd.length = envlen+1+entry->length+extlen;
-    char *tmp = bufd.pointer = malloc(bufd.length);
-    memcpy(tmp,env,envlen);tmp+=envlen;*(tmp++) = ':';		// adds "<env>:"
-    memcpy(tmp,entry->pointer,entry->length);tmp+=entry->length;// adds "<entry>"
-    memcpy(tmp,ext,extlen);					// adds "<ext>\0"
-  }
-  void *ctx = 0;
-  status = LibFindFileRecurseCaseBlind((mdsdsc_t*)&bufd, (mdsdsc_t*)&bufd, &ctx);
-  LibFindFileEnd(&ctx);
-  if STATUS_OK {
-    *file = memcpy(malloc(bufd.length+1), bufd.pointer, bufd.length);
-    (*file)[bufd.length] = '\0';
-  }
-  FREED_NOW(bufd);
-  return status;
-}
 
 static pthread_mutex_t public_lock = PTHREAD_MUTEX_INITIALIZER;
 #define LOCK_PUBLIC pthread_mutex_lock(&public_lock)
@@ -596,37 +575,91 @@ int Tdi1Present(opcode_t opcode __attribute__ ((unused)), int narg __attribute__
 /***************************************************************
         Execute a function. Set up the arguments.
 */
+typedef enum {
+EXT_NONE,EXT_FUN,EXT_PY
+} ext_t;
+
+static inline ext_t matchext(const mdsdsc_d_t* file){
+  if (file->length<4) return EXT_NONE;
+  char* p = file->pointer+file->length-4;
+  char ext[5] = {p[0],toupper(p[1]),toupper(p[2]),toupper(p[3]),'\0'};
+  if (strcmp(ext,".FUN")==0) return EXT_FUN;
+  if (strcmp(ext+1,".PY")==0) return EXT_PY;
+  return EXT_NONE;
+}
+static inline int findfile_fun(mdsdsc_t *entry, char**funfile,char** pyfile) {
+  int status;
+  INIT_AND_FREED_ON_EXIT(bufd,DTYPE_T);
+  ext_t isext = EXT_NONE;
+  {
+    const char ext[] = ".*";
+    const char env[] = "MDS_PATH:";
+    const size_t extlen = sizeof(ext)-1 , envlen = sizeof(env)-1;
+    bufd.length = envlen+entry->length+extlen;
+    char *tmp = bufd.pointer = malloc(bufd.length);
+    memcpy(tmp,env,envlen);tmp+=envlen;            		// adds "<env>:"
+    memcpy(tmp,entry->pointer,entry->length);tmp+=entry->length;// adds "<entry>"
+    memcpy(tmp,ext,extlen);					// adds "<ext>\0"
+  }
+  void *ctx = 0;
+  do{
+    status = LibFindFileRecurseCaseBlind((mdsdsc_t*)&bufd, (mdsdsc_t*)&bufd, &ctx);
+  } while(STATUS_OK && (isext=matchext(&bufd)) == EXT_NONE);
+  LibFindFileEnd(&ctx);
+  if STATUS_OK {
+    char* file = memcpy(malloc(bufd.length+1), bufd.pointer, bufd.length);
+    file[bufd.length] = '\0';
+    if (isext == EXT_PY) {
+      *pyfile = file;
+      isext = EXT_FUN;
+      bufd.pointer = realloc(bufd.pointer,++bufd.length);
+      memcpy(bufd.pointer+bufd.length-4,".FUN",4);
+    } else {
+      *funfile = file;
+      isext = EXT_PY;
+      bufd.pointer = realloc(bufd.pointer,--bufd.length);
+      memcpy(bufd.pointer+bufd.length-3,".PY",3);
+    }
+    if IS_OK(LibFindFileCaseBlind((mdsdsc_t*)&bufd, (mdsdsc_t*)&bufd, &ctx)) {
+      file = memcpy(malloc(bufd.length+1), bufd.pointer, bufd.length);
+      file[bufd.length] = '\0';
+      if (isext == EXT_PY)
+        *pyfile = file;
+      else
+        *funfile = file;
+    }
+    LibFindFileEnd(&ctx);
+  }
+  FREED_NOW(bufd);
+  return status;
+}
+
 extern int TdiCompile();
-int compile_fun(struct descriptor *entry)
-{
+int compile_fun(mdsdsc_t *entry,char *file) {
+  if (!file) return  TdiUNKNOWN_VAR;
   int status;
   INIT_AND_FREEXD_ON_EXIT(tmp);
-  INIT_AND_FREE_ON_EXIT(char*,file);
-  status = findfile_ext_env(entry,".FUN","MDS_PATH",&file);
-  if STATUS_OK {
-    DBG("compile: %s\n",file);
-    FILE *unit = fopen(file, "rb");
-    if (unit) {
-      fseek(unit, 0, SEEK_END);
-      size_t flen = ftell(unit);
-      if (flen > 0xffff) {
-	fclose(unit);
-	status = TdiSTRTOOLON;
-      } else {
-	fseek(unit, 0, SEEK_SET);
-	mdsdsc_t dcs = { flen, DTYPE_T, CLASS_D, (char*)malloc(flen) };
-	FREED_ON_EXIT(&dcs);
-	size_t readlen = fread(dcs.pointer, 1, flen, unit);
-	if (readlen < flen)
-	  perror("Error reading tdi function\n");
-	fclose(unit);
-	status = TdiCompile(&dcs, &tmp MDS_END_ARG);
-	FREED_NOW(&dcs);
-      }
-    } else
-      status = TdiUNKNOWN_VAR;
-  } else status = TdiUNKNOWN_VAR;
-  FREE_NOW(&file);
+  DBG("compile: %s\n",file);
+  FILE *unit = fopen(file, "rb");
+  if (unit) {
+    fseek(unit, 0, SEEK_END);
+    size_t flen = ftell(unit);
+    if (flen > 0xffff) {
+      fclose(unit);
+      status = TdiSTRTOOLON;
+    } else {
+      fseek(unit, 0, SEEK_SET);
+      mdsdsc_t dcs = { flen, DTYPE_T, CLASS_D, (char*)malloc(flen) };
+      FREED_ON_EXIT(&dcs);
+      size_t readlen = fread(dcs.pointer, 1, flen, unit);
+      if (readlen < flen)
+        perror("Error reading tdi function\n");
+      fclose(unit);
+      status = TdiCompile(&dcs, &tmp MDS_END_ARG);
+      FREED_NOW(&dcs);
+    }
+  } else
+    status = TdiUNKNOWN_VAR;
   if STATUS_OK {
     struct descriptor_function *pfun = (struct descriptor_function *)tmp.pointer;
     if (pfun->dtype == DTYPE_FUNCTION) {
@@ -648,12 +681,9 @@ int compile_fun(struct descriptor *entry)
   return status;
 }
 
-extern char* findModule();
-extern int loadPyFunction(char*dirspec,char*filename);
-extern int callPyFunction(char*filename,int nargs,struct descriptor_r **args,struct descriptor_xd *out_ptr);
-int TdiDoFun(struct descriptor *ident_ptr,
-	     int nactual, struct descriptor_r *actual_arg_ptr[], struct descriptor_xd *out_ptr)
-{
+extern int loadPyFunction(const char*filepath,char**funname);
+extern int callPyFunction(const char*filename,int nargs,mdsdsc_r_t **args,mdsdsc_xd_t *out_ptr);
+int TdiDoFun(mdsdsc_t *ident_ptr, int nactual, mdsdsc_r_t *actual_arg_ptr[], mdsdsc_xd_t *out_ptr) {
   node_type *node_ptr;
 	/******************************************
         Get name of function to do. Check its type.
@@ -665,28 +695,29 @@ int TdiDoFun(struct descriptor *ident_ptr,
   pthread_cleanup_push((void*)pthread_mutex_unlock,&lock);
   status = TdiFindIdent(7, (struct descriptor_r *)ident_ptr, 0, &node_ptr, 0);
   if (status==TdiUNKNOWN_VAR) {
-    char *filename = NULL, *dirspec = NULL;
-    FREE_ON_EXIT(filename);
-    FREE_ON_EXIT(dirspec);
-    // check if method is python
-    dirspec = findModule(ident_ptr,&filename);
-    if (dirspec) {
-      status = loadPyFunction(dirspec,filename);
+    INIT_AND_FREE_ON_EXIT(char*,pyfile);
+    INIT_AND_FREE_ON_EXIT(char*,funfile);
+    // check if we can find method as either .py or .fun
+    status = findfile_fun(ident_ptr, &funfile, &pyfile);
+    if (pyfile) {
+      char *funname;
+      status = loadPyFunction(pyfile,&funname);
       if STATUS_OK {
-        struct descriptor function = {(short)strlen(filename),DTYPE_T,CLASS_S,filename};
+        struct descriptor function = {strlen(funname),DTYPE_T,CLASS_S,funname};
         struct descriptor_xd tmp = EMPTY_XD;
         status = MdsCopyDxXd((struct descriptor *)&function, &tmp);
+        free(funname);
         if STATUS_OK {
           status = TdiPutIdent((struct descriptor_r *)ident_ptr, &tmp);
           MdsFree1Dx(&tmp, NULL);
         }
       }
       if STATUS_NOT_OK // unable to load python method try tdi alternative
-	status = compile_fun(ident_ptr);
+	status = compile_fun(ident_ptr,funfile);
     } else // not a python method, load tdi fun
-      status = compile_fun(ident_ptr);
-    FREE_NOW(dirspec);
-    FREE_NOW(filename);
+      status = compile_fun(ident_ptr,funfile);
+    FREE_NOW(funfile);
+    FREE_NOW(pyfile);
     if STATUS_OK status = TdiFindIdent(7, (struct descriptor_r *)ident_ptr, 0, &node_ptr, 0);
   }
   pthread_cleanup_pop(1);

--- a/testing/windowslinks.bat
+++ b/testing/windowslinks.bat
@@ -1,0 +1,14 @@
+@ECHO OFF
+CALL :makewinlink MDSplus
+CALL :makewinlink MitDevices
+CALL :makewinlink RfxDevices
+CALL :makewinlink W7xDevices
+GOTO EOF
+:makewinlink
+IF NOT EXIST "%1~" (
+  IF NOT EXIST "%1" GOTO:EOF
+  RENAME "%1" "%1~"
+)
+SET /P link=<"%1~"
+MKLINK /D "%1" "%link:/=\%"
+:EOF


### PR DESCRIPTION
This speeds it up by 10 to 100 times depending on the file system/latency.
* We have a file size cap for tdi funs due to String length limit.
 - raise an TdiSTRTOOLON error rather than trying to compile the truncated part. 