### PR TITLE
Feature: Add node obeys usage when using .name syntax

### DIFF
--- a/treeshr/TreeAddNode.c
+++ b/treeshr/TreeAddNode.c
@@ -172,7 +172,7 @@ int _TreeAddNode(void *dbid, char const *name, int *nid_out, char usage)
 	    new_ptr->name[i] = ' ';
 	  new_ptr->child = 0;
 	  loadint16(&new_ptr->conglomerate_elt, &idx);
-	  if (is_child || usage == TreeUSAGE_STRUCTURE
+	  if ((is_child && (usage == TreeUSAGE_ANY)) || usage == TreeUSAGE_STRUCTURE
 	      || usage == TreeUSAGE_SUBTREE) {
 	    status = TreeInsertChild(parent, new_ptr, dblist->tree_info->header->sort_children);
 	    new_ptr->usage = usage == TreeUSAGE_SUBTREE ? TreeUSAGE_SUBTREE : TreeUSAGE_STRUCTURE;


### PR DESCRIPTION
In the past when adding a new node the code would look for a leading
period and would add a child node (usage structure) even if the usage
specified depicted a typical member node.

This change will create a child node only under the following conditions:

  1) The usage is "structure" or "subtree"
  2) The usage is "any" (default in most cases) and the node name is
     preceeded by a period.

Otherwise a member node will be created with the specified usage.

This fixes #1732 