### PR TITLE
Zck mdip stuck recv

### DIFF
--- a/mdstcpip/ioroutinesx.h
+++ b/mdstcpip/ioroutinesx.h
@@ -301,31 +301,35 @@ static ssize_t io_recv_to(Connection* c, void *bptr, size_t num, int to_msec){
   if (sock != INVALID_SOCKET) {
     PushSocket(sock);
     signal(SIGABRT, ABORT);
-    if (to_msec<0)
-      recved = RECV(sock, bptr, num, MSG_NOSIGNAL);
-    else {
 #ifdef _TCP
-      struct timeval timeout;
+    struct timeval to,timeout;
+    if (to_msec<0) {
+      timeout.tv_sec  = 10;
+      timeout.tv_usec = 0;
+    } else {
       timeout.tv_sec  = to_msec/1000;
-      timeout.tv_usec = (to_msec%1000)*1000;
-      fd_set readfds;
-      FD_ZERO(&readfds);
-      FD_SET(sock, &readfds);
-      recved = select(sock+1, &readfds, NULL, NULL, &timeout);
+      timeout.tv_usec =(to_msec%1000)*1000;
+    }
+    fd_set rf,readfds;
+    FD_ZERO(&readfds);
+    FD_SET(sock, &readfds);
+    do {
+      to = timeout; rf = readfds;
+      recved = select(sock+1, &rf, NULL, NULL, &to);
 #else
-      struct pollfd fd;
-      fd.fd = sock;
-      fd.events = POLLIN;
-      recved = poll(&fd, 1, to_msec);
+    struct pollfd fd;
+    fd.fd = sock;
+    fd.events = POLLIN;
+    int to_val = to_msec<0 ? 10 : to_msec;
+    do {
+      recved = poll(&fd, 1, to_val);
 #endif
-      switch (recved) {
-      case -1: break; // Error
-      case  0: break; // Timeout
-      default: // for select this will be 1
+      if (recved > 0) {// for select this will be 1
 	recved = RECV(sock, bptr, num, MSG_NOSIGNAL);
 	break;
       }
-    }
+      if (recved < 0) break; // Error
+    } while (to_msec<0); // else timeout
     PopSocket(sock);
   }
   return recved;

--- a/mdstcpip/mdsip_connections.h
+++ b/mdstcpip/mdsip_connections.h
@@ -84,6 +84,7 @@ typedef struct _connection {
   SOCKET readfd;
   struct _io_routines *io;
   unsigned short version;
+  char *rm_user;
 } Connection;
 
 #define INVALID_CONNECTION_ID 0


### PR DESCRIPTION
mdsip seems to get stuck in recv when hosting. This replaces the blocking recv with a timeout loop select.
Furthermore the requested username of the client will be store in connection struct for debugging purposes (since the process uid might have mapped it to something else or not map at all).

Finally thick clients wont keep connections open when they become unused. this should improve the situation with dangling connections as a cleanup currently requires the user to trigger disconnect old connection. TODO: if the keep allive feature for unused connections should be required we should spawn a thread cleaning up old connection after some time out if not reuse by then.