### PR TITLE
Fix: repair python TreeNode.doMethod() method

### DIFF
--- a/python/MDSplus/tree.py
+++ b/python/MDSplus/tree.py
@@ -1648,9 +1648,12 @@ class TreeNode(_dat.TreeRef,_dat.Data): # HINT: TreeNode begin  (maybe subclass 
         xd=_dsc.Descriptor_xd()
         argsobj = [_scr.Int32(self.nid),_scr.String(method)]
         arglist+=list(map(_dat.Data.byref,argsobj))
-        arglist+=[len(args)]
-        argsobj= list(map(_dat.Data,args))
-        arglist+= list(map(_dat.Data.byref,argsobj))
+        arglist.append(len(args))
+        if len(args)>0:
+            argsobj= list(map(_dat.Data,args))
+            arglist.append(_N.array(map(_dat.Data.byref,argsobj)))
+        else:
+            arglist.append(_C.c_void_p(0))
         arglist+=[xd.ref]
         _exc.checkStatus(_TreeShr._TreeDoMethodA(*arglist))
         return xd._setTree(self.tree).value

--- a/python/MDSplus/tree.py
+++ b/python/MDSplus/tree.py
@@ -1651,6 +1651,7 @@ class TreeNode(_dat.TreeRef,_dat.Data): # HINT: TreeNode begin  (maybe subclass 
         arglist+=[len(args)]
         argsobj= list(map(_dat.Data,args))
         arglist+= list(map(_dat.Data.byref,argsobj))
+        arglist+=[xd.ref]
         _exc.checkStatus(_TreeShr._TreeDoMethodA(*arglist))
         return xd._setTree(self.tree).value
 

--- a/python/MDSplus/tree.py
+++ b/python/MDSplus/tree.py
@@ -1645,12 +1645,13 @@ class TreeNode(_dat.TreeRef,_dat.Data): # HINT: TreeNode begin  (maybe subclass 
         @rtype: None
         """
         arglist=[self.ctx]
-        xd=_dsc.descriptor_xd()
+        xd=_dsc.Descriptor_xd()
         argsobj = [_scr.Int32(self.nid),_scr.String(method)]
-        argsobj+= list(map(_dat.Data,args))
+        arglist+=list(map(_dat.Data.byref,argsobj))
+        arglist+=[len(args)]
+        argsobj= list(map(_dat.Data,args))
         arglist+= list(map(_dat.Data.byref,argsobj))
-        arglist+= [xd.ref,_ver.MdsEND_ARG]
-        _exc.checkStatus(_TreeShr._TreeDoMethod(*arglist))
+        _exc.checkStatus(_TreeShr._TreeDoMethodA(*arglist))
         return xd._setTree(self.tree).value
 
     @classmethod


### PR DESCRIPTION
A change to the python TreeNode implementation broke the doMethod
method. This should fix #1829