### PR TITLE
Zck fixes

### DIFF
--- a/mdstcpip/ParseCommand.c
+++ b/mdstcpip/ParseCommand.c
@@ -36,6 +36,7 @@ void PrintHelp(char *option)
   printf("mdsip - MDSplus data server\n\n"
 	 "  Format:\n\n"
 	 "    mdsip [-P protocol] [-m|-s] [-i|-r] [-h hostfile] [-c|+c] [-p port] [protocol-specific-options]\n\n"
+	 "      -?                 This help message\n"
 	 "      -P protocol        Specifies server protocol, defaults to tcp\n"
 	 "      -p port|service    Specifies port number or tcp service name\n"
 	 "      -m                 Use multi mode (accepts multiple connections each with own context)\n"
@@ -53,7 +54,8 @@ void PrintHelp(char *option)
 	 "      --server\n"
 	 "      --install\n"
 	 "      --remove\n"
-	 "      --hostfile=hostfile\n" "      --compression [level,default=9]\n\n");
+	 "      --hostfile=hostfile\n"
+	 "      --compression [level,default=9]\n\n");
   exit(1);
 }
 
@@ -75,7 +77,7 @@ void ParseCommand(int argc, char **argv, Options options[], int more, int *rem_a
       arg++;
       arglen--;
       if (strcmp("help", arg) == 0)
-	PrintHelp(0);
+        PrintHelp(0);
       for (opt = 0; options[opt].short_name || options[opt].long_name; opt++) {
 	if (*arg == '-' && options[opt].long_name) {
 	  char *lonarg = arg + 1;
@@ -139,6 +141,7 @@ void ParseStdArgs(int argc, char **argv, int *extra_argc, char ***extra_argv)
       {"s", "server", 0, 0, 0},
       {"m", "multi", 0, 0, 0},
       {"c", "compression", 1, 0, 0},
+      {"?", "help", 1, 0, 0},
       {0, 0, 0, 0,0}
   };
   ParseCommand(argc, argv, options, 1, extra_argc, extra_argv);
@@ -161,4 +164,7 @@ void ParseStdArgs(int argc, char **argv, int *extra_argc, char ***extra_argv)
   }
   if (options[4].present && options[4].value)
     SetCompressionLevel(atoi(options[4].value));
+  if (options[5].present)
+    PrintHelp(0);
+
 }

--- a/tcl/tcl_do_method.c
+++ b/tcl/tcl_do_method.c
@@ -103,9 +103,12 @@ EXPORT int TclDoMethod(void *ctx, char **error, char **output __attribute__ ((un
       }
       if STATUS_OK {
         status = TreeDoMethodA(&nid_dsc,&method_dsc,argc,arglist,&xd);
-	if (STATUS_OK && xd.pointer) {
-	  TdiGetLong(&xd,&status);
-          MdsFree1Dx(&xd, NULL);
+	if STATUS_OK {
+          if (xd.pointer) {
+	    TdiGetLong(&xd,&status);
+            MdsFree1Dx(&xd, NULL);
+          } else
+            status = SsSUCCESS;
         }
       }
       if (method)

--- a/tditest/tditest.c
+++ b/tditest/tditest.c
@@ -101,6 +101,8 @@ char *character_name_generator(const char *text, int state){
   // use case sensitivity to distinguish between builtins and tdi.funs
   while ((name = character_names[list_index++]))
     if (strncmp(name, text, len) == 0) {
+      if (name[0] == '$') // constants like $PI
+        return strdup(name);
       size_t len = strlen(name);
       char *match = memcpy(malloc(len+2),name,len);
       match[len]='(';match[len+1]='\0';

--- a/treeshr/TreeGetSetShotId.c
+++ b/treeshr/TreeGetSetShotId.c
@@ -139,7 +139,7 @@ static int OpenShotIdFile(char *experiment, int mode)
 int TreeGetCurrentShotId(char const *experiment)
 {
   int shot = 0;
-  int status = 0;
+  int status = TreeFAILURE;
   char *path = 0;
   char *exp = strcpy(malloc(strlen(experiment) + 6), experiment);
   int i;
@@ -172,12 +172,12 @@ int TreeGetCurrentShotId(char const *experiment)
   if (path)
     TranslateLogicalFree(path);
   free(exp);
-  return (status & 1) ? shot : 0;
+  return STATUS_OK ? shot : 0;
 }
 
 int TreeSetCurrentShotId(char const *experiment, int shot)
 {
-  int status = 0;
+  int status = TreeFAILURE;
   char *path = 0;
   char *exp = strcpy(malloc(strlen(experiment) + 6), experiment);
   size_t slen;


### PR DESCRIPTION
minor bug fixes
- get set current shot init with status=0 which is undefined
- mdsip helptext
- tditest tab completion adds '(' even to $constants
- tcl do/method should return 1 like devices used to do 