### PR TITLE
Fix: getOriginalPartName returns a str not String

### DIFF
--- a/pydevices/MitDevices/acq.py
+++ b/pydevices/MitDevices/acq.py
@@ -548,7 +548,7 @@ add_cmd get.trig >> $settingsf
             print("finishing doInit")
 
     def storeClock(self):
-        clock_src=self.clock_src.record.getOriginalPartName().getString()[1:]
+        clock_src=str(self.clock_src.record.getOriginalPartName())[1:]
         if self.debugging():
             print("clock_src = %s" % (clock_src,))
         try:
@@ -630,7 +630,7 @@ add_cmd get.trig >> $settingsf
             print("starting trigger")
         try:
             boardip = self.getBoardIp()
-            trig_src=self.trig_src.record.getOriginalPartName().getString()[1:]
+            trig_src=str(self.trig_src.record.getOriginalPartName())[1:]
             if self.debugging() :
                 print("executing trigger on board %s, trig_src is %s."% (boardip, trig_src,))
             trig_src = trig_src[2:]

--- a/pydevices/MitDevices/acq132.py
+++ b/pydevices/MitDevices/acq132.py
@@ -78,21 +78,21 @@ class ACQ132(acq.Acq):
             print("have active chan")
 
         try:
-            trig_src=self.trig_src.record.getOriginalPartName().getString()[1:]
+            trig_src=str(self.trig_src.record.getOriginalPartName())[1:]
         except Exception as e:
             raise DevBAD_TRIG_SRC(str(e))
         if self.debugging():
             print("have trig_src")
 
         try:
-            clock_src=self.clock_src.record.getOriginalPartName().getString()[1:]
+            clock_src=str(self.clock_src.record.getOriginalPartName())[1:]
         except Exception as e:
             raise DevBAD_CLOCK_SRC(str(e))
         if self.debugging():
             print("have clock src")
 
         try:
-            clock_out=self.clock_out.record.getOriginalPartName().getString()[1:]
+            clock_out=str(self.clock_out.record.getOriginalPartName())[1:]
         except:
             clock_out=None
 
@@ -180,7 +180,7 @@ class ACQ132(acq.Acq):
         chanMask = self.settings['getChannelMask'].split('=')[-1]
         if self.debugging():
             print("chan_mask = %s" % (chanMask,))
-        clock_src=self.clock_src.record.getOriginalPartName().getString()[1:]
+        clock_src=str(self.clock_src.record.getOriginalPartName())[1:]
         if self.debugging():
             print("clock_src = %s" % (clock_src,))
         if clock_src == 'INT_CLOCK' :

--- a/pydevices/MitDevices/acq196.py
+++ b/pydevices/MitDevices/acq196.py
@@ -81,21 +81,21 @@ class ACQ196(acq.Acq):
             print "have active chan\n";
 
         try:
-            trig_src=self.trig_src.record.getOriginalPartName().getString()[1:]
+            trig_src=str(self.trig_src.record.getOriginalPartName())[1:]
         except Exception, e:
             raise DevBAD_TRIG_SRC(str(e))
         if self.debugging():
             print "have trig_src\n";
 
         try:
-            clock_src=self.clock_src.record.getOriginalPartName().getString()[1:]
+            clock_src=str(self.clock_src.record.getOriginalPartName())[1:]
         except Exception, e:
             raise DevBAD_CLOCK_SRC(str(e))
         if self.debugging():
             print "have clock src\n";
 
         try:
-            clock_out=self.clock_out.record.getOriginalPartName().getString()[1:]
+            clock_out=str(self.clock_out.record.getOriginalPartName())[1:]
         except:
             clock_out=None
 

--- a/pydevices/MitDevices/acq196ao.py
+++ b/pydevices/MitDevices/acq196ao.py
@@ -129,13 +129,13 @@ class ACQ196AO(Acq):
             if max_samples < 0 :
                 raise Exception(message)
             msg="Could not read clock source"
-            clock_src=self.ao_clock.record.getOriginalPartName().getString()[1:]
+            clock_src=str(self.ao_clock.record.getOriginalPartName())[1:]
             msg="Clock must be filled in with valid Range value"
             clock = self.__getattr__(clock_src.lower())
             if self.debugging():
                 print "clock source is %s clock is %s\n"%(clock_src, clock,)
             msg="Could not read trigger source"
-            trig_src=self.ao_trig.record.getOriginalPartName().getString()[1:]
+            trig_src=str(self.ao_trig.record.getOriginalPartName())[1:]
             msg="Trigger time must be defined  at init time"
             trigger = self.__getattr__(trig_src.lower())
             msg="FAWG_DIV must be a postive integer"

--- a/pydevices/MitDevices/acq216.py
+++ b/pydevices/MitDevices/acq216.py
@@ -80,21 +80,21 @@ class ACQ216(acq.Acq):
             print "have active chan\n";
 
         try:
-            trig_src=self.trig_src.record.getOriginalPartName().getString()[1:]
+            trig_src=str(self.trig_src.record.getOriginalPartName())[1:]
         except Exception, e:
             raise DevBAD_TRIG_SRC(str(e))
         if self.debugging():
             print "have trig_src\n";
 
         try:
-            clock_src=self.clock_src.record.getOriginalPartName().getString()[1:]
+            clock_src=str(self.clock_src.record.getOriginalPartName())[1:]
         except Exception, e:
             raise DevBAD_CLOCK_SRC(str(e))
         if self.debugging():
             print "have clock src\n";
 
         try:
-            clock_out=self.clock_out.record.getOriginalPartName().getString()[1:]
+            clock_out=str(self.clock_out.record.getOriginalPartName())[1:]
         except:
             clock_out=None
 

--- a/pydevices/MitDevices/acq216_ftp.py
+++ b/pydevices/MitDevices/acq216_ftp.py
@@ -72,11 +72,11 @@ class ACQ216_FTP(ACQ_FTP):
                 print "active chans must be in (2, 4, 8, 16 )"
                 active_chan = 16
             msg="Could not read trigger source"
-            trig_src=self.trig_src.record.getOriginalPartName().getString()[1:]
+            trig_src=str(self.trig_src.record.getOriginalPartName())[1:]
             msg="Could not read clock source"
-            clock_src=self.clock_src.record.getOriginalPartName().getString()[1:]
+            clock_src=str(self.clock_src.record.getOriginalPartName())[1:]
             msg=None
-            clock_out=self.clock_out.record.getOriginalPartName().getString()[1:]
+            clock_out=str(self.clock_out.record.getOriginalPartName())[1:]
             msg="Must specify pre trigger samples"
             pre_trig=int(self.pre_trig.data()*1024)
             msg="Must specify post trigger samples"
@@ -218,7 +218,7 @@ class ACQ216_FTP(ACQ_FTP):
         chanMask = settings['getChannelMask'].split('=')[-1]
         if self.debugging():
             print "chan_mask = %s\n" % (chanMask,)
-        clock_src=self.clock_src.record.getOriginalPartName().getString()[1:]
+        clock_src=str(self.clock_src.record.getOriginalPartName())[1:]
         if self.debugging():
             print "clock_src = %s\n" % (clock_src,)
         if clock_src == 'INT_CLOCK' :

--- a/pydevices/MitDevices/acq_ftp.py
+++ b/pydevices/MitDevices/acq_ftp.py
@@ -199,7 +199,7 @@ class ACQ_FTP(MDSplus.Device):
     def trigger(self, arg):
         boardip = self.getBoardIp()
         try:
-            trig_src=self.trig_src.record.getOriginalPartName().getString()[1:]
+            trig_src=str(self.trig_src.record.getOriginalPartName())[1:]
         except:
             print "could not read trigger source"
             return 0

--- a/pydevices/MitDevices/dt132.py
+++ b/pydevices/MitDevices/dt132.py
@@ -155,7 +155,7 @@ class DT132(Device):
                 print "active chans must be in (8, 16, 32)"
                 active_chans = 32
             error="Trig source must be a string"
-            trig_src=self.trig_src.record.getOriginalPartName().getString()[1:]
+            trig_src=str(self.trig_src.record.getOriginalPartName())[1:]
             error=None
             if debug:
                 print "trig_src is %s\n" % trig_src
@@ -165,7 +165,7 @@ class DT132(Device):
             trig_edge=self.trig_edge.record.getString()
             error=None
             error="Clock source must be a string"
-            clock_src=self.clock_src.record.getOriginalPartName().getString()[1:]
+            clock_src=str(self.clock_src.record.getOriginalPartName())[1:]
             error=None
             if debug:
                 print "clock_src is %s\n" % clock_src
@@ -287,7 +287,7 @@ class DT132(Device):
             post = int(post)-1
             mask = UUT.uut.acqcmd('getChannelMask').split('=')[-1]
             error="Clock source must be a string"
-            clock_src=self.clock_src.record.getOriginalPartName().getString()[1:]
+            clock_src=str(self.clock_src.record.getOriginalPartName())[1:]
             error=None
             if clock_src == 'INT_CLOCK' :
                 self.clock.record = Range(delta=1./self.getInternalClock(UUT))

--- a/pydevices/MitDevices/dt196b.py
+++ b/pydevices/MitDevices/dt196b.py
@@ -158,12 +158,12 @@ class DT196B(Device):
             if active_chans not in (32,64,96) :
                 print "active chans must be in (32, 64, 96 )"
                 active_chans = 96
-            trig_src=self.check('self.trig_src.record.getOriginalPartName().getString()[1:]', "Trig source must be a string")
+            trig_src=self.check('str(self.trig_src.record.getOriginalPartName())[1:]', "Trig source must be a string")
             print "trig_src is %s\n" % trig_src
             if not trig_src in self.trig_sources:
                 raise Exception, "Trig_src must be in %s" % str(self.trig_sources)
             trig_edge=self.check('self.trig_edge.record.getString()', 'Trig edge must be a string')
-            clock_src=self.check('self.clock_src.record.getOriginalPartName().getString()[1:]', "Clock source must be a string")
+            clock_src=self.check('str(self.clock_src.record.getOriginalPartName())[1:]', "Clock source must be a string")
             if debug:
                 print "clock_src is %s\n" % clock_src
             if not clock_src in self.clock_sources:
@@ -282,7 +282,7 @@ class DT196B(Device):
             mask = UUT.uut.acqcmd('getChannelMask').split('=')[-1]
             if debug:
                 print "pre = %d, post = %d" % (pre, post, )
-            clock_src=self.check('self.clock_src.record.getOriginalPartName().getString()[1:]', "Clock source must be a string")
+            clock_src=self.check('str(self.clock_src.record.getOriginalPartName())[1:]', "Clock source must be a string")
             if clock_src == 'INT_CLOCK' :
                 self.clock.record = Range(delta=1./self.getInternalClock(UUT))
             else:

--- a/pydevices/MitDevices/dt216b.py
+++ b/pydevices/MitDevices/dt216b.py
@@ -158,12 +158,12 @@ class DT216B(Device):
             if active_chans not in (2,4,8,16) :
                 print "active chans must be in (2, 4,8, 16 )"
                 active_chans = 16
-            trig_src=self.check('self.trig_src.record.getOriginalPartName().getString()[1:]', "Trig source must be a string")
+            trig_src=self.check('str(self.trig_src.record.getOriginalPartName())[1:]', "Trig source must be a string")
             print "trig_src is %s\n" % trig_src
             if not trig_src in self.trig_sources:
                 raise Exception, "Trig_src must be in %s" % str(self.trig_sources)
             trig_edge=self.check('self.trig_edge.record.getString()', 'Trig edge must be a string')
-            clock_src=self.check('self.clock_src.record.getOriginalPartName().getString()[1:]', "Clock source must be a string")
+            clock_src=self.check('str(self.clock_src.record.getOriginalPartName())[1:]', "Clock source must be a string")
             if debug:
                 print "clock_src is %s\n" % clock_src
             if not clock_src in self.clock_sources:
@@ -266,7 +266,7 @@ class DT216B(Device):
             mask = UUT.uut.acqcmd('getChannelMask').split('=')[-1]
             if debug:
                 print "pre = %d, post = %d" % (pre, post, )
-            clock_src=self.check('self.clock_src.record.getOriginalPartName().getString()[1:]', "Clock source must be a string")
+            clock_src=self.check('str(self.clock_src.record.getOriginalPartName())[1:]', "Clock source must be a string")
             if clock_src == 'INT_CLOCK' or clock_src == 'MASTER' :
                 self.clock.record = Range(delta=1./self.getInternalClock(UUT))
             else:


### PR DESCRIPTION
getOriginalPartName used to return an MDSplus String object.
Several of the Mit Device models then called its getString method
to get a python string from it.

This was changed (when ?) to return a python string, which does
not have a getString method.

Since the python string is a more natural response, the device
code is now changed to assume it returns a python str.