### PR TITLE
Fix: change timebase of cryocon_shot

### DIFF
--- a/pydevices/HtsDevices/cryocon18i.py
+++ b/pydevices/HtsDevices/cryocon18i.py
@@ -230,7 +230,8 @@ class CRYOCON18I_SHOT(CRYOCON18I):
     def store(self):
         event_name = self.data_event.data()
         now = time.time()
-        self.t2.record = MDSplus.Int64(now)
+        if self.t2.rlength == 0:
+            self.t2.record = MDSplus.Int64(now)
         trend_tree = self.getTrendTree()
         trend_dev = trend_tree.getNode(self.trend_device.data())
 

--- a/pydevices/HtsDevices/cryocon24c.py
+++ b/pydevices/HtsDevices/cryocon24c.py
@@ -325,7 +325,8 @@ class CRYOCON24C_SHOT(CRYOCON24C):
 
     def store(self):
         event_name = self.data_event.data()
-        self.t2.record = MDSplus.Int64(time.time()*1000.)
+        if self.t2.rlength == 0:
+            self.t2.record = MDSplus.Int64(time.time()*1000.)
         trend_tree = self.getTrendTree()
         trend_dev = trend_tree.getNode(self.trend_device.data())
 


### PR DESCRIPTION
Change the store method of the shot device to:
1 - not write T2 if it is already filled in
2 - use T2*1000. instead of now()*1000 for the end time
This allows us to run the store method of the shot over again
(setting the nodes nowrite_once) to fix the start time of the stored
data