### PR TITLE
Fix: MdsGet1DxA's align should be able to handle size=0

### DIFF
--- a/mdsshr/MdsGet1DxA.c
+++ b/mdsshr/MdsGet1DxA.c
@@ -74,7 +74,10 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <mdsshr.h>
 #include <STATICdef.h>
 
-#define align(bytes,size) ((((bytes) + (size) - 1)/(size)) * (size))
+static inline l_length_t align(l_length_t bytes, l_length_t size) {
+  if (size == 0) return bytes;
+  return ((bytes + size -1)/size)*size;
+}
 
 EXPORT int MdsGet1DxA(const mdsdsc_a_t *const in_ptr, const length_t *const length_ptr, const dtype_t *const dtype_ptr, mdsdsc_xd_t *const out_xd){
   array_coeff *in_dsc = (array_coeff *) in_ptr;

--- a/tditest/testing/test-tdishr.ans
+++ b/tditest/testing/test-tdishr.ans
@@ -6171,6 +6171,10 @@ data(build_signal(1:10,*,*))
 [1,2,3,4,5,6,7,8,9,10]
 data_with_units(build_signal(10*$VALUE,build_with_units(1:10,"counts"),*))
 Build_With_Units([10,20,30,40,50,60,70,80,90,100], "counts")
+data(*)
+$Missing
+data(*)[0]
+[]
 I_TO_X(BUILD_DIM(BUILD_WINDOW(2,5,1.1),BUILD_RANGE(,,3)))
 Set_Range(2:5,[7.1,10.1,13.1,16.1])
 I_TO_X(BUILD_DIM(BUILD_WINDOW(2,7,1.1),BUILD_RANGE(,,3)),1:4)

--- a/tditest/testing/test-tdishr.tdi
+++ b/tditest/testing/test-tdishr.tdi
@@ -3011,6 +3011,8 @@ wait(.01)
 !
 data(build_signal(1:10,*,*))
 data_with_units(build_signal(10*$VALUE,build_with_units(1:10,"counts"),*))
+data(*)
+data(*)[0]
 !
 ! Functions implemented in TdiItoX.c
 !


### PR DESCRIPTION
Fixes https://github.com/MDSplus/mdsplus/issues/1786

Which describes a segmentation fault that can occur when subscripting an empty array.

A regression test for this problem was also added.