### PR TITLE
Fix: acq435st back from process to thread

### DIFF
--- a/pydevices/HtsDevices/acq435st.py
+++ b/pydevices/HtsDevices/acq435st.py
@@ -100,7 +100,6 @@ class ACQ435ST(MDSplus.Device):
             # make a thread safe copy of the device node with a non-global context
             self.dev = dev.copy()
         def run(self):
-            self.dev.tree.normal()
             self.dev.stream()
 
     debug=None


### PR DESCRIPTION
Looks like the problems in: #1563 were related to garbage collection not to a race condition.

This commit removes the process stuff and uses a defined thread class to do the work.

I (Tom's idea) do not think there is a need to store the device and or thread persistently in the class.  It may be good enough for the thread to make a copy of the device.

Note:  It is sufficient for the init of the thread to copy its argument, because the init is done synchronously before the thread is started, so 'self' is still in scope during its execution

Note: Note: capturing stdout from the thread is problematic as all the threads in a process share the same 
FD table.  The solution for this to use a logger - which can be implemented later.  For now the output is mixed in with the main process's output.