### PR TITLE
Fix: Use tmp directory for createrepo repodata

### DIFF
--- a/deploy/platform/redhat/redhat_docker_build.sh
+++ b/deploy/platform/redhat/redhat_docker_build.sh
@@ -137,6 +137,10 @@ publish(){
     then
         use_deltas="--deltas"
     fi
-    :&& createrepo -q --update --cachedir /publish/${BRANCH}/cache ${use_deltas} /publish/${BRANCH}/RPMS
-    checkstatus abort "Failure: Problem creating rpm repository in publish area!" $?
+    tmpdir=$(mktemp -d)
+    :&& createrepo -q --update --cachedir /publish/${BRANCH}/cache ${use_deltas} -o ${tmpdir} /publish/${BRANCH}/RPMS
+    stat=$?
+    :&& rsync -a ${tmpdir}/repodata /public/${BRANCH}/RPMS/
+    rm -Rf ${tmpdir}
+    checkstatus abort "Failure: Problem creating rpm repository in publish area!" $stat
 }

--- a/deploy/platform/redhat/redhat_docker_build.sh
+++ b/deploy/platform/redhat/redhat_docker_build.sh
@@ -138,9 +138,9 @@ publish(){
         use_deltas="--deltas"
     fi
     tmpdir=$(mktemp -d)
+    trap 'rm -Rf ${tmpdir}' EXIT
     :&& createrepo -q --update --cachedir /publish/${BRANCH}/cache ${use_deltas} -o ${tmpdir} /publish/${BRANCH}/RPMS
-    stat=$?
+    checkstatus abort "Failure: Problem creating rpm repository in publish area!" $?
     :&& rsync -a ${tmpdir}/repodata /public/${BRANCH}/RPMS/
-    rm -Rf ${tmpdir}
-    checkstatus abort "Failure: Problem creating rpm repository in publish area!" $stat
+    checkstatus abort "Failure: Problem rsyncing rpm repository with publish area!" $?
 }


### PR DESCRIPTION
The use of createrepo on nfs served repository directory causes
errors. The fix will create the repodata in a temporary location
and rsync the data to the real repository directory instead.