### PR TITLE
Fix:Conversion to double in ScopeUtilities

### DIFF
--- a/mdsmisc/ScopeUtilities.c
+++ b/mdsmisc/ScopeUtilities.c
@@ -77,7 +77,7 @@ static double to_doublex(const void *const ptr, const dtype_t dtype, const doubl
       return (double)*(int32_t *)ptr;
     case DTYPE_Q:
     case DTYPE_QU:
-      if (is_time) return ((double)*(int64_t *)ptr)/1e9;
+      if (is_time) return ((double)*(int64_t *)ptr);
       return (double)*(int64_t *)ptr;
     default:
       printf("Unsupported Type in getData\n");


### PR DESCRIPTION
Removed the division by 1e9 if DTYPE_Q or DTYPE_UQ to be converted, that broke jScope dynamic resampling for absolute times. No assumption must be made when time is expressed in 64bit long format (EPICS Time counts nanoseconds, UTC time counts milliseconds), so the value (converted to double) must be returned as it is.