### PR TITLE
Fix:  acq2106_423_Nst devices to acq435 threads

### DIFF
--- a/pydevices/HtsDevices/acq2106_423_1st.py
+++ b/pydevices/HtsDevices/acq2106_423_1st.py
@@ -62,3 +62,6 @@ class ACQ2106_423_1ST(Acq2106_423st):
                      'type':'NUMERIC', 
                      'value':1, 
                      'options':('no_write_shot')})
+    def __getnewargs__(self):#this line
+        return (ACQ2106_423_1ST.__str__(self),)
+

--- a/pydevices/HtsDevices/acq2106_423_2st.py
+++ b/pydevices/HtsDevices/acq2106_423_2st.py
@@ -62,3 +62,6 @@ class ACQ2106_423_2ST(Acq2106_423st):
                      'type':'NUMERIC', 
                      'value':1, 
                      'options':('no_write_shot')})
+    def __getnewargs__(self):#this line
+        return (ACQ2106_423_2ST.__str__(self),)
+

--- a/pydevices/HtsDevices/acq2106_423_3st.py
+++ b/pydevices/HtsDevices/acq2106_423_3st.py
@@ -62,3 +62,6 @@ class ACQ2106_423_3ST(Acq2106_423st):
                      'type':'NUMERIC', 
                      'value':1, 
                      'options':('no_write_shot')})
+    def __getnewargs__(self):#this line
+        return (ACQ2106_423_3ST.__str__(self),)
+

--- a/pydevices/HtsDevices/acq2106_423_4st.py
+++ b/pydevices/HtsDevices/acq2106_423_4st.py
@@ -62,3 +62,6 @@ class ACQ2106_423_4ST(Acq2106_423st):
                      'type':'NUMERIC', 
                      'value':1, 
                      'options':('no_write_shot')})
+    def __getnewargs__(self):#this line
+        return (ACQ2106_423_4ST.__str__(self),)
+

--- a/pydevices/HtsDevices/acq2106_423_5st.py
+++ b/pydevices/HtsDevices/acq2106_423_5st.py
@@ -62,3 +62,6 @@ class ACQ2106_423_5ST(Acq2106_423st):
                      'type':'NUMERIC', 
                      'value':1, 
                      'options':('no_write_shot')})
+    def __getnewargs__(self):#this line
+        return (ACQ2106_423_5ST.__str__(self),)
+

--- a/pydevices/HtsDevices/acq2106_423_6st.py
+++ b/pydevices/HtsDevices/acq2106_423_6st.py
@@ -62,3 +62,5 @@ class ACQ2106_423_6ST(Acq2106_423st):
                      'type':'NUMERIC', 
                      'value':1, 
                      'options':('no_write_shot')})
+    def __getnewargs__(self):#this line
+        return (ACQ2106_423_6ST.__str__(self),)

--- a/pydevices/HtsDevices/acq2106_423st.py
+++ b/pydevices/HtsDevices/acq2106_423st.py
@@ -93,9 +93,11 @@ class Acq2106_423st(MDSplus.Device):
            It should at least take one argument: teh device node  
         """
         def __init__(self,dev):
+            print(MDSplus.__file__)
+            print(MDSplus.__version__)
             super(Acq2106_423st.Worker,self).__init__(name=dev.path)
             # make a thread safe copy of the device node with a non-global context
-            self.dev = dev.copy()
+            self.dev = MDSplus.TreeNode.copy(dev)
         def run(self):
             self.dev.stream()
 

--- a/pydevices/HtsDevices/acq2106_423st.py
+++ b/pydevices/HtsDevices/acq2106_423st.py
@@ -93,7 +93,7 @@ class Acq2106_423st(MDSplus.Device):
            It should at least take one argument: teh device node  
         """
         def __init__(self,dev):
-            super(ACQ2106_423ST.Worker,self).__init__(name=dev.path)
+            super(Acq2106_423st.Worker,self).__init__(name=dev.path)
             # make a thread safe copy of the device node with a non-global context
             self.dev = dev.copy()
         def run(self):
@@ -128,6 +128,11 @@ class Acq2106_423st(MDSplus.Device):
                 coeff.record = coeffs[i]
                 offset = self.__getattr__('input_%3.3d_offset'%(card*32+i+1))
                 offset.record = offsets[i]
+        if self.trig_mode.data() == 'hard':
+            uut.s1.set_knob('trg', '1,0,1')
+        else:
+            uut.s1.set_knob('trg', '1,1,1')
+
         self.running.on=True
         thread = self.Worker(self)
         thread.start()

--- a/pydevices/HtsDevices/acq435st.py
+++ b/pydevices/HtsDevices/acq435st.py
@@ -170,7 +170,7 @@ class ACQ435ST(MDSplus.Device):
     def trig(self):
         acq400_hapi=self.importPyDeviceModule('acq400_hapi')
         uut = acq400_hapi.Acq400(self.node.data(), monitor=False)
-        uut.so.set_knob('soft_trigger','1')
+        uut.s0.set_knob('soft_trigger','1')
         return 1
     TRIG=trig
 

--- a/pydevices/HtsDevices/acq435st.py
+++ b/pydevices/HtsDevices/acq435st.py
@@ -98,7 +98,7 @@ class ACQ435ST(MDSplus.Device):
         def __init__(self,dev):
             super(ACQ435ST.Worker,self).__init__(name=dev.path)
             # make a thread safe copy of the device node with a non-global context
-            self.dev = dev.copy()
+            self.dev = MDSplus.TreeNode.copy(dev)
         def run(self):
             self.dev.stream()
 

--- a/pydevices/HtsDevices/cryocon18i.py
+++ b/pydevices/HtsDevices/cryocon18i.py
@@ -23,14 +23,7 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 import MDSplus
-
-def threaded(fn):
-    def wrapper(*args, **kwargs):
-        import threading
-        thread = threading.Thread(target=fn, args=args, kwargs=kwargs)
-        thread.start()
-        return thread
-    return wrapper
+import threading
 
 class CRYOCON18I(MDSplus.Device):
     """
@@ -123,6 +116,20 @@ class CRYOCON18I(MDSplus.Device):
         return 1
     QUERY=query
 
+    class Worker(threading.Thread):
+        """An async worker should be a proper class
+           This ensures that the methods remian in memory
+           It should at least take one argument: teh device node
+        """
+        def __init__(self,dev):
+            print(MDSplus.__file__)
+            print(MDSplus.__version__)
+            super(CRYOCON18I.Worker,self).__init__(name=dev.path)
+            # make a thread safe copy of the device node with a non-global context
+            self.dev = MDSplus.TreeNode.copy(dev)
+        def run(self):
+            self.dev.stream()
+
     def init(self):
         '''
         init method for cryocon 18i
@@ -158,7 +165,9 @@ class CRYOCON18I(MDSplus.Device):
         print(instrument.query('CALCUR'))
         # start it streaming
         self.running.on=True
-        self.stream()
+        # self.stream()
+        thread = self.Worker(self)
+        thread.start()
         return 1
     INIT=init
 
@@ -224,7 +233,6 @@ class CRYOCON18I(MDSplus.Device):
         return 1
     STOP=stop
 
-    @threaded
     def stream(self):
         import pyvisa
         import datetime


### PR DESCRIPTION
In order to test the threading behavior under realistic conditions
we need at least 2 devices.  The acq435st was changed to use a
thread that copies the device object.

Issue: #1563 outlines some potential problems along these lines.

This commit changes to acq2106 to match the new acq435 code so they
can be tested on the SPARC network.