### PR TITLE
Fix: Fixing python3 compatibility with acq435st

### DIFF
--- a/pydevices/HtsDevices/acq400_hapi/__init__.py
+++ b/pydevices/HtsDevices/acq400_hapi/__init__.py
@@ -1,12 +1,9 @@
-from netclient import Netclient
-from netclient import Siteclient
-from netclient import Logclient
-from acq400 import Acq400, STATE, AcqPorts
-from acq400 import Acq2106
-from rad_dds import RAD3DDS
-from shotcontrol import ShotController, ActionScript
-from shotcontrol import intSI as intSI
-import cleanup
-
-
-
+from .netclient import Netclient
+from .netclient import Siteclient
+from .netclient import Logclient
+from .acq400 import Acq400, STATE, AcqPorts
+from .acq400 import Acq2106
+from .rad_dds import RAD3DDS
+from .shotcontrol import ShotController, ActionScript
+from .shotcontrol import intSI as intSI
+from . import cleanup

--- a/pydevices/HtsDevices/acq400_hapi/acq400.py
+++ b/pydevices/HtsDevices/acq400_hapi/acq400.py
@@ -22,11 +22,12 @@ import os
 import errno
 import signal
 import sys
-import netclient
 import numpy
 import socket
 import timeit
 import time
+
+from . import netclient
 
 class AcqPorts:
     """server port constants"""

--- a/pydevices/HtsDevices/acq400_hapi/rad_dds.py
+++ b/pydevices/HtsDevices/acq400_hapi/rad_dds.py
@@ -18,8 +18,8 @@ Created on Sun Jan  8 12:36:38 2017
 @author: pgm
 """
 
-import acq400
-import netclient
+from . import acq400
+from . import netclient
 
 class RAD3DDS(acq400.Acq400):
 

--- a/pydevices/HtsDevices/acq435st.py
+++ b/pydevices/HtsDevices/acq435st.py
@@ -25,7 +25,7 @@
 import numpy as np
 import MDSplus
 import threading
-import Queue
+from queue import Queue
 
 try:
     acq400_hapi = __import__('acq400_hapi', globals(), level=1)


### PR DESCRIPTION
Changed `import Queue` to `from queue import Queue`
Changed syntax of relative imports to work in both python 2 and 3