### PR TITLE
Fix: Support default_tree_path with shotids

### DIFF
--- a/treeshr/TreeGetSetShotId.c
+++ b/treeshr/TreeGetSetShotId.c
@@ -171,7 +171,6 @@ int TreeSetCurrentShotId(char const *experiment, int shot)
   char exp[16]={0};
   char *path = TreePath(experiment,exp);
   size_t slen;
-  path = TreePath(experiment,NULL);
   if (path && ((slen = strlen(path)) > 2) && (path[slen - 1] == ':') && (path[slen - 2] == ':')) {
     path[slen - 2] = 0;
     status = TreeSetCurrentShotIdRemote(exp, path, shot);


### PR DESCRIPTION
get current shot and set current shot routines did not support the
new default_tree_path feature. This should fix https://github.com/MDSplus/mdsplus/issues/1680