### PR TITLE
Fix: restore compatibility with stable

### DIFF
--- a/treeshr/RemoteAccess.c
+++ b/treeshr/RemoteAccess.c
@@ -1158,7 +1158,7 @@ EXPORT ssize_t MDS_IO_WRITE(int idx, void *buff, size_t count){
 #ifdef USE_PERF
   TreePerfWrite(count);
 #endif
-  return write(i.fd, buff, (unsigned int)count);
+  return write(i.fd, buff, (uint32_t)count);
 }
 
 inline static ssize_t io_read_remote(int conid, int fd, void *buff, size_t count){


### PR DESCRIPTION
According to http://man7.org/linux/man-pages/man2/write.2.html

On Linux, write() (and similar system calls) will transfer at most
0x7ffff000 (2,147,479,552) bytes, returning the number of bytes
actually transferred.  (This is true on both 32-bit and 64-bit
systems.)

we dont need to return int64_t