### PR TITLE
Build: added logic to determine if we should make a new maven release

### DIFF
--- a/deploy/platform/maven/check_version.sh
+++ b/deploy/platform/maven/check_version.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+javadir=java/
+
+get_latest() {
+ URL="https://oss.sonatype.org/content/groups/public/org/mdsplus/mdsplus-parent/maven-metadata.xml"
+ while [ -z $LATEST ]
+ do
+  echo request LATEST >&2
+  export LATEST=$(curl -s -m 10 $URL 2>/dev/null | grep -oP '(?<=\<latest\>).*(?=\</latest\>)')
+  if [ $? -eq 130 ]; then exit 130; fi
+ done
+ echo $LATEST
+}
+
+get_release_diff() {
+ export LATEST=$(get_latest)
+ git diff alpha_release-${LATEST//./-} --name-only $javadir
+}
+
+get_modules() {
+ echo $(grep -oP '(?<=\<module\>).*(?=\</module\>)' ${javadir}pom.xml)
+}
+
+project_changed() {
+ export LATEST=$(get_latest)
+ MODULES=$(get_modules)
+ if get_release_diff|grep -P "^$javadir(${MODULES// /\|})/.*.java\$" >/dev/null
+ then
+  echo yes
+  return 0
+ else
+  echo no
+  return 1
+ fi
+}
+
+if [ -n "$1" ]
+then
+  test -n "$WORKSPACE"&&cd $WORKSPACE
+  for cmd in "$@"
+  do eval $cmd
+  done
+fi

--- a/deploy/platform/maven/maven_build.sh
+++ b/deploy/platform/maven/maven_build.sh
@@ -49,9 +49,14 @@ then
 else PROGRAM=/scripts/run_maven.sh
 fi
 
+if [ "$BRANCH" != "alpha" ]
+then RELEASE_VERSION=0.0.0-SNAPSHOT
+fi
+
 docker run -t $INTERACTIVE -u $(id -u) --network=host -a stdout -a stderr --cidfile="$WORKSPACE/docker-cid" \
    -e MVN="$MVN" \
    -e MVNGOAL="$MVNGOAL" \
+   -e BRANCH="$BRANCH" \
    -e RELEASE_VERSION="$RELEASE_VERSION" \
    -e GNUPGHOME=/sign_keys/.gnupg \
    -e HOME=/release/maven \

--- a/deploy/platform/maven/run_maven.sh
+++ b/deploy/platform/maven/run_maven.sh
@@ -9,5 +9,6 @@ do
 done
 cd /workspace/maven||exit $?
 mkdir -p /release/maven
-$MVN versions:set -DgenerateBackupPoms=false -DnewVersion=$RELEASE_VERSION -DartifactId=* &&\
+
+$MVN versions:set -DgenerateBackupPoms=false -DnewVersion=$RELEASE_VERSION -DartifactId=*
 $MVN $MVNGOAL


### PR DESCRIPTION
This added some scripts to determine if the java projects in question have been updated since the last maven release. The 2-maven Task can now run automatically after an 1-alpha-release and will roll roll out a release only if necessary.