### PR TITLE
Feature:Use Compile in place of Execute to return dimension in getSeg…

### DIFF
--- a/tditest/testing/test-treeshr.ans
+++ b/tditest/testing/test-treeshr.ans
@@ -384,10 +384,10 @@ BeginSegment(segs,0.,99.,0.:99.,data(0:99))
 265388041
 putsegment(segs,-1,data(0:9))
 265389633
-getsegment(segs,0)
-Build_Signal([0,1,2,3,4,5,6,7,8,9], *, [0.,1.,2.,3.,4.,5.,6.,7.,8.,9.])
-segs
-Build_Signal([0,1,2,3,4,5,6,7,8,9], *, [0.,1.,2.,3.,4.,5.,6.,7.,8.,9.])
+data(getsegment(segs, 0))
+[0,1,2,3,4,5,6,7,8,9]
+data(dim_of(getsegment(segs, 0)))
+[0.,1.,2.,3.,4.,5.,6.,7.,8.,9.]
 TreeWrite('main',_shot)
 265388041
 TreeClose()

--- a/tditest/testing/test-treeshr.tdi
+++ b/tditest/testing/test-treeshr.tdi
@@ -187,8 +187,8 @@ segs
 TreePutRecord(segs,)
 BeginSegment(segs,0.,99.,0.:99.,data(0:99))
 putsegment(segs,-1,data(0:9))
-getsegment(segs,0)
-segs
+data(getsegment(segs, 0))
+data(dim_of(getsegment(segs, 0)))
 TreeWrite('main',_shot)
 TreeClose()
 TreeShr->TreeCompressDatafile(ref('main'),val(_shot))

--- a/treeshr/TreeSegments.c
+++ b/treeshr/TreeSegments.c
@@ -1303,6 +1303,7 @@ int _TreeGetNumSegments(void *dbid, int nid, int *num){
 }
 
 static int (*_TdiExecute) () = NULL;
+static int (*_TdiCompile) () = NULL;
 /* checks last segment and trims it down to last written row if necessary */
 static int trim_last_segment(void* dbid, struct descriptor_xd *dim, int filled_rows){
   INIT_TREESUCCESS;
@@ -1366,11 +1367,11 @@ static int trim_last_segment(void* dbid, struct descriptor_xd *dim, int filled_r
       return status;
     }
 fallback: ;
-    status = LibFindImageSymbol_C("TdiShr", "_TdiExecute", &_TdiExecute);
+    status = LibFindImageSymbol_C("TdiShr", "_TdiCompile", &_TdiCompile);
     if STATUS_OK {
       STATIC_CONSTANT DESCRIPTOR(expression, "execute('$1[$2 : $2+$3-1]',$1,lbound($1,-1),$2)");
       DESCRIPTOR_LONG(row_d, &filled_rows);
-      status = _TdiExecute(&dbid,&expression,dim,&row_d,dim MDS_END_ARG);
+      status = _TdiCompile(&dbid,&expression,dim,&row_d,dim MDS_END_ARG);
     }
   return status;
 }


### PR DESCRIPTION
…ment()

It may happen that getSegment() is used even in case the associate dimension is inconsistent. Using TdiExecute() for the returned dim in this case makes getSegment() fail or crash. The problem is solved by just compiling the returned dimension.  NOTE: dimension must be consisted when the whole signal ir retrieved, i.e. when xtreeshr is involved.