### PR TITLE
Fix: added average resample mode to xtreeshr and made it default

### DIFF
--- a/mdsmisc/ScopeUtilities.c
+++ b/mdsmisc/ScopeUtilities.c
@@ -177,13 +177,13 @@ inline static int64_t estimateNumSamples(const mdsdsc_t *const dsc, mdsdsc_t *co
   int nextRow, segmentSamples, numActSegments, segmentIdx;
   EMPTYXD(xd);
   int nid = recIsSegmented(dsc);
-  if(!nid) return -1;
+  if(!nid) goto return_neg1;
   int status = TreeGetNumSegments(nid, &numSegments);
-  if STATUS_NOT_OK return -1;
+  if STATUS_NOT_OK goto return_neg1;
   if(xMin != NULL || xMax != NULL) {
     if(xMin) XTreeConvertToLongTime(xMin, &startTime);
     if(xMax) XTreeConvertToLongTime(xMax,   &endTime);
-    if(numSegments < NUM_SEGMENTS_THRESHOLD) return -1;
+    if(numSegments < NUM_SEGMENTS_THRESHOLD) goto return_neg1;
     startIdx = 0; //If no start time specified, take all initial segments
     if(xMin) {
       while(startIdx < numSegments) {
@@ -237,6 +237,12 @@ inline static int64_t estimateNumSamples(const mdsdsc_t *const dsc, mdsdsc_t *co
   *estimatedSegmentSamples = segmentSamples;
   return segmentSamples * (int64_t)numActSegments;
 return_neg1: ;
+  if (xMin && IS_OK(TdiData(xMin, &xd MDS_END_ARG)))
+    *dMin = to_doublex(xd.pointer->pointer,xd.pointer->dtype,-INFINITY,TRUE);
+  else *dMin = -INFINITY;
+  if (xMax && IS_OK(TdiData(xMax, &xd MDS_END_ARG)))
+    *dMax = to_doublex(xd.pointer->pointer,xd.pointer->dtype, INFINITY,TRUE);
+  else *dMax =  INFINITY;
   MdsFree1Dx(&xd, NULL);
   return -1;
 }

--- a/mdsobjects/python/tests/segmentsUnitTest.py
+++ b/mdsobjects/python/tests/segmentsUnitTest.py
@@ -31,6 +31,8 @@ def _mimport(name, level=1):
     except:
         return __import__(name, globals())
 _UnitTest=_mimport("_UnitTest")
+from MDSplus import setenv
+setenv("MDSPLUS_DEFAULT_RESAMPLE_MODE","interp")
 class Tests(_UnitTest.TreeTests):
     shotinc = 12
     tree    =  'segments'
@@ -242,6 +244,12 @@ class Tests(_UnitTest.TreeTests):
         Tree.setTimeContext(1,2,3)
         self.assertEqual(Tree.getTimeContext(),(1,2,3))
         self.assertEqual(node.tree.getTimeContext(),(30,70,15))
+
+        sig = node.record # interp as set by env
+        self.assertEqual(sig.data().tolist(),[3,4.5,6])
+        self.assertEqual(sig.dim_of().data().tolist(),[30,45,60])
+
+        node.setExtendedAttribute("ResampleMode","Average")
         sig = node.record
         self.assertEqual(sig.data().tolist(),[3.5,5.,6.5])
         self.assertEqual(sig.dim_of().data().tolist(),[37,52,67]) # 35,45,65

--- a/mdsobjects/python/tests/segmentsUnitTest.py
+++ b/mdsobjects/python/tests/segmentsUnitTest.py
@@ -242,7 +242,7 @@ class Tests(_UnitTest.TreeTests):
         Tree.setTimeContext(1,2,3)
         self.assertEqual(node.tree.getTimeContext(),(30,70,20))
         self.assertEqual(Tree.getTimeContext(),(1,2,3))
-        self.assertEqual(node.record.data().tolist(),[3,5]+[6])  # delta is applied per segment
+        self.assertEqual(node.record.data().tolist(),[3.,4.5,6.,7.5])  # delta is applied per segment
         node.tree.setTimeContext()
         self.assertEqual(node.tree.getTimeContext(),(None,None,None))
         self.assertEqual(node.record.data().tolist(),list(range(-9,9)))

--- a/mdsobjects/python/tests/segmentsUnitTest.py
+++ b/mdsobjects/python/tests/segmentsUnitTest.py
@@ -223,7 +223,7 @@ class Tests(_UnitTest.TreeTests):
         self.assertTrue(sig.dim_of().tolist(),(arange(0,length,dtype=int64)*int(1e9/clk)).tolist())
 
     def TimeContext(self):
-        from MDSplus import Tree,Int64,Int64Array,Int32Array,tdi
+        from MDSplus import Tree,Int64,Int64Array,Float32Array,tdi
         Tree.setTimeContext() # test initPinoDb
         self.assertEqual(Tree.getTimeContext(),(None,None,None))
         with Tree(self.tree,self.shot+5,'NEW') as ptree:
@@ -232,17 +232,40 @@ class Tests(_UnitTest.TreeTests):
         ptree.normal()
         for i in range(-9,9,3):
             d = Int64Array(range(3))*10+i*10
-            v = Int32Array(range(3))+i
+            v = Float32Array(range(3))+i
             node.makeSegment(d[0],d[2],d,v)
         self.assertEqual(node.getSegmentList(20,59).dim_of(0).tolist(),[0,30])
         self.assertEqual(node.getSegmentList(20,60).dim_of(0).tolist(),[0,30,60])
         self.assertEqual(node.getSegmentList(21,60).dim_of(0).tolist(),[30,60])
         self.assertEqual(node.record.data().tolist(),list(range(-9,9)))
-        node.tree.setTimeContext(Int64(30),Int64(70),Int64(20))
+        node.tree.setTimeContext(Int64(30),Int64(70),Int64(15))
         Tree.setTimeContext(1,2,3)
-        self.assertEqual(node.tree.getTimeContext(),(30,70,20))
         self.assertEqual(Tree.getTimeContext(),(1,2,3))
-        self.assertEqual(node.record.data().tolist(),[3.,4.5,6.,7.5])  # delta is applied per segment
+        self.assertEqual(node.tree.getTimeContext(),(30,70,15))
+        sig = node.record
+        self.assertEqual(sig.data().tolist(),[3.5,5.,6.5])
+        self.assertEqual(sig.dim_of().data().tolist(),[37,52,67]) # 35,45,65
+        
+        node.setExtendedAttribute("ResampleMode","MinMax")
+        sig = node.record
+        self.assertEqual(sig.data().tolist(),[3,4,5,5,6,7])
+        self.assertEqual(sig.dim_of().data().tolist(),[37,37,52,52,67,67])
+
+        node.setExtendedAttribute("ResampleMode","INTERP")
+        sig = node.record
+        self.assertEqual(sig.data().tolist(),[3,4.5,6])
+        self.assertEqual(sig.dim_of().data().tolist(),[30,45,60])
+
+        node.setExtendedAttribute("ResampleMode","Previous")
+        sig = node.record
+        self.assertEqual(sig.data().tolist(),[3,4,6])
+        self.assertEqual(sig.dim_of().data().tolist(),[30,45,60])
+
+        node.setExtendedAttribute("ResampleMode","Closest")
+        sig = node.record
+        self.assertEqual(sig.data().tolist(),[3,5,6])
+        self.assertEqual(sig.dim_of().data().tolist(),[30,45,60])
+
         node.tree.setTimeContext()
         self.assertEqual(node.tree.getTimeContext(),(None,None,None))
         self.assertEqual(node.record.data().tolist(),list(range(-9,9)))

--- a/xtreeshr/XTreeDefaultResample.c
+++ b/xtreeshr/XTreeDefaultResample.c
@@ -32,10 +32,13 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <treeshr.h>
 #include <xtreeshr.h>
 
-#define INTERPOLATION 1
-#define CLOSEST_SAMPLE 2
-#define PREVIOUS_SAMPLE 3
-#define MINMAX 4
+typedef enum{
+AVERAGE,
+INTERPOLATION,
+CLOSEST_SAMPLE,
+PREVIOUS_SAMPLE,
+MINMAX,
+} res_mode_t;
 
 //static int lessThan(struct descriptor *in1D, struct descriptor *in2D, char *less);
 //static int getMinMax(struct descriptor *dimD, char isMin, struct descriptor_xd *outXd);
@@ -47,371 +50,202 @@ extern int TdiEvaluate();
 extern int XTreeConvertToLongTime(struct descriptor *timeD, int64_t * converted);
 
 static int XTreeDefaultResampleMode(struct descriptor_signal *inSignalD, struct descriptor *startD,
-				    struct descriptor *endD, struct descriptor *deltaD, char mode,
-				    struct descriptor_xd *outSignalXd);
+	    struct descriptor *endD, struct descriptor *deltaD, const res_mode_t mode,
+	    struct descriptor_xd *outSignalXd);
 
 //64 bit time-based resampling function. It is assumed here that the 64 bit representation of time is the count
 //of a given, fixed amount of time, starting from a given time in the past
 //The closest point is selected as representative for a given time
 static void resample(int64_t start, int64_t end, int64_t delta, int64_t * inTimebase,
 		     int inTimebaseSamples, int numDims, int *dims, char *inData, int dataSize,
-		     char dataType, int mode, char *outData, int64_t * outDim, int *retSamples)
+		     char dataType, const res_mode_t mode, char **retData, int64_t ** retDim, int *retSamples)
 {
-	int i, j, timebaseIdx, outIdx, itemSize, outSamples, startIdx, timebaseSamples;
-	int64_t refTime, delta1, delta2;
-	int64_t *timebase;
-	char *data;
-	int numDataItems;
-	int prevTimebaseIdx;
+  int i, j;
+  double prevData, nextData, currData;
+  int itemSize = dataSize;
+  for (i = 0; i < numDims - 1; i++)
+    itemSize *= dims[i];
+  int numDataItems = itemSize/dataSize;
+  int outItemSize;
+  if (mode == AVERAGE) {// use FLOAT or DOUBLE
+    *retSamples += 3;
+    outItemSize = dataSize<8 ? itemSize*4/dataSize : itemSize;
+  } else {
+    if (mode == MINMAX)
+      *retSamples *=2;//Make enough room for MINMAX mode
+    outItemSize = itemSize;
+  }
+  // Make sure enough room is allocated
 
-	double prevData, nextData, currData;
+  char    *outData = *retData = malloc(*retSamples * outItemSize);
+  int64_t *outDim  = *retDim  = malloc(*retSamples * 8);
 
-	itemSize = dataSize;
-	for (i = 0; i < numDims - 1; i++)
-		itemSize *= dims[i];
+  if (start < inTimebase[0])
+    start = inTimebase[0];
+  if (end > inTimebase[inTimebaseSamples - 1])
+    end = inTimebase[inTimebaseSamples - 1];
+  int timebaseIdx = 0, outSamples = 0;
+  int startIdx = 0;
+  for (; startIdx < inTimebaseSamples && inTimebase[startIdx] < start ; startIdx++);
+  if (startIdx == inTimebaseSamples) {  //Not possible in any case
+    *retSamples = 0;
+    return;
+  }
 
-	numDataItems = itemSize / dataSize;
-
-	if (start < inTimebase[0])
-		start = inTimebase[0];
-	if (end > inTimebase[inTimebaseSamples - 1])
-		end = inTimebase[inTimebaseSamples - 1];
-
-	timebaseIdx = outIdx = outSamples = 0;
-
-	for (startIdx = 0; startIdx < inTimebaseSamples && inTimebase[startIdx] < start; startIdx++) ;
-
-	if (startIdx == inTimebaseSamples) {	//Not possible in any case
-	  *retSamples = 0;
-	  return;
-  	}
-
-  	timebase = &inTimebase[startIdx];
-  	timebaseSamples = inTimebaseSamples - startIdx;
-  	data = &inData[startIdx * itemSize];
-
-  	refTime = start;
-	if (delta) {
-		prevTimebaseIdx = timebaseIdx;
-		while (refTime <= end)
-		{
-			while (timebaseIdx < timebaseSamples && timebase[timebaseIdx] < refTime)
-				timebaseIdx++;
-			switch (mode) {
-				case CLOSEST_SAMPLE:
-			//Select closest sample
-					if (timebaseIdx > 0 && timebaseIdx < timebaseSamples) {
-						delta1 = timebase[timebaseIdx] - refTime;
-						delta2 = refTime - timebase[timebaseIdx - 1];
-						if (delta2 < delta1)
-							timebaseIdx--;
-					}
-					memcpy(&outData[outSamples * itemSize], &data[timebaseIdx * itemSize], itemSize);
-					break;
-				case PREVIOUS_SAMPLE:
-			//Select closest sample
-					if (timebaseIdx > 0 && timebaseIdx < timebaseSamples) {
-						timebaseIdx--;
-					}
-					memcpy(&outData[outSamples * itemSize], &data[timebaseIdx * itemSize], itemSize);
-					break;
-				case INTERPOLATION:
-                                        if(timebaseIdx <= 0)
-						timebaseIdx = 1;  //Avoid referring to negative indexes
-					switch (dataType) {
-						case DTYPE_BU:
-							for (i = 0; i < numDataItems; i++) {
-								prevData = ((unsigned char *)(&data[(timebaseIdx - 1) * itemSize]))[i];
-								nextData = ((unsigned char *)(&data[timebaseIdx * itemSize]))[i];
-								currData = prevData + (nextData - prevData) * (refTime - timebase[timebaseIdx - 1])
-								/ (timebase[timebaseIdx] - timebase[timebaseIdx - 1]);
-								((unsigned char *)(&outData[outSamples * itemSize]))[i] = currData;
-							}
-							break;
-						case DTYPE_B:
-							for (i = 0; i < numDataItems; i++) {
-								prevData = ((char *)(&data[(timebaseIdx - 1) * itemSize]))[i];
-								nextData = ((char *)(&data[timebaseIdx * itemSize]))[i];
-								currData = prevData + (nextData - prevData) * (refTime - timebase[timebaseIdx - 1])
-								/ (timebase[timebaseIdx] - timebase[timebaseIdx - 1]);
-								((char *)&outData[outSamples * itemSize])[i] = currData;
-							}
-							break;
-						case DTYPE_WU:
-							for (i = 0; i < numDataItems; i++) {
-								prevData = ((unsigned short *)(&data[(timebaseIdx - 1) * itemSize]))[i];
-								nextData = ((unsigned short *)(&data[timebaseIdx * itemSize]))[i];
-								currData = prevData + (nextData - prevData) * (refTime - timebase[timebaseIdx - 1])
-								/ (timebase[timebaseIdx] - timebase[timebaseIdx - 1]);
-								((unsigned short *)(&outData[outSamples * itemSize]))[i] = currData;
-							}
-							break;
-						case DTYPE_W:
-							for (i = 0; i < numDataItems; i++) {
-								prevData = ((short *)(&data[(timebaseIdx - 1) * itemSize]))[i];
-								nextData = ((short *)(&data[timebaseIdx * itemSize]))[i];
-								currData = prevData + (nextData - prevData) * (refTime - timebase[timebaseIdx - 1])
-								/ (timebase[timebaseIdx] - timebase[timebaseIdx - 1]);
-								((short *)&outData[outSamples * itemSize])[i] = currData;
-							}
-							break;
-						case DTYPE_LU:
-							for (i = 0; i < numDataItems; i++) {
-								prevData = ((unsigned int *)(&data[(timebaseIdx - 1) * itemSize]))[i];
-								nextData = ((unsigned int *)(&data[timebaseIdx * itemSize]))[i];
-								currData = prevData + (nextData - prevData) * (refTime - timebase[timebaseIdx - 1])
-								/ (timebase[timebaseIdx] - timebase[timebaseIdx - 1]);
-								((unsigned int *)(&outData[outSamples * itemSize]))[i] = currData;
-							}
-							break;
-						case DTYPE_L:
-							for (i = 0; i < numDataItems; i++) {
-								prevData = ((int *)(&data[(timebaseIdx - 1) * itemSize]))[i];
-								nextData = ((int *)(&data[timebaseIdx * itemSize]))[i];
-								currData = prevData + (nextData - prevData) * (refTime - timebase[timebaseIdx - 1])
-								/ (timebase[timebaseIdx] - timebase[timebaseIdx - 1]);
-								((int *)(&outData[outSamples * itemSize]))[i] = currData;
-							}
-							break;
-						case DTYPE_QU:
-							for (i = 0; i < numDataItems; i++) {
-								prevData = ((uint64_t *) (&data[(timebaseIdx - 1) * itemSize]))[i];
-								nextData = ((uint64_t *) (&data[timebaseIdx * itemSize]))[i];
-								currData = prevData + (nextData - prevData) * (refTime - timebase[timebaseIdx - 1])
-								/ (timebase[timebaseIdx] - timebase[timebaseIdx - 1]);
-								((uint64_t *) (&outData[outSamples * itemSize]))[i] = currData;
-							}
-							break;
-						case DTYPE_Q:
-							for (i = 0; i < numDataItems; i++) {
-								prevData = ((int64_t *) (&data[(timebaseIdx - 1) * itemSize]))[i];
-								nextData = ((int64_t *) (&data[timebaseIdx * itemSize]))[i];
-								currData = prevData + (nextData - prevData) * (refTime - timebase[timebaseIdx - 1])
-								/ (timebase[timebaseIdx] - timebase[timebaseIdx - 1]);
-								((int64_t *) (&outData[outSamples * itemSize]))[i] = currData;
-							}
-							break;
-						case DTYPE_FLOAT:
-							for (i = 0; i < numDataItems; i++) {
-								prevData = ((float *)(&data[(timebaseIdx - 1) * itemSize]))[i];
-								nextData = ((float *)(&data[timebaseIdx * itemSize]))[i];
-								currData = prevData + (nextData - prevData) * (refTime - timebase[timebaseIdx - 1])
-								/ (timebase[timebaseIdx] - timebase[timebaseIdx - 1]);
-								((float *)(&outData[outSamples * itemSize]))[i] = currData;
-							}
-							break;
-						case DTYPE_DOUBLE:
-							for (i = 0; i < numDataItems; i++) {
-								prevData = ((double *)(&data[(timebaseIdx - 1) * itemSize]))[i];
-								nextData = ((double *)(&data[timebaseIdx * itemSize]))[i];
-								currData = prevData + (nextData - prevData) * (refTime - timebase[timebaseIdx - 1])
-								/ (timebase[timebaseIdx] - timebase[timebaseIdx - 1]);
-								((double *)(&outData[outSamples * itemSize]))[i] = currData;
-							}
-							break;
-					}
-					break;
-				case MINMAX:     //Two points for every (resampled) sample!!!!!!!!!!!
-					switch (dataType) {
-						case DTYPE_BU:
-							for (i = 0; i < numDataItems; i++) {
-								unsigned char currData, minData, maxData;
-								minData = maxData = ((unsigned char *)(&data[(prevTimebaseIdx) * itemSize]))[i];
-								for(j = prevTimebaseIdx + 1; j < timebaseIdx; j++)
-								{
-									currData = ((unsigned char *)(&data[j * itemSize]))[i];
-									if(currData > maxData)
-										maxData = currData;
-									if(currData < minData)
-										minData = currData;
-								}
-								((unsigned char *)(&outData[2*outSamples * itemSize]))[i] = minData;
-								((unsigned char *)(&outData[(2*outSamples+1) * itemSize]))[i] = maxData;
-							}
-							break;
-						case DTYPE_B:
-							for (i = 0; i < numDataItems; i++) {
-								char currData, minData, maxData;
-								minData = maxData = ((char *)(&data[(prevTimebaseIdx) * itemSize]))[i];
-								for(j = prevTimebaseIdx + 1; j < timebaseIdx; j++)
-								{
-									currData = ((char *)(&data[j * itemSize]))[i];
-									if(currData > maxData)
-										maxData = currData;
-									if(currData < minData)
-										minData = currData;
-								}
-								((char *)(&outData[2*outSamples * itemSize]))[i] = minData;
-								((char *)(&outData[(2*outSamples+1) * itemSize]))[i] = maxData;
-							}
-							break;
-						case DTYPE_WU:
-							for (i = 0; i < numDataItems; i++) {
-								unsigned short currData, minData, maxData;
-								minData = maxData = ((unsigned short *)(&data[(prevTimebaseIdx) * itemSize]))[i];
-								for(j = prevTimebaseIdx + 1; j < timebaseIdx; j++)
-								{
-									currData = ((unsigned short *)(&data[j * itemSize]))[i];
-									if(currData > maxData)
-										maxData = currData;
-									if(currData < minData)
-										minData = currData;
-								}
-								((unsigned short *)(&outData[2*outSamples * itemSize]))[i] = minData;
-								((unsigned short *)(&outData[(2*outSamples+1) * itemSize]))[i] = maxData;
-							}
-							break;
-						case DTYPE_W:
-							for (i = 0; i < numDataItems; i++) {
-								short currData, minData, maxData;
-								minData = maxData = ((short *)(&data[(prevTimebaseIdx) * itemSize]))[i];
-								for(j = prevTimebaseIdx + 1; j < timebaseIdx; j++)
-								{
-									currData = ((short *)(&data[j * itemSize]))[i];
-									if(currData > maxData)
-										maxData = currData;
-									if(currData < minData)
-										minData = currData;
-								}
-								((short *)(&outData[2*outSamples * itemSize]))[i] = minData;
-								((short *)(&outData[(2*outSamples+1) * itemSize]))[i] = maxData;
-							}
-							break;
-						case DTYPE_LU:
-							for (i = 0; i < numDataItems; i++) {
-								unsigned int currData, minData, maxData;
-								minData = maxData = ((unsigned int *)(&data[(prevTimebaseIdx) * itemSize]))[i];
-								for(j = prevTimebaseIdx + 1; j < timebaseIdx; j++)
-								{
-									currData = ((unsigned int *)(&data[j * itemSize]))[i];
-									if(currData > maxData)
-										maxData = currData;
-									if(currData < minData)
-										minData = currData;
-								}
-								((unsigned int *)(&outData[2*outSamples * itemSize]))[i] = minData;
-								((unsigned int *)(&outData[(2*outSamples+1) * itemSize]))[i] = maxData;
-							}
-							break;
-						case DTYPE_L:
-							for (i = 0; i < numDataItems; i++) {
-								int currData, minData, maxData;
-								minData = maxData = ((int *)(&data[(prevTimebaseIdx) * itemSize]))[i];
-								for(j = prevTimebaseIdx + 1; j < timebaseIdx; j++)
-								{
-									currData = ((int *)(&data[j * itemSize]))[i];
-									if(currData > maxData)
-										maxData = currData;
-									if(currData < minData)
-										minData = currData;
-								}
-								((int *)(&outData[2*outSamples * itemSize]))[i] = minData;
-								((int *)(&outData[(2*outSamples+1) * itemSize]))[i] = maxData;
-							}
-							break;
-						case DTYPE_QU:
-							for (i = 0; i < numDataItems; i++) {
-								uint64_t currData, minData, maxData;
-								minData = maxData = ((uint64_t *)(&data[(prevTimebaseIdx) * itemSize]))[i];
-								for(j = prevTimebaseIdx + 1; j < timebaseIdx; j++)
-								{
-									currData = ((uint64_t *)(&data[j * itemSize]))[i];
-									if(currData > maxData)
-										maxData = currData;
-									if(currData < minData)
-										minData = currData;
-								}
-								((uint64_t *)(&outData[2*outSamples * itemSize]))[i] = minData;
-								((uint64_t *)(&outData[(2*outSamples+1) * itemSize]))[i] = maxData;
-							}
-							break;
-						case DTYPE_Q:
-							for (i = 0; i < numDataItems; i++) {
-								int64_t currData, minData, maxData;
-								minData = maxData = ((int64_t *)(&data[(prevTimebaseIdx) * itemSize]))[i];
-								for(j = prevTimebaseIdx + 1; j < timebaseIdx; j++)
-								{
-									currData = ((int64_t *)(&data[j * itemSize]))[i];
-									if(currData > maxData)
-										maxData = currData;
-									if(currData < minData)
-										minData = currData;
-								}
-								((int64_t *)(&outData[2*outSamples * itemSize]))[i] = minData;
-								((int64_t *)(&outData[(2*outSamples+1) * itemSize]))[i] = maxData;
-							}
-							break;
-						case DTYPE_FLOAT:
-							for (i = 0; i < numDataItems; i++) {
-								float currData, minData, maxData;
-								minData = maxData = ((float *)(&data[(prevTimebaseIdx) * itemSize]))[i];
-								for(j = prevTimebaseIdx + 1; j < timebaseIdx; j++)
-								{
-									currData = ((float *)(&data[j * itemSize]))[i];
-									if(currData > maxData)
-										maxData = currData;
-									if(currData < minData)
-										minData = currData;
-								}
-								((float *)(&outData[2*outSamples * itemSize]))[i] = minData;
-								((float *)(&outData[(2*outSamples+1) * itemSize]))[i] = maxData;
-							}
-							break;
-						case DTYPE_DOUBLE:
-							for (i = 0; i < numDataItems; i++) {
-								double currData, minData, maxData;
-								minData = maxData = ((double *)(&data[(prevTimebaseIdx) * itemSize]))[i];
-								for(j = prevTimebaseIdx + 1; j < timebaseIdx; j++)
-								{
-									currData = ((double *)(&data[j * itemSize]))[i];
-									if(currData > maxData)
-										maxData = currData;
-									if(currData < minData)
-										minData = currData;
-								}
-								((double *)(&outData[2*outSamples * itemSize]))[i] = minData;
-								((double *)(&outData[(2*outSamples+1) * itemSize]))[i] = maxData;
-							}
-							break;
-					}
-					break;
-				default:		//Not able to do interpolation
-					if (timebaseIdx > 0 && timebaseIdx < timebaseSamples) {
-						timebaseIdx--;
-					}
-					memcpy(&outData[outSamples * itemSize], &data[timebaseIdx * itemSize], itemSize);
-			}
-			if(mode == MINMAX) //twice the number of points
-			{
-    			outDim[2*outSamples] = refTime - delta/2;
-    			outDim[2*outSamples+1] = refTime;
-			}
-			else
-   				outDim[outSamples] = refTime;
-			outSamples++;
-    		refTime += delta;
-			prevTimebaseIdx = timebaseIdx;
-  		}
-		if(mode == MINMAX)
- 			*retSamples = 2*outSamples;
-		else
- 			*retSamples = outSamples;
-	}
-	else  //delta == NULL
-	{
-    	while (timebaseIdx < *retSamples && timebase[timebaseIdx] <= end)
-		{
-      		memcpy(&outData[timebaseIdx * itemSize], &data[timebaseIdx * itemSize], itemSize);
-      		outDim[timebaseIdx] = timebase[timebaseIdx];
-      		timebaseIdx++;
-    	}
-    	*retSamples = timebaseIdx;
-  	}
+  int64_t *timebase = &inTimebase[startIdx];
+  int timebaseSamples = inTimebaseSamples - startIdx;
+  char *data = &inData[startIdx * itemSize];
+  int64_t refTime = start;
+  if (delta) {
+    int64_t delta1 = (delta  )/2;
+    int64_t delta2 = delta+delta1;
+    switch (mode) {
+      case INTERPOLATION:
+      case MINMAX:
+      case AVERAGE:
+	refTime += delta1;
+	end     += delta;
+      break;default:break;
+    }
+    int prevTimebaseIdx = timebaseIdx;
+    while (refTime <= end) {
+      while (timebaseIdx < timebaseSamples && timebase[timebaseIdx] < refTime)
+	timebaseIdx++;
+      switch (mode) {
+	case CLOSEST_SAMPLE: // Select closest sample
+	  if (timebaseIdx > 0 && timebaseIdx < timebaseSamples) {
+	    delta1 = timebase[timebaseIdx] - refTime;
+	    delta2 = refTime - timebase[timebaseIdx - 1];
+	    if (delta2 < delta1)
+	      timebaseIdx--;
+	  }
+	  memcpy(&outData[outSamples * outItemSize], &data[timebaseIdx * itemSize], itemSize);
+	  break;
+	case PREVIOUS_SAMPLE: //Select closest sample
+	  if (timebaseIdx > 0 && timebaseIdx < timebaseSamples)
+	    timebaseIdx--;
+	  memcpy(&outData[outSamples * outItemSize], &data[timebaseIdx * itemSize], itemSize);
+	  break;
+	case INTERPOLATION:
+#define INTERPOLATION_FORLOOP(type) for (i = 0; i < numDataItems; i++) { \
+  prevData = ((type *)(&data[(timebaseIdx - 1) * itemSize]))[i]; \
+  nextData = ((type *)(&data[timebaseIdx * itemSize]))[i]; \
+  currData = prevData + (nextData - prevData) * (refTime - timebase[timebaseIdx - 1]) / (timebase[timebaseIdx] - timebase[timebaseIdx - 1]); \
+  ((type *)(&outData[outSamples * outItemSize]))[i] = currData; \
+}
+	  if(timebaseIdx <= 0) timebaseIdx = 1;  //Avoid referring to negative indexes
+	  switch (dataType) {
+	    case DTYPE_BU:	INTERPOLATION_FORLOOP( uint8_t);break;
+	    case DTYPE_B:	INTERPOLATION_FORLOOP(  int8_t);break;
+	    case DTYPE_WU:	INTERPOLATION_FORLOOP(uint16_t);break;
+	    case DTYPE_W:	INTERPOLATION_FORLOOP( int16_t);break;
+	    case DTYPE_LU:	INTERPOLATION_FORLOOP(uint32_t);break;
+	    case DTYPE_L:	INTERPOLATION_FORLOOP( int32_t);break;
+	    case DTYPE_QU:	INTERPOLATION_FORLOOP(uint64_t);break;
+	    case DTYPE_Q:	INTERPOLATION_FORLOOP( int64_t);break;
+	    case DTYPE_FLOAT:	INTERPOLATION_FORLOOP(   float);break;
+	    case DTYPE_DOUBLE:	INTERPOLATION_FORLOOP(  double);break;
+	  }
+	  break;
+	case MINMAX:     //Two points for every (resampled) sample!!!!!!!!!!!
+#define MINMAX_FORLOOP(type) for (i = 0; i < numDataItems; i++) { \
+type currData, minData, maxData; \
+minData = maxData = ((type *)(&data[(prevTimebaseIdx) * itemSize]))[i]; \
+for(j = prevTimebaseIdx + 1; j < timebaseIdx && j<inTimebaseSamples ; j++){ \
+  currData = ((type *)(&data[j * itemSize]))[i]; \
+  if(currData > maxData) maxData = currData; \
+  if(currData < minData) minData = currData; \
+} \
+((type *)(&outData[outSamples * outItemSize]))[i] = minData; \
+((type *)(&outData[(outSamples+1) * itemSize]))[i] = maxData; \
+}
+	  switch (dataType) {
+	    case DTYPE_BU:	MINMAX_FORLOOP( uint8_t);break;
+	    case DTYPE_B:	MINMAX_FORLOOP(  int8_t);break;
+	    case DTYPE_WU:	MINMAX_FORLOOP(uint16_t);break;
+	    case DTYPE_W:	MINMAX_FORLOOP( int16_t);break;
+	    case DTYPE_LU:	MINMAX_FORLOOP(uint32_t);break;
+  	    case DTYPE_L:	MINMAX_FORLOOP( int32_t);break;
+	    case DTYPE_QU:	MINMAX_FORLOOP(uint64_t);break;
+	    case DTYPE_Q:	MINMAX_FORLOOP( int64_t);break;
+	    case DTYPE_FLOAT:	MINMAX_FORLOOP(   float);break;
+	    case DTYPE_DOUBLE:	MINMAX_FORLOOP(  double);break;
+	  }
+	  break;
+	case AVERAGE:
+#define AVERAGE_FORLOOP(type_out,type) for (i = 0; i < numDataItems; i++) { \
+type_out accData = ((type *)(&data[(prevTimebaseIdx) * itemSize]))[i]; \
+for(j = prevTimebaseIdx + 1; j < timebaseIdx; j++) \
+  accData += ((type *)(&data[j * itemSize]))[i]; \
+const int range = (timebaseIdx-prevTimebaseIdx); \
+((type_out *)(&outData[outSamples * outItemSize]))[i] = range>0 ? accData / range : accData; \
+}
+	  switch (dataType) {
+	    case DTYPE_BU:	AVERAGE_FORLOOP( float, uint8_t);break;
+	    case DTYPE_B:	AVERAGE_FORLOOP( float,  int8_t);break;
+	    case DTYPE_WU:	AVERAGE_FORLOOP( float,uint16_t);break;
+	    case DTYPE_W:	AVERAGE_FORLOOP( float, int16_t);break;
+  	    case DTYPE_L:	AVERAGE_FORLOOP( float, int32_t);break;
+	    case DTYPE_QU:	AVERAGE_FORLOOP(double,uint64_t);break;
+	    case DTYPE_Q:	AVERAGE_FORLOOP(double, int64_t);break;
+	    case DTYPE_FLOAT:	AVERAGE_FORLOOP( float,   float);break;
+	    case DTYPE_DOUBLE:	AVERAGE_FORLOOP(double,  double);break;
+	  }
+	  break;
+	default://Not able to do interpolation
+	  if (timebaseIdx > 0 && timebaseIdx < timebaseSamples)
+	    timebaseIdx--;
+	  memcpy(&outData[outSamples * outItemSize], &data[timebaseIdx * itemSize], itemSize);
+	  break;
+      }
+      switch (mode) {
+	case INTERPOLATION:
+	case MINMAX:
+	case AVERAGE:
+	refTime -= delta1;
+	if(mode == MINMAX) //twice the number of points
+	  outDim[outSamples++] = refTime;
+        outDim[outSamples++] = refTime;
+	refTime += delta2;
+	break;
+      default:
+        outDim[outSamples++] = refTime;
+        refTime += delta;
+	break;
+      }
+      prevTimebaseIdx = timebaseIdx;
+    }
+    *retSamples = outSamples;
+  } else { //delta == NULL
+    if (mode == AVERAGE && dataType != DTYPE_FLOAT && dataType != DTYPE_DOUBLE) {
+      while (timebaseIdx < timebaseSamples && timebase[timebaseIdx] <= end) {
+	switch (dataType) {
+	  case DTYPE_BU:(*( float*)&outData[timebaseIdx*outItemSize]) = *( uint8_t*)&data[timebaseIdx*itemSize];break;
+	  case DTYPE_B: (*( float*)&outData[timebaseIdx*outItemSize]) = *(  int8_t*)&data[timebaseIdx*itemSize];break;
+	  case DTYPE_WU:(*( float*)&outData[timebaseIdx*outItemSize]) = *(uint16_t*)&data[timebaseIdx*itemSize];break;
+	  case DTYPE_W: (*( float*)&outData[timebaseIdx*outItemSize]) = *( int16_t*)&data[timebaseIdx*itemSize];break;
+	  case DTYPE_LU:(*( float*)&outData[timebaseIdx*outItemSize]) = *(uint32_t*)&data[timebaseIdx*itemSize];break;
+  	  case DTYPE_L: (*( float*)&outData[timebaseIdx*outItemSize]) = *( int32_t*)&data[timebaseIdx*itemSize];break;
+	  case DTYPE_QU:(*(double*)&outData[timebaseIdx*outItemSize]) = *(uint64_t*)&data[timebaseIdx*itemSize];break;
+	  case DTYPE_Q: (*(double*)&outData[timebaseIdx*outItemSize]) = *( int64_t*)&data[timebaseIdx*itemSize];break;
+        }
+        outDim[timebaseIdx] = timebase[timebaseIdx];
+        timebaseIdx++;
+      }
+    } else {
+      while (timebaseIdx < timebaseSamples && timebase[timebaseIdx] <= end) {
+	memcpy(&outData[timebaseIdx * outItemSize], &data[timebaseIdx * itemSize], itemSize);
+	outDim[timebaseIdx] = timebase[timebaseIdx];
+	timebaseIdx++;
+      }
+    }
+    *retSamples = timebaseIdx;
+  }
 }
 
 //The default resample handles int64 timebases
 //return 0 if the conversion is  not possible
-static int64_t *convertTimebaseToInt64(struct descriptor_signal *inSignalD, int *outSamples, int *isFloat){
+inline static int64_t *convertTimebaseToInt64(struct descriptor_signal *inSignalD, int *outSamples, int *isFloat){
   if (inSignalD->ndesc<3) {
     ARRAY_COEFF(char *, MAX_DIMS) *dataD = (void*)inSignalD->data;
     if (dataD->dimct == 1)
@@ -453,12 +287,11 @@ static int64_t *convertTimebaseToInt64(struct descriptor_signal *inSignalD, int 
     status = TdiFloat(&currXd, &currXd MDS_END_ARG);
   }
   currDim = (struct descriptor_a *)currXd.pointer;
-  if (!(status & 1) || currDim->class != CLASS_A
-      || (currDim->dtype != DTYPE_FLOAT && currDim->dtype != DTYPE_DOUBLE))
+  if (STATUS_NOT_OK || currDim->class != CLASS_A
+      || (currDim->dtype != DTYPE_FLOAT && currDim->dtype != DTYPE_DOUBLE)) {
     //Cannot perform conversion
-  {
     MdsFree1Dx(&currXd, 0);
-    return 0;
+    return NULL;
   }
   numSamples = currDim->arsize / currDim->length;
   outPtr = malloc(8 * numSamples);
@@ -466,8 +299,7 @@ static int64_t *convertTimebaseToInt64(struct descriptor_signal *inSignalD, int 
     floatPtr = (float *)currDim->pointer;
     for (i = 0; i < numSamples; i++)
       outPtr[i] = (int64_t)(floatPtr[i]*1e9);
-  } else			//currDim->dtype == DTYPE_DOUBLE)
-  {
+  } else {//currDim->dtype == DTYPE_DOUBLE)
     doublePtr = (double *)currDim->pointer;
     for (i = 0; i < numSamples; i++)
       outPtr[i] = (int64_t)(doublePtr[i]*1e9);
@@ -481,9 +313,9 @@ static int64_t *convertTimebaseToInt64(struct descriptor_signal *inSignalD, int 
 typedef ARRAY_COEFF(char, 256) Array_coeff_type;
 
 EXPORT struct descriptor_xd *XTreeResampleClosest(struct descriptor_signal *inSignalD,
-						  struct descriptor *startD,
-						  struct descriptor *endD,
-						  struct descriptor *deltaD)
+			  struct descriptor *startD,
+			  struct descriptor *endD,
+			  struct descriptor *deltaD)
 {
   static EMPTYXD(retXd);
   XTreeDefaultResampleMode(inSignalD, startD, endD, deltaD, CLOSEST_SAMPLE, &retXd);
@@ -491,9 +323,9 @@ EXPORT struct descriptor_xd *XTreeResampleClosest(struct descriptor_signal *inSi
 }
 
 EXPORT struct descriptor_xd *XTreeResamplePrevious(struct descriptor_signal *inSignalD,
-						   struct descriptor *startD,
-						   struct descriptor *endD,
-						   struct descriptor *deltaD)
+			   struct descriptor *startD,
+			   struct descriptor *endD,
+			   struct descriptor *deltaD)
 {
   static EMPTYXD(retXd);
   XTreeDefaultResampleMode(inSignalD, startD, endD, deltaD, PREVIOUS_SAMPLE, &retXd);
@@ -501,15 +333,22 @@ EXPORT struct descriptor_xd *XTreeResamplePrevious(struct descriptor_signal *inS
 }
 
 EXPORT int XTreeDefaultResample(struct descriptor_signal *inSignalD, struct descriptor *startD,
-				struct descriptor *endD, struct descriptor *deltaD,
-				struct descriptor_xd *outSignalXd)
+	struct descriptor *endD, struct descriptor *deltaD,
+	struct descriptor_xd *outSignalXd)
+{
+  return XTreeDefaultResampleMode(inSignalD, startD, endD, deltaD, AVERAGE, outSignalXd);
+}
+
+EXPORT int XTreeInterpResample(struct descriptor_signal *inSignalD, struct descriptor *startD,
+	struct descriptor *endD, struct descriptor *deltaD,
+	struct descriptor_xd *outSignalXd)
 {
   return XTreeDefaultResampleMode(inSignalD, startD, endD, deltaD, INTERPOLATION, outSignalXd);
 }
 
 EXPORT int XTreeMinMaxResample(struct descriptor_signal *inSignalD, struct descriptor *startD,
-				struct descriptor *endD, struct descriptor *deltaD,
-				struct descriptor_xd *outSignalXd)
+	struct descriptor *endD, struct descriptor *deltaD,
+	struct descriptor_xd *outSignalXd)
 {
   return XTreeDefaultResampleMode(inSignalD, startD, endD, deltaD, MINMAX, outSignalXd);
 }
@@ -517,15 +356,14 @@ EXPORT int XTreeMinMaxResample(struct descriptor_signal *inSignalD, struct descr
 extern int getShape(struct descriptor *dataD, int *dims, int *numDims);
 
 static int XTreeDefaultResampleMode(struct descriptor_signal *inSignalD, struct descriptor *startD,
-				    struct descriptor *endD, struct descriptor *inDeltaD, char mode,
-				    struct descriptor_xd *outSignalXd)
+	    struct descriptor *endD, struct descriptor *inDeltaD, const res_mode_t mode,
+	    struct descriptor_xd *outSignalXd)
 {
   int64_t start64, end64, delta64, *timebase64, *outDim;
   double *timebaseDouble;
   int dims[64];
   int numDims;
   int numTimebaseSamples;
-  int outSamples, itemSize;
   int isFloat = 0;
   int status, i, currIdx;
   int numYSamples;
@@ -553,12 +391,12 @@ static int XTreeDefaultResampleMode(struct descriptor_signal *inSignalD, struct 
     if (delta64 == 0)   deltaD = 0;
   }
 
-//This version handles only 64 bit time format
+  // This version handles only 64 bit time format
 
   timebase64 = convertTimebaseToInt64(inSignalD, &numTimebaseSamples, &isFloat);
   if (!timebase64) {
     MdsCopyDxXd((struct descriptor *)&inSignalD, outSignalXd);
-    return 3;			//Cannot convert timebase to 64 bit int
+    return 3;	//Cannot convert timebase to 64 bit int
   }
   if (!startD)  start64 = timebase64[0];
   if (!endD)    end64   = timebase64[numTimebaseSamples - 1];
@@ -567,7 +405,7 @@ static int XTreeDefaultResampleMode(struct descriptor_signal *inSignalD, struct 
   if (end64 > timebase64[numTimebaseSamples - 1])
     end64 = timebase64[numTimebaseSamples - 1];
 
-//Get shapes(dimensions) for data
+  // Get shapes(dimensions) for data
   if (inSignalD->data->class == CLASS_A) {
     dataD = (struct descriptor_a *)inSignalD->data;
   } else {
@@ -583,40 +421,43 @@ static int XTreeDefaultResampleMode(struct descriptor_signal *inSignalD, struct 
     MdsFree1Dx(&dataXd, 0);
     return status;
   }
+  //Check data array too short
+  if (numYSamples < numTimebaseSamples)
+    numTimebaseSamples = numYSamples;
 
-  itemSize = dataD->length;
-  for (i = 0; i < numDims - 1; i++)
-    itemSize *= dims[i];
-  //Make sure enough room is allocated
+  int outSamples;
   if (!deltaD) {
-    //Count number of copied samples
-    for (currIdx = 0; currIdx < numTimebaseSamples && currIdx < numYSamples && timebase64[currIdx] < start64; currIdx++) ;
-    for (outSamples = 0; currIdx < numTimebaseSamples && currIdx < numYSamples && timebase64[currIdx] <= end64;
-	 currIdx++, outSamples++) ;
+    // Count number of copied samples
+    for (currIdx = 0; currIdx < numTimebaseSamples && timebase64[currIdx] < start64; currIdx++) ;
+    for (outSamples = currIdx ; outSamples < numTimebaseSamples && timebase64[outSamples] <= end64; outSamples++) ;
+    outSamples = outSamples - currIdx;
   } else
     outSamples = (end64 - start64) / delta64 + 1;
 
-//  outData = malloc(outSamples * itemSize);
-  outData = malloc(2* outSamples * itemSize);  //Make enough room for MINMAX mode
-//  outDim = malloc(outSamples * 8);
-  outDim = malloc(2 * outSamples * 8);
-
-  //Check data array too short
-  if ((int)(dataD->arsize / dataD->length) < numTimebaseSamples)
-    numTimebaseSamples = dataD->arsize / dataD->length;
-
   resample(start64, end64, (deltaD) ? delta64 : 0, timebase64, numTimebaseSamples, numDims, dims,
-	   dataD->pointer, dataD->length, dataD->dtype, mode, outData, outDim, &outSamples);
+	   dataD->pointer, dataD->length, dataD->dtype, mode, &outData, &outDim, &outSamples);
 
   //Build array descriptor for out data
-  outDataArray.length = dataD->length;
-  outDataArray.dtype = dataD->dtype;
+  if (mode == AVERAGE) { // use FLOAT or DOUBLE
+    if (dataD->length<8) {
+      outDataArray.length = 4;
+      outDataArray.dtype  = DTYPE_FLOAT;
+    } else {
+      outDataArray.length = 8;
+      outDataArray.dtype  = DTYPE_DOUBLE;
+    }
+  } else {
+    outDataArray.length = dataD->length;
+    outDataArray.dtype = dataD->dtype;
+  }
+  int itemSize = outDataArray.length;
+  for (i = 0; i < numDims - 1; i++)
+    itemSize *= dims[i];
   outDataArray.pointer = outDataArray.a0 = outData;
   outDataArray.arsize = itemSize * outSamples;
   outDataArray.dimct = numDims;
-  for (i = 0; i < numDims - 1; i++) {
+  for (i = 0; i < numDims - 1; i++)
     outDataArray.m[i] = dims[i];
-  }
   outDataArray.m[numDims - 1] = outSamples;
   //If originally float, convert  dimension to float
   if (isFloat) {
@@ -627,9 +468,8 @@ static int XTreeDefaultResampleMode(struct descriptor_signal *inSignalD, struct 
     outDimArray.arsize = sizeof(double) * outSamples;
     outDimArray.dtype = DTYPE_DOUBLE;
     outDimArray.pointer = outDataArray.a0 = (char *)timebaseDouble;
-  }
-
-  else {
+  } else {
+    timebaseDouble = NULL;
     outDimArray.length = 8;
     outDimArray.arsize = 8 * outSamples;
     outDimArray.dtype = DTYPE_Q;
@@ -639,8 +479,7 @@ static int XTreeDefaultResampleMode(struct descriptor_signal *inSignalD, struct 
   MdsCopyDxXd((struct descriptor *)&outSignalD, outSignalXd);
   free(timebase64);
   free(outDim);
-  if (isFloat)
-    free(timebaseDouble);
+  free(timebaseDouble);
   free(outData);
   //MdsFree1Dx(&shapeXd, 0);
   MdsFree1Dx(&dataXd, 0);

--- a/xtreeshr/XTreeDefaultResample.c
+++ b/xtreeshr/XTreeDefaultResample.c
@@ -53,196 +53,6 @@ static int XTreeDefaultResampleMode(struct descriptor_signal *inSignalD, struct 
 	    struct descriptor *endD, struct descriptor *deltaD, const res_mode_t mode,
 	    struct descriptor_xd *outSignalXd);
 
-//64 bit time-based resampling function. It is assumed here that the 64 bit representation of time is the count
-//of a given, fixed amount of time, starting from a given time in the past
-//The closest point is selected as representative for a given time
-static void resample(int64_t start, int64_t end, int64_t delta, int64_t * inTimebase,
-		     int inTimebaseSamples, int numDims, int *dims, char *inData, int dataSize,
-		     char dataType, const res_mode_t mode, char **retData, int64_t ** retDim, int *retSamples)
-{
-  int i, j;
-  double prevData, nextData, currData;
-  int itemSize = dataSize;
-  for (i = 0; i < numDims - 1; i++)
-    itemSize *= dims[i];
-  int numDataItems = itemSize/dataSize;
-  int outItemSize;
-  if (mode == AVERAGE) {// use FLOAT or DOUBLE
-    *retSamples += 3;
-    outItemSize = dataSize<8 ? itemSize*4/dataSize : itemSize;
-  } else {
-    if (mode == MINMAX)
-      *retSamples *=2;//Make enough room for MINMAX mode
-    outItemSize = itemSize;
-  }
-  // Make sure enough room is allocated
-
-  char    *outData = *retData = malloc(*retSamples * outItemSize);
-  int64_t *outDim  = *retDim  = malloc(*retSamples * 8);
-
-  if (start < inTimebase[0])
-    start = inTimebase[0];
-  if (end > inTimebase[inTimebaseSamples - 1])
-    end = inTimebase[inTimebaseSamples - 1];
-  int timebaseIdx = 0, outSamples = 0;
-  int startIdx = 0;
-  for (; startIdx < inTimebaseSamples && inTimebase[startIdx] < start ; startIdx++);
-  if (startIdx == inTimebaseSamples) {  //Not possible in any case
-    *retSamples = 0;
-    return;
-  }
-
-  int64_t *timebase = &inTimebase[startIdx];
-  int timebaseSamples = inTimebaseSamples - startIdx;
-  char *data = &inData[startIdx * itemSize];
-  int64_t refTime = start;
-  if (delta) {
-    int64_t delta1 = (delta  )/2;
-    int64_t delta2 = delta+delta1;
-    switch (mode) {
-      case INTERPOLATION:
-      case MINMAX:
-      case AVERAGE:
-	refTime += delta1;
-	end     += delta;
-      break;default:break;
-    }
-    int prevTimebaseIdx = timebaseIdx;
-    while (refTime <= end) {
-      while (timebaseIdx < timebaseSamples && timebase[timebaseIdx] < refTime)
-	timebaseIdx++;
-      switch (mode) {
-	case CLOSEST_SAMPLE: // Select closest sample
-	  if (timebaseIdx > 0 && timebaseIdx < timebaseSamples) {
-	    delta1 = timebase[timebaseIdx] - refTime;
-	    delta2 = refTime - timebase[timebaseIdx - 1];
-	    if (delta2 < delta1)
-	      timebaseIdx--;
-	  }
-	  memcpy(&outData[outSamples * outItemSize], &data[timebaseIdx * itemSize], itemSize);
-	  break;
-	case PREVIOUS_SAMPLE: //Select closest sample
-	  if (timebaseIdx > 0 && timebaseIdx < timebaseSamples)
-	    timebaseIdx--;
-	  memcpy(&outData[outSamples * outItemSize], &data[timebaseIdx * itemSize], itemSize);
-	  break;
-	case INTERPOLATION:
-#define INTERPOLATION_FORLOOP(type) for (i = 0; i < numDataItems; i++) { \
-  prevData = ((type *)(&data[(timebaseIdx - 1) * itemSize]))[i]; \
-  nextData = ((type *)(&data[timebaseIdx * itemSize]))[i]; \
-  currData = prevData + (nextData - prevData) * (refTime - timebase[timebaseIdx - 1]) / (timebase[timebaseIdx] - timebase[timebaseIdx - 1]); \
-  ((type *)(&outData[outSamples * outItemSize]))[i] = currData; \
-}
-	  if(timebaseIdx <= 0) timebaseIdx = 1;  //Avoid referring to negative indexes
-	  switch (dataType) {
-	    case DTYPE_BU:	INTERPOLATION_FORLOOP( uint8_t);break;
-	    case DTYPE_B:	INTERPOLATION_FORLOOP(  int8_t);break;
-	    case DTYPE_WU:	INTERPOLATION_FORLOOP(uint16_t);break;
-	    case DTYPE_W:	INTERPOLATION_FORLOOP( int16_t);break;
-	    case DTYPE_LU:	INTERPOLATION_FORLOOP(uint32_t);break;
-	    case DTYPE_L:	INTERPOLATION_FORLOOP( int32_t);break;
-	    case DTYPE_QU:	INTERPOLATION_FORLOOP(uint64_t);break;
-	    case DTYPE_Q:	INTERPOLATION_FORLOOP( int64_t);break;
-	    case DTYPE_FLOAT:	INTERPOLATION_FORLOOP(   float);break;
-	    case DTYPE_DOUBLE:	INTERPOLATION_FORLOOP(  double);break;
-	  }
-	  break;
-	case MINMAX:     //Two points for every (resampled) sample!!!!!!!!!!!
-#define MINMAX_FORLOOP(type) for (i = 0; i < numDataItems; i++) { \
-type currData, minData, maxData; \
-minData = maxData = ((type *)(&data[(prevTimebaseIdx) * itemSize]))[i]; \
-for(j = prevTimebaseIdx + 1; j < timebaseIdx && j<inTimebaseSamples ; j++){ \
-  currData = ((type *)(&data[j * itemSize]))[i]; \
-  if(currData > maxData) maxData = currData; \
-  if(currData < minData) minData = currData; \
-} \
-((type *)(&outData[outSamples * outItemSize]))[i] = minData; \
-((type *)(&outData[(outSamples+1) * itemSize]))[i] = maxData; \
-}
-	  switch (dataType) {
-	    case DTYPE_BU:	MINMAX_FORLOOP( uint8_t);break;
-	    case DTYPE_B:	MINMAX_FORLOOP(  int8_t);break;
-	    case DTYPE_WU:	MINMAX_FORLOOP(uint16_t);break;
-	    case DTYPE_W:	MINMAX_FORLOOP( int16_t);break;
-	    case DTYPE_LU:	MINMAX_FORLOOP(uint32_t);break;
-  	    case DTYPE_L:	MINMAX_FORLOOP( int32_t);break;
-	    case DTYPE_QU:	MINMAX_FORLOOP(uint64_t);break;
-	    case DTYPE_Q:	MINMAX_FORLOOP( int64_t);break;
-	    case DTYPE_FLOAT:	MINMAX_FORLOOP(   float);break;
-	    case DTYPE_DOUBLE:	MINMAX_FORLOOP(  double);break;
-	  }
-	  break;
-	case AVERAGE:
-#define AVERAGE_FORLOOP(type_out,type) for (i = 0; i < numDataItems; i++) { \
-type_out accData = ((type *)(&data[(prevTimebaseIdx) * itemSize]))[i]; \
-for(j = prevTimebaseIdx + 1; j < timebaseIdx; j++) \
-  accData += ((type *)(&data[j * itemSize]))[i]; \
-const int range = (timebaseIdx-prevTimebaseIdx); \
-((type_out *)(&outData[outSamples * outItemSize]))[i] = range>0 ? accData / range : accData; \
-}
-	  switch (dataType) {
-	    case DTYPE_BU:	AVERAGE_FORLOOP( float, uint8_t);break;
-	    case DTYPE_B:	AVERAGE_FORLOOP( float,  int8_t);break;
-	    case DTYPE_WU:	AVERAGE_FORLOOP( float,uint16_t);break;
-	    case DTYPE_W:	AVERAGE_FORLOOP( float, int16_t);break;
-  	    case DTYPE_L:	AVERAGE_FORLOOP( float, int32_t);break;
-	    case DTYPE_QU:	AVERAGE_FORLOOP(double,uint64_t);break;
-	    case DTYPE_Q:	AVERAGE_FORLOOP(double, int64_t);break;
-	    case DTYPE_FLOAT:	AVERAGE_FORLOOP( float,   float);break;
-	    case DTYPE_DOUBLE:	AVERAGE_FORLOOP(double,  double);break;
-	  }
-	  break;
-	default://Not able to do interpolation
-	  if (timebaseIdx > 0 && timebaseIdx < timebaseSamples)
-	    timebaseIdx--;
-	  memcpy(&outData[outSamples * outItemSize], &data[timebaseIdx * itemSize], itemSize);
-	  break;
-      }
-      switch (mode) {
-	case INTERPOLATION:
-	case MINMAX:
-	case AVERAGE:
-	refTime -= delta1;
-	if(mode == MINMAX) //twice the number of points
-	  outDim[outSamples++] = refTime;
-        outDim[outSamples++] = refTime;
-	refTime += delta2;
-	break;
-      default:
-        outDim[outSamples++] = refTime;
-        refTime += delta;
-	break;
-      }
-      prevTimebaseIdx = timebaseIdx;
-    }
-    *retSamples = outSamples;
-  } else { //delta == NULL
-    if (mode == AVERAGE && dataType != DTYPE_FLOAT && dataType != DTYPE_DOUBLE) {
-      while (timebaseIdx < timebaseSamples && timebase[timebaseIdx] <= end) {
-	switch (dataType) {
-	  case DTYPE_BU:(*( float*)&outData[timebaseIdx*outItemSize]) = *( uint8_t*)&data[timebaseIdx*itemSize];break;
-	  case DTYPE_B: (*( float*)&outData[timebaseIdx*outItemSize]) = *(  int8_t*)&data[timebaseIdx*itemSize];break;
-	  case DTYPE_WU:(*( float*)&outData[timebaseIdx*outItemSize]) = *(uint16_t*)&data[timebaseIdx*itemSize];break;
-	  case DTYPE_W: (*( float*)&outData[timebaseIdx*outItemSize]) = *( int16_t*)&data[timebaseIdx*itemSize];break;
-	  case DTYPE_LU:(*( float*)&outData[timebaseIdx*outItemSize]) = *(uint32_t*)&data[timebaseIdx*itemSize];break;
-  	  case DTYPE_L: (*( float*)&outData[timebaseIdx*outItemSize]) = *( int32_t*)&data[timebaseIdx*itemSize];break;
-	  case DTYPE_QU:(*(double*)&outData[timebaseIdx*outItemSize]) = *(uint64_t*)&data[timebaseIdx*itemSize];break;
-	  case DTYPE_Q: (*(double*)&outData[timebaseIdx*outItemSize]) = *( int64_t*)&data[timebaseIdx*itemSize];break;
-        }
-        outDim[timebaseIdx] = timebase[timebaseIdx];
-        timebaseIdx++;
-      }
-    } else {
-      while (timebaseIdx < timebaseSamples && timebase[timebaseIdx] <= end) {
-	memcpy(&outData[timebaseIdx * outItemSize], &data[timebaseIdx * itemSize], itemSize);
-	outDim[timebaseIdx] = timebase[timebaseIdx];
-	timebaseIdx++;
-      }
-    }
-    *retSamples = timebaseIdx;
-  }
-}
-
 //The default resample handles int64 timebases
 //return 0 if the conversion is  not possible
 inline static int64_t *convertTimebaseToInt64(struct descriptor_signal *inSignalD, int *outSamples, int *isFloat){
@@ -309,9 +119,6 @@ inline static int64_t *convertTimebaseToInt64(struct descriptor_signal *inSignal
   return outPtr;
 }
 
-//Handle resampling in when dimension is specified as a range
-typedef ARRAY_COEFF(char, 256) Array_coeff_type;
-
 EXPORT struct descriptor_xd *XTreeResampleClosest(struct descriptor_signal *inSignalD,
 			  struct descriptor *startD,
 			  struct descriptor *endD,
@@ -356,56 +163,14 @@ EXPORT int XTreeMinMaxResample(struct descriptor_signal *inSignalD, struct descr
 extern int getShape(struct descriptor *dataD, int *dims, int *numDims);
 
 static int XTreeDefaultResampleMode(struct descriptor_signal *inSignalD, struct descriptor *startD,
-	    struct descriptor *endD, struct descriptor *inDeltaD, const res_mode_t mode,
+	    struct descriptor *endD, struct descriptor *deltaD, const res_mode_t mode,
 	    struct descriptor_xd *outSignalXd)
 {
-  int64_t start64, end64, delta64, *timebase64, *outDim;
-  double *timebaseDouble;
-  int dims[64];
-  int numDims;
-  int numTimebaseSamples;
-  int isFloat = 0;
-  int status, i, currIdx;
-  int numYSamples;
-  char *outData;
-  struct descriptor_a *dataD;
-  EMPTYXD(dataXd);
-
-  DESCRIPTOR_A_COEFF(outDataArray, 0, 0, 0, 255, 0);
-  DESCRIPTOR_A(outDimArray, 0, 0, 0, 0);
-  DESCRIPTOR_SIGNAL_1(outSignalD, &outDataArray, 0, &outDimArray);
-  struct descriptor *deltaD;
-
-  deltaD = inDeltaD;
-  if (startD) {
-    status = XTreeConvertToLongTime(startD, &start64);
-    if STATUS_NOT_OK return status;
-  }
-  if (endD) {
-    status = XTreeConvertToLongTime(endD, &end64);
-    if STATUS_NOT_OK return status;
-  }
-  if (deltaD) {
-    status = XTreeConvertToLongTime(deltaD, &delta64);
-    if STATUS_NOT_OK return status;
-    if (delta64 == 0)   deltaD = 0;
-  }
-
-  // This version handles only 64 bit time format
-
-  timebase64 = convertTimebaseToInt64(inSignalD, &numTimebaseSamples, &isFloat);
-  if (!timebase64) {
-    MdsCopyDxXd((struct descriptor *)&inSignalD, outSignalXd);
-    return 3;	//Cannot convert timebase to 64 bit int
-  }
-  if (!startD)  start64 = timebase64[0];
-  if (!endD)    end64   = timebase64[numTimebaseSamples - 1];
-  if (start64 < timebase64[0])
-    start64 = timebase64[0];
-  if (end64 > timebase64[numTimebaseSamples - 1])
-    end64 = timebase64[numTimebaseSamples - 1];
+  int status;
 
   // Get shapes(dimensions) for data
+  EMPTYXD(dataXd);
+  struct descriptor_a *dataD;
   if (inSignalD->data->class == CLASS_A) {
     dataD = (struct descriptor_a *)inSignalD->data;
   } else {
@@ -413,53 +178,240 @@ static int XTreeDefaultResampleMode(struct descriptor_signal *inSignalD, struct 
     if STATUS_NOT_OK return status;
     dataD = (struct descriptor_a *)dataXd.pointer;
   }
-  numYSamples = dataD->arsize/dataD->length;
-
-
+  int dims[MAX_DIMS];
+  int numDims;
   status = getShape((struct descriptor *)dataD, dims, &numDims);
   if STATUS_NOT_OK {
     MdsFree1Dx(&dataXd, 0);
     return status;
   }
+
+  // get timebase
+  int isFloat = FALSE;
+  int64_t start, end, delta, *fulltimebase;
+  int numTimebase, numData = (numDims <= 1) ? (int)(dataD->arsize/dataD->length) : dims[numDims-1];
+  fulltimebase = convertTimebaseToInt64(inSignalD, &numTimebase, &isFloat);
+  if (!fulltimebase) {
+    MdsFree1Dx(&dataXd, 0);
+    MdsCopyDxXd((struct descriptor *)&inSignalD, outSignalXd);
+    return 3;	//Cannot convert timebase to 64 bit int
+  }
+
   //Check data array too short
-  if (numYSamples < numTimebaseSamples)
-    numTimebaseSamples = numYSamples;
+  if (numData < numTimebase) numTimebase = numData;
+
+  int startIdx = 0;
+  if (startD) {
+    status = XTreeConvertToLongTime(startD, &start);
+    if STATUS_NOT_OK return status;
+    if (start < fulltimebase[0])
+      start = fulltimebase[0];
+    for (; startIdx < numTimebase && fulltimebase[startIdx] < start ; startIdx++);
+  } else start = fulltimebase[0];
+  if (endD) {
+    status = XTreeConvertToLongTime(endD, &end);
+    if STATUS_NOT_OK return status;
+    if (end > fulltimebase[numTimebase - 1])
+      end = fulltimebase[numTimebase - 1];
+  } else end = fulltimebase[numTimebase - 1];
+  if (deltaD) {
+    status = XTreeConvertToLongTime(deltaD, &delta);
+    if STATUS_NOT_OK return status;
+  } else delta = 0;
 
   int outSamples;
-  if (!deltaD) {
+  if (startIdx == numTimebase) {  //Not possible in any case
+    outSamples = 0;
+  } else if (delta<=0) {
     // Count number of copied samples
-    for (currIdx = 0; currIdx < numTimebaseSamples && timebase64[currIdx] < start64; currIdx++) ;
-    for (outSamples = currIdx ; outSamples < numTimebaseSamples && timebase64[outSamples] <= end64; outSamples++) ;
-    outSamples = outSamples - currIdx;
+    for (outSamples = startIdx ; outSamples < numTimebase && fulltimebase[outSamples] <= end; outSamples++) ;
+    outSamples = outSamples - startIdx;
   } else
-    outSamples = (end64 - start64) / delta64 + 1;
+    outSamples = (end - start +1) / delta + 1;
 
-  resample(start64, end64, (deltaD) ? delta64 : 0, timebase64, numTimebaseSamples, numDims, dims,
-	   dataD->pointer, dataD->length, dataD->dtype, mode, &outData, &outDim, &outSamples);
-
-  //Build array descriptor for out data
-  if (mode == AVERAGE) { // use FLOAT or DOUBLE
-    if (dataD->length<8) {
-      outDataArray.length = 4;
-      outDataArray.dtype  = DTYPE_FLOAT;
-    } else {
-      outDataArray.length = 8;
-      outDataArray.dtype  = DTYPE_DOUBLE;
-    }
+  int i, j;
+  double prevData, nextData, currData;
+  int itemSize = dataD->arsize/numData;
+  int numDataItems = itemSize/dataD->length;
+  int outItemSize;
+  DESCRIPTOR_A_COEFF(outDataArray, 0, 0, 0, MAX_DIMS, 0);
+  if (mode == AVERAGE && delta>0) { // use FLOAT or DOUBLE
   } else {
     outDataArray.length = dataD->length;
     outDataArray.dtype = dataD->dtype;
   }
-  int itemSize = outDataArray.length;
-  for (i = 0; i < numDims - 1; i++)
-    itemSize *= dims[i];
+  // Make sure enough room is allocated
+  char    *outData;
+  int64_t *outDim;
+
+  int timebaseIdx = 0;
+  int timebaseSamples = numTimebase - startIdx;
+  int64_t *timebase = &fulltimebase[startIdx];
+  char *data = &dataD->pointer[startIdx * itemSize];
+  int64_t refTime = start;
+  if (delta>0) {
+    if (mode == AVERAGE && delta>0) {// use FLOAT or DOUBLE
+      outSamples ++;
+      if (dataD->length<8) {
+	outDataArray.length = sizeof(float);
+	outDataArray.dtype  = DTYPE_FLOAT;
+      } else {
+	outDataArray.length = sizeof(double);
+	outDataArray.dtype  = DTYPE_DOUBLE;
+      }
+      outItemSize = itemSize*outDataArray.length/dataD->length;
+    } else {
+      if (mode == MINMAX) outSamples *=2;//Make enough room for MINMAX mode
+      outItemSize = itemSize;
+      outDataArray.length = dataD->length;
+      outDataArray.dtype = dataD->dtype;
+    }
+    outData =  malloc(outSamples * outItemSize);
+    outDim  =  malloc(outSamples * sizeof(int64_t));
+    outSamples = 0;
+    int64_t delta1 = (delta  )/2;
+    int64_t delta2 = delta+delta1;
+    switch (mode) {
+      case INTERPOLATION:
+      case MINMAX:
+      case AVERAGE:
+	refTime += delta1;
+	end     += delta;
+      break;default:break;
+    }
+    int prevTimebaseIdx = timebaseIdx;
+    while (refTime <= end) {
+      while (timebaseIdx < timebaseSamples && timebase[timebaseIdx] < refTime)
+	timebaseIdx++;
+      switch (mode) {
+	case CLOSEST_SAMPLE: // Select closest sample
+	  if (timebaseIdx > 0 && timebaseIdx < timebaseSamples) {
+	    delta1 = timebase[timebaseIdx] - refTime;
+	    delta2 = refTime - timebase[timebaseIdx - 1];
+	    if (delta2 < delta1)
+	      timebaseIdx--;
+	  }
+	  memcpy(&outData[outSamples * outItemSize], &data[timebaseIdx * itemSize], itemSize);
+	  break;
+	case PREVIOUS_SAMPLE: //Select closest sample
+	  if (timebaseIdx > 0 && timebaseIdx < timebaseSamples)
+	    timebaseIdx--;
+	  memcpy(&outData[outSamples * outItemSize], &data[timebaseIdx * itemSize], itemSize);
+	  break;
+	case INTERPOLATION:
+#define INTERPOLATION_FORLOOP(type) for (i = 0; i < numDataItems; i++) { \
+  prevData = ((type *)(&data[(timebaseIdx - 1) * itemSize]))[i]; \
+  nextData = ((type *)(&data[timebaseIdx * itemSize]))[i]; \
+  currData = prevData + (nextData - prevData) * (refTime - timebase[timebaseIdx - 1]) / (timebase[timebaseIdx] - timebase[timebaseIdx - 1]); \
+  ((type *)(&outData[outSamples * outItemSize]))[i] = currData; \
+}
+	  if(timebaseIdx <= 0) timebaseIdx = 1;  //Avoid referring to negative indexes
+	  switch (dataD->dtype) {
+	    case DTYPE_BU:	INTERPOLATION_FORLOOP( uint8_t);break;
+	    case DTYPE_B:	INTERPOLATION_FORLOOP(  int8_t);break;
+	    case DTYPE_WU:	INTERPOLATION_FORLOOP(uint16_t);break;
+	    case DTYPE_W:	INTERPOLATION_FORLOOP( int16_t);break;
+	    case DTYPE_LU:	INTERPOLATION_FORLOOP(uint32_t);break;
+	    case DTYPE_L:	INTERPOLATION_FORLOOP( int32_t);break;
+	    case DTYPE_QU:	INTERPOLATION_FORLOOP(uint64_t);break;
+	    case DTYPE_Q:	INTERPOLATION_FORLOOP( int64_t);break;
+	    case DTYPE_FLOAT:	INTERPOLATION_FORLOOP(   float);break;
+	    case DTYPE_DOUBLE:	INTERPOLATION_FORLOOP(  double);break;
+	    default:break;
+	  }
+	  break;
+	case MINMAX:     //Two points for every (resampled) sample!!!!!!!!!!!
+#define MINMAX_FORLOOP(type) for (i = 0; i < numDataItems; i++) { \
+type currData, minData, maxData; \
+minData = maxData = ((type *)(&data[(prevTimebaseIdx) * itemSize]))[i]; \
+for(j = prevTimebaseIdx + 1; j < timebaseIdx && j<numTimebase ; j++){ \
+  currData = ((type *)(&data[j * itemSize]))[i]; \
+  if(currData > maxData) maxData = currData; \
+  if(currData < minData) minData = currData; \
+} \
+((type *)(&outData[outSamples * outItemSize]))[i] = minData; \
+((type *)(&outData[(outSamples+1) * itemSize]))[i] = maxData; \
+}
+	  switch (dataD->dtype) {
+	    case DTYPE_BU:	MINMAX_FORLOOP( uint8_t);break;
+	    case DTYPE_B:	MINMAX_FORLOOP(  int8_t);break;
+	    case DTYPE_WU:	MINMAX_FORLOOP(uint16_t);break;
+	    case DTYPE_W:	MINMAX_FORLOOP( int16_t);break;
+	    case DTYPE_LU:	MINMAX_FORLOOP(uint32_t);break;
+	    case DTYPE_L:	MINMAX_FORLOOP( int32_t);break;
+	    case DTYPE_QU:	MINMAX_FORLOOP(uint64_t);break;
+	    case DTYPE_Q:	MINMAX_FORLOOP( int64_t);break;
+	    case DTYPE_FLOAT:	MINMAX_FORLOOP(   float);break;
+	    case DTYPE_DOUBLE:	MINMAX_FORLOOP(  double);break;
+	    default:break;
+	  }
+	  break;
+	case AVERAGE:
+#define AVERAGE_FORLOOP(type_out,type) for (i = 0; i < numDataItems; i++) { \
+type_out accData = ((type *)(&data[(prevTimebaseIdx) * itemSize]))[i]; \
+for(j = prevTimebaseIdx + 1; j < timebaseIdx; j++) \
+  accData += ((type *)(&data[j * itemSize]))[i]; \
+const int range = (timebaseIdx-prevTimebaseIdx); \
+((type_out *)(&outData[outSamples * outItemSize]))[i] = range>0 ? accData / range : accData; \
+}
+	  switch (dataD->dtype) {
+	    case DTYPE_BU:	AVERAGE_FORLOOP( float, uint8_t);break;
+	    case DTYPE_B:	AVERAGE_FORLOOP( float,  int8_t);break;
+	    case DTYPE_WU:	AVERAGE_FORLOOP( float,uint16_t);break;
+	    case DTYPE_W:	AVERAGE_FORLOOP( float, int16_t);break;
+	    case DTYPE_LU:	AVERAGE_FORLOOP( float,uint32_t);break;
+	    case DTYPE_L:	AVERAGE_FORLOOP( float, int32_t);break;
+	    case DTYPE_QU:	AVERAGE_FORLOOP(double,uint64_t);break;
+	    case DTYPE_Q:	AVERAGE_FORLOOP(double, int64_t);break;
+	    case DTYPE_FLOAT:	AVERAGE_FORLOOP( float,   float);break;
+	    case DTYPE_DOUBLE:	AVERAGE_FORLOOP(double,  double);break;
+	    default:break;
+	  }
+	  break;
+	default://Not able to do interpolation
+	  if (timebaseIdx > 0 && timebaseIdx < timebaseSamples)
+	    timebaseIdx--;
+	  memcpy(&outData[outSamples * outItemSize], &data[timebaseIdx * itemSize], itemSize);
+	  break;
+      }
+      switch (mode) {
+	case INTERPOLATION:
+	case MINMAX:
+	case AVERAGE:
+	refTime -= delta1;
+	if(mode == MINMAX) //twice the number of points
+	  outDim[outSamples++] = refTime;
+	outDim[outSamples++] = refTime;
+	refTime += delta2;
+	break;
+      default:
+	outDim[outSamples++] = refTime;
+	refTime += delta;
+	break;
+      }
+      prevTimebaseIdx = timebaseIdx;
+    }
+  } else { //delta <= 0
+    while (timebaseIdx < timebaseSamples && timebase[timebaseIdx] <= end) timebaseIdx++;
+    outData = data;
+    outDim  = timebase;
+    outSamples = timebaseIdx;
+    outItemSize = itemSize;
+    outDataArray.length = dataD->length;
+    outDataArray.dtype = dataD->dtype;
+  }
+
+  DESCRIPTOR_A(outDimArray, 0, 0, 0, 0);
+  DESCRIPTOR_SIGNAL_1(outSignalD, &outDataArray, 0, &outDimArray);
+  //Build array descriptor for out data
   outDataArray.pointer = outDataArray.a0 = outData;
-  outDataArray.arsize = itemSize * outSamples;
+  outDataArray.arsize = outItemSize * outSamples;
   outDataArray.dimct = numDims;
   for (i = 0; i < numDims - 1; i++)
     outDataArray.m[i] = dims[i];
   outDataArray.m[numDims - 1] = outSamples;
   //If originally float, convert  dimension to float
+  double *timebaseDouble;
   if (isFloat) {
     timebaseDouble = (double *)malloc(outSamples * sizeof(double));
     for (i = 0; i < outSamples; i++)
@@ -470,19 +422,20 @@ static int XTreeDefaultResampleMode(struct descriptor_signal *inSignalD, struct 
     outDimArray.pointer = outDataArray.a0 = (char *)timebaseDouble;
   } else {
     timebaseDouble = NULL;
-    outDimArray.length = 8;
-    outDimArray.arsize = 8 * outSamples;
+    outDimArray.length = sizeof(int64_t);
+    outDimArray.arsize = sizeof(int64_t) * outSamples;
     outDimArray.dtype = DTYPE_Q;
     outDimArray.pointer = outDataArray.a0 = (char *)outDim;
   }
 
   MdsCopyDxXd((struct descriptor *)&outSignalD, outSignalXd);
-  free(timebase64);
-  free(outDim);
+  free(fulltimebase);
   free(timebaseDouble);
-  free(outData);
+  if (delta>0) {
+    free(outDim);
+    free(outData);
+  }
   //MdsFree1Dx(&shapeXd, 0);
   MdsFree1Dx(&dataXd, 0);
-
   return 1;
 }

--- a/xtreeshr/XTreeGetTimedRecord.c
+++ b/xtreeshr/XTreeGetTimedRecord.c
@@ -42,6 +42,7 @@ static int timedAccessFlag = 0;
 #endif
 extern int XTreeConvertToLongTime(mdsdsc_t *timeD, int64_t * converted);
 #define RESAMPLE_FUN(name) int name(mds_signal_t *inSignalD,mdsdsc_t *startD, mdsdsc_t *endD, mdsdsc_t *deltaD, mdsdsc_xd_t  *outSignalXd)
+extern RESAMPLE_FUN(XTreeAverageResample);
 extern RESAMPLE_FUN(XTreeMinMaxResample);
 extern RESAMPLE_FUN(XTreeInterpResample);
 extern RESAMPLE_FUN(XTreeClosestResample);
@@ -306,6 +307,8 @@ EXPORT int XTreeGetTimedRecord(int inNid, mdsdsc_t *startD,
       status = TdiEvaluate((mdsdsc_t *)&resampleFunD, &resampledXds[currSegIdx] MDS_END_ARG);
     } else if((!startD && !endD && !minDeltaD) || currSignalD.ndesc == 1) //If no resampling required
       status = MdsCopyDxXd((const mdsdsc_t *)&currSignalD, &resampledXds[currSegIdx]);
+    else if(!strcasecmp(resampleMode, "Average"))
+      status = XTreeAverageResample((mds_signal_t *)&currSignalD, startD, endD, minDeltaD, &resampledXds[currSegIdx]);
     else if(!strcasecmp(resampleMode, "MinMax"))
       status = XTreeMinMaxResample((mds_signal_t *)&currSignalD, startD, endD, minDeltaD, &resampledXds[currSegIdx]);
     else if(!strcasecmp(resampleMode, "Interp"))

--- a/xtreeshr/XTreeGetTimedRecord.c
+++ b/xtreeshr/XTreeGetTimedRecord.c
@@ -44,8 +44,9 @@ extern int XTreeConvertToLongTime(mdsdsc_t *timeD, int64_t * converted);
 #define RESAMPLE_FUN(name) int name(mds_signal_t *inSignalD,mdsdsc_t *startD, mdsdsc_t *endD, mdsdsc_t *deltaD, mdsdsc_xd_t  *outSignalXd)
 extern RESAMPLE_FUN(XTreeMinMaxResample);
 extern RESAMPLE_FUN(XTreeInterpResample);
-extern RESAMPLE_FUN(XTreeResampleClosest);
-extern RESAMPLE_FUN(XTreeResamplePrevious);
+extern RESAMPLE_FUN(XTreeClosestResample);
+extern RESAMPLE_FUN(XTreePreviousResample);
+extern RESAMPLE_FUN(XTreeDefaultResample);
 
 
 EXPORT void XTreeResetTimedAccessFlag(){
@@ -310,9 +311,9 @@ EXPORT int XTreeGetTimedRecord(int inNid, mdsdsc_t *startD,
     else if(!strcasecmp(resampleMode, "Interp"))
       status = XTreeInterpResample((mds_signal_t *)&currSignalD, startD, endD, minDeltaD, &resampledXds[currSegIdx]);
     else if(!strcasecmp(resampleMode, "Closest"))
-      status = XTreeResampleClosest((mds_signal_t *)&currSignalD, startD, endD, minDeltaD, &resampledXds[currSegIdx]);
+      status = XTreeClosestResample((mds_signal_t *)&currSignalD, startD, endD, minDeltaD, &resampledXds[currSegIdx]);
     else if(!strcasecmp(resampleMode, "Previous"))
-      status = XTreeResamplePrevious((mds_signal_t *)&currSignalD, startD, endD, minDeltaD, &resampledXds[currSegIdx]);
+      status = XTreePreviousResample((mds_signal_t *)&currSignalD, startD, endD, minDeltaD, &resampledXds[currSegIdx]);
     else
       status = XTreeDefaultResample((mds_signal_t *)&currSignalD, startD, endD, minDeltaD, &resampledXds[currSegIdx]);
 


### PR DESCRIPTION
This one is tricky.. the default resampling method in xtreeshr is worthless if used for evaluation and has not real use (at least i cannot think of any non artificial) This PR will change the default resampling method to moving average.