### PR TITLE
Feature: Add default_tree_path

### DIFF
--- a/treeshr/TreeOpen.c
+++ b/treeshr/TreeOpen.c
@@ -137,6 +137,8 @@ EXPORT char *TreePath(char const *tree, char *tree_lower_out){
   if (tree_lower_out)
     strcpy(tree_lower_out, tree_lower);
   path = TranslateLogical(pathname);
+  if (path == NULL)
+    path = TranslateLogical(TREE_DEFAULT_PATH);
   if (path) {
     // remove trailing spaces
     for (i = strlen(path); i > 0 && (path[i - 1] == ' ' || path[i - 1] == 9); i--)

--- a/treeshr/treeshr_messages.xml
+++ b/treeshr/treeshr_messages.xml
@@ -93,7 +93,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
     <status name="INVSHAPE" value="4601" severity="Error" text="Invalid shape for this data segment"/>
     <status name="INVSHOT" value="4603" severity="Error" text="Invalid shot number - must be -1 (model), 0 (current), or Positive"/>
     <status name="INVTAG" value="4605" severity="Error" text="Invalid tagname - must begin with alpha followed by 0-22 alphanumeric or underscores"/>
-    <status name="NOPATH" value="4606" severity="Error" text="No 'treename'_path environment variable defined. Cannot locate tree files."/>
+    <status name="NOPATH" value="4606" severity="Error" text="No 'treename'_path or default_tree_path environment variables defined. Cannot locate tree files."/>
     <status name="TREEFILEREADERR" value="4607" severity="Error" text="Error reading in tree file contents."/>
     <status name="MEMERR" value="4608" severity="Error" text="Memory allocation error."/>
     <status name="NOCURRENT" value="4609" severity="Error" text="No current shot number set for this tree."/>

--- a/treeshr/treeshrp.h
+++ b/treeshr/treeshrp.h
@@ -729,6 +729,7 @@ to databases
 #define IS_OPEN_FOR_EDIT(db) (IS_OPEN(db) ? (db)->open_for_edit : 0)
 
 #define TREE_PATH_SUFFIX "_path"
+#define TREE_DEFAULT_PATH "default_tree_path"
 #define TREE_PATH_DELIM  "/"
 
 /************* Prototypes for internal functions *************/


### PR DESCRIPTION
You will now be able to define a default tree path using the
default_tree_path environment variable. For example defining

export default_tree_path=/trees/~

You could do something like:

$ mkdir /trees/mytree1
$ mkdir /trees/mytree2
$ mdstcl
TCL> edit/new mytree1
...
TCL> edit/new mytree2
...

without needing mytree1_path and mytree2_path environment variables.

fixes https://github.com/MDSplus/mdsplus/issues/1667