### PR TITLE
Build: Repair repository creation on redhat and alpine

### DIFF
--- a/deploy/platform/alpine/alpine_docker_build.sh
+++ b/deploy/platform/alpine/alpine_docker_build.sh
@@ -55,5 +55,6 @@ buildrelease() {
 }
 
 publish() {
-    rsync -a /release/${BRANCH} /publish/
+    mkdir -p /publish/${BRANCH}
+    rsync -a /release/${BRANCH}/${ARCH} /publish/${BRANCH}/
 }

--- a/deploy/platform/redhat/redhat_docker_build.sh
+++ b/deploy/platform/redhat/redhat_docker_build.sh
@@ -13,6 +13,20 @@
 # /publish/$branch/cache/$arch/*.rpm-*
 #
 
+do_createrepo() {
+    repodir=$1
+    tmpdir=$(mktemp -d)
+    trap 'rm -Rf ${tmpdir}' EXIT
+    if [ -d ${repodir}/${BRANCH}/RPMS/repodata ]
+    then
+	rsync -a ${repodir}/${BRANCH}/RPMS/repodata ${tmpdir}
+	update_args="--update --cachdir ${repodir}/${BRANCH}/cache ${use_deltas}"
+    fi
+    :&& createrepo -q $update_args -o ${tmpdir} ${repodir}/${BRANCH}/RPMS
+    checkstatus abort "Failure: Problem creating rpm repository in ${repodir}!" $?
+    :&& rsync -a ${tmpdir}/repodata ${repodir}/${BRANCH}/RPMS/
+}
+
 srcdir=$(readlink -e $(dirname ${0})/../..)
 
 test64="64 x86_64-linux bin64 lib64 --with-gsi=/usr:gcc64"
@@ -96,7 +110,7 @@ EOF
           BUILDROOT=${BUILDROOT} \
           PLATFORM=${PLATFORM} \
           ${srcdir}/deploy/platform/${PLATFORM}/${PLATFORM}_build_rpms.py;
-    createrepo -q /release/${BRANCH}/RPMS
+    do_createrepo /release
     badrpm=0
     for rpm in $(find /release/${BRANCH}/RPMS -name '*\.rpm')
     do
@@ -137,10 +151,6 @@ publish(){
     then
         use_deltas="--deltas"
     fi
-    tmpdir=$(mktemp -d)
-    trap 'rm -Rf ${tmpdir}' EXIT
-    :&& createrepo -q --update --cachedir /publish/${BRANCH}/cache ${use_deltas} -o ${tmpdir} /publish/${BRANCH}/RPMS
-    checkstatus abort "Failure: Problem creating rpm repository in publish area!" $?
-    :&& rsync -a ${tmpdir}/repodata /publish/${BRANCH}/RPMS/
+    do_createrepo /publish
     checkstatus abort "Failure: Problem rsyncing rpm repository with publish area!" $?
 }


### PR DESCRIPTION
Since the MDSplus repositories were moved to a nfs share exported
by a new nfs server there were locking errors running the createrepo
command. A workaround was added for the publish operation to use
a /tmp directory for the repodata. This workaround was not implemented
for the release operation but is necessary unless another nfs server is
used to serve the release directory tree. To avoid this need for using
a separate nfs server the same /tmp workaround will now be used for both
the /release and /publish repositories.

The use of two nfs server mounts also can cause problems if some of
the jenkins slaves fail to mount one of these mounts which can cause
problems if the release build and the publish build do not occur on the
same slave. With the above workaround the build and publish diretories
will by served by the same nfs server.

There was also a bug in the alpine repository creation script which
caused each alpine platform build to rsync the entire repository
directory from release to publish instead of just rsync'ing the repository
specific to the architecture being built. This should fix that problem
too.