### PR TITLE
Fix:TreeNode::data()

### DIFF
--- a/include/mdsplus/Mutex.hpp
+++ b/include/mdsplus/Mutex.hpp
@@ -39,7 +39,13 @@ public:
 private:
 #if defined (MDS_PTHREAD)
 	pthread_mutex_t mutex;
-	void _create() { pthread_mutex_init(&mutex, NULL); }
+	void _create() 
+	{ 
+	    pthread_mutexattr_t attr;
+	    pthread_mutexattr_init(&attr);
+	    pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_RECURSIVE);
+	    pthread_mutex_init(&mutex, &attr);
+	}
 	void _lock() { pthread_mutex_lock(&mutex); }
 	void _unlock() { pthread_mutex_unlock(&mutex); }
 	void _destroy() { pthread_mutex_destroy(&mutex); }

--- a/mdsobjects/cpp/mdstreeobjects.cpp
+++ b/mdsobjects/cpp/mdstreeobjects.cpp
@@ -611,6 +611,8 @@ void *TreeNode::convertToDsc()
 Data *TreeNode::data()
 {
 	Data *d = getData();
+	AutoLock lock(treeMutex);
+	setActiveTree(tree);
 	Data *outD = d->data();
 	MDSplus::deleteData(d);
 	return outD;


### PR DESCRIPTION
After the changes in setActiveTree() usage, method data() must be changed in order to set the nid-associated tree before evaluating. The mutex has been changed to recursive in order to avoid deadlocks.