### PR TITLE
Fix: acq2106_423st.py was throwing an error due to a missing "dev.".

### DIFF
--- a/pydevices/HtsDevices/acq2106_423st.py
+++ b/pydevices/HtsDevices/acq2106_423st.py
@@ -171,7 +171,7 @@ class _ACQ2106_423ST(MDSplus.Device):
 
             def __init__(self,mds):
                 threading.Thread.__init__(self)
-                self.debug = mds.debug
+                self.debug = mds.dev.debug
                 self.node_addr = mds.dev.node.data()
                 self.seg_length = mds.dev.seg_length.data()
                 self.segment_bytes = mds.segment_bytes


### PR DESCRIPTION
Small PR to fix a bug in the acq2106_423st.py file. This was causing the script to error out.