### PR TITLE
Fix: Dispatch replies not sent when client restart

### DIFF
--- a/servershr/ServerSendMessage.c
+++ b/servershr/ServerSendMessage.c
@@ -724,10 +724,13 @@ static void DoMessage(Client * c, fd_set * fdactive)
   int msglen;
   int num;
   int nbytes;
-  nbytes = recv(c->reply_sock, reply, 60, MSG_WAITALL);
-  if (nbytes != 60) {
-    RemoveClient(c, fdactive);
-    return;
+  int i;
+  for (i=0;i<2;i++) {
+    nbytes = recv(c->reply_sock, reply+(i*30), 30, MSG_WAITALL);
+    if (nbytes != 30) {
+      RemoveClient(c, fdactive);
+      return;
+    }
   }
   num = sscanf(reply, "%d %d %d %d", &jobid, &replyType, &status, &msglen);
   if (num != 4) {

--- a/servershr/ServerSendMessage.c
+++ b/servershr/ServerSendMessage.c
@@ -724,7 +724,7 @@ static void DoMessage(Client * c, fd_set * fdactive)
   int msglen;
   int num;
   int nbytes;
-  nbytes = recv(c->reply_sock, reply, 60, 0);
+  nbytes = recv(c->reply_sock, reply, 60, MSG_WAITALL);
   if (nbytes != 60) {
     RemoveClient(c, fdactive);
     return;


### PR DESCRIPTION
ServerSendReply is used by dispatch to send status back to
requesting clients. It creates a socket to the client for
this purpose and keeps a list of these socket / port combinations
for reuse.

If a client dispatches an action and exits, then is run again, the
second time, ServerSendReply does not notice that saved socket is
not valid.  It writes the message to the old socket, and the client
never sees the response.

It turns out that the first write to a socket whose far side is no
longer running succeeds.  Errors are only reported, and detectible,
on subsequent writes.

(https://www.softlab.ntua.gr/facilities/documentation/unix/unix-socket-faq/unix-socket-faq-2.html)
said: ` It is less clear what happens to write() calls in this case; I
would expect EPIPE, not on the next call, but the one after.` about the
matter

Breaking the write into 2 chunks allows the code to detect this
condition, and make a new socket.

Fixes: #1760