### PR TITLE
Fix: Handle deny rules in mdsip.hosts

### DIFF
--- a/mdstcpip/CheckClient.c
+++ b/mdstcpip/CheckClient.c
@@ -146,8 +146,10 @@ int CheckClient(char *username, int num, char **matchString)
 		}
 	      } else {
 		StrRight((struct descriptor *)&access_id, (struct descriptor *)&access_id, &two);
-		if (StrMatchWild((struct descriptor *)&match, &access_id) & 1)
+		if (StrMatchWild((struct descriptor *)&match, &access_id) & 1) {
 		  ok = 2;
+		  break;
+		}
 	      }
 	      StrFree1Dx(&match);
 	    }


### PR DESCRIPTION
Lines beginning with exclamation points must deny access from
connections matching the connection pattern. This broke at some
point. This should fix that.