### PR TITLE
Zck getsegment treats dim as data if dim not stored.

### DIFF
--- a/mdsobjects/python/tests/segmentsUnitTest.py
+++ b/mdsobjects/python/tests/segmentsUnitTest.py
@@ -292,12 +292,14 @@ class Tests(_UnitTest.TreeTests):
         len = 100;dt=.001
         node = ptree.S
         for i in range(0,1000,len):
-            node.beginSegment(i*dt,(i+len-1)*dt,None,Float32Array(range(i,i+len)))
-        seg0 = Float32Array(range(0,len))
+            seg = Float32Array(range(i,i+len))*dt
+            start, end = seg[0],seg[len-1]
+            if i == 0: seg0 = seg
+            node.beginSegment(start, end, None, seg)
         self.assertEqual(node.getSegment(0).data().tolist(),seg0.tolist(),1e-5)
         self.assertEqual(node.record.data()[0:100].tolist(),seg0.tolist(),1e-5)
         ptree.setTimeContext(.12,.13,None) # interval contained in segment 1 
-        self.assertEqual(node.record.data().tolist(),node.getSegment(1).data().tolist(),1e-5)
+        self.assertEqual(node.record.data().tolist(),node.getSegment(1).data().tolist()[20:31],1e-5)
 
     def CompressSegments(self):
         from MDSplus import Tree,DateToQuad,ZERO,Int32,Int32Array,Int64Array,Range

--- a/mdsobjects/python/tree.py
+++ b/mdsobjects/python/tree.py
@@ -2326,12 +2326,12 @@ class TreeNode(_dat.TreeRef,_dat.Data): # HINT: TreeNode begin  (maybe subclass 
                                      _C.byref(_C.c_int64(int(timestamp))),
                                      _dat.Data.byref(data)))
 
-    def putSegment(self,data,idx):
+    def putSegment(self,data,idx=-1):
         """Load a segment in a node
         @param data: data to load into segment
         @type data: Array or Scalar
         @param idx: index into segment to load data
-        @type idx: int
+        @type idx: int (default: append)
         @rtype: None
         """
         data = _dat.Data(data)

--- a/tdi/segments/BeginSegment.fun
+++ b/tdi/segments/BeginSegment.fun
@@ -1,7 +1,11 @@
-public fun BeginSegment(as_is _node, in _start, in _end, as_is _dim, in _array, optional _idx) {
+public fun BeginSegment(as_is _node, in _start, in _end, optional as_is _dim, in _array, optional _idx) {
   _nid=getnci(_node,"NID_NUMBER");
   if (!present(_idx)) {
     _idx=-1;
   }
-  return(TreeShr->TreeBeginSegment(val(_nid),descr(_start),descr(_end),xd(_dim),descr(data(_array)),val(_idx)));
+  if (!present(_dim)) {
+    return(TreeShr->TreeBeginSegment(val(_nid),descr(_start),descr(_end), val(0) ,descr(data(_array)),val(_idx)));
+  } else {
+    return(TreeShr->TreeBeginSegment(val(_nid),descr(_start),descr(_end),xd(_dim),descr(data(_array)),val(_idx)));
+  }
 }

--- a/tdi/segments/MakeSegment.fun
+++ b/tdi/segments/MakeSegment.fun
@@ -1,12 +1,16 @@
-public fun MakeSegment(as_is _node, in _start, in _end, as_is _dim, in _array, optional _idx, in _rows_filled) {
+public fun MakeSegment(as_is _node, in _start, in _end, optional as_is _dim, in _array, optional _idx, in _rows_filled) {
   _nid=getnci(_node,"NID_NUMBER");
   if (!present(_idx)) {
     _idx=-1;
   }
-  if (kind(_array) == 217) {
-      write(*,_array);
-      return(TreeShr->TreeMakeSegment(val(_nid),descr(_start),descr(_end),xd(_dim),xd(_array),val(_idx),val(_rows_filled)));
+  if (kind(_array) == 217) { /*is opaque*/
+    if (!present(_dim)) abort("Missing dim while storing OPAQUE segment.");
+    return(TreeShr->TreeMakeSegment(val(_nid),descr(_start),descr(_end),xd(_dim),xd(_array),val(_idx),val(_rows_filled)));
   } else {
+    if (!present(_dim)) {
+      return(TreeShr->TreeMakeSegment(val(_nid),descr(_start),descr(_end), val(0) ,descr(data(_array)),val(_idx),val(_rows_filled)));
+    } else {
       return(TreeShr->TreeMakeSegment(val(_nid),descr(_start),descr(_end),xd(_dim),descr(data(_array)),val(_idx),val(_rows_filled)));
+    }
   }
 }

--- a/tdi/segments/PutSegment.fun
+++ b/tdi/segments/PutSegment.fun
@@ -1,4 +1,5 @@
-public fun PutSegment(as_is _node, in _idx, in _data) {
-   _nid=getnci(_node,"NID_NUMBER");
-   return(TreeShr->TreePutSegment(val(_nid),val(_idx),descr(data(_data))));
+public fun PutSegment(as_is _node, optional in _idx, in _data) {
+  _nid=getnci(_node,"NID_NUMBER");
+  if (!present(_idx)) _idx=-1;
+  return(TreeShr->TreePutSegment(val(_nid),val(_idx),descr(data(_data))));
 }

--- a/treeshr/TreeSegments.c
+++ b/treeshr/TreeSegments.c
@@ -1032,14 +1032,11 @@ int _TreePutSegment(void *dbid, int nid, const int startIdx, struct descriptor_a
     || (data->dimct > 1 && memcmp(vars->shead.dims, a_coeff->m, (data->dimct - 1) * sizeof(int))))
       {status = TreeFAILURE;goto end;}
   }
-  int start_idx;
-  /*CHECK_STARTIDX*/{
-    if (startIdx == -1)
-      start_idx = vars->shead.next_row;
-    else if (startIdx < -1 || startIdx > vars->shead.dims[vars->shead.dimct - 1])
-      {status = TreeBUFFEROVF;goto end;}
-    else start_idx = startIdx;
-  }
+  /*CHECK_STARTIDX*/
+  const int start_idx = (startIdx == -1) ? vars->shead.next_row : startIdx;
+  if (start_idx < 0 || start_idx >= vars->shead.dims[vars->shead.dimct - 1])
+    {status = TreeBUFFEROVF;goto end;}
+  /*CHECK_DATA_SIZE*/
   int bytes_per_row,i;
   for (bytes_per_row = vars->shead.length, i = 0; i < vars->shead.dimct - 1;
        bytes_per_row *= vars->shead.dims[i], i++) ;


### PR DESCRIPTION
You can store normal segments (not opaque via TreeMakeSegment) without dim (pass val(0), i.e. NULL). Reading the segment will behave as if the dimension is the same a the raw data of the segment.
This allows to efficiently store timestamps, while still be able to use tools like provided by xtreeshr.