### PR TITLE
Fix:fix random crashes in Distributed Client

### DIFF
--- a/mdstcpip/Connections.c
+++ b/mdstcpip/Connections.c
@@ -214,11 +214,11 @@ int DisconnectConnection(int conid){
   if (c) {
     c->state |= CON_DISCONNECT;
     pthread_cond_broadcast(&c->cond);
-    if (c->state & !CON_DISCONNECT) {
+    if (c->state & ~CON_DISCONNECT) {
       struct timespec tp;
       clock_gettime(CLOCK_REALTIME, &tp);
       tp.tv_sec += 10; // wait upto 10 seconds to allow current task to finish
-      while (c->state & !CON_DISCONNECT && pthread_cond_timedwait(&c->cond,&connection_mutex,&tp));
+      while (c->state & ~CON_DISCONNECT && pthread_cond_timedwait(&c->cond,&connection_mutex,&tp));
     }
     // remove after tast is complete
     if (p)      p->next = c->next;

--- a/treeshr/RemoteAccess.c
+++ b/treeshr/RemoteAccess.c
@@ -147,9 +147,9 @@ static int remote_access_disconnect(int conid, int force){
     DBG("Connection %d< %d\n",conid,host->h.connections);
   } else DBG("Disconnected %d\n",conid);
   for (host = host_list; host ;) {
-    if ((force && host->h.conid == conid) || (host->h.connections <= 0
+    if ((force && host->h.conid == conid) || (host->h.conid == conid && host->h.connections <= 0
 #ifdef USE_TIME
-	host->h.time < time(0)-USE_TIME
+	 && host->h.time < time(0)-USE_TIME
 #endif
 )) {
       DBG("Disconnecting %d: %d\n",host->h.conid,host->h.connections);


### PR DESCRIPTION
When calling remote disconnect, disconnectFromMds was called with wrong id in case a connection whith h.connections == 0 was found in the host list. This can happen (and indeed it happened often in our configuration) if some subtree is missing.

In addition, binary not has been used in place of the wrong logical not  in DisconnectConnections