### PR TITLE
Fix: mdsip not getting connection hostname

### DIFF
--- a/conf/valgrind-mdsplus.supp
+++ b/conf/valgrind-mdsplus.supp
@@ -1,4 +1,19 @@
 {
+   Bug in getnameinfo
+   Memcheck:Leak
+   match-leak-kinds: definite
+   fun:malloc
+   fun:__libc_alloc_buffer_allocate
+   fun:__resolv_conf_allocate
+   fun:__resolv_conf_load
+   fun:__resolv_conf_get_current
+   fun:__res_vinit
+   fun:__resolv_context_get
+   fun:gethostbyaddr_r@@GLIBC_2.2.5
+   fun:gni_host_inet_name.isra.1
+   fun:getnameinfo
+}
+{
    seen in rhel6
    Memcheck:Param
    timer_create(evp)

--- a/conf/valgrind-mdsplus.supp
+++ b/conf/valgrind-mdsplus.supp
@@ -9,7 +9,7 @@
    fun:__resolv_conf_get_current
    fun:__res_vinit
    fun:__resolv_context_get
-   fun:gethostbyaddr_r@@GLIBC_2.2.5
+   fun:gethostbyaddr_r@@GLIBC_*
    fun:gni_host_inet_name.isra.1
    fun:getnameinfo
 }


### PR DESCRIPTION
Changes to mdsip broke the mapping rules based on hostnames.
This should fix this problem.