### PR TITLE
Feature: Cryocon24c support & Cryocon18i updates

### DIFF
--- a/deploy/packaging/debian/htsdevices.noarch
+++ b/deploy/packaging/debian/htsdevices.noarch
@@ -9,3 +9,4 @@
 ./usr/local/mdsplus/pydevices/HtsDevices/acq400_hapi/shotcontrol.py
 ./usr/local/mdsplus/pydevices/HtsDevices/acq435st.py
 ./usr/local/mdsplus/pydevices/HtsDevices/cryocon18i.py
+./usr/local/mdsplus/pydevices/HtsDevices/cryocon24c.py

--- a/deploy/packaging/redhat/htsdevices.noarch
+++ b/deploy/packaging/redhat/htsdevices.noarch
@@ -11,3 +11,4 @@
 ./usr/local/mdsplus/pydevices/HtsDevices/acq400_hapi/shotcontrol.py
 ./usr/local/mdsplus/pydevices/HtsDevices/acq435st.py
 ./usr/local/mdsplus/pydevices/HtsDevices/cryocon18i.py
+./usr/local/mdsplus/pydevices/HtsDevices/cryocon24c.py

--- a/pydevices/HtsDevices/cryocon18i.py
+++ b/pydevices/HtsDevices/cryocon18i.py
@@ -111,7 +111,7 @@ class CRYOCON18I(MDSplus.Device):
         import pyvisa
         rm = pyvisa.ResourceManager('@py')
         instrument = rm.open_resource('TCPIP::%s'% str(self.node.data()))
-        answer = instrument.query(cmd)
+        answer = instrument.query(cmd)[:-1]
         print("cmd:%s\nans:%s"%(cmd,answer))
         return 1
     QUERY=query
@@ -195,25 +195,23 @@ class CRYOCON18I(MDSplus.Device):
             chan = self.__getattr__('input_%c'%(chr(i),))
             if chan.on:
                 query_cmd = 'INP %c?;INP %c:SENP?;'%(chr(i), chr(i),)
-                ans = instrument.query(query_cmd).split(';')
+                ans = instrument.query(query_cmd)[:-1].split(';')
                 t_time=time.time()
                 try:
-                    temp = float(ans[0].split('\x00')[0])
+                    temp = float(ans[0])
                 except:
                     if self.debugging():
-                        print("Could not parse temperature /%s/"%
-                           ans[0].split('\x00')[0])
+                        print("Could not parse temperature /%s/"% ans)
                     temp = 0.0
                 chan.putRow(1000,
                             MDSplus.Float32(temp),
                             MDSplus.Int64(t_time*1000.))
                 r_chan=self.__getattr__('input_%c_resistence' % (chr(i)))
                 try:
-                    resist = float(ans[1].split('\x00')[0])
+                    resist = float(ans[1])
                 except:
                     if self.debugging():
-                        print("Could not parse resist /%s/"%
-                               ans[1].split('\x00')[0])
+                        print("Could not parse resist /%s/"% ans)
                     resist = 0.0
                 r_chan.putRow(1000,
                           MDSplus.Float32(resist),
@@ -267,19 +265,12 @@ class CRYOCON18I(MDSplus.Device):
                 resists.append(np.zeros(seg_length))
                 t_chans.append(chan)
                 r_chans.append(self.__getattr__('input_%c_resistence' % (chr(i))))
-                query_cmd = query_cmd+'INP %c?;INP %c:SENP?;'%(chr(i), chr(i),)
-        # note the time
-        # while not stopped and not done
-        #    for each sample in segment
-        #        read all temps and resists
-        #        for each channel
-        #            make the temp and resist a float
-        #    trim segment if necessary
-        #    write the segment
+
         segment = 0
         start_time = time.time()
         previous_time = 0
         self.trig_time.record = start_time
+
         while self.running.on and segment < max_segments:
             if self.debugging():
                 print ("starting on segment %d" % segment)
@@ -288,24 +279,29 @@ class CRYOCON18I(MDSplus.Device):
                     break
                 if previous_time != 0:
                     time.sleep(dt - (time.time()-previous_time))
-                ans = instrument.query(query_cmd).split(';')
                 previous_time = time.time()
                 times[sample] = previous_time - start_time
-                for i in range(len(temps)):
-                    try:
-                        temps[i][sample] = float(ans[2*i].split('\x00')[0])
-                    except:
-                        if self.debugging():
-                            print("Could not parse temperature /%s/"%
-                                   ans[2*i].split('\x00')[0])
-                        temps[i][sample] = 0.0
-                    try:
-                        resists[i][sample] = float(ans[2*i+1].split('\x00')[0])
-                    except:
-                        if self.debugging():
-                            print("Could not parse resist /%s/"%
-                                   ans[2*i+1].split('\x00')[0])
-                        resists[i][sample] = 0.0
+                idx = 0
+                for i in range(ord('a'), ord('i')):
+                    if chan.on:
+                        query_cmd = 'INP %c?;INP %c:SENP?;'%(chr(i), chr(i),)
+                        ans = instrument.query(query_cmd)[:-1].split(';')
+                        try:
+                            temp = float(ans[0])
+                        except:
+                            if self.debugging():
+                                print("Could not parse temperature /%s/"% ans)
+                            temp = 0.0
+                        temps[idx][sample] = temp
+
+                        try:
+                            resist = float(ans[1])
+                        except:
+                            if self.debugging():
+                                print("Could not parse resist /%s/"% ans)
+                            resist = 0.0
+                        resists[idx][sample] = resist
+                        idx += 1
 
             if sample != seg_length-1:
                 for i in range(len(temps)):

--- a/pydevices/HtsDevices/cryocon24c.py
+++ b/pydevices/HtsDevices/cryocon24c.py
@@ -389,11 +389,7 @@ class CRYOCON24C_SHOT(CRYOCON24C):
         return trend_tree
 
     def stop(self):
-        timeStamps   = []
-        temps   = []
-        resists = []
-        outpower= []
-        
+
         self.t2.record = MDSplus.Int64(time.time()*1000.)
         trend_tree = self.trendTree()
         trend = trend_tree.getNode(self.trend_device.data())
@@ -403,50 +399,29 @@ class CRYOCON24C_SHOT(CRYOCON24C):
 
         # Getting T1 from TREND:
         t1 = trend.t1.data()
-        deltaT1T2 = abs(self.t2.data() - t1)
-        print('Delta Times ' + str(deltaT1T2))
-
-        trend_temp_node = trend.__getattr__('input_a_temperature')
-        trend_temp = trend_tree.getNode(trend_temp_node)
-
-        # print(trend_temp.getSegment(0).data())
-        # print(trend_temp.getSegment(0).dim_of().data())
-
-        temps      = trend_temp.getSegment(0).data()
-        timeStamps = trend_temp.getSegment(0).dim_of().data()
-
-        # get the SHOT chunk of data from T1 to T2:
-        print('SHOT chunk of data from T1 to T2')
-        trend_temp.getSegmentList(t1, self.t2.data())
-        print(trend_temp.getSegmentList(t1, self.t2.data()))
 
         #Set Time Context
         trend_tree.setTimeContext(t1, self.t2.data())
-
-        trend_temp_node = trend.__getattr__('input_a_temperature')
-        trend_temp = trend_tree.getNode(trend_temp_node)
-        temps = trend_temp.data()
-        times = trend_temp.dim_of().data()
-
-        trend_resis_node = trend.__getattr__('input_a_resistence')
-        trend_resis = trend_tree.getNode(trend_resis_node)
-        resists = trend_resis.data()
-
-        trend_outpower_node = trend.__getattr__('input_a_output_power')
-        trend_outpower = trend_tree.getNode(trend_outpower_node)
-        outpower = trend_outpower.data() 
-
-        print(temps)
-        print(times)
-        print(resists)
-        print(outpower)
-
+        
         print('Writing data into shot node')
-        # for i in np.arange(0, delta_shot, 1./float(self.shot_rate.data())):
+        for i in range(ord('a'), ord('e')):
+            trend_temp_node     = trend.__getattr__('input_%c_temperature'% (chr(i)))
+            trend_resis_node    = trend.__getattr__('input_%c_resistence'%  (chr(i)))
+            trend_outpower_node = trend.__getattr__('input_%c_output_power'% (chr(i)))
+            
+            trend_temp     = trend_tree.getNode(trend_temp_node)
+            trend_resis    = trend_tree.getNode(trend_resis_node)
+            trend_outpower = trend_tree.getNode(trend_outpower_node)
+            
+            times    = trend_temp.dim_of().data()
+            temps    = trend_temp.data()
+            resists  = trend_resis.data()
+            outpower = trend_outpower.data()
 
-        #     self.temperature.record = trend_temp.data()    
-        #     self.resistence.record = trend_resis.data() 
-        #     self.output_power.record = trend_outpower.data()
+            for j in range(len(times)):
+                (self.__getattr__('input_%c_temperature' % (chr(i)))).putRow(1000, temps, times[j])
+                (self.__getattr__('input_%c_resistence' % (chr(i)))).putRow(1000, resists, times[j])
+                (self.__getattr__('input_%c_output_power' % (chr(i)))).putRow(1000, outpower, times[j])
 
 
 def main():

--- a/pydevices/HtsDevices/cryocon24c.py
+++ b/pydevices/HtsDevices/cryocon24c.py
@@ -1,120 +1,157 @@
-#
-# Copyright (c) 2019, Massachusetts Institute of Technology All rights reserved.
-#
-# Redistribution and use in source and binary forms, with or without
-# modification, are permitted provided that the following conditions are met:
-#
-# Redistributions of source code must retain the above copyright notice, this
-# list of conditions and the following disclaimer.
-#
-# Redistributions in binary form must reproduce the above copyright notice, this
-# list of conditions and the following disclaimer in the documentation and/or
-# other materials provided with the distribution.
-#
-# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-#
 import MDSplus
 import threading
+import socket
+import time
 
 class CRYOCON24C(MDSplus.Device):
     """
-    8 channel Cryocon temperature monitor
+     4 channel Cryocon temperature monitor
 
-    Each channel (A-D):
-      channel_[a-d] - measured resistence
-                     (for trend timestamp record, for daq segmented record)
-      serial_no - serial number of the sensor
-      calibration - 2d array of calibration values read from device
-      temperature - measured temperature
-                   (for trend timestamp record, for daq segmented record)
+     Each channel (A-D):
+       channel_[a-d] - measured resistence
+                      (for trend timestamp record, for daq segmented record)
+       serial_no - serial number of the sensor
+       calibration - 2d array of calibration values read from device
+       temperature - measured temperature
+                    (for trend timestamp record, for daq segmented record)
 
-    Methods:
-       init - start daq loop
-       stop - stop daq loop
-       trend - store one trend sample for each channel
+     Methods:
+        init - start daq loop
+        stop - stop daq loop
+        trend - store one trend sample for each channel
 
-    debugging() - is debugging enabled.
-                  Controlled by environment variable DEBUG_DEVICES
+     debugging() - is debugging enabled.
+                   Controlled by environment variable DEBUG_DEVICES
 
-    """
+     """
 
-    parts=[
-        {'path':':NODE','type':'text','value':'192.168.0.254',
-         'options':('no_write_shot')},
-        {'path':':COMMENT','type':'text', 'options':('no_write_shot')},
-        {'path':':TREND_EVENT','type':'text', 'value': 'CRYOCON_TREND',
-         'options':('no_write_shot')},
-        {'path':':DATA_EVENT','type':'text', 'value': 'CRYOCCON_STREAM',
-         'options':('no_write_shot')},
-        {'path':':STATUS_CMDS','type':'text',
-         'value':MDSplus.makeArray(['IDN?',
-                                    'SYSTem:HWRev?',
-                                    'SYSTem:FWREV?',
-                                    'SYSTem:AMBient?']),
-         'options':('no_write_shot',)},
-        {'path':':STATUS_OUT',
-         'type':'any',
-         'options':('write_shot','write_once','no_write_model')},
-        {'path':':SEG_LENGTH',
-         'type':'numeric',
-         'value':5,
-         'options':('no_write_shot')},
-        {'path':':MAX_SEGMENTS',
-         'type':'numeric',
-         'value':200,
-         'options':('no_write_shot')},
-        {'path':':RATE',
-         'type':'numeric',
-         'value':.25,
-         'options':('no_write_shot')},
-        {'path':':TRIG_TIME','type':'numeric', 'options':('write_shot')},
-        {'path':':TRIG_STR','type':'text', 'options':('nowrite_shot'),
-         'valueExpr':"EXT_FUNCTION(None,'ctime',head.TRIG_TIME)"},
-        {'path':':RUNNING','type':'numeric', 'options':('no_write_model')},
-        {'path':':INIT_ACTION','type':'action',
+    parts = [
+        {'path': ':NODE', 'type': 'text', 'value': '192.168.0.254',
+         'options': ('no_write_shot')},
+        {'path': ':COMMENT', 'type': 'text', 'options': ('no_write_shot')},
+        {'path': ':TREND_EVENT', 'type': 'text', 'value': 'CRYOCON_TREND',
+         'options': ('no_write_shot')},
+        {'path': ':DATA_EVENT', 'type': 'text', 'value': 'CRYOCCON_STREAM',
+         'options': ('no_write_shot')},
+        {'path': ':STATUS_CMDS', 'type': 'text',
+         'value': MDSplus.makeArray(['*IDN?',
+                                     'SYSTem:HWRev?',
+                                     'SYSTem:FWREV?',
+                                     'SYSTem:AMBient?']),
+         'options': ('no_write_shot',)},
+        {'path': ':STATUS_OUT',
+         'type': 'any',
+         'options': ('write_shot', 'write_once', 'no_write_model')},
+        {'path': ':SEG_LENGTH',
+         'type': 'numeric',
+         'value': 5,
+         'options': ('no_write_shot')},
+        {'path': ':MAX_SEGMENTS',
+         'type': 'numeric',
+         'value': 200,
+         'options': ('no_write_shot')},
+        {'path': ':RATE',
+         'type': 'numeric',
+         'value': .25,
+         'options': ('no_write_shot')},
+        {'path': ':TRIG_TIME', 'type': 'numeric', 'options': ('write_shot')},
+        {'path': ':TRIG_STR', 'type': 'text', 'options': ('nowrite_shot'),
+         'valueExpr': "EXT_FUNCTION(None,'ctime',head.TRIG_TIME)"},
+        {'path': ':RUNNING', 'type': 'numeric', 'options': ('no_write_model')},
+        {'path': ':INIT_ACTION', 'type': 'action',
          'valueExpr':
              "Action(Dispatch('S','INIT',50,None),Method(None,'INIT',head))",
-         'options':('no_write_shot',)},
-        {'path':':STOP_ACTION','type':'action',
+         'options': ('no_write_shot',)},
+        {'path': ':STOP_ACTION', 'type': 'action',
          'valueExpr':
              "Action(Dispatch('S','STORE',50,None),Method(None,'STOP',head))",
-         'options':('no_write_shot',)},
-        ]
+         'options': ('no_write_shot',)},
+    ]
 
     for c in range(ord('A'), ord('E')):
-        parts.append({'path':':INPUT_%c'%(c,),
-                      'type':'signal',
-                      'options':('no_write_model','write_once',)})
-        parts.append({'path':':INPUT_%c:SERIAL_NO'%(c,),
-                      'type':'TEXT',
-                      'options':('no_write_shot')})
-        parts.append({'path':':INPUT_%c:CALIBRATION'%(c,),
-                      'type':'TEXT',
-                      'options':('no_write_model', 'write_once',)})
-        parts.append({'path':':INPUT_%c:TEMPERATURE'%(c,),
-                      'type':'SIGNAL',
-                      'options':('no_write_model', 'write_once',)})
+        parts.append({'path': ':INPUT_%c' % (c,),
+                      'type': 'signal',
+                      'options': ('no_write_model', 'write_once',)})
+
+        parts.append({'path': ':INPUT_%c:SERIAL_NO' % (c,),
+                      'type': 'TEXT', 'options': ('no_write_shot')})
+
+        parts.append({'path': ':INPUT_%c:CALIBRATION' % (c,),
+                      'type': 'TEXT',
+                      'options': ('no_write_model', 'write_once',)})
+
+        parts.append({'path': ':INPUT_%c:PROPOR_GAIN' % (c,),
+                      'type': 'NUMERIC', 'options': ('no_write_model')})
+
+        parts.append({'path': ':INPUT_%c:INTEGR_GAIN' % (c,),
+                      'type': 'NUMERIC', 'options': ('no_write_model')})
+
+        parts.append({'path': ':INPUT_%c:DERIVA_GAIN' % (c,),
+                      'type': 'NUMERIC', 'options': ('no_write_model')})
+
+        parts.append({'path': ':INPUT_%c:TEMPERATURE' % (c,),
+                      'type': 'signal',
+                      'options': ('no_write_model', 'write_once',)})
+
+        parts.append({'path': ':INPUT_%c:RESISTENCE' % (c,),
+                      'type': 'signal',
+                      'options': ('no_write_model', 'write_once',)})
+
+        parts.append({'path': ':INPUT_%c:OUTPUT_POWER' % (c,),
+                      'type': 'signal',
+                      'options': ('no_write_model', 'write_once',)})
+
+
     del c
+    debug = None
 
-    debug=None
+    def sendCommand(self,s,cmd):
+        s.send(cmd + "\r\n")
 
-    def query(self, cmd):
-        import pyvisa
-        rm = pyvisa.ResourceManager('@py')
-        instrument = rm.open_resource('TCPIP::%s'% str(self.node.data()))
-        answer = instrument.query(cmd)
-        print("cmd:%s\nans:%s"%(cmd,answer))
+    def recvResponse(self,s):
+        msg = ""
+        while True:
+            c = s.recv(1)
+            if c == "\r":
+                continue
+            if c == "\n":
+                break
+            msg += c
+        return msg
+
+    def queryCommand(self,s,cmd):
+        self.sendCommand(s,cmd)
+        return self.recvResponse(s)
+
+
+    def debugging(self):
+        import os
+        if self.debug == None:
+            self.debug=os.getenv("DEBUG_DEVICES")
+        return(self.debug)
+
+
+class CRYOCON24C_TREND(CRYOCON24C):
+    '''
+    trend class for cryocon 24c
+
+    Store one sample for each of the channels that is on using
+    putRow.  The timestamp will be time since the unix EPOCH in msec
+    '''
+
+    def init(self):
+        '''start the stream
+           socket
+        '''
+
+        # start it trending
+        self.running.on=True
+
+        # self.stream()
+        thread = self.Worker(self)
+        thread.start()
         return 1
-    QUERY=query
+    INIT = init
 
     class Worker(threading.Thread):
         """An async worker should be a proper class
@@ -124,217 +161,236 @@ class CRYOCON24C(MDSplus.Device):
         def __init__(self,dev):
             print(MDSplus.__file__)
             print(MDSplus.__version__)
-            super(CRYOCON24C.Worker,self).__init__(name=dev.path)
+            super(CRYOCON24C_TREND.Worker,self).__init__(name=dev.path)
             # make a thread safe copy of the device node with a non-global context
             self.dev = MDSplus.TreeNode.copy(dev)
+
         def run(self):
-            # self.dev.stream()
-            self.dev.trend()
-    def init(self):
-        '''
-        init method for cryocon 24c
+            max_segments = self.max_segments.data()
 
-        record the values of the status commands
-        start the stream
+            s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            s.connect((str(self.node.data()), 5000))
 
-        STILL NEEDS TO STORE Calibration CURVES !!
-        '''
-        import pyvisa
-        # open the instrument
-        if self.debugging():
-            print("about to open cryocon device %s" % str(self.node.data()))
-        rm = pyvisa.ResourceManager('@py')
-        instrument = rm.open_resource('TCPIP::%s'% str(self.node.data()))
-        # read and save the status commands
-        status_out={}
-        for cmd in self.status_cmds:
+            # open the instrument
             if self.debugging():
-                print('about to send %s' % cmd)
-            status_out[str(cmd)] = instrument.query(str(cmd))
-            if self.debugging():
-                print('  got back %s' % status_out[str(cmd)])
-        self.status_out.record = status_out
+                print("about to open cryocon device %s" % str(self.node.data()))
+            event_name = self.data_event.data()
 
-        for i in range(ord('a'), ord('e')):
-            chan = self.__getattr__('input_%c'%(chr(i),))
-            if chan.on:
-              cal = self.__getattr__('input_%c_calibration'%(chr(i),))
-              ans = instrument.query('CALCUR %c?'%(chr(i)))
-              print(ans)
-              cal.record = ans
-        print(instrument.query('CALCUR'))
-        # start it streaming
-        self.running.on=True
-        # self.stream()
-        thread = self.Worker(self)
-        thread.start()
-        return 1
-    INIT=init
+            # read and save the status commands
+            status_out={}
 
-    def trend(self):
-        '''
-        trend method for cryocon 24c
+            for cmd in self.status_cmds:
+                if self.debugging():
+                    print('about to send %s' % cmd)
 
-        Store one sample for each of the channels that is on using
-        putRow.  The timestamp will be time since the unix EPOCH in msec
-        '''
+                # status_out[str(cmd)] = instrument.query(str(cmd))
+                status_out[str(cmd)] = self.queryCommand(s, str(cmd))
 
-        import pyvisa
-        import MDSplus
-        import time
+                if self.debugging():
+                    print('  got back %s' % status_out[str(cmd)])
 
-        # open the instrument
-        if self.debugging():
-            print("about to open cryocon device %s" % str(self.node.data()))
-        event_name = self.data_event.data()
-        rm = pyvisa.ResourceManager('@py')
-        instrument = rm.open_resource('TCPIP::%s'% str(self.node.data()))
-        chans = []
-        t_chans = []
-        resists = []
-        temps = []
-        query_cmd = ''
-        for i in range(ord('a'), ord('e')):
-            chan = self.__getattr__('input_%c'%(chr(i),))
-            if chan.on:
-                t_chan=self.__getattr__('input_%c_temperature' % (chr(i)))
-                query_cmd = 'INP %c?;INP %c:SENP?;'%(chr(i), chr(i),)
-                ans = instrument.query(query_cmd).split(';')
-                t_time=time.time()
-                try:
-                    print("Parsing temperature")
-                    temp = float(ans[0].split('\x00')[0])
-                except:
-                    if self.debugging():
-                        print("Could not parse temperature /%s/"%
-                           ans[0].split('\x00')[0])
-                    temp = 0.0
+            self.status_out.record = status_out
 
-                t_chan.putRow(1000,
-                              MDSplus.Float32(temp),
-                               MDSplus.Int64(t_time*1000.))
+            # Control Loop PID values Numeric Entry The Pgain, Igain and Dgain lines correspond to the Proportional,
+            # Integral and Derivative coefficients of the control loop. Pman is the output power that will be applied
+            # to the load if the manual control mode is selected.
+            # Values for the Proportional, or P, gain term range from zero to 1000. This is a unit- less gain term
+            # that is applied to the control loop. Gain is scaled to reflect the actual heater range and the load resistance.
+            # Integrator gain values range from zero to 10,000. The units of this term are Seconds. A value of zero
+            # turns the integration function off.
+            # Derivative gain values have units of inverse Seconds and may have values from zero to 1000. A value of
+            # zero turns the Derivative control function off.
+
+            for i in range(ord('a'), ord('e')):
+                # Proportional gain, or P term for PID control.
+                # This is a numeric field that is a percent of full scale.
+                pgain_chan = self.__getattr__('input_%c_propor_gain' % (chr(i)))
+                query_cmd = 'LOOP %c:PGA?' % (chr(i),)
+
+                ansQuery = self.queryCommand(s, query_cmd)
 
                 try:
-                    resist = float(ans[1].split('\x00')[0])
+                    print("Parsing Proportional Gain /%s/" % ansQuery)
+                    pgain = float(ansQuery)
                 except:
                     if self.debugging():
-                        print("Could not parse resist /%s/"%
-                               ans[1].split('\x00')[0])
-                    resist = 0.0
+                        print("Could not Proportional Gain /%s/" % ansQuery)
+                    pgain = 0.0
 
-                chan.putRow(1000,
-                          MDSplus.Float32(resist),
-                          MDSplus.Int64(t_time*1000.))
+                pgain_chan.putRow(1000,
+                                  MDSplus.Float32(pgain),
+                                  MDSplus.Int64(t_time * 1000.))
 
-        MDSplus.Event.setevent(event_name)
-    TREND=trend
+                # Integrator gain term, in Seconds, for PID control.
+                # This is a numeric field that is a percent of full scale.
+                igain_chan = self.__getattr__('input_%c_integr_gain' % (chr(i)))
+                query_cmd = 'LOOP %c:IGA?' % (chr(i),)
+
+                ansQuery = self.queryCommand(s, query_cmd)
+
+                try:
+                    print("Parsing Integral Gain /%s/" % ansQuery)
+                    igain = float(ansQuery)
+                except:
+                    if self.debugging():
+                        print("Could not Integral Gain /%s/" % ansQuery)
+                    igain = 0.0
+
+                igain_chan.putRow(1000,
+                                  MDSplus.Float32(igain),
+                                  MDSplus.Int64(t_time * 1000.))
+
+                # Derivative gain term, in inverse-Seconds, for PID control.
+                # This is a numeric field that is a percent of full scale.
+                dgain_chan = self.__getattr__('input_%c_deriva_gain' % (chr(i)))
+                query_cmd = 'LOOP %c:DGA?' % (chr(i),)
+
+                ansQuery = self.queryCommand(s, query_cmd)
+
+                try:
+                    print("Parsing Derivative Gain /%s/" % ansQuery)
+                    dgain = float(ansQuery)
+                except:
+                    if self.debugging():
+                        print("Could not Derivative Gain /%s/" % ansQuery)
+                    dgain = 0.0
+
+                dgain_chan.putRow(1000,
+                                  MDSplus.Float32(dgain),
+                                  MDSplus.Int64(t_time * 1000.))
+
+            # For the storage of calibration curves
+            index    = 1
+            caltable = []
+            strCalcur= ''
+
+            query_cmd = ''
+            answer    = []
+
+            segment = 0
+            while self.running.on and segment < max_segments:
+                for i in range(ord('a'), ord('e')):
+                    chan = self.__getattr__('input_%c' % (chr(i),))
+                    if chan.on:
+
+                        # Calibrartion Curve storage
+                        cal = self.__getattr__('input_%c_calibration' % (chr(i),))
+                        self.sendCommand(s, 'CALCUR %d?' % (index))
+
+                        while ';' not in strCalcur:
+                            ans = self.recvResponse(s)
+                            print('Answer: ', ans)
+                            caltable.append(ans)
+
+                        ans = 1 #Disable for now
+                        cal.record = ans
+
+                        # Temperature reading
+                        temp_chan = self.__getattr__('input_%c_temperature' % (chr(i)))
+                        query_cmd = 'INP %c:TEMP?;UNIT?' % (chr(i),)
+
+                        ansQuery = self.queryCommand(s, query_cmd)
+                        answer = ansQuery.split(';')
+                        print(answer)
+
+                        t_time = time.time()
+                        try:
+                            print("Parsing temperature /%s/" % ans[0])
+                            temp = float(answer[0])
+                        except:
+                            if self.debugging():
+                                print("Could not parse temperature /%s/" % answer[0])
+                            temp = 0.0
+
+                        temp_chan.putRow(1000,
+                                      MDSplus.Float32(temp),
+                                      MDSplus.Int64(t_time * 1000.))
+
+
+                        # Resistence reading
+                        resist_chan = self.__getattr__('input_%c_resistence' % (chr(i)))
+                        query_cmd = 'INP %c:SENP?' % (chr(i),)
+
+                        ansQuery = self.queryCommand(s, query_cmd)
+
+                        try:
+                            print("Parsing resistance /%s/" % ansQuery)
+                            resist = float(ansQuery)
+                        except:
+                            if self.debugging():
+                                print("Could not parse resist /%s/" % ansQuery)
+                            resist = 0.0
+
+                        resist_chan.putRow(1000,
+                                    MDSplus.Float32(resist),
+                                    MDSplus.Int64(t_time * 1000.))
+
+
+                        # Output Power reading: Queries the output power of the selected control loop.
+                        # This is a numeric field that is a percent of full scale.
+                        outp_chan = self.__getattr__('input_%c_output_power' % (chr(i)))
+                        query_cmd = 'LOOP %c:OUTP?' % (chr(i),)
+
+                        ansQuery = self.queryCommand(s, query_cmd)
+
+                        try:
+                            print("Parsing output power /%s/" % ansQuery)
+                            outpower = float(ansQuery)
+                        except:
+                            if self.debugging():
+                                print("Could not parse output power /%s/" % ansQuery)
+                            outpower = 0.0
+
+                        outp_chan.putRow(1000,
+                                    MDSplus.Float32(outpower),
+                                    MDSplus.Int64(t_time * 1000.))
+
+
+                s.close()
+
+            MDSplus.Event.setevent(event_name)
+
 
     def stop(self):
         '''
         stop method for the cryocon 24c
-
         set the stop flag by turning off the 'running' node
         '''
         self.running.on = False
         return 1
-    STOP=stop
 
-    def stream(self):
-        import pyvisa
-        import datetime
-        import time
-        import numpy as np
-        import MDSplus
+    STOP = stop
 
-        try:
-            dt = 1./float(self.rate)
-        except:
-            dt = 1
-        print("starting streamer for %s %s %s\nat: %s"%
-              (self.tree, self.tree.shot, self.path, datetime.datetime.now()))
-        event_name = self.data_event.data()
-        seg_length = self.seg_length.data()
+class CRYOCON24C_SHOT(CRYOCON24C):
+    def init(self):
+        pass
+    def stop(self):
+        pass
+    pass
 
-        # open the instrument
-        rm = pyvisa.ResourceManager('@py')
-        instrument = rm.open_resource('TCPIP::%s'% str(self.node.data()))
 
-        # set up arrays of data and nodes to use in the loop
-        seg_length = int(self.seg_length.data())
-        max_segments = self.max_segments.data()
-        chans = []
-        t_chans = []
-        resists = []
-        temps = []
-        times = np.zeros(seg_length)
-        query_cmd = ''
-        for i in range(ord('a'), ord('e')):
-            chan = self.__getattr__('input_%c'%(chr(i),))
-            if chan.on:
-                temps.append(np.zeros(seg_length))
-                resists.append(np.zeros(seg_length))
-                chans.append(chan)
-                t_chans.append(self.__getattr__('input_%c_temperature' % (chr(i))))
-                query_cmd = query_cmd+'INP %c?;INP %c:SENP?;'%(chr(i), chr(i),)
-        # note the time
-        # while not stopped and not done
-        #    for each sample in segment
-        #        read all temps and resists
-        #        for each channel
-        #            make the temp and resist a float
-        #    trim segment if necessary
-        #    write the segment
-        segment = 0
-        start_time = time.time()
-        previous_time = 0
-        self.trig_time.record = start_time
-        while self.running.on and segment < max_segments:
-            if self.debugging():
-                print ("starting on segment %d" % segment)
-            for sample in range(seg_length):
-                if not self.running.on:
-                    break
-                if previous_time != 0:
-                    time.sleep(dt - (time.time()-previous_time))
-                ans = instrument.query(query_cmd).split(';')
-                previous_time = time.time()
-                times[sample] = previous_time - start_time
-                for i in range(len(temps)):
-                    try:
-                        temps[i][sample] = float(ans[2*i].split('\x00')[0])
-                    except:
-                        if self.debugging():
-                            print("Could not parse temperature /%s/"%
-                                   ans[2*i].split('\x00')[0])
-                        temps[i][sample] = 0.0
-                    try:
-                        resists[i][sample] = float(ans[2*i+1].split('\x00')[0])
-                    except:
-                        if self.debugging():
-                            print("Could not parse resist /%s/"%
-                                   ans[2*i+1].split('\x00')[0])
-                        resists[i][sample] = 0.0
 
-            if sample != seg_length-1:
-                for i in range(len(temps)):
-                    times = times[0:sample]
-                    temps[i] = temps[i][0:sample]
-                    resists[i] = resists[i][0:sample]
-            for i in range(len(temps)):
-                chans[i].makeSegment(times[0],
-                                     times[-1],
-                                     times,
-                                     resists[i])
-                t_chans[i].makeSegment(times[0],
-                                       times[-1],
-                                       times,
-                                       temps[i])
-                MDSplus.Event.setevent(event_name)
-            segment += 1
-        return 1
+def main():
 
-    def debugging(self):
-        import os
-        if self.debug == None:
-            self.debug=os.getenv("DEBUG_DEVICES")
-        return(self.debug)
+    # create tree model
+    tree_model = MDSplus.Tree('cryocon24c', -1, 'NEW')
+    CRYOCON24C_TREND.Add(tree_model, 'CRYOCON24C')
+    node = tree_model.getNode('\CRYOCON24C::TOP:CRYOCON24C:NODE')
+    node.putData('198.125.182.159')
+    print('Writing Tree for device ' + '198.125.182.159')
+    tree_model.write()
+    print('Closing Tree')
+    tree_model.close()
+
+    #Executing the experiment:
+    print('Running INIT from cryocon24c using MDS-TCL')
+    tree = MDSplus.Tree('cryocon24c', -1)
+    tree.tcl('set tree cryocon24c/shot=-1')
+    tree.tcl('set current cryocon24c/increment')
+    tree.tcl('create pulse 0')
+    tree.tcl('set tree cryocon24c/shot=0')
+    tree.tcl('do /meth CRYOCON24C INIT')
+    return 1
+
+if __name__ == '__main__':
+    main()

--- a/pydevices/HtsDevices/cryocon24c.py
+++ b/pydevices/HtsDevices/cryocon24c.py
@@ -375,21 +375,10 @@ class CRYOCON24C_SHOT(CRYOCON24C):
     def init(self):
         self.t1.record = time.time()
 
-        # tree_name = self.trend_tree.data()
-        # shot_number = self.trend_shot.data()
-        # trend_device_name = self.trend_device.data()
-
-        # trend_tree = MDSplus.Tree(tree_name, shot_number, 'NORMAL')
-        # trend = trend_tree.getNode(trend_device_name)
         trend_tree = self.trendTree()
         trend = trend_tree.getNode(self.trend_device.data())
         trend.rate.record = self.shot_rate.data()
-        
-        # trend_temp_node = trend.__getattr__('input_a_temperature')
-        # trend_temp = trend_tree.getNode(trend_temp_node)
-        # temps = trend_temp.data()
-        # times = trend_temp.dim_of().data()
-        # print(temps,times)
+ 
 
     def trendTree(self):
         tree_name         = self.trend_tree.data()
@@ -405,9 +394,6 @@ class CRYOCON24C_SHOT(CRYOCON24C):
         
         self.t2.record = time.time()
         delta_shot= self.t2.data() - self.t1.data()
-
-        # trend_tree = MDSplus.Tree('cryocon24c', 0, 'NORMAL')
-        # trend = trend_tree.getNode('cryo24_trend')
  
         trend_tree = self.trendTree()
         trend = trend_tree.getNode(self.trend_device.data())
@@ -415,6 +401,8 @@ class CRYOCON24C_SHOT(CRYOCON24C):
         # Resetting the original rate:
         trend.rate.record = trend.trend_rate.data()
     
+
+
         trend_temp_node = trend.__getattr__('input_a_temperature')
         trend_temp = trend_tree.getNode(trend_temp_node)
         temps = trend_temp.data()

--- a/pydevices/HtsDevices/cryocon24c.py
+++ b/pydevices/HtsDevices/cryocon24c.py
@@ -361,7 +361,7 @@ class CRYOCON24C_SHOT(CRYOCON24C):
     INIT=init
 
     def stop(self):
-        event_name = self.shot_event.data()
+        event_name = self.data_event.data()
         self.t2.record = MDSplus.Int64(time.time()*1000.)
         trend_tree = self.getTrendTree()
         trend_dev = trend_tree.getNode(self.trend_device.data())

--- a/pydevices/HtsDevices/cryocon24c.py
+++ b/pydevices/HtsDevices/cryocon24c.py
@@ -332,18 +332,17 @@ class CRYOCON24C_TREND(CRYOCON24C):
         '''
         self.running.on = False
         return 1
-
     STOP = stop
 
 class CRYOCON24C_SHOT(CRYOCON24C):
     parts = copy.copy(CRYOCON24C.parts)
-    parts.append({'path': ':T1', 'type': 'numeric', 'options': ('no_write_shot'), 'help': 'The time in milliseconds that the shot began taking data'})
+    parts.append({'path': ':T1', 'type': 'numeric', 'options': ('no_write_shot'), 'help': 'The time in seconds that the shot began taking data'})
     parts.append({'path': ':T2', 'type': 'numeric', 'value': 0,'options': ('write_shot')})
     # SHOT_RATE in Hz.     
     parts.append({'path': ':SHOT_RATE', 'type': 'numeric', 'value': 5,'options': ('no_write_shot')})
     parts.append({'path': ':TREND_TREE', 'type': 'text', 'options': ('no_write_shot')})
     parts.append({'path': ':TREND_DEVICE', 'type': 'text', 'options': ('no_write_shot')})
-    parts.append({'path': ':TREND_SHOT', 'type': 'numeric', 'options': ('write_shot'), 'help': 'The record of the shot number of the trend this data came from'})
+    parts.append({'path': ':TREND_SHOT', 'type': 'numeric', 'value': 0, 'options': ('write_shot'), 'help': 'The record of the shot number of the trend this data came from'})
 
     def getTrendTree(self):
         tree_name    = self.trend_tree.data()
@@ -355,6 +354,7 @@ class CRYOCON24C_SHOT(CRYOCON24C):
         trend_tree = self.getTrendTree()
         trend_dev = trend_tree.getNode(self.trend_device.data())
         trend_dev.rate.record = self.shot_rate.data()
+    INIT=init
 
     def stop(self):
         self.t2.record = MDSplus.Int64(time.time()*1000.)
@@ -365,7 +365,7 @@ class CRYOCON24C_SHOT(CRYOCON24C):
         trend_dev.rate.record = trend_dev.trend_rate.data()
 
         # Getting T1 from TREND:
-	t1 = MDSplus.Int64(self.t1.data())
+	t1 = MDSplus.Int64(self.t1.data()*1000.)
 
         #Saving TREND shot number information into the tree:
         self.trend_shot.record = trend_tree.getCurrent(self.trend_tree.data())
@@ -390,11 +390,11 @@ class CRYOCON24C_SHOT(CRYOCON24C):
                 times[j] -= start_time
                 times[j] = float(times[j]) / 1000.
             
-            shot_temp     = self.__getattr__('input_%c' % (char(i)))
-            shot_resis    = self.__getattr__('input_%c_resistence' % (char(i)))
-            shot_outpower = self.__getattr__('input_%c_output_power' % (char(i)))
+            shot_temp     = self.__getattr__('input_%c' % (chr(i)))
+            shot_resis    = self.__getattr__('input_%c_resistence' % (chr(i)))
+            shot_outpower = self.__getattr__('input_%c_output_power' % (chr(i)))
 
             shot_temp.record     = MDSplus.Signal(temps, None, times)
             shot_resis.record    = MDSplus.Signal(temps, None, times)
             shot_outpower.record = MDSplus.Signal(temps, None, times)
-
+    STOP=stop

--- a/pydevices/HtsDevices/cryocon24c.py
+++ b/pydevices/HtsDevices/cryocon24c.py
@@ -375,14 +375,10 @@ class CRYOCON24C_SHOT(CRYOCON24C):
         
         print('Writing data into shot node')
         for i in range(ord('a'), ord('e')):
-            trend_temp_node     = trend_dev.__getattr__('input_%c'% (chr(i)))
-            trend_resis_node    = trend_dev.__getattr__('input_%c_resistence'%  (chr(i)))
-            trend_outpower_node = trend_dev.__getattr__('input_%c_output_power'% (chr(i)))
+            trend_temp     = trend_dev.__getattr__('input_%c'% (chr(i)))
+            trend_resis    = trend_dev.__getattr__('input_%c_resistence'%  (chr(i)))
+            trend_outpower = trend_dev.__getattr__('input_%c_output_power'% (chr(i)))
             
-            trend_temp     = trend_tree.getNode(trend_temp_node)
-            trend_resis    = trend_tree.getNode(trend_resis_node)
-            trend_outpower = trend_tree.getNode(trend_outpower_node)
-
             times    = trend_temp.dim_of().data()
             temps    = trend_temp.data()
             resists  = trend_resis.data()
@@ -393,65 +389,12 @@ class CRYOCON24C_SHOT(CRYOCON24C):
             for j in range(len(times)):
                 times[j] -= start_time
                 times[j] = float(times[j]) / 1000.
+            
+            shot_temp     = self.__getattr__('input_%c' % (char(i)))
+            shot_resis    = self.__getattr__('input_%c_resistence' % (char(i)))
+            shot_outpower = self.__getattr__('input_%c_output_power' % (char(i)))
 
-            self.__getattr__('input_%c' % (char(i))).record = MDSplus.Signal(temps, None, times)
-            self.__getattr__('input_%c_resistence' % (char(i))).record = MDSplus.Signal(temps, None, times)
-            self.__getattr__('input_%c_output_power' % (char(i))).record = MDSplus.Signal(temps, None, times)
+            shot_temp.record     = MDSplus.Signal(temps, None, times)
+            shot_resis.record    = MDSplus.Signal(temps, None, times)
+            shot_outpower.record = MDSplus.Signal(temps, None, times)
 
-def main():
-
-    # create tree model
-    tree_model = MDSplus.Tree('cryocon24c', -1, 'NEW')
-    print('Creating Device CRYO24_TREND')
-    CRYOCON24C_TREND.Add(tree_model, 'CRYO24_TREND')
-    node = tree_model.getNode('\CRYOCON24C::TOP:CRYO24_TREND:NODE')
-    ipaddress = '172.20.240.110'
-    # node.putData('198.125.182.159')
-    node.putData(ipaddress)
-    print('Writing Tree for device ' + ipaddress)
-    tree_model.write()
-
-    print('Creating Device CRYO24_SHOT')
-    CRYOCON24C_SHOT.Add(tree_model, 'CRYO24_SHOT')
-
-    print('Writing Tree Node TREND_TREE called ' + 'cryocon24c')
-    node = tree_model.getNode('\CRYOCON24C::TOP:CRYO24_SHOT:TREND_TREE')
-    node.putData('cryocon24c')
-
-    print('Writing Tree Node TREND_DEVICE with the device called ' + 'cryo24_trend')
-    node = tree_model.getNode('\CRYOCON24C::TOP:CRYO24_SHOT:TREND_DEVICE')
-    node.putData('cryo24_trend')
-
-    print('Writing the Tree')
-    tree_model.write()
-
-    print('Closing the Tree')
-    tree_model.close()
-
-    #Executing the experiment:
-    print('Running INIT from cryocon24c using Python calls')
-    tree = MDSplus.Tree('cryocon24c', -1)
-    tree.setCurrent('cryocon24c', 1)
-    
-    tree.setCurrent('cryocon24c', tree.getCurrent('cryocon24c') + 1)
-    
-    tree.createPulse(0)
-    tree = MDSplus.Tree('cryocon24c', 0)
-    
-    dev_trend = tree.getNode('cryo24_trend')
-    dev_trend.init()
-    time.sleep(10)
-
-
-    dev_shot = tree.getNode('cryo24_shot')
-    dev_shot.init()
-
-    time.sleep(10)
-    dev_shot.stop()
-
-    time.sleep(10)
-    dev_trend.stop()
-    return 1
-
-if __name__ == '__main__':
-    main()


### PR DESCRIPTION
Adds support for the Cryocon24c device
The cryocon24c uses a long trend device `CRYOCON24C_TREND` that samples data at a fixed `RATE`, defaulting to the usually slower `TREND_RATE`. When a shot is started by calling `INIT()` on the sister `CRYOCON24C_SHOT` device, located in the shot tree, the `RATE` is increased to the usually faster `SHOT_RATE`. When the shot is concluded by calling the shot device's `STOP()` method, the data is copied from the trend device to the shot device, on a timescale of `T1` to `T2`, and the `RATE` is returned to `TREND_RATE`.