### PR TITLE
Build: Allow backslash in release tag

### DIFF
--- a/deploy/trigger.sh
+++ b/deploy/trigger.sh
@@ -528,7 +528,7 @@ then
   "target_commitish":"${BRANCH}",
   "name":"${RELEASE_TAG}",
   "body":"Commits since last release:\n\n
-$(git log --decorate=full --no-merges ${LAST_RELEASE_COMMIT}..HEAD | awk '{gsub("\"","\\\"");print $0"\\n"}')"
+$(git log --decorate=full --no-merges ${LAST_RELEASE_COMMIT}..HEAD | awk '{gsub("\\\\","\\\\");gsub("\"","\\\"");print $0"\\n"}')"
 }
 EOF
 	   if ( ! grep tag_name ${WORKSPACE}/tag_release.log > /dev/null )


### PR DESCRIPTION
The release tag information includes the comments
from commits added since the previous release. If a commit
comment includes a backslash then this needs to be escaped or
it will produce a json error when sending the tag to github.
This should permit comments with backslashes to be included
in the release text.

Note: The added gsub in the awk command looks to be a noop but due
to strange handling of backslashes by awk the first 4 backslashes end up
matching a single backslash in the input while the second 4 backslashes
ends up substituting a double backslash.