### PR TITLE
Fix: acq2106_423 decimation fixes using MDSplus.Range() and correcting the ends of the range by accounting for decimation values.

### DIFF
--- a/pydevices/HtsDevices/acq2106_423st.py
+++ b/pydevices/HtsDevices/acq2106_423st.py
@@ -128,6 +128,9 @@ class _ACQ2106_423ST(MDSplus.Device):
 
             decimator = lcma(self.decim)
 
+            if self.seg_length % decimator:		
+                 self.seg_length = (self.seg_length // decimator + 1) * decimator
+
             self.device_thread.start()
 
             segment = 0

--- a/pydevices/HtsDevices/acq2106_423st.py
+++ b/pydevices/HtsDevices/acq2106_423st.py
@@ -119,9 +119,6 @@ class _ACQ2106_423ST(MDSplus.Device):
                     ans = lcm(ans, e)
                 return int(ans)
 
-            def truncate(f, n):
-                return math.floor(f * 10 ** n) / 10 ** n
-
             if self.dev.debug:
                 print("MDSWorker running")
 

--- a/pydevices/HtsDevices/acq2106_423st.py
+++ b/pydevices/HtsDevices/acq2106_423st.py
@@ -131,7 +131,6 @@ class _ACQ2106_423ST(MDSplus.Device):
             self.device_thread.start()
 
             segment = 0
-            begin   = 0.0
             running = self.dev.running
             max_segments = self.dev.max_segments.data()
             while running.on and segment < max_segments:
@@ -147,11 +146,11 @@ class _ACQ2106_423ST(MDSplus.Device):
                         b = buffer[i::self.nchans*self.decim[i]]
                         
                         dim_limits=[begin, begin + self.seg_length*dt - 1]
+                        begin = (segment * self.seg_length*dt)
                         cull_dim  =MDSplus.CULL(dim_limits, None, MDSplus.Range(begin, begin + self.seg_length*dt -1, dt*self.decim[i]))
                         c.makeSegment(begin, begin + self.seg_length*dt, cull_dim, b)
                     i += 1
                 segment += 1
-                begin   += self.seg_length*dt
                 MDSplus.Event.setevent(event_name)
 
                 self.empty_buffers.put(buf)

--- a/pydevices/HtsDevices/acq2106_423st.py
+++ b/pydevices/HtsDevices/acq2106_423st.py
@@ -25,7 +25,7 @@
 import MDSplus
 from MDSplus import Event,Range,CULL
 import threading
-import Queue
+from queue import Queue, Empty
 import time
 import socket
 import math
@@ -101,8 +101,8 @@ class _ACQ2106_423ST(MDSplus.Device):
             self.seg_length = self.dev.seg_length.data()
             self.segment_bytes = self.seg_length*self.nchans*np.int16(0).nbytes
 
-            self.empty_buffers = Queue.Queue()
-            self.full_buffers = Queue.Queue()
+            self.empty_buffers = Queue()
+            self.full_buffers  = Queue()
 
             for i in range(self.NUM_BUFFERS):
                 self.empty_buffers.put(bytearray(self.segment_bytes))
@@ -141,7 +141,7 @@ class _ACQ2106_423ST(MDSplus.Device):
             while running.on and segment < max_segments:
                 try:
                     buf = self.full_buffers.get(block=True, timeout=1)
-                except Queue.Empty:
+                except Empty:
                     continue
 
                 buffer = np.frombuffer(buf, dtype='int16')
@@ -197,7 +197,7 @@ class _ACQ2106_423ST(MDSplus.Device):
                 while self.running:
                     try:
                         buf = self.empty_buffers.get(block=False)
-                    except Queue.Empty:
+                    except Empty:
                         print("NO BUFFERS AVAILABLE. MAKING NEW ONE")
                         buf = bytearray(self.segment_bytes)
                         

--- a/pydevices/HtsDevices/acq2106_423st.py
+++ b/pydevices/HtsDevices/acq2106_423st.py
@@ -23,7 +23,6 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 import MDSplus
-from MDSplus import Event,Range,CULL
 import threading
 from queue import Queue, Empty
 import time
@@ -151,12 +150,12 @@ class _ACQ2106_423ST(MDSplus.Device):
                         b = buffer[i::self.nchans*self.decim[i]]
                         
                         dim_limits=[begin, begin + self.seg_length*dt - 1]
-                        cull_dim  =CULL(dim_limits, None, Range(begin, begin + self.seg_length*dt -1, dt*self.decim[i]))
+                        cull_dim  =MDSplus.CULL(dim_limits, None, MDSplus.Range(begin, begin + self.seg_length*dt -1, dt*self.decim[i]))
                         c.makeSegment(begin, begin + self.seg_length*dt, cull_dim, b)
                     i += 1
                 segment += 1
                 begin   += self.seg_length*dt
-                Event.setevent(event_name)
+                MDSplus.Event.setevent(event_name)
 
                 self.empty_buffers.put(buf)
 

--- a/pydevices/HtsDevices/acq2106_423st.py
+++ b/pydevices/HtsDevices/acq2106_423st.py
@@ -145,10 +145,10 @@ class _ACQ2106_423ST(MDSplus.Device):
                     if c.on:
                         b = buffer[i::self.nchans*self.decim[i]]
                         
-                        dim_limits=[begin, begin + self.seg_length*dt - 1]
                         begin = (segment * self.seg_length*dt)
-                        cull_dim  =MDSplus.CULL(dim_limits, None, MDSplus.Range(begin, begin + self.seg_length*dt -1, dt*self.decim[i]))
-                        c.makeSegment(begin, begin + self.seg_length*dt, cull_dim, b)
+                        dim_limits=[begin, begin + (self.seg_length-1)*dt]
+                        cull_dim  =MDSplus.CULL(dim_limits, None, MDSplus.Range(begin, begin + (self.seg_length-1)*dt, dt*self.decim[i]))
+                        c.makeSegment(begin, begin + (self.seg_length-1)*dt, cull_dim, b)
                     i += 1
                 segment += 1
                 MDSplus.Event.setevent(event_name)

--- a/pydevices/HtsDevices/acq2106_423st.py
+++ b/pydevices/HtsDevices/acq2106_423st.py
@@ -142,13 +142,14 @@ class _ACQ2106_423ST(MDSplus.Device):
                 buffer = np.frombuffer(buf, dtype='int16')
                 i = 0
                 for c in self.chans:
+                    slength = self.seg_length/self.decim[i]
+                    deltat  = dt * self.decim[i]
                     if c.on:
                         b = buffer[i::self.nchans*self.decim[i]]
-                        
-                        begin = (segment * self.seg_length*dt)
-                        dim_limits=[begin, begin + (self.seg_length-1)*dt]
-                        cull_dim  =MDSplus.CULL(dim_limits, None, MDSplus.Range(begin, begin + (self.seg_length-1)*dt, dt*self.decim[i]))
-                        c.makeSegment(begin, begin + (self.seg_length-1)*dt, cull_dim, b)
+                        begin = segment * slength * deltat
+                        end   = begin + (slength - 1) * deltat
+                        dim   = MDSplus.Range(begin, end, deltat)
+                        c.makeSegment(begin, end, dim, b)
                     i += 1
                 segment += 1
                 MDSplus.Event.setevent(event_name)

--- a/pydevices/HtsDevices/acq435st.py
+++ b/pydevices/HtsDevices/acq435st.py
@@ -152,7 +152,6 @@ class ACQ435ST(MDSplus.Device):
             self.device_thread.start()
 
             segment = 0
-            begin   = 0.0
             first = True
             running = self.dev.running
             max_segments = self.dev.max_segments.data()
@@ -170,12 +169,12 @@ class ACQ435ST(MDSplus.Device):
                         b = buffer[i::self.nchans*self.decim[i]]
                         
                         dim_limits=[begin, begin + self.seg_length*dt - 1]
+                        begin = (segment * self.seg_length*dt)
                         cull_dim  =MDSplus.CULL(dim_limits, None, MDSplus.Range(begin, begin + self.seg_length*dt -1, dt*self.decim[i]))
                         c.makeSegment(begin, begin + self.seg_length*dt, cull_dim, b)
 
                     i += 1
                 segment += 1
-                begin   += self.seg_length*dt
                 MDSplus.Event.setevent(event_name)
 
                 self.empty_buffers.put(buf)

--- a/pydevices/HtsDevices/acq435st.py
+++ b/pydevices/HtsDevices/acq435st.py
@@ -148,6 +148,9 @@ class ACQ435ST(MDSplus.Device):
                 dt = 1./self.dev.freq.data()
 
             decimator = lcma(self.decim)
+            
+            if self.seg_length % decimator:		
+                 self.seg_length = (self.seg_length // decimator + 1) * decimator		
              
             self.device_thread.start()
 

--- a/pydevices/HtsDevices/acq435st.py
+++ b/pydevices/HtsDevices/acq435st.py
@@ -168,10 +168,10 @@ class ACQ435ST(MDSplus.Device):
                     if c.on:
                         b = buffer[i::self.nchans*self.decim[i]]
                         
-                        dim_limits=[begin, begin + self.seg_length*dt - 1]
                         begin = (segment * self.seg_length*dt)
-                        cull_dim  =MDSplus.CULL(dim_limits, None, MDSplus.Range(begin, begin + self.seg_length*dt -1, dt*self.decim[i]))
-                        c.makeSegment(begin, begin + self.seg_length*dt, cull_dim, b)
+                        dim_limits=[begin, begin + (self.seg_length -1)*dt]
+                        cull_dim  =MDSplus.CULL(dim_limits, None, MDSplus.Range(begin, begin + (self.seg_length-1)*dt, dt*self.decim[i]))
+                        c.makeSegment(begin, begin + (self.seg_length-1)*dt, cull_dim, b)
 
                     i += 1
                 segment += 1
@@ -217,7 +217,7 @@ class ACQ435ST(MDSplus.Device):
                 while self.running:
                     try:
                         buf = self.empty_buffers.get(block=False)
-                    except Queue.Empty:
+                    except Empty:
                         print("NO BUFFERS AVAILABLE. MAKING NEW ONE")
                         buf = bytearray(self.segment_bytes)
 


### PR DESCRIPTION
The changes are two fold:
1. To Homogenize the way `acq435st.py` and `acq2106_423st.py` deal with the creation of the time dimension segments. We have now corrected the ends of the ranges by accounting for the decimation value. We use MDSplus.Range(). The defined function called truncate() no longer is used.
2. Bring Queue and Empty Python 2 libraries to comply with Python 3 queue library

TODO
- [x] Port changes to `acq435st.py`