### PR TITLE
Fix: A commit message content can break the release tag jaon

### DIFF
--- a/deploy/trigger.sh
+++ b/deploy/trigger.sh
@@ -533,6 +533,17 @@ $(git log --decorate=full --no-merges ${LAST_RELEASE_COMMIT}..HEAD | awk '{gsub(
 EOF
 	   if ( ! grep tag_name ${WORKSPACE}/tag_release.log > /dev/null )
 	   then
+	   curl --data @- "https://api.github.com/repos/MDSplus/mdsplus/releases?access_token=$(cat $KEYS/.git_token)" > ${WORKSPACE}/tag_release.log 2>&1 <<EOF
+{
+  "tag_name":"${RELEASE_TAG}",
+  "target_commitish":"${BRANCH}",
+  "name":"${RELEASE_TAG}",
+  "body":"New release. Commit messages could not be included"
+}
+EOF
+	   fi
+	   if ( ! grep tag_name ${WORKSPACE}/tag_release.log > /dev/null )
+	   then 
 	       RED
 	       cat <<EOF >&2
 =========================================================


### PR DESCRIPTION
The release tag sent to github is a jason which contains a list
of the new commits added to make the release. If this contains
certain charactors it might break the jason format which prevents
the release from being tagged. This first tries with the comments
and if that fails will just send the tag with a comment indicating
the changes could not be described in the tag info.