### PR TITLE
Removing extra writes to stdout

### DIFF
--- a/mdsobjects/cpp/mdstreeobjects.cpp
+++ b/mdsobjects/cpp/mdstreeobjects.cpp
@@ -1627,7 +1627,6 @@ TreeNode *TreeNode::getNode(String *relPathStr)
 
 TreeNodeArray *TreeNode::getNodeWild(char const * path, int usageMask)
 {
-	std::cout << "In C++ TreeNode getNodeWild..." << std::endl;
 	int status;
 	void *wildCtx = 0;
 


### PR DESCRIPTION
It seems a previous cleanup missed a few writes to stdout.