### PR TITLE
Fix: create TdiRefZone.l_zone only if none exists

### DIFF
--- a/conf/valgrind-java.supp
+++ b/conf/valgrind-java.supp
@@ -152,3 +152,39 @@
    ...
    obj:**/libjvm.so
 }
+
+{
+   jvm java-8-openjdk (rare)
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:__libc_alloc_buffer_allocate
+   fun:__resolv_conf_allocate
+   fun:__resolv_conf_load
+   fun:__resolv_conf_get_current
+   fun:__res_vinit
+   fun:__resolv_context_get
+   fun:gaih_inet.constprop.7
+   fun:getaddrinfo
+   fun:Java_java_net_Inet4AddressImpl_lookupAllHostAddr
+   obj:*
+   obj:*
+   obj:*
+   obj:*
+   obj:*
+   obj:*
+   obj:*
+   obj:*
+   obj:*
+   obj:*
+   obj:*
+   obj:*
+   obj:*
+   obj:*
+   obj:*
+   obj:/usr/lib/jvm/java-1.8.0-openjdk-1.8.0.171-3.b10.fc26.x86_64/jre/lib/amd64/server/libjvm.so
+   obj:/usr/lib/jvm/java-1.8.0-openjdk-1.8.0.171-3.b10.fc26.x86_64/jre/lib/amd64/server/libjvm.so
+   obj:/usr/lib/jvm/java-1.8.0-openjdk-1.8.0.171-3.b10.fc26.x86_64/jre/lib/amd64/server/libjvm.so
+   fun:JVM_InvokeMethod
+   obj:*
+}

--- a/tdishr/TdiCompile.c
+++ b/tdishr/TdiCompile.c
@@ -116,7 +116,8 @@ static inline int tdi_compile(ThreadStatic * TdiThreadStatic_p,struct descriptor
   TdiThreadStatic_p->compiler_recursing = 1;
   pthread_mutex_lock(&lock);
   pthread_cleanup_push((void*)cleanup_compile,(void*)TdiThreadStatic_p);
-  status = LibCreateVmZone(&TdiRefZone.l_zone);
+  if (!TdiRefZone.l_zone)
+    status = LibCreateVmZone(&TdiRefZone.l_zone);
   TdiRefZone.l_status = TdiBOMB;  // In case we bomb out
   TdiRefZone.a_begin  = TdiRefZone.a_cur = memcpy(malloc(text_ptr->length), text_ptr->pointer, text_ptr->length);
   TdiRefZone.a_end    = TdiRefZone.a_cur + text_ptr->length;


### PR DESCRIPTION
fixes #1810 for stable