### PR TITLE
Fix: number of intervals in RANGE should round to lesser integer

### DIFF
--- a/tdishr/TdiDtypeRange.c
+++ b/tdishr/TdiDtypeRange.c
@@ -170,11 +170,8 @@ int Tdi1DtypeRange(opcode_t opcode, int narg, struct descriptor *list[], struct 
     status = TdiDivide(&nelem, dat[2].pointer, &nelem MDS_END_ARG);
   if STATUS_OK
     status = TdiDim(&nelem, &minus_one, &nelem MDS_END_ARG);
-  if (STATUS_OK && nelem.pointer->dtype != DTYPE_L) {
-    status = TdiNint(&nelem, &nelem MDS_END_ARG);
-    if (STATUS_OK && nelem.pointer->dtype != DTYPE_L)
-      status = TdiLong(&nelem, &nelem MDS_END_ARG);
-  }
+  if (STATUS_OK && nelem.pointer->dtype != DTYPE_L)
+    status = TdiLong(&nelem, &nelem MDS_END_ARG);
   if STATUS_OK {
     N_ELEMENTS(nelem.pointer, nseg);
   }


### PR DESCRIPTION
according to #1802 the behaviour of Range is wrong. Well its different from python's range. Given the source code, the difference might have been intentional.