### PR TITLE
Feature: Add python TreeNode.tcl() method

### DIFF
--- a/python/MDSplus/tree.py
+++ b/python/MDSplus/tree.py
@@ -2669,6 +2669,18 @@ class TreeNode(_dat.TreeRef,_dat.Data): # HINT: TreeNode begin  (maybe subclass 
                                             _C.c_int32(int(rows_filled))))
 
 
+    def tcl(self,cmd):
+        """Issue a tcl command with this node being the default node
+        @param cmd: tcl command string
+        @type cmd: str
+        @rtype: int
+        """
+        olddef=self.tree.default
+        self.tree.default=self
+        ans=self.tree.tcl(cmd)
+        self.tree.default=olddef
+        return ans
+
     def updateSegment(self,start,end,dim,idx):
         """Update a segment
         @param start: index of first row of segment

--- a/python/MDSplus/tree.py
+++ b/python/MDSplus/tree.py
@@ -2677,9 +2677,10 @@ class TreeNode(_dat.TreeRef,_dat.Data): # HINT: TreeNode begin  (maybe subclass 
         """
         olddef=self.tree.default
         self.tree.default=self
-        ans=self.tree.tcl(cmd)
-        self.tree.default=olddef
-        return ans
+        try:
+            return self.tree.tcl(cmd)
+        finally:
+            self.tree.default=olddef
 
     def updateSegment(self,start,end,dim,idx):
         """Update a segment


### PR DESCRIPTION
Add tcl method to TreeNode which uses the TreeNode as the current
default node before executing the command.