### PR TITLE
Fix: Restore menu updates for Windows

### DIFF
--- a/deploy/packaging/windows/mdsplus.nsi
+++ b/deploy/packaging/windows/mdsplus.nsi
@@ -996,7 +996,7 @@ Function .onInit
 FunctionEnd ; .onInit
 
 Function .onGUIEnd
-	SendMessage ${HWND_BROADCAST} ${WM_WININICHANGE} 0 "STR:Environment" /TIMEOUT=5000
+	SendMessage ${HWND_BROADCAST} ${WM_SETTINGCHANGE} 0 "STR:Environment" /TIMEOUT=5000
 	${ShowLog}
 FunctionEnd
 ### END INSTALLER ###
@@ -1009,7 +1009,7 @@ Function un.onInit
 functionEnd ; un.onInit
 
 Function un.onGUIEnd
-	SendMessage ${HWND_BROADCAST} ${WM_WININICHANGE} 0 "STR:Environment" /TIMEOUT=5000
+	SendMessage ${HWND_BROADCAST} ${WM_SETTINGCHANGE} 0 "STR:Environment" /TIMEOUT=5000
 FunctionEnd
  
 Section uninstall


### PR DESCRIPTION
The latest Windows operating system updates seemed to deprecate
the use of a obsolete Windows message used to trigger the update
of the Start Menu items after new shortcuts are added or deleted during
a package installation or removal. This fix changes the message
type sent after the MDSplus installation to ensure the menus are
updated.