### PR TITLE
Fix:Top level devices in Java DecompileTree and Signal compile in mds…

### DIFF
--- a/include/mdsobjects.h
+++ b/include/mdsobjects.h
@@ -1542,6 +1542,9 @@ public:
     {
 	setAccessory(units, error, help, validation);
     }
+//Signal descriptor requires length = 0, so override the method
+    void * convertToDsc();
+
 #endif // DOXYGEN end of hidden code
 
     Signal(Data *data, Data *raw, Data *dimension, Data *units = 0, Data *error = 0, Data *help = 0, Data *validation = 0)

--- a/include/mdsobjects.h
+++ b/include/mdsobjects.h
@@ -1534,7 +1534,7 @@ private:
 /// ordered sequence of data. Nothing in common with software objects
 /// signalling systems.
 
-class Signal: public Compound {
+class EXPORT Signal: public Compound {
 public:
 #ifndef DOXYGEN // hide this part from documentation
     Signal(int dtype, int length, char *ptr, int nDescs, char **descs, Data *units = 0, Data *error = 0, Data *help = 0, Data *validation = 0):

--- a/java/jtraverser/src/main/java/DecompileTree.java
+++ b/java/jtraverser/src/main/java/DecompileTree.java
@@ -92,7 +92,7 @@ public class DecompileTree
 	        NodeInfo info = mdsTree.getInfo(members[i], 0);
 	        if(info.getUsage() == NodeInfo.USAGE_DEVICE)
 	            docMember = (Element) document.createElement("device");
-	        if(info.getUsage() == NodeInfo.USAGE_COMPOUND_DATA)
+	        else if(info.getUsage() == NodeInfo.USAGE_COMPOUND_DATA)
 	            docMember = (Element) document.createElement("compound_data");
 	        else
 	            docMember = (Element) document.createElement("member");

--- a/mdsobjects/cpp/mdsdataobjects.cpp
+++ b/mdsobjects/cpp/mdsdataobjects.cpp
@@ -1359,6 +1359,11 @@ void *Compound::convertToDsc()
 	return completeConversionToDsc(convertToCompoundDsc(clazz, dtype, sizeof(short), (void *)&opcode, descs.size(), (void **)(&descs[0])));
 }
 
+void *Signal::convertToDsc()
+{
+	return completeConversionToDsc(convertToCompoundDsc(clazz, dtype, 0, (void *)&opcode, descs.size(), (void **)(&descs[0])));
+}
+
 void *Apd::convertToDsc()
 {
 	return completeConversionToDsc(convertToApdDsc(dtype, descs.size(), (void **)&descs[0]));

--- a/mdsobjects/cpp/testing/MdsTreeSegments.cpp
+++ b/mdsobjects/cpp/testing/MdsTreeSegments.cpp
@@ -93,14 +93,14 @@ void BlockAndRows(){
     int d[2] = {0,7};  unique_ptr<Int32Array> s = new Int32Array(d,2);
     n->beginTimestampedSegment(s);
   }
-  TEST1(AutoString(unique_ptr<Data>(n->getData())->decompile()).string == "Build_Signal(0, [], *, [])");
+  TEST1(AutoString(unique_ptr<Data>(n->getData())->decompile()).string == "Build_Signal([], *, [])");
   // beginning adding row increments next_row to 1
   {
     int  d[1] = {1};    unique_ptr<Int32Array> s = new Int32Array(d,1);
     int64_t t= -1;
     n->putRow(s,&t,10);
   }
-  TEST1(AutoString(unique_ptr<Data>(n->getData()    )->decompile()).string == "Build_Signal(0, [1], *, [-1Q])");
+  TEST1(AutoString(unique_ptr<Data>(n->getData()    )->decompile()).string == "Build_Signal([1], *, [-1Q])");
   TEST1(AutoString(unique_ptr<Data>(n->getSegment(0))->decompile()).string == "[1]");
   /**************************************************************
    beginning a new block set next_row back to 0 of the new block
@@ -110,11 +110,11 @@ void BlockAndRows(){
     int d[2] = {0,0};  unique_ptr<Int32Array> s = new Int32Array(d,2);
     n->beginTimestampedSegment(s);
   }
-  TEST1(AutoString(unique_ptr<Data>(n->getData()    )->decompile()).string == "Build_Signal(0, [1,7], *, [-1Q,0Q])");
+  TEST1(AutoString(unique_ptr<Data>(n->getData()    )->decompile()).string == "Build_Signal([1,7], *, [-1Q,0Q])");
   TEST1(AutoString(unique_ptr<Data>(n->getSegment(0))->decompile()).string == "[1,7]");
   n->setSegmentScale(unique_ptr<Data>(compile("$VALUE*2")));
   TEST1(AutoString(unique_ptr<Data>(n->getSegmentScale())->decompile()).string == "$VALUE * 2");
-  TEST1(AutoString(unique_ptr<Data>(n->getData()    )->decompile()).string == "Build_Signal(0, $VALUE * 2, [1,7], [-1Q,0Q])");
+  TEST1(AutoString(unique_ptr<Data>(n->getData()    )->decompile()).string == "Build_Signal($VALUE * 2, [1,7], [-1Q,0Q])");
   AutoData<Data> nData = n->data(); 
   std::vector<int> data = nData->getIntArray();
   TEST1(data[0]==2);


### PR DESCRIPTION
…objects cpp

1) Devices at top level were not recognized as devices. Not they are
2) The Signal descriptor now requires that length field be 0. Solved by adding a Signal specific convertToDsc() method overriding that of Compound