### PR TITLE
Fix: Obey deny rules in mdsip.hosts

### DIFF
--- a/mdstcpip/CheckClient.c
+++ b/mdstcpip/CheckClient.c
@@ -113,7 +113,6 @@ int CheckClient(char *username, int num, char **matchString)
   if (strncmp(hostfile, "TDI", 3)) {
     FILE *f = fopen(hostfile, "r");
     static int zero = 0, one = 1;
-    static unsigned short two = 2;
     if (f) {
       static char line_c[1024];
       static struct descriptor line_d = { 0, DTYPE_T, CLASS_S, line_c };
@@ -145,9 +144,13 @@ int CheckClient(char *username, int num, char **matchString)
 		    ok = GetMulti()? 1 : BecomeUser(username, &local_user);
 		}
 	      } else {
-		StrRight((struct descriptor *)&access_id, (struct descriptor *)&access_id, &two);
-		if (StrMatchWild((struct descriptor *)&match, &access_id) & 1)
+		access_id.length-=1;
+		access_id.pointer+=1;
+		if (StrMatchWild((struct descriptor *)&match, &access_id) & 1) {
 		  ok = 2;
+		}
+		access_id.length+=1;
+		access_id.pointer-=1;
 	      }
 	      StrFree1Dx(&match);
 	    }


### PR DESCRIPTION
Lines beginning with exclamation points should deny access if
the connection matches the match string after the exclamation point.

This should fix: https://github.com/MDSplus/mdsplus/issues/1684