### PR TITLE
Feature: reentrant TdiCompile

### DIFF
--- a/mdsobjects/cpp/testing/MdsExpressionCompileTest.cpp
+++ b/mdsobjects/cpp/testing/MdsExpressionCompileTest.cpp
@@ -108,7 +108,7 @@ int main(int argc UNUSED_ARGUMENT, char *argv[] UNUSED_ARGUMENT){
     // TODO: adds more tests .. //
     END_TESTING;
 
-    BEGIN_TESTING(GetIdentPutIdent);
+    BEGIN_TESTING(MultiThreadPub);
     MultiThreadTest(PubNCmd,PubCmds);
     END_TESTING;
 

--- a/tdishr/TdiCompile.c
+++ b/tdishr/TdiCompile.c
@@ -148,7 +148,7 @@ EXPORT int Tdi1Compile(opcode_t opcode, int narg, struct descriptor *list[], str
   int status;
   GET_TDITHREADSTATIC_P;
   if (TdiThreadStatic_p->compiler_recursing == 1) {
-    fprintf(stderr, "Error: Recursive calls to TDI Compile is not supported");
+    fprintf(stderr, "Error: Recursive calls to TDI Compile is not supported\n");
     return TdiRECURSIVE;
   }
   INIT_AND_FREEXD_ON_EXIT(tmp);

--- a/tdishr/TdiCompile.c
+++ b/tdishr/TdiCompile.c
@@ -42,6 +42,12 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "tdithreadsafe.h"
 #include <mdsshr.h>
 #include <strroutines.h>
+#define DEBUG
+#ifdef DEBUG
+ #define DBG(...) fprintf(stderr,__VA_ARGS__)
+#else
+ #define DBG(...) {/**/}
+#endif
 
 extern int Tdi1Evaluate();
 extern int TdiYacc();
@@ -51,25 +57,19 @@ extern int TdiYacc();
 	YACC converts TdiYacc.Y to TdiYacc.C to parse TDI statements. Also YACC subroutines.
 	LEX converts TdiLex.X to TdiLex.C for lexical analysis. Also LEX subroutines.
 
-	Limitations:
-	For recursion must pass LEX:
-	        zone status bol cur end
-	        tdiyylval tdiyyval
-	        tdiyytext[YYLMAX] tdiyyleng tdiyymorfg tdiyytchar tdiyyin? tdiyyout?
-	For recursion must pass YACC also:
-	        tdiyydebug? tdiyyv[YYMAXDEPTH] tdiyychar tdiyynerrs tdiyyerrflag
-	Thus no recursion because the tdiyy's are built into LEX and YACC.
-	IMMEDIATE (`) must never call COMPILE. NEED to prevent this.
+	supports (`) on COMPILE
 */
 
 static pthread_mutex_t lock = PTHREAD_MUTEX_INITIALIZER;
 static void cleanup_compile(ThreadStatic * TdiThreadStatic_p){
-  LibResetVmZone(&TdiRefZone.l_zone);
-  if (TdiRefZone.a_begin) {
-    free(TdiRefZone.a_begin);
-    TdiRefZone.a_begin=NULL;
+  LibResetVmZone(&TDI_REFZONE.l_zone);
+  if (TDI_REFZONE.a_begin) {
+    free(TDI_REFZONE.a_begin);
+    TDI_REFZONE.a_begin=NULL;
   }
-  pthread_mutex_unlock(&lock);
+  TDI_COMPILE_REC = FALSE;
+  if (TDI_STACK_IDX==0) // makes it reentrant
+    pthread_mutex_unlock(&lock);
 }
 
 static inline void add_compile_info(int status,ThreadStatic * TdiThreadStatic_p) {
@@ -80,15 +80,14 @@ static inline void add_compile_info(int status,ThreadStatic * TdiThreadStatic_p)
     || status==TreeNNF
     || status==TdiBOMB)) return;
   static const DESCRIPTOR(compile_err, "%TDI Error compiling region marked by ^\n");
-  struct descriptor_d *message = &TdiThreadStatic_p->TdiIntrinsic_message;
-  if (!TdiRefZone.a_begin || message->length >= MAXMESS)
+  if (!TDI_REFZONE.a_begin || TDI_INTRINSIC_MSG.length >= MAXMESS)
     return;
   // b------x----c----e
   // '-l_ok-'-xc-'-ce-'
-  char *b = TdiRefZone.a_begin;
-  char *e = TdiRefZone.a_end;
-  char *c = MINMAX(b, TdiRefZone.a_cur, e);
-  char *x = MINMAX(b, b + TdiRefZone.l_ok, c);
+  char *b = TDI_REFZONE.a_begin;
+  char *e = TDI_REFZONE.a_end;
+  char *c = MINMAX(b, TDI_REFZONE.a_cur, e);
+  char *x = MINMAX(b, b + TDI_REFZONE.l_ok, c);
   int xc = MINMAX(0, c-x, MAXLINE);
   int ce = MINMAX(0, e-c, MAXLINE);
   int bx = MINMAX(0, x-b, MAXLINE);
@@ -97,63 +96,63 @@ static inline void add_compile_info(int status,ThreadStatic * TdiThreadStatic_p)
   if (bx+xc+ce > MAXLINE)
     bx = MINMAX(0, bx, MAXFRAC);
   int len = bx+xc+2;
-  struct descriptor marker = { len, DTYPE_T, CLASS_S, memset(malloc(len+1),' ',len) };
-  struct descriptor region = { bx+xc+ce, DTYPE_T, CLASS_S, x-bx };
+  mdsdsc_t marker = { len, DTYPE_T, CLASS_S, memset(malloc(len+1),' ',len) };
+  mdsdsc_t region = { bx+xc+ce, DTYPE_T, CLASS_S, x-bx };
   marker.pointer[bx]='^';
   marker.pointer[0] = marker.pointer[len-1]='\n';
   if (xc>0)
     marker.pointer[bx+xc]='^';
   else if (bx>0)
     marker.pointer[bx]='^';
-  StrAppend(message,(struct descriptor *)&compile_err);
-  StrAppend(message,(struct descriptor *)&region);
-  StrAppend(message,(struct descriptor *)&marker);
+  StrAppend(&TDI_INTRINSIC_MSG,(mdsdsc_t *)&compile_err);
+  StrAppend(&TDI_INTRINSIC_MSG,(mdsdsc_t *)&region);
+  StrAppend(&TDI_INTRINSIC_MSG,(mdsdsc_t *)&marker);
   free(marker.pointer);
 }
 
-static inline int tdi_compile(ThreadStatic * TdiThreadStatic_p,struct descriptor * text_ptr, int narg, struct descriptor *list[], struct descriptor_xd *out_ptr) {
+static inline int tdi_compile(ThreadStatic * TdiThreadStatic_p,mdsdsc_t * text_ptr, int narg, mdsdsc_t *list[], mdsdsc_xd_t *out_ptr) {
   int status;
-  TdiThreadStatic_p->compiler_recursing = 1;
-  pthread_mutex_lock(&lock);
+  if (TDI_STACK_IDX==0) // makes it reentrant
+    pthread_mutex_lock(&lock);
+  TDI_COMPILE_REC = TRUE;
   pthread_cleanup_push((void*)cleanup_compile,(void*)TdiThreadStatic_p);
-  if (!TdiRefZone.l_zone)
-    status = LibCreateVmZone(&TdiRefZone.l_zone);
-  TdiRefZone.l_status = TdiBOMB;  // In case we bomb out
-  TdiRefZone.a_begin  = TdiRefZone.a_cur = memcpy(malloc(text_ptr->length), text_ptr->pointer, text_ptr->length);
-  TdiRefZone.a_end    = TdiRefZone.a_cur + text_ptr->length;
-  TdiRefZone.l_ok     = 0;
-  TdiRefZone.l_narg   = narg - 1;
-  TdiRefZone.l_iarg   = 0;
-  TdiRefZone.a_list   = list;
-  if (IS_NOT_OK(TdiYacc()) && IS_OK(TdiRefZone.l_status))
+  if (!TDI_REFZONE.l_zone)
+    status = LibCreateVmZone(&TDI_REFZONE.l_zone);
+  TDI_REFZONE.l_status = TdiBOMB;  // In case we bomb out
+  TDI_REFZONE.a_begin  = TDI_REFZONE.a_cur = memcpy(malloc(text_ptr->length), text_ptr->pointer, text_ptr->length);
+  TDI_REFZONE.a_end    = TDI_REFZONE.a_cur + text_ptr->length;
+  TDI_REFZONE.l_ok     = 0;
+  TDI_REFZONE.l_narg   = narg - 1;
+  TDI_REFZONE.l_iarg   = 0;
+  TDI_REFZONE.a_list   = list;
+  if (IS_NOT_OK(TdiYacc()) && IS_OK(TDI_REFZONE.l_status))
     status = TdiSYNTAX;
   else
-    status = TdiRefZone.l_status;
+    status = TDI_REFZONE.l_status;
  /************************
   Move from temporary zone.
   ************************/
   if STATUS_OK {
-    if (TdiRefZone.a_result == 0)
+    if (TDI_REFZONE.a_result == 0)
       MdsFree1Dx(out_ptr, NULL);
     else
-      status = MdsCopyDxXd((struct descriptor *)TdiRefZone.a_result, out_ptr);
+      status = MdsCopyDxXd((mdsdsc_t *)TDI_REFZONE.a_result, out_ptr);
   }
   add_compile_info(status,TdiThreadStatic_p);
   pthread_cleanup_pop(1);
-  TdiThreadStatic_p->compiler_recursing = 0;
   return status;
 }
 
-EXPORT int Tdi1Compile(opcode_t opcode, int narg, struct descriptor *list[], struct descriptor_xd *out_ptr){
+EXPORT int Tdi1Compile(opcode_t opcode, int narg, mdsdsc_t *list[], mdsdsc_xd_t *out_ptr){
   int status;
   GET_TDITHREADSTATIC_P;
-  if (TdiThreadStatic_p->compiler_recursing == 1) {
-    fprintf(stderr, "Error: Recursive calls to TDI Compile is not supported\n");
+  if (TDI_COMPILE_REC) {
+    fprintf(stderr, "Error: Recursive calls to TDI Compile\n");
     return TdiRECURSIVE;
   }
   INIT_AND_FREEXD_ON_EXIT(tmp);
   status = Tdi1Evaluate(opcode, 1, list, &tmp);// using Tdi1Evaluate over TdiEvaluate saves 3 stack levels
-  struct descriptor *text_ptr = tmp.pointer;
+  mdsdsc_t *text_ptr = tmp.pointer;
   if (STATUS_OK && text_ptr->dtype != DTYPE_T)
     status = TdiINVDTYDSC;
   else if (STATUS_OK && text_ptr->length > 0)
@@ -167,7 +166,7 @@ EXPORT int Tdi1Compile(opcode_t opcode, int narg, struct descriptor *list[], str
   Compile and evaluate an expression.
       result = EXECUTE(string, [arg1,...])
 */
-int Tdi1Execute(opcode_t opcode, int narg, struct descriptor *list[], struct descriptor_xd *out_ptr){
+int Tdi1Execute(opcode_t opcode, int narg, mdsdsc_t *list[], mdsdsc_xd_t *out_ptr){
   INIT_STATUS;
   FREEXD_ON_EXIT(out_ptr);
   INIT_AND_FREEXD_ON_EXIT(tmp);

--- a/tdishr/TdiCull.c
+++ b/tdishr/TdiCull.c
@@ -63,7 +63,7 @@ extern int Tdi2Range();
 
 extern unsigned short OpcValue;
 STATIC_CONSTANT DESCRIPTOR_FUNCTION_0(value, &OpcValue);
-STATIC_CONSTANT DESCRIPTOR_RANGE(EMPTY_RANGEE, 0, 0, (struct descriptor *)&value);
+STATIC_CONSTANT DESCRIPTOR_RANGE(EMPTY_RANGE, 0, 0, (struct descriptor *)&value);
 
 /**********************************************
 	Redo culled array or scalar.
@@ -288,25 +288,25 @@ STATIC_ROUTINE int work(int rroutine(struct descriptor *, struct descriptor_a *,
 	while (new[2] && new[2]->class == CLASS_XD)
 	  new[2] = (struct descriptor_range *)new[2]->pointer;
 	struct descriptor *keep[3];
-	memcpy(keep,TdiThreadStatic_p->TdiRANGE_PTRS,sizeof(keep));
-	TdiThreadStatic_p->TdiRANGE_PTRS[0] = &dx0;
-	TdiThreadStatic_p->TdiRANGE_PTRS[1] = &dx1;
-	TdiThreadStatic_p->TdiRANGE_PTRS[2] = 0;
+	memcpy(keep,TDI_RANGE_PTRS,sizeof(keep));
+	TDI_RANGE_PTRS[0] = &dx0;
+	TDI_RANGE_PTRS[1] = &dx1;
+	TDI_RANGE_PTRS[2] = 0;
 	if (in.pointer->dtype == DTYPE_DIMENSION) {
-	  TdiThreadStatic_p->TdiRANGE_PTRS[2] = in.pointer;
+	  TDI_RANGE_PTRS[2] = in.pointer;
 		/************************************************************
 	        Dimensions conversion with missing increment uses all values.
 	        ************************************************************/
 	  if (new[2]->dtype == DTYPE_RANGE
 	      && (new[2]->ndesc == 2 || (new[2]->ndesc == 3 && new[2]->deltaval == 0))) {
-	    fake_range = EMPTY_RANGEE;
+	    fake_range = EMPTY_RANGE;
 	    fake_range.begin = new[2]->begin;
 	    fake_range.ending = new[2]->ending;
 	    new[2] = &fake_range;
 	  }
 	}
 	status = TdiGetArgs(opcode, 3, new, sig, uni, dat, cats);
-	memcpy(TdiThreadStatic_p->TdiRANGE_PTRS,keep,sizeof(keep));
+	memcpy(TDI_RANGE_PTRS,keep,sizeof(keep));
       }
       if STATUS_OK
 	status = Tdi2Range(3, uni, dat, cats, 0);

--- a/tdishr/TdiDecompile.c
+++ b/tdishr/TdiDecompile.c
@@ -34,8 +34,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <tdishr_messages.h>
 #include <STATICdef.h>
 
-#define TdiDECOMPILE_MAX TdiThreadStatic_p->TdiDecompile_max
-
 #include "tdirefcat.h"
 #include "tdirefstandard.h"
 #include <strroutines.h>
@@ -66,17 +64,17 @@ EXPORT int Tdi1Decompile(opcode_t opcode __attribute__ ((unused)), int narg, str
   INIT_STATUS;
   GET_TDITHREADSTATIC_P;
   struct descriptor_d answer = { 0, DTYPE_T, CLASS_D, 0 };
-  TdiThreadStatic_p->TdiIndent = 1;
+  TDI_INDENT = 1;
   if (narg > 1 && list[1])
-    status = TdiGetLong(list[1], &TdiDECOMPILE_MAX);
+    status = TdiGetLong(list[1], &TDI_DECOMPILE_MAX);
   else
-    TdiDECOMPILE_MAX = 0xffff;
+    TDI_DECOMPILE_MAX = 0xffff;
   if STATUS_OK
     status = Tdi0Decompile(list[0], 9999, &answer);
-  while (status == StrSTRTOOLON && TdiDECOMPILE_MAX > 10) {
-    TdiDECOMPILE_MAX /= 10;
-    if (TdiDECOMPILE_MAX > 100)
-      TdiDECOMPILE_MAX = 100;
+  while (status == StrSTRTOOLON && TDI_DECOMPILE_MAX > 10) {
+    TDI_DECOMPILE_MAX /= 10;
+    if (TDI_DECOMPILE_MAX > 100)
+      TDI_DECOMPILE_MAX = 100;
     StrFree1Dx(&answer);
     status = Tdi0Decompile(list[0], 9999, &answer);
   }
@@ -662,7 +660,7 @@ complex: ;
       int coeff = a_ptr->aflags.coeff;
       int dimct = coeff ? a_ptr->dimct : 1;
       unsigned int count = (int)a_ptr->arsize / max(1, length);
-      int more = count > TdiDECOMPILE_MAX || a_ptr->arsize >= 32768;
+      int more = count > TDI_DECOMPILE_MAX || a_ptr->arsize >= 32768;
 
 		/**************************************
 	        Special data types made easier to read.

--- a/tdishr/TdiDecompileR.c
+++ b/tdishr/TdiDecompileR.c
@@ -152,10 +152,10 @@ STATIC_ROUTINE int Indent(int step, struct descriptor_d *pout){
   GET_TDITHREADSTATIC_P;
 #ifdef _WIN32
   const char* newline= "\r\n\t\t\t\t\t\t\t";
-  int identlen = ((TdiThreadStatic_p->TdiIndent += step) < 8 ? TdiThreadStatic_p->TdiIndent : 8)+1;
+  int identlen = ((TDI_INDENT += step) < 8 ? TDI_INDENT : 8)+1;
 #else
   const char* newline= "\n\t\t\t\t\t\t\t";
-  int identlen = ((TdiThreadStatic_p->TdiIndent += step) < 8 ? TdiThreadStatic_p->TdiIndent : 8);
+  int identlen = ((TDI_INDENT += step) < 8 ? TDI_INDENT : 8);
 #endif
   struct descriptor_d new = { 0, DTYPE_T, CLASS_D, 0 };
   new.length = pout->length + identlen;

--- a/tdishr/TdiDtypeRange.c
+++ b/tdishr/TdiDtypeRange.c
@@ -102,11 +102,11 @@ int Tdi1DtypeRange(opcode_t opcode, int narg, struct descriptor *list[], struct 
     DESCRIPTOR_RANGE(range, 0, 0, 0);
     range.begin = &dx0;
     range.ending = &dx1;
-    if (!TdiThreadStatic_p->TdiRANGE_PTRS[2])
+    if (!TDI_RANGE_PTRS[2])
       return TdiNULL_PTR;
     if (new[0] == 0 && new[1] == 0)
-      return TdiItoX(TdiThreadStatic_p->TdiRANGE_PTRS[2], out_ptr MDS_END_ARG);
-    status = TdiXtoI(TdiThreadStatic_p->TdiRANGE_PTRS[2], TdiItoXSpecial, &limits MDS_END_ARG);
+      return TdiItoX(TDI_RANGE_PTRS[2], out_ptr MDS_END_ARG);
+    status = TdiXtoI(TDI_RANGE_PTRS[2], TdiItoXSpecial, &limits MDS_END_ARG);
     if STATUS_OK {
       dx0 = *limits.pointer;
       dx0.class = CLASS_S;
@@ -115,25 +115,25 @@ int Tdi1DtypeRange(opcode_t opcode, int narg, struct descriptor *list[], struct 
 
       dat[0] = dat[1] = EMPTY_XD;
       if (new[0]) {
-	status = TdiXtoI(TdiThreadStatic_p->TdiRANGE_PTRS[2], new[0], &dat[0] MDS_END_ARG);
+	status = TdiXtoI(TDI_RANGE_PTRS[2], new[0], &dat[0] MDS_END_ARG);
 	range.begin = dat[0].pointer;
       }
     }
     if (new[1] && STATUS_OK) {
-      status = TdiXtoI(TdiThreadStatic_p->TdiRANGE_PTRS[2], new[1], &dat[1] MDS_END_ARG);
+      status = TdiXtoI(TDI_RANGE_PTRS[2], new[1], &dat[1] MDS_END_ARG);
       range.ending = dat[1].pointer;
     }
     if STATUS_OK
-      status = TdiItoX(TdiThreadStatic_p->TdiRANGE_PTRS[2], &range, out_ptr MDS_END_ARG);
+      status = TdiItoX(TDI_RANGE_PTRS[2], &range, out_ptr MDS_END_ARG);
     MdsFree1Dx(&dat[1], NULL);
     MdsFree1Dx(&dat[0], NULL);
     MdsFree1Dx(&limits, NULL);
     return status;
   }
   if (new[0] == 0)
-    new[0] = TdiThreadStatic_p->TdiRANGE_PTRS[0];
+    new[0] = TDI_RANGE_PTRS[0];
   if (new[1] == 0)
-    new[1] = TdiThreadStatic_p->TdiRANGE_PTRS[1];
+    new[1] = TDI_RANGE_PTRS[1];
   if (new[2] == 0)
     nnew = 2;
 

--- a/tdishr/TdiGetArgs.c
+++ b/tdishr/TdiGetArgs.c
@@ -72,8 +72,8 @@ int TdiGetSignalUnitsData(struct descriptor *in_ptr,
     case DTYPE_SIGNAL:
       *signal_ptr = *data_ptr;
       *data_ptr = EMPTY_XD;
-      keep = TdiThreadStatic_p->TdiSELF_PTR;
-      TdiThreadStatic_p->TdiSELF_PTR = (struct descriptor_xd *)signal_ptr->pointer;
+      keep = TDI_SELF_PTR;
+      TDI_SELF_PTR = (struct descriptor_xd *)signal_ptr->pointer;
       status = TdiGetData(omitu, ((struct descriptor_signal *)signal_ptr->pointer)->data, data_ptr);
       if STATUS_OK
 	switch (data_ptr->pointer->dtype) {
@@ -91,7 +91,7 @@ int TdiGetSignalUnitsData(struct descriptor *in_ptr,
 	  MdsFree1Dx(units_ptr, NULL);
 	  break;
 	}
-      TdiThreadStatic_p->TdiSELF_PTR = keep;
+      TDI_SELF_PTR = keep;
       break;
     case DTYPE_WITH_UNITS:
       tmp = *data_ptr;

--- a/tdishr/TdiIntrinsic.c
+++ b/tdishr/TdiIntrinsic.c
@@ -78,25 +78,26 @@ extern int Tdi0Decompile();
 extern int TdiConvert();
 extern int TdiGetLong();
 extern int SysGetMsg();
-STATIC_ROUTINE struct descriptor *FixedArray();
+STATIC_ROUTINE mdsdsc_t *FixedArray();
 
-STATIC_CONSTANT struct descriptor miss_dsc = { 0, DTYPE_MISSING, CLASS_S, 0 };
+STATIC_CONSTANT mdsdsc_t miss_dsc = { 0, DTYPE_MISSING, CLASS_S, 0 };
 
 /****************************
 Explain in 300 words or less.
 ****************************/
 #define MAXMESS 1800
-STATIC_ROUTINE void add(char *text)
+#define ADD(text) add(text, TdiThreadStatic_p)
+STATIC_ROUTINE void add(char *const text, ThreadStatic *const TdiThreadStatic_p)
 {
   struct descriptor_d new = { 0, DTYPE_T, CLASS_D, 0 };
-  struct descriptor_d *message = &((TdiGetThreadStatic())->TdiIntrinsic_message);
-  new.length = (unsigned short)strlen(text);
+  new.length = (length_t)strlen(text);
   new.pointer = text;
-  if (message->length + new.length < MAXMESS)
-    StrAppend(message, (struct descriptor *)&new);
+  if (TDI_INTRINSIC_MSG.length + new.length < MAXMESS)
+    StrAppend(&TDI_INTRINSIC_MSG, (mdsdsc_t *)&new);
 }
 
-STATIC_ROUTINE void numb(int count)
+#define NUMB(count) numb(count, TdiThreadStatic_p)
+STATIC_ROUTINE void numb(int count, ThreadStatic *const TdiThreadStatic_p)
 {
   STATIC_CONSTANT char blanks[] = "            ";
   char val[sizeof(blanks)], *pval;
@@ -111,7 +112,7 @@ STATIC_ROUTINE void numb(int count)
       *--pval = (char)(count % 10 + '0');
   if (pval > val)
     *--pval = ' ';
-  add(pval);
+  ADD(pval);
 }
 
 /***************************************************
@@ -119,88 +120,90 @@ Danger: this routine is used by DECOMPILE to report.
 ***************************************************/
 int TdiTrace(opcode_t opcode __attribute__ ((unused)),
 	     int narg __attribute__ ((unused)),
-	     struct descriptor *list[] __attribute__ ((unused)),
+	     mdsdsc_t *list[] __attribute__ ((unused)),
 	     struct descriptor_xd *out_ptr)
 {
-  struct descriptor_d *message = &(TdiGetThreadStatic()->TdiIntrinsic_message);
-  if (message->length > MAXMESS)
+  GET_TDITHREADSTATIC_P;
+  if (TDI_INTRINSIC_MSG.length > MAXMESS)
     return MDSplusERROR;
-  add("%TDI Decompile text_length");
-  numb(out_ptr->length);
-  add(" partial text: ");
-  if (out_ptr->length < MAXLINE - 70)
-    StrAppend(message, (struct descriptor *)out_ptr);
-  else {
+  ADD("%TDI Decompile text_length");
+  NUMB(out_ptr->length);
+  ADD(" partial text: ");
+  if (out_ptr->length < MAXLINE - 70) {
+    StrAppend(&TDI_INTRINSIC_MSG, (mdsdsc_t *)out_ptr);
+  } else {
     *((char *)out_ptr->pointer + MAXLINE - 70) = '\0';
-    add((char *)out_ptr->pointer);
+    ADD((char *)out_ptr->pointer);
   }
   return MDSplusSUCCESS;
 }
 
 static inline void TRACE(opcode_t opcode, int narg,
-	  struct descriptor *list[],
+	  mdsdsc_t *list[],
 	  struct descriptor_xd *out_ptr __attribute__ ((unused)))
 {
-  struct descriptor_d *message = &((TdiGetThreadStatic())->TdiIntrinsic_message);
-  if (message->length >= MAXMESS)
+  GET_TDITHREADSTATIC_P;
+  if (TDI_INTRINSIC_MSG.length >= MAXMESS)
     return;
-  unsigned short now = message->length;
+  unsigned short now = TDI_INTRINSIC_MSG.length;
   int j;
   struct descriptor_d text = { 0, DTYPE_T, CLASS_D, 0 };
   if (opcode < TdiFUNCTION_MAX) {
     struct TdiFunctionStruct *pfun = (struct TdiFunctionStruct *)&TdiRefFunction[opcode];
     if (narg < pfun->m1 || narg > pfun->m2) {
-      add("%TDI Requires");
-      numb(pfun->m1);
+      ADD("%TDI Requires");
+      NUMB(pfun->m1);
       if (pfun->m1 != pfun->m2) {
-	add(" to");
-	numb(pfun->m2);
+	ADD(" to");
+	NUMB(pfun->m2);
       }
-      add(" input arguments for ");
+      ADD(" input arguments for ");
     } else
-      add("%TDI Error in ");
-    add(pfun->name);
+      ADD("%TDI Error in ");
+    ADD(pfun->name);
   } else
-    add("%TDI Unknown opcode ");
-  add("(");
+    ADD("%TDI Unknown opcode ");
+  ADD("(");
   for (j = 0; j < narg;) {
     if IS_OK(Tdi0Decompile(list[j], PREC_COMMA, &text, 5)) {
-      if (message->length - now + text.length < MAXLINE - 2)
-	StrAppend(message, (struct descriptor *)&text);
+      if (TDI_INTRINSIC_MSG.length - now + text.length < MAXLINE - 2)
+	StrAppend(&TDI_INTRINSIC_MSG, (mdsdsc_t *)&text);
       else {
 	*(text.pointer + MAXFRAC) = '\0';
-	add(text.pointer);
-	add(" ...");
+	ADD(text.pointer);
+	ADD(" ...");
       }
     } else
-      add("BAD_INPUT");
+      ADD("BAD_INPUT");
     StrFree1Dx(&text);
     if (++j < narg) {
-      if (message->length - now < MAXLINE - MAXFRAC - 7)
-	add(", ");
+      if (TDI_INTRINSIC_MSG.length - now < MAXLINE - MAXFRAC - 7)
+	ADD(", ");
       else {
-	add(",\n");
-	now = message->length;
-	add("%- ");
+	ADD(",\n");
+	now = TDI_INTRINSIC_MSG.length;
+	ADD("%- ");
       }
     }
   }
-  add(")\n");
+  ADD(")\n");
 }
 
 struct _fixed {
   int n;
   char f[256];
-  struct descriptor *a[256];
+  mdsdsc_t *a[256];
 };
 void cleanup_list(void* fixed_in) {
+  GET_TDITHREADSTATIC_P;
   struct _fixed* fixed = (struct _fixed*)fixed_in;
-    for (; --fixed->n >= 0 ;)
-      if (fixed->f[fixed->n])
-	free(fixed->a[fixed->n]);
+  for (; --fixed->n >= 0 ;)
+    if (fixed->f[fixed->n])
+      free(fixed->a[fixed->n]);
+  TDI_INTRINSIC_REC--;
 }
 
-EXPORT int TdiIntrinsic(opcode_t opcode, int narg, struct descriptor *list[], struct descriptor_xd *out_ptr)
+EXPORT int TdiIntrinsic(opcode_t opcode, int narg, mdsdsc_t *list[], struct descriptor_xd *out_ptr)
 {
   int status;
   struct TdiFunctionStruct *fun_ptr = (struct TdiFunctionStruct *)&TdiRefFunction[opcode];
@@ -209,16 +212,16 @@ EXPORT int TdiIntrinsic(opcode_t opcode, int narg, struct descriptor *list[], st
   FREEXD_ON_EXIT(&tmp);
   FREEXD_ON_EXIT(out_ptr);
   status = MDSplusSUCCESS;
-  struct descriptor *dsc_ptr;
-  TdiThreadStatic_p->TdiIntrinsic_recursion_count++;
+  mdsdsc_t *dsc_ptr;
   if (narg < fun_ptr->m1)
     status = TdiMISS_ARG;
   else if (narg > fun_ptr->m2)
     status = TdiEXTRA_ARG;
-  else if (TdiThreadStatic_p->TdiIntrinsic_recursion_count > 1800)
+  else if (TDI_INTRINSIC_REC > 1800)
     status = TdiRECURSIVE;
   else {
     struct _fixed fixed = {0};
+    TDI_INTRINSIC_REC++;
     pthread_cleanup_push(cleanup_list,&fixed);
     for (fixed.n = 0; fixed.n < narg; fixed.n++)
       if (list[fixed.n] != NULL && list[fixed.n]->class == CLASS_NCA) {
@@ -252,13 +255,13 @@ EXPORT int TdiIntrinsic(opcode_t opcode, int narg, struct descriptor *list[], st
 	  (char *)tmp.pointer || (char *)out_ptr->pointer >= (char *)tmp.pointer + tmp.l_length)
 	MdsFree1Dx(out_ptr, NULL);
       else if (out_ptr->l_length) {
-	add("%TDI DANGER, part of old output descriptor was input to below.\n");
+	ADD("%TDI DANGER, part of old output descriptor was input to below.\n");
 	TRACE(opcode, narg, list, out_ptr);
       }
       if (tmp.class == CLASS_XD)
 	*out_ptr = tmp;
       else {
-	stat1 = MdsCopyDxXd((struct descriptor *)&tmp, out_ptr);
+	stat1 = MdsCopyDxXd((mdsdsc_t *)&tmp, out_ptr);
 	MdsFree1Dx(&tmp, NULL);
       }
       break;
@@ -267,9 +270,9 @@ EXPORT int TdiIntrinsic(opcode_t opcode, int narg, struct descriptor *list[], st
       To D, allocate and copy it (free XD).
       ************************************/
       if (tmp.class == CLASS_XD)
-	dsc_ptr = (struct descriptor *)tmp.pointer;
+	dsc_ptr = (mdsdsc_t *)tmp.pointer;
       else
-	dsc_ptr = (struct descriptor *)&tmp;
+	dsc_ptr = (mdsdsc_t *)&tmp;
       if (dsc_ptr == 0)
 	stat1 = StrFree1Dx((struct descriptor_d *)out_ptr);
       else
@@ -299,7 +302,7 @@ EXPORT int TdiIntrinsic(opcode_t opcode, int narg, struct descriptor *list[], st
       if (tmp.class == CLASS_XD)
 	dsc_ptr = tmp.pointer;
       else
-	dsc_ptr = (struct descriptor *)&tmp;
+	dsc_ptr = (mdsdsc_t *)&tmp;
       if (dsc_ptr)
 	stat1 = TdiConvert(dsc_ptr, out_ptr);
       else
@@ -308,11 +311,11 @@ EXPORT int TdiIntrinsic(opcode_t opcode, int narg, struct descriptor *list[], st
       break;
     case CLASS_NCA:
       {
-	struct descriptor *fixed_out_ptr = FixedArray(out_ptr);
+	mdsdsc_t *fixed_out_ptr = FixedArray(out_ptr);
 	if (tmp.class == CLASS_XD)
 	  dsc_ptr = tmp.pointer;
 	else
-	  dsc_ptr = (struct descriptor *)&tmp;
+	  dsc_ptr = (mdsdsc_t *)&tmp;
 	if (dsc_ptr)
 	  stat1 = TdiConvert(dsc_ptr, out_ptr);
 	else
@@ -322,7 +325,7 @@ EXPORT int TdiIntrinsic(opcode_t opcode, int narg, struct descriptor *list[], st
       }
       break;
     }
-    if (stat1 & 1)
+    if IS_OK(stat1)
       goto done;
     status = stat1;
   }
@@ -331,14 +334,13 @@ EXPORT int TdiIntrinsic(opcode_t opcode, int narg, struct descriptor *list[], st
     MdsFree1Dx(out_ptr, NULL);
  notmp:MdsFree1Dx(&tmp, NULL);
  done:;
-  TdiThreadStatic_p->TdiIntrinsic_recursion_count--;
-  if (!TdiThreadStatic_p->TdiIntrinsic_recursion_count)
-    TdiThreadStatic_p->TdiIntrinsic_mess_stat = status;
+  if (TDI_INTRINSIC_REC==0)
+    TDI_INTRINSIC_STAT = status;
   FREE_CANCEL(&tmp);
   FREE_CANCEL(out_ptr);
   return status;
 }
-EXPORT int _TdiIntrinsic(void** ctx, opcode_t opcode, int narg, struct descriptor *list[], struct descriptor_xd *out_ptr){
+EXPORT int _TdiIntrinsic(void** ctx, opcode_t opcode, int narg, mdsdsc_t *list[], struct descriptor_xd *out_ptr){
   int status;
   CTX_PUSH(ctx);
   status = TdiIntrinsic(opcode, narg, list, out_ptr);
@@ -357,44 +359,42 @@ EXPORT int _TdiIntrinsic(void** ctx, opcode_t opcode, int narg, struct descripto
 */
 int Tdi1Debug(opcode_t opcode __attribute__ ((unused)),
 	      int narg,
-	      struct descriptor *list[],
+	      mdsdsc_t *list[],
 	      struct descriptor_xd *out_ptr)
 {
   INIT_STATUS;
   GET_TDITHREADSTATIC_P;
   int option = -1;
-  int mess_stat = TdiThreadStatic_p->TdiIntrinsic_mess_stat;
-  struct descriptor_d *message = &TdiThreadStatic_p->TdiIntrinsic_message;
   if (narg > 0 && list[0])
     status = TdiGetLong(list[0], &option);
-  if (option & 1 && mess_stat != 1) {
-    struct descriptor dmsg = { 0, DTYPE_T, CLASS_S, 0 };
-    dmsg.pointer = MdsGetMsg(mess_stat);
+  if (option & 1 && TDI_INTRINSIC_STAT!=SsSUCCESS) {
+    mdsdsc_t dmsg = { 0, DTYPE_T, CLASS_S, 0 };
+    dmsg.pointer = MdsGetMsg(TDI_INTRINSIC_STAT);
     dmsg.length = strlen(dmsg.pointer);
     // in order to prepend we need to move the original message into temp desc
-    struct descriptor_d oldmsg = *message;
-    message->length=0; message->pointer=NULL;
-    static const DESCRIPTOR(newline, "\n");
-    StrConcat((struct descriptor *)message, &dmsg, &newline, &oldmsg MDS_END_ARG);
+    mdsdsc_d_t oldmsg = TDI_INTRINSIC_MSG;
+    TDI_INTRINSIC_MSG.length=0; TDI_INTRINSIC_MSG.pointer=NULL;
+    const DESCRIPTOR(newline, "\n");
+    StrConcat((mdsdsc_t *)&TDI_INTRINSIC_MSG, &dmsg, &newline, &oldmsg MDS_END_ARG);
     StrFree1Dx(&oldmsg);
   }
-  if (message->length) {
+  if (TDI_INTRINSIC_MSG.length) {
     if (option & 2)
-      printf("%.*s", message->length, message->pointer);
+      printf("%.*s", TDI_INTRINSIC_MSG.length, TDI_INTRINSIC_MSG.pointer);
     if (option & 4) {
       if (option & 8)
-	status = MdsCopyDxXd((struct descriptor *)message, out_ptr);
-      StrFree1Dx(message);
+	status = MdsCopyDxXd((mdsdsc_t *)&TDI_INTRINSIC_MSG, out_ptr);
+      StrFree1Dx(&TDI_INTRINSIC_MSG);
       return status;
     }
   }
-  return MdsCopyDxXd((struct descriptor *)message, out_ptr);
+  return MdsCopyDxXd((mdsdsc_t *)&TDI_INTRINSIC_MSG, out_ptr);
 }
 
-STATIC_ROUTINE struct descriptor *FixedArray(struct descriptor *in)
+STATIC_ROUTINE mdsdsc_t *FixedArray(mdsdsc_t *in)
 {
   array_coeff *a = (array_coeff *) in;
-  int dsize = sizeof(struct descriptor_a) + sizeof(int) + 3 * sizeof(int) * a->dimct;
+  int dsize = sizeof(mdsdsc_a_t) + sizeof(int) + 3 * sizeof(int) * a->dimct;
   int i;
   BOUNDS *bounds = (BOUNDS *) & a->m[a->dimct];
   array_coeff *answer = (array_coeff *) memcpy(malloc(dsize), a, dsize);
@@ -404,5 +404,5 @@ STATIC_ROUTINE struct descriptor *FixedArray(struct descriptor *in)
   answer->aflags.bounds = 1;
   for (i = 0; i < a->dimct; i++)
     answer->m[i] = bounds[i].u - bounds[i].l + 1;
-  return (struct descriptor *)answer;
+  return (mdsdsc_t *)answer;
 }

--- a/tdishr/TdiItoX.c
+++ b/tdishr/TdiItoX.c
@@ -148,9 +148,9 @@ int Tdi1ItoX(opcode_t opcode, int narg, struct descriptor *list[], struct descri
   unsigned char omits[] = { DTYPE_WITH_UNITS, DTYPE_DIMENSION, 0 };
   dk0.pointer = (char *)&k0;
   dk1.pointer = (char *)&k1;
-  keep[0] = TdiThreadStatic_p->TdiRANGE_PTRS[0];
-  keep[1] = TdiThreadStatic_p->TdiRANGE_PTRS[1];
-  keep[2] = TdiThreadStatic_p->TdiRANGE_PTRS[2];
+  keep[0] = TDI_RANGE_PTRS[0];
+  keep[1] = TDI_RANGE_PTRS[1];
+  keep[2] = TDI_RANGE_PTRS[2];
 	/************************************************************
 	Remove and save outer WITH_UNITS.
 	8-Apr-1991 allow BUILD_WITH_UNITS(BUILD_DIM(,range),units).
@@ -505,9 +505,9 @@ int Tdi1ItoX(opcode_t opcode, int narg, struct descriptor *list[], struct descri
 	} else if (arg1) {
 	  struct descriptor_range *rptr = (struct descriptor_range *)list[1];
 	  MdsFree1Dx(out_ptr, NULL);
-	  TdiThreadStatic_p->TdiRANGE_PTRS[0] = &dk0;
-	  TdiThreadStatic_p->TdiRANGE_PTRS[1] = &dk1;
-	  TdiThreadStatic_p->TdiRANGE_PTRS[2] = flag ? 0 : dimen.pointer;
+	  TDI_RANGE_PTRS[0] = &dk0;
+	  TDI_RANGE_PTRS[1] = &dk1;
+	  TDI_RANGE_PTRS[2] = flag ? 0 : dimen.pointer;
 						/******************************************************
 						 * For subscripts of signals, want range step to be all.
 						 ******************************************************/
@@ -522,9 +522,9 @@ int Tdi1ItoX(opcode_t opcode, int narg, struct descriptor *list[], struct descri
 	    status = TdiGetArgs(opcode, 1, &rptr, &sig1, &uni1, out_ptr, cats);
 	  } else
 	    status = TdiGetArgs(opcode, 1, &rptr, &sig1, &uni1, out_ptr, cats);
-	  TdiThreadStatic_p->TdiRANGE_PTRS[0] = keep[0];
-	  TdiThreadStatic_p->TdiRANGE_PTRS[1] = keep[1];
-	  TdiThreadStatic_p->TdiRANGE_PTRS[2] = keep[2];
+	  TDI_RANGE_PTRS[0] = keep[0];
+	  TDI_RANGE_PTRS[1] = keep[1];
+	  TDI_RANGE_PTRS[2] = keep[2];
 	  arg1 = cats[0].in_dtype != DTYPE_MISSING;
 	} else
 	  status = TdiDtypeRange(&dk0, &dk1, out_ptr MDS_END_ARG);

--- a/tdishr/TdiStatement.c
+++ b/tdishr/TdiStatement.c
@@ -206,14 +206,14 @@ int Tdi1IfError(opcode_t opcode __attribute__ ((unused)), int narg, struct descr
   INIT_STATUS;
   int keep, j;
   GET_TDITHREADSTATIC_P;
-  keep = TdiON_ERROR;
-  TdiON_ERROR = 0;
+  keep = TDI_ON_ERROR;
+  TDI_ON_ERROR = FALSE;
   for (j = 0; j < narg; ++j) {
     status = TdiEvaluate(list[j], out_ptr MDS_END_ARG);
     if STATUS_OK
       break;
   }
-  TdiON_ERROR = keep;
+  TDI_ON_ERROR = keep;
   if (j >= narg)
     status = MdsFree1Dx(out_ptr, NULL);
   return status;

--- a/tdishr/TdiSubscript.c
+++ b/tdishr/TdiSubscript.c
@@ -107,7 +107,7 @@ int Tdi1Subscript(opcode_t opcode, int narg, struct descriptor *list[], struct d
   int stride[MAX_DIMS + 1], *px[MAX_DIMS], count[MAX_DIMS];
   struct descriptor_signal *psig;
   struct descriptor_dimension *pdim;
-  struct descriptor_xd *keeps = TdiThreadStatic_p->TdiSELF_PTR;
+  struct descriptor_xd *keeps = TDI_SELF_PTR;
   array_coeff *pdat, *pdi = 0;
   array_coeff arr = {1,DTYPE_B,CLASS_A,0,0,0,{0,1,1,1,0},MAX_DIMS,1,0,{0}};
   struct descriptor ddim = { sizeof(dim), DTYPE_L, CLASS_S, 0 };
@@ -188,7 +188,7 @@ int Tdi1Subscript(opcode_t opcode, int narg, struct descriptor *list[], struct d
       pdim = (struct descriptor_dimension *)psig;
       if (psig && dim < psig->ndesc - 2 &&
 	  (pdim = (struct descriptor_dimension *)psig->dimensions[dim]) != 0) {
-	TdiThreadStatic_p->TdiSELF_PTR = (struct descriptor_xd *)psig;
+	TDI_SELF_PTR = (struct descriptor_xd *)psig;
 	status = TdiCull(psig, &ddim, dim + 1 < narg ? list[dim + 1] : 0, &xx[dim] MDS_END_ARG);
 	if STATUS_OK
 	  status = TdiXtoI(pdim, xx[dim].pointer, &ii[dim] MDS_END_ARG);
@@ -214,7 +214,7 @@ int Tdi1Subscript(opcode_t opcode, int narg, struct descriptor *list[], struct d
 	  }
 	  MdsFree1Dx(&xd, NULL);
 	}
-	TdiThreadStatic_p->TdiSELF_PTR = keeps;
+	TDI_SELF_PTR = keeps;
 	if (STATUS_OK && bounded)
 	  pin += *(int *)&pdat->m[dim * 2 + dimct] * stride[dim];
 	highdim = dim + 1;
@@ -233,17 +233,17 @@ int Tdi1Subscript(opcode_t opcode, int narg, struct descriptor *list[], struct d
 	  status = TdiUbound(pdat, &ddim, &dright MDS_END_ARG);
 	if (dim + 1 < narg && list[dim + 1]) {
 	  struct descriptor *keep[3];
-	  keep[0] = TdiThreadStatic_p->TdiRANGE_PTRS[0];
-	  keep[1] = TdiThreadStatic_p->TdiRANGE_PTRS[1];
-	  keep[2] = TdiThreadStatic_p->TdiRANGE_PTRS[2];
-	  TdiThreadStatic_p->TdiRANGE_PTRS[0] = (struct descriptor *)&dleft;
-	  TdiThreadStatic_p->TdiRANGE_PTRS[1] = (struct descriptor *)&dright;
-	  TdiThreadStatic_p->TdiRANGE_PTRS[2] = 0;
+	  keep[0] = TDI_RANGE_PTRS[0];
+	  keep[1] = TDI_RANGE_PTRS[1];
+	  keep[2] = TDI_RANGE_PTRS[2];
+	  TDI_RANGE_PTRS[0] = (struct descriptor *)&dleft;
+	  TDI_RANGE_PTRS[1] = (struct descriptor *)&dright;
+	  TDI_RANGE_PTRS[2] = 0;
 	  if STATUS_OK
 	    status = TdiData(list[dim + 1], &ii[dim] MDS_END_ARG);
-	  TdiThreadStatic_p->TdiRANGE_PTRS[0] = keep[0];
-	  TdiThreadStatic_p->TdiRANGE_PTRS[1] = keep[1];
-	  TdiThreadStatic_p->TdiRANGE_PTRS[2] = keep[2];
+	  TDI_RANGE_PTRS[0] = keep[0];
+	  TDI_RANGE_PTRS[1] = keep[1];
+	  TDI_RANGE_PTRS[2] = keep[2];
 	  if STATUS_OK
 	    status = TdiLong(&ii[dim], &ii[dim] MDS_END_ARG);
 	  if STATUS_OK
@@ -365,9 +365,9 @@ int Tdi1Map(opcode_t opcode, int narg __attribute__ ((unused)), struct descripto
   array_coeff *pa;
   char *abase, *po = 0;
   int *pindex = 0;
-  keep[0] = TdiThreadStatic_p->TdiRANGE_PTRS[0];
-  keep[1] = TdiThreadStatic_p->TdiRANGE_PTRS[1];
-  keep[2] = TdiThreadStatic_p->TdiRANGE_PTRS[2];
+  keep[0] = TDI_RANGE_PTRS[0];
+  keep[1] = TDI_RANGE_PTRS[1];
+  keep[2] = TDI_RANGE_PTRS[2];
   range[0].pointer = (char *)&left;
   range[1].pointer = (char *)&right;
 	/*************************
@@ -392,14 +392,14 @@ int Tdi1Map(opcode_t opcode, int narg __attribute__ ((unused)), struct descripto
 	Get subscript expression B and its signality.
 	Must have default ranges defined before get.
 	********************************************/
-  TdiThreadStatic_p->TdiRANGE_PTRS[0] = &range[0];
-  TdiThreadStatic_p->TdiRANGE_PTRS[1] = &range[1];
-  TdiThreadStatic_p->TdiRANGE_PTRS[2] = 0;
+  TDI_RANGE_PTRS[0] = &range[0];
+  TDI_RANGE_PTRS[1] = &range[1];
+  TDI_RANGE_PTRS[2] = 0;
   if STATUS_OK
     status = TdiGetArgs(opcode, 1, &list[1], sig, uni, dat, cats);
-  TdiThreadStatic_p->TdiRANGE_PTRS[0] = keep[0];
-  TdiThreadStatic_p->TdiRANGE_PTRS[1] = keep[1];
-  TdiThreadStatic_p->TdiRANGE_PTRS[2] = keep[2];
+  TDI_RANGE_PTRS[0] = keep[0];
+  TDI_RANGE_PTRS[1] = keep[1];
+  TDI_RANGE_PTRS[2] = keep[2];
   if (uni[0].pointer)
     MdsFree1Dx(&uni[0], NULL);
   uni[0].pointer = (struct descriptor *)pwu->units;

--- a/tdishr/TdiVar.c
+++ b/tdishr/TdiVar.c
@@ -142,7 +142,8 @@ STATIC_THREADSAFE block_type _public = { 0, 0, 0, 1 };
 STATIC_CONSTANT DESCRIPTOR(star, "*");
 STATIC_CONSTANT DESCRIPTOR(percent, "%");
 mdsdsc_t *Tdi3Narg(){
-  return &TdiGetThreadStatic()->TdiVar_new_narg_d;
+  GET_TDITHREADSTATIC_P;
+  return &TDI_VAR_NEW_NARG_D;
 }
 
 /*--------------------------------------------------------------
@@ -200,7 +201,7 @@ STATIC_ROUTINE int allocate(mdsdsc_t *key_ptr,
 	search: 1=private 2=public 4=check that it exists.
 	if block_ptr is returned and public public_lock is acquired
 */
-#define _private (*(block_type*)&TdiThreadStatic_p->TdiVar_private)
+#define _private (*(block_type*)&TDI_VAR_PRIVATE)
 STATIC_ROUTINE int TdiFindIdent(int search,
 	                        mdsdsc_r_t *ident_ptr,
 	                        mdsdsc_t *key_ptr,
@@ -739,8 +740,7 @@ int TdiDoFun(mdsdsc_t *ident_ptr, int nactual, mdsdsc_r_t *actual_arg_ptr[], mds
   GET_TDITHREADSTATIC_P;
   mdsdsc_xd_t tmp = EMPTY_XD;
   node_type *old_head, *new_head = 0;
-  int *new_narg = &TdiThreadStatic_p->TdiVar_new_narg;
-  int old_narg = *new_narg;
+  int old_narg = TDI_VAR_NEW_NARG;
 	/**************************************
 	 Now copy input arguments into new head.
 	 Pick up some keywords from prototype.
@@ -826,7 +826,7 @@ int TdiDoFun(mdsdsc_t *ident_ptr, int nactual, mdsdsc_r_t *actual_arg_ptr[], mds
 	**************************/
   old_head = _private.head;
   _private.head = new_head;
-  *new_narg = nactual;
+  TDI_VAR_NEW_NARG = nactual;
   if STATUS_OK {
     status = TdiEvaluate(formal_ptr->dscptrs[1], out_ptr MDS_END_ARG);
     if (status == TdiRETURN)
@@ -864,7 +864,7 @@ int TdiDoFun(mdsdsc_t *ident_ptr, int nactual, mdsdsc_r_t *actual_arg_ptr[], mds
   TdiDeallocate(&tmp MDS_END_ARG);
   MdsFree1Dx(&tmp, NULL);
   _private.head = old_head;
-  *new_narg = old_narg;
+  TDI_VAR_NEW_NARG = old_narg;
   return status;
 }
 

--- a/tdishr/TdiYacc.c
+++ b/tdishr/TdiYacc.c
@@ -55,7 +55,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 	NOT and INOT of AND OR etc., form NAND or AND_NOT etc. See KNOT1 and KNOT2. Not after 9/25/89.
 -*/
 #include <mdsplus/mdsplus.h>
-#include <STATICdef.h>
 #include <stdio.h>
 #include <string.h>
 #include "tdithreadsafe.h"
@@ -79,7 +78,7 @@ extern int TdiYacc_ARG();
 extern int TdiLexPath();
 
 #define YYMAXDEPTH      250
-#define __RUN(method) do{if IS_NOT_OK(method) tdiyyerror(0); else TdiRefZone.l_ok = TdiRefZone.a_cur - TdiRefZone.a_begin;}while(0)
+#define __RUN(method) do{if IS_NOT_OK(method) tdiyyerror(0); else TDI_REFZONE.l_ok = TDI_REFZONE.a_cur - TDI_REFZONE.a_begin;}while(0)
 
 #define _RESOLVE(arg)   			__RUN(TdiYacc_RESOLVE(&arg.rptr))
 
@@ -94,16 +93,13 @@ extern int TdiLexPath();
 #define _JUST3(opcode,arg1,arg2,arg3,out)       __RUN(TdiYacc_BUILD(  3, 3, opcode, &out, &arg1, &arg2, &arg3, NULL ))
 #define _JUST4(opcode,arg1,arg2,arg3,arg4,out)  __RUN(TdiYacc_BUILD(  4, 4, opcode, &out, &arg1, &arg2, &arg3, &arg4))
 
-STATIC_THREADSAFE struct marker _EMPTY_MARKER = { 0 };
+static const struct marker _EMPTY_MARKER = { 0 };
 
 #include "tdiyacc.h"
 
 #define tdiyyclearin tdiyychar = -1
 #define tdiyyerrok tdiyyerrflag = 0
-extern int tdiyychar;
-#ifndef YYMAXDEPTH
-#define YYMAXDEPTH 150
-#endif
+
 
 /* __YYSCLASS defines the scoping/storage class for global objects
  * that are NOT renamed by the -p option.  By default these names
@@ -116,13 +112,9 @@ extern int tdiyychar;
 #ifndef __YYSCLASS
 #define __YYSCLASS STATIC_THREADSAFE
 #endif
-YYSTYPE tdiyylval;
-__YYSCLASS YYSTYPE tdiyyval;
 typedef int tdiyytabelem;
 #define YYERRCODE 256
 
-
-YYSTYPE *TdiYylvalPtr = &tdiyylval;
 __YYSCLASS tdiyytabelem tdiyyexca[] = {
   -1, 0,
   0, 120,
@@ -608,13 +600,12 @@ __YYSCLASS char *tdiyyreds[] = {
 ** yacc user known macros and defines
 */
 #define YYERROR         goto tdiyyerrlab
-
-#ifndef __RUNTIME_YYMAXDEPTH
-#define YYACCEPT        {return MDSplusSUCCESS;}
-#define YYABORT         {return MDSplusERROR;}
+#ifdef  __RUNTIME_YYMAXDEPTH
+# define YYACCEPT        {free_stacks(); return MDSplusSUCCESS;}
+# define YYABORT         {free_stacks(); return MDSplusERROR;}
 #else
-#define YYACCEPT        {free_stacks(); return MDSplusSUCCESS;}
-#define YYABORT         {free_stacks(); return MDSplusERROR;}
+# define YYACCEPT        {return MDSplusSUCCESS;}
+# define YYABORT         {return MDSplusERROR;}
 #endif
 
 #define YYBACKUP( newtoken, newvalue ) {\
@@ -639,12 +630,6 @@ __YYSCLASS char *tdiyyreds[] = {
 /*
 ** global variables used by the parser
 */
-#ifndef __RUNTIME_YYMAXDEPTH
-__YYSCLASS YYSTYPE tdiyyv[YYMAXDEPTH];	/* value stack */
-__YYSCLASS int tdiyys[YYMAXDEPTH];	/* state stack */
-#else
-__YYSCLASS YYSTYPE *tdiyyv;	/* pointer to malloc'ed value stack */
-__YYSCLASS int *tdiyys;		/* pointer to malloc'ed stack stack */
 
 #if defined(__STDC__) || defined (__cplusplus)
 #include <stdlib.h>
@@ -654,23 +639,14 @@ extern char *realloc();
 extern void free();
 #endif				/* __STDC__ or __cplusplus */
 
-STATIC_ROUTINE int allocate_stacks();
-STATIC_ROUTINE void free_stacks();
+#ifdef __RUNTIME_YYMAXDEPTH
+static int allocate_stacks();
+static void free_stacks();
 #ifndef YYINCREMENT
 #define YYINCREMENT (YYMAXDEPTH/2) + 10
 #endif
 #endif				/* __RUNTIME_YYMAXDEPTH */
-long tdiyymaxdepth = YYMAXDEPTH;
 
-__YYSCLASS YYSTYPE *tdiyypv;	/* top of value stack */
-__YYSCLASS int *tdiyyps;		/* top of state stack */
-
-__YYSCLASS int tdiyystate;		/* current state */
-__YYSCLASS int tdiyytmp;		/* extra var (lasts between blocks) */
-
-int tdiyynerrs;			/* number of errors */
-__YYSCLASS int tdiyyerrflag;	/* error recovery flag */
-int tdiyychar;			/* current input token number */
 
 /*
 ** tdiyyparse - return 0 if worked, 1 if syntax error not recovered from
@@ -678,26 +654,33 @@ int tdiyychar;			/* current input token number */
 // TdiYacc aka tdiyyparse         TdiYacc
 
 int TdiYacc(){
+  YYSTYPE tdiyylval;
+  YYSTYPE tdiyyval;
   GET_TDITHREADSTATIC_P;
+  long tdiyymaxdepth = YYMAXDEPTH;
   YYSTYPE *tdiyypvt;	/* top of value stack for $vars */
-
   /*
    ** Initialize externals - tdiyyparse may be called more than once
    */
 #ifdef __RUNTIME_YYMAXDEPTH
-  if (allocate_stacks())
+  YYSTYPE *tdiyyv;	/* pointer to malloc'ed value stack */
+  int *tdiyys;		/* pointer to malloc'ed stack stack */
+  if (allocate_stacks(tdiyymaxdepth))
     YYABORT;
+#else
+  YYSTYPE tdiyyv[YYMAXDEPTH];  /* value stack */
+  int tdiyys[YYMAXDEPTH];      /* state stack */
 #endif
   tdiyyval.mark.w_ok=0;
   //  tdiyypv = &tdiyyv[-1];
-  tdiyypv = tdiyyv - 1;
+  YYSTYPE *tdiyypv = tdiyyv - 1;
   //  tdiyyps = &tdiyys[-1];
-  tdiyyps = tdiyys - 1;
-  tdiyystate = 0;
-  tdiyytmp = 0;
-  tdiyynerrs = 0;
-  tdiyyerrflag = 0;
-  tdiyychar = -1;
+  int *tdiyyps = tdiyys - 1;
+  int tdiyystate = 0;
+  int tdiyytmp = 0;
+  int tdiyynerrs = 0;
+  int tdiyyerrflag = 0;
+  int tdiyychar = -1;
 
   {
     YYSTYPE *tdiyy_pv;	/* top of value stack */
@@ -754,7 +737,7 @@ int TdiYacc(){
  tdiyy_newstate:
     if ((tdiyy_n = tdiyypact[tdiyy_state]) <= YYFLAG)
       goto tdiyy_default;		/* simple state */
-    if ((tdiyychar < 0) && ((tdiyychar = TdiLex()) < 0))
+    if ((tdiyychar < 0) && ((tdiyychar = TdiLex(&tdiyylval)) < 0))
       tdiyychar = 0;		/* reached EOF */
     YYDEBUG_("Received token ")
     if (((tdiyy_n += tdiyychar) < 0) || (tdiyy_n >= YYLAST))
@@ -770,7 +753,7 @@ int TdiYacc(){
 
  tdiyy_default:
     if ((tdiyy_n = tdiyydef[tdiyy_state]) == -2) {
-      if ((tdiyychar < 0) && ((tdiyychar = TdiLex()) < 0))
+      if ((tdiyychar < 0) && ((tdiyychar = TdiLex(&tdiyylval)) < 0))
 	tdiyychar = 0;		/* reached EOF */
       YYDEBUG_("received token ")
       /*
@@ -901,8 +884,8 @@ int TdiYacc(){
     {
       tdiyyval.mark.rptr = tdiyypvt[-0].mark.rptr;
       tdiyyval.mark.builtin = -2;
-      TdiRefZone.l_status = TdiYacc_IMMEDIATE(&tdiyyval.mark.rptr);
-      if (!(TdiRefZone.l_status & 1))
+      TDI_REFZONE.l_status = TdiYacc_IMMEDIATE(&tdiyyval.mark.rptr);
+      if (!(TDI_REFZONE.l_status & 1))
 	tdiyyerror(0);
     }
     break;
@@ -927,11 +910,11 @@ int TdiYacc(){
 	  tdiyyval.mark.rptr->dscptrs[0] = (struct descriptor *)tdiyypvt[-2].mark.rptr;
 	  ++tdiyyval.mark.rptr->ndesc;
 	} else {
-	  TdiRefZone.l_status = TdiEXTRA_ARG;
+	  TDI_REFZONE.l_status = TdiEXTRA_ARG;
 	  return MDSplusERROR;
       } else {
 	unsigned int vmlen = sizeof(struct descriptor_range);
-	LibGetVm(&vmlen, (void **)&tdiyyval.mark.rptr, &TdiRefZone.l_zone);
+	LibGetVm(&vmlen, (void **)&tdiyyval.mark.rptr, &TDI_REFZONE.l_zone);
 	tdiyyval.mark.rptr->length = 0;
 	tdiyyval.mark.rptr->dtype = DTYPE_RANGE;
 	tdiyyval.mark.rptr->class = CLASS_R;
@@ -1152,19 +1135,19 @@ int TdiYacc(){
     break;
   case 74: // using0 : USING '('
     {
-      ++TdiRefZone.l_rel_path;
+      ++TDI_REFZONE.l_rel_path;
     }
     break;
   case 75: // using : using0 ass ',' ass ','
     {
       _FULL2(OPC_ABORT, tdiyypvt[-3].mark, tdiyypvt[-1].mark, tdiyyval.mark);
-      --TdiRefZone.l_rel_path;
+      --TDI_REFZONE.l_rel_path;
     }
     break;
   case 76: // using : using0 ass ',' ','
     {
       _FULL2(OPC_ABORT, tdiyypvt[-2].mark, _EMPTY_MARKER, tdiyyval.mark);
-      --TdiRefZone.l_rel_path;
+      --TDI_REFZONE.l_rel_path;
     }
     break;
   case 78: // opt : /* empty */
@@ -1229,7 +1212,7 @@ int TdiYacc(){
 	    && strlen(TdiREF_CAT[j].name) == tdiyypvt[-3].mark.rptr->length)
 	  break;
       if (j < 0) {
-	TdiRefZone.l_status = TdiINVDTYDSC;
+	TDI_REFZONE.l_status = TdiINVDTYDSC;
 	return MDSplusERROR;
       }
       tdiyyval.mark.rptr->dtype = DTYPE_CALL;
@@ -1252,7 +1235,7 @@ int TdiYacc(){
   case 86: // postX : using0 ass ',' ass ')'
     {
       _JUST2(OPC_USING, tdiyypvt[-3].mark, tdiyypvt[-1].mark, tdiyyval.mark);
-      --TdiRefZone.l_rel_path;
+      --TDI_REFZONE.l_rel_path;
     }
     break;
   case 88: // textX : textX TEXT
@@ -1279,7 +1262,7 @@ int TdiYacc(){
 	  tdiyyval.mark.rptr->dtype = DTYPE_IDENT;
 	} else {
 	  if ((TdiRefFunction[tdiyyval.mark.builtin].token & LEX_M_TOKEN) == LEX_ARG) {
-	    if (!((TdiRefZone.l_status = TdiYacc_ARG(&tdiyyval.mark)) & 1))
+	    if (!((TDI_REFZONE.l_status = TdiYacc_ARG(&tdiyyval.mark)) & 1))
 	      tdiyyerror(0);
 	  } else {
 	    if ((TdiRefFunction[tdiyyval.mark.builtin].token & LEX_M_TOKEN) == LEX_CONST)
@@ -1289,11 +1272,11 @@ int TdiYacc(){
       } else if (*tdiyyval.mark.rptr->pointer == '_')
 	tdiyyval.mark.rptr->dtype = DTYPE_IDENT;
       else if (TdiLexPath(tdiyypvt[-0].mark.rptr->length, tdiyypvt[-0].mark.rptr->pointer, &tdiyyval.mark) == LEX_ERROR) {
-	TdiRefZone.l_ok = tdiyypvt[-1].mark.w_ok;
-	TdiRefZone.a_cur = TdiRefZone.a_begin + TdiRefZone.l_ok + tdiyypvt[-0].mark.rptr->length;
+	TDI_REFZONE.l_ok = tdiyypvt[-1].mark.w_ok;
+	TDI_REFZONE.a_cur = TDI_REFZONE.a_begin + TDI_REFZONE.l_ok + tdiyypvt[-0].mark.rptr->length;
 	return MDSplusERROR;
       } else
-	TdiRefZone.l_ok = tdiyypvt[-0].mark.w_ok;
+	TDI_REFZONE.l_ok = tdiyypvt[-0].mark.w_ok;
     }
     break;
   case 95: // primaX : bracket ']'
@@ -1325,7 +1308,7 @@ int TdiYacc(){
 	tdiyyval.mark.rptr->dscptrs[j + 2] = tdiyyval.mark.rptr->dscptrs[j];
       tdiyyval.mark.rptr->dscptrs[0] = (struct descriptor *)tdiyypvt[-3].mark.rptr;
       tdiyyval.mark.rptr->ndesc += 2;
-      ++TdiRefZone.l_rel_path;
+      ++TDI_REFZONE.l_rel_path;
     } break;
   case 100: // stmt : BREAK ';'
     {
@@ -1395,15 +1378,15 @@ int TdiYacc(){
     break;
   case 113: // stmt : fun stmt
     {
-      TdiRefZone.l_rel_path--;
+      TDI_REFZONE.l_rel_path--;
       tdiyyval.mark.rptr->dscptrs[1] = (struct descriptor *)tdiyypvt[-0].mark.rptr;
     } break;
   case 114: // stmt : '`' stmt
     {
       tdiyyval.mark.rptr = tdiyypvt[-0].mark.rptr;
       tdiyyval.mark.builtin = -2;
-      TdiRefZone.l_status = TdiYacc_IMMEDIATE(&tdiyyval.mark.rptr);
-      if (!(TdiRefZone.l_status & 1))
+      TDI_REFZONE.l_status = TdiYacc_IMMEDIATE(&tdiyyval.mark.rptr);
+      if (!(TDI_REFZONE.l_status & 1))
 	tdiyyerror(0);
     }
     break;
@@ -1436,8 +1419,8 @@ int TdiYacc(){
   case 119: // program : stmt_lst
     {
       _RESOLVE(tdiyyval.mark);	/*statements */
-      TdiRefZone.a_result = (struct descriptor_d *)tdiyyval.mark.rptr;
-      TdiRefZone.l_status = 1;
+      TDI_REFZONE.a_result = (struct descriptor_d *)tdiyyval.mark.rptr;
+      TDI_REFZONE.l_status = 1;
     } break;
   case 120: // program : /* empty */
     {
@@ -1450,7 +1433,7 @@ int TdiYacc(){
     break;
   case 122: // program : error
     {
-      TdiRefZone.l_status = TdiSYNTAX;
+      TDI_REFZONE.l_status = TdiSYNTAX;
     }
     break;
   }
@@ -1459,12 +1442,11 @@ int TdiYacc(){
 
 #ifdef __RUNTIME_YYMAXDEPTH
 
-STATIC_ROUTINE int allocate_stacks()
+STATIC_ROUTINE int allocate_stacks(const long size)
 {
-  GET_THREADSTATIC_P;
   /* allocate the tdiyys and tdiyyv stacks */
-  tdiyys = (int *)malloc(tdiyymaxdepth * sizeof(int));
-  tdiyyv = (YYSTYPE *) malloc(tdiyymaxdepth * sizeof(YYSTYPE));
+  tdiyys = (int *)malloc(size * sizeof(int));
+  tdiyyv = (YYSTYPE *) malloc(size * sizeof(YYSTYPE));
 
   if (tdiyys == 0 || tdiyyv == 0) {
     tdiyyerror((nl_msg(30004, "unable to allocate space for yacc stacks")));

--- a/tdishr/tdilexdef.h
+++ b/tdishr/tdilexdef.h
@@ -2,8 +2,8 @@
 #ifdef getc
 #undef getc
 #endif
-#define getc(file)		(TdiRefZone.a_cur < TdiRefZone.a_end ? *TdiRefZone.a_cur++ : \
-				(TdiRefZone.a_cur++ == TdiRefZone.a_end ? ';' : 0))
+#define getc(file)		(TDI_REFZONE.a_cur < TDI_REFZONE.a_end ? *TDI_REFZONE.a_cur++ : \
+				(TDI_REFZONE.a_cur++ == TDI_REFZONE.a_end ? ';' : 0))
 #ifdef output
 #undef output
 #endif
@@ -12,6 +12,6 @@
 #ifdef unput
 #undef unput
 #endif
-#define unput(c)	--TdiRefZone.a_cur
-#define pos()		(TdiYylvalPtr->w_ok = TdiRefZone.a_cur - TdiRefZone.a_begin)
+#define unput(c)	--TDI_REFZONE.a_cur
+#define pos()		(TdiYylvalPtr->w_ok = TDI_REFZONE.a_cur - TDI_REFZONE.a_begin)
 #define nlpos()

--- a/tdishr/tdirefzone.h
+++ b/tdishr/tdirefzone.h
@@ -6,7 +6,7 @@
 
 	Ken Klare, LANL CTR-7	(c)1989,1990
 */
-struct TdiZoneStruct {
+typedef struct {
   char *a_begin;		/*beginning of text     */
   char *a_cur;			/*current character     */
   char *a_end;			/*end of buffer + 1     */
@@ -18,11 +18,10 @@ struct TdiZoneStruct {
   int l_iarg;			/*current arguments     */
   struct descriptor **a_list;	/*first argument        */
   int l_rel_path;		/*keep relative paths   */
-};
+} TdiRefZone_t;
 
 #include <libroutines.h>
 #include "tdithreadsafe.h"
-#define TdiRefZone (TdiThreadStatic_p->TdiRefZone)
 
 struct marker {
   struct descriptor_r *rptr;
@@ -41,12 +40,12 @@ struct marker {
 	/*--------------------------------------------------
 	Definitions needed by Lex and Yacc.
 	--------------------------------------------------*/
-#define tdiyyerror(s)	do{TdiRefZone.l_ok = tdiyyval.mark.w_ok; return MDSplusERROR;}while(0)
+#define tdiyyerror(s)	do{TDI_REFZONE.l_ok = tdiyyval.mark.w_ok; return MDSplusERROR;}while(0)
 
 #define MAKE_S(dtype_in,bytes,out)					\
 	{unsigned int dsc_size = sizeof(struct descriptor_s);			\
 	unsigned int vm_size = (dsc_size + (bytes));			\
-	LibGetVm(&vm_size,(void *)&(out),(void *)&TdiRefZone.l_zone);	\
+	LibGetVm(&vm_size,(void *)&(out),(void *)&TDI_REFZONE.l_zone);	\
 	((struct descriptor *)(out))->length = bytes;			\
 	((struct descriptor *)(out))->dtype = dtype_in;			\
 	((struct descriptor *)(out))->class = CLASS_S;			\
@@ -55,7 +54,7 @@ struct marker {
 #define MAKE_XD(dtype_in,bytes,out)					\
 	{unsigned int dsc_size = sizeof(struct descriptor_xd);			\
 	unsigned int vm_size = dsc_size + (bytes);			\
-	LibGetVm(&vm_size,(void *)&(out),(void *)&TdiRefZone.l_zone);	\
+	LibGetVm(&vm_size,(void *)&(out),(void *)&TDI_REFZONE.l_zone);	\
 	((struct descriptor_xd *)(out))->l_length = bytes;		\
 	((struct descriptor_xd *)(out))->length = 0;			\
 	((struct descriptor_xd *)(out))->dtype = dtype_in;		\
@@ -65,7 +64,7 @@ struct marker {
 #define MAKE_R(ndesc,dtype_in,bytes,out)				\
 	{unsigned int dsc_size = sizeof($RECORD(ndesc));				\
 	unsigned int vm_size = dsc_size + (bytes);			\
-	LibGetVm(&vm_size,(void *)&(out),(void *)&TdiRefZone.l_zone);	\
+	LibGetVm(&vm_size,(void *)&(out),(void *)&TDI_REFZONE.l_zone);	\
 	((struct descriptor *)(out))->length = bytes;			\
 	((struct descriptor *)(out))->dtype = dtype_in;			\
 	((struct descriptor *)(out))->class = CLASS_R;			\

--- a/tdishr/tdithreadsafe.h
+++ b/tdishr/tdithreadsafe.h
@@ -5,34 +5,56 @@
 #define TDITHREADSAFE_H
 #include <pthread_port.h>
 
+#define GET_TDITHREADSTATIC_P ThreadStatic *TdiThreadStatic_p = TdiGetThreadStatic()
+
+#define TDI_STACK_SIZE	3
+#define TDI_STACK_IDX	TdiThreadStatic_p->stack_idx
+#define TDI_STACK	TdiThreadStatic_p->stack[TDI_STACK_IDX]
+#define TDI_STACK1	TdiThreadStatic_p->stack[TDI_STACK_IDX+1]
+#define TDI_VAR_PRIVATE	TdiThreadStatic_p->var_private
+#define TDI_INTRINSIC_MSG	TdiThreadStatic_p->intrinsic_msg
+#define TDI_INTRINSIC_STAT	TdiThreadStatic_p->intrinsic_stat
+#define TDI_INTRINSIC_REC	TdiThreadStatic_p->intrinsic_rec
+#define TDI_RANGE_PTRS		TdiThreadStatic_p->range_ptrs
+#define TDI_ON_ERROR		TdiThreadStatic_p->on_error
+#define TDI_SELF_PTR		TdiThreadStatic_p->self_ptr
+#define TDI_VAR_NEW_NARG	TdiThreadStatic_p->var_new_narg
+#define TDI_VAR_NEW_NARG_D	TdiThreadStatic_p->var_new_narg_d
+
+#define TDI_DECOMPILE_MAX	TDI_STACK.decompile_max
+#define TDI_COMPILE_REC		TDI_STACK.compile_rec
+#define TDI_GETDATA_REC		TDI_STACK.getdata_rec
+#define TDI_INDENT		TDI_STACK.indent
+#define TDI_REFZONE		TDI_STACK.refzone
+
 typedef struct _thread_static {
-  int TdiGetData_recursion_count;
-  int TdiIntrinsic_mess_stat;
-  int TdiIntrinsic_recursion_count;
-  struct descriptor_d TdiIntrinsic_message;
+  int stack_idx;
+  struct stack {
+    TdiRefZone_t refzone;	// TdiCompile
+    int compile_rec;		// TdiCompile
+    int getdata_rec;		// TdiGetData
+    int indent;			// TdiDecompile, TdiDecompileR
+    uint16_t decompile_max;	// TdiDecompile
+  } stack[TDI_STACK_SIZE];
   struct {
     void *head;
     void *head_zone;
     void *data_zone;
     int public;
-  } TdiVar_private;
-  int TdiVar_new_narg;
-  struct descriptor TdiVar_new_narg_d;
-  int compiler_recursing;
-  struct descriptor *TdiRANGE_PTRS[3];
-  struct descriptor_xd *TdiSELF_PTR;
-  struct TdiZoneStruct TdiRefZone;
-  unsigned int TdiIndent;
-  unsigned short TdiDecompile_max;
-  int TdiOnError;
+  } var_private;		// TdiVar
+  mdsdsc_t	 var_new_narg_d;// TdiVar
+  int var_new_narg;		// TdiVar
+  mdsdsc_t	*range_ptrs[3];	// TdiCull, TdiDtypeRange, TdiItoX, TdiSubscript
+  mdsdsc_xd_t	*self_ptr;	// TdiGetArgs, TdiGetData, TdiSubscript
+  mdsdsc_d_t	 intrinsic_msg;	// TdiIntrinsic
+  int intrinsic_rec;		// TdiIntrinsic
+  int intrinsic_stat;		// TdiIntrinsic
+  int on_error;		// TdiStatement
 } ThreadStatic;
 
 extern ThreadStatic *TdiGetThreadStatic();
 extern void LockTdiMutex(pthread_mutex_t *, int *);
 extern void UnlockTdiMutex(pthread_mutex_t *);
-
-#define TdiON_ERROR TdiThreadStatic_p->TdiOnError
-#define GET_TDITHREADSTATIC_P ThreadStatic *TdiThreadStatic_p = TdiGetThreadStatic()
 
 #endif
 #endif

--- a/tditest/testing/test-tdishr.ans
+++ b/tditest/testing/test-tdishr.ans
@@ -6277,3 +6277,5 @@ fun nid()nid
 Fun nid () {
 	nid;
 }
+`compile("1")
+1

--- a/tditest/testing/test-tdishr.tdi
+++ b/tditest/testing/test-tdishr.tdi
@@ -3136,3 +3136,4 @@ decompile(`dict(,"a",1,"b",2),1)
 decompile(`zero(32758,1))
 ! test if functions compile without treectx when containing pathlike NIDs
 fun nid()nid
+`compile("1")


### PR DESCRIPTION
* before TdiCompile had some limitations:
> 	For recursion must pass LEX:
> 	        zone status bol cur end
> 	        tdiyylval tdiyyval
> 	        tdiyytext[YYLMAX] tdiyyleng tdiyymorfg tdiyytchar tdiyyin? tdiyyout?
> 	For recursion must pass YACC also:
> 	        tdiyydebug? tdiyyv[YYMAXDEPTH] tdiyychar tdiyynerrs tdiyyerrflag
> 	Thus no recursion because the tdiyy's are built into LEX and YACC.
> 	IMMEDIATE (`) must never call COMPILE. NEED to prevent this.

this PR  supports (`) on COMPILE