### PR TITLE
Fixing an edgecase in setup.sh/setup.csh

### DIFF
--- a/setup.csh
+++ b/setup.csh
@@ -1,4 +1,4 @@
-# mdsplus.csh  - to be sourced during login from csh or derivative
+# mdsplus.csh  - to be sourced during login from csh or derivative 
 # 
 # this script will search for the first environment variable definition file
 # it can find looking in the following order:

--- a/setup.csh
+++ b/setup.csh
@@ -76,8 +76,13 @@ if ( $?temp_sym_name ) then
   if ( $temp_sym_old_value == '' ) then
     setenv $temp_sym_name $temp_sym_value
   else
-    echo $temp_sym_old_value | grep $temp_sym_value > /dev/null
-    if ( $status) then
+    set found=false
+    foreach v (`echo ${temp_sym_old_value} | tr "${temp_delim}" "\n"`)
+      if ( $v == $temp_sym_value ) then
+        set found=true
+      endif
+    end
+    if ( $found == 'false' ) then
       switch ($temp_direction)
       case '>':
         setenv $temp_sym_name ${temp_sym_old_value}${temp_delim}${temp_sym_value}
@@ -151,4 +156,3 @@ if ( ! $?PyLib ) then
   endif
   unset pyver
 endif
-

--- a/setup.sh
+++ b/setup.sh
@@ -94,8 +94,17 @@ then
     eval $temp_sym_name='`echo $temp_sym_value`'
     doExport $temp_sym_name
   else
-    if echo $temp_sym_old_value | grep $temp_sym_value > /dev/null ; then
-	:
+    found=false
+    for v in `echo ${temp_sym_old_value} | tr "${temp_delim}" "\n"`
+    do
+        if ( test "$v" == "$temp_sym_value")
+        then
+            found=true
+            break
+        fi
+    done
+    if ( test "$found" == "true" ) ; then
+        :
     else
       case $temp_direction in
       '>')
@@ -194,4 +203,3 @@ then
     fi
   fi
 fi
-


### PR DESCRIPTION
When you wanted to add to an environment variable, but the string you
wanted to include was already a substring of the current environment
variable, it would not add your string.
e.g.

```
MDS_PATH /usr/local/mdsplus/tdi
MDS_PATH /tdi <;
```