### PR TITLE
Fix: Initializing the xds with EMPTY_XD

### DIFF
--- a/tdishr/TdiBound.c
+++ b/tdishr/TdiBound.c
@@ -67,7 +67,7 @@ int Tdi1Bound(opcode_t opcode, int narg, struct descriptor *list[], struct descr
 {
   INIT_STATUS;
   array_bounds *pa = 0;
-  struct descriptor_xd sig[1], uni[1], dat[1];
+  struct descriptor_xd sig[1] = {EMPTY_XD}, uni[1] = {EMPTY_XD}, dat[1] = {EMPTY_XD};
   struct TdiCatStruct cats[2];
   int dim, rank = 0;
 
@@ -242,7 +242,7 @@ int Tdi1Ebound(opcode_t opcode, int narg, struct descriptor *list[], struct desc
 {
   INIT_STATUS;
   array_bounds *pa = 0;
-  struct descriptor_xd sig[1], uni[1], dat[1];
+  struct descriptor_xd sig[1] = {EMPTY_XD}, uni[1] = {EMPTY_XD}, dat[1] = {EMPTY_XD};
   struct TdiCatStruct cats[2];
   struct descriptor_xd outs[MAX_DIMS];
   struct descriptor *new[MAX_DIMS];

--- a/tdishr/TdiCull.c
+++ b/tdishr/TdiCull.c
@@ -195,7 +195,7 @@ STATIC_ROUTINE int work(int rroutine(struct descriptor *, struct descriptor_a *,
   struct descriptor_signal *psig = 0;
   struct descriptor_range fake_range;
   struct descriptor dx0, dx1;
-  struct descriptor_xd sig[3], uni[3], dat[3];
+  struct descriptor_xd sig[3] = {EMPTY_XD}, uni[3] = {EMPTY_XD}, dat[3] = {EMPTY_XD};
   struct TdiCatStruct cats[4];
   STATIC_CONSTANT unsigned char omits[] = { DTYPE_DIMENSION, DTYPE_SIGNAL, DTYPE_DIMENSION, 0 };
   STATIC_CONSTANT unsigned char omitd[] = { DTYPE_WITH_UNITS, DTYPE_DIMENSION, 0 };

--- a/tdishr/TdiDecompress.c
+++ b/tdishr/TdiDecompress.c
@@ -53,7 +53,7 @@ extern int TdiMasterData();
 int Tdi1Decompress(opcode_t opcode, int narg, struct descriptor *list[], struct descriptor_xd *out_ptr)
 {
   INIT_STATUS;
-  struct descriptor_xd sig[4], uni[4], dat[4];
+  struct descriptor_xd sig[4] = {EMPTY_XD}, uni[4] = {EMPTY_XD}, dat[4] = {EMPTY_XD};
   struct TdiCatStruct cats[5];
   int cmode = -1, j, (*symbol) ();
   int bit = 0;

--- a/tdishr/TdiDtypeRange.c
+++ b/tdishr/TdiDtypeRange.c
@@ -83,7 +83,7 @@ int Tdi1DtypeRange(opcode_t opcode, int narg, struct descriptor *list[], struct 
   struct descriptor_xd nelem = EMPTY_XD, limits = EMPTY_XD;
   struct descriptor dx0, dx1;
   array arr = *(array *) & arr0;
-  struct descriptor_xd sig[3], uni[3], dat[3];
+  struct descriptor_xd sig[3] = {EMPTY_XD}, uni[3] = {EMPTY_XD}, dat[3] = {EMPTY_XD};
   struct TdiCatStruct cats[4];
 
   new[0] = list[0];

--- a/tdishr/TdiItoX.c
+++ b/tdishr/TdiItoX.c
@@ -141,7 +141,7 @@ int Tdi1ItoX(opcode_t opcode, int narg, struct descriptor *list[], struct descri
   struct descriptor tst1, del1, int1;
   struct descriptor_xd dimen = EMPTY_XD, window = EMPTY_XD, axis = EMPTY_XD, xat0 = EMPTY_XD;
   struct descriptor_xd cnt = EMPTY_XD, tmp = EMPTY_XD, units = EMPTY_XD;
-  struct descriptor_xd sig[3], uni[3], dat[3];
+  struct descriptor_xd sig[3] = {EMPTY_XD}, uni[3] = {EMPTY_XD}, dat[3] = {EMPTY_XD};
   struct descriptor_xd sig1 = EMPTY_XD, uni1 = EMPTY_XD;
   struct TdiCatStruct cats[4];
   FUNCTION(255 / 3) vec[3];

--- a/tdishr/TdiMatrix.c
+++ b/tdishr/TdiMatrix.c
@@ -88,7 +88,7 @@ int Tdi1Diagonal(opcode_t opcode, int narg, struct descriptor *list[], struct de
   struct descriptor *fillptr = NULL;
   struct descriptor_a *pv, *po;
   DESCRIPTOR_A_COEFF(proto, 1, DTYPE_BU, 0, 2, 0);
-  struct descriptor_xd sig[1], uni[1], dat[1];
+  struct descriptor_xd sig[1] = {EMPTY_XD}, uni[1] = {EMPTY_XD}, dat[1] = {EMPTY_XD};
   struct TdiCatStruct cats[2];
 
   status = TdiGetArgs(opcode, 1, list, sig, uni, dat, cats);

--- a/tdishr/TdiPack.c
+++ b/tdishr/TdiPack.c
@@ -62,7 +62,7 @@ int Tdi1Pack(opcode_t opcode, int narg, struct descriptor *list[], struct descri
   INIT_STATUS;
   int lena, lenm, numa, numm, numv = 0, bytes, j, cmode = -1;
   char *pi, *pm, *po;
-  struct descriptor_xd sig[3], uni[3], dat[3];
+  struct descriptor_xd sig[3] = {EMPTY_XD}, uni[3] = {EMPTY_XD}, dat[3] = {EMPTY_XD};
   struct TdiCatStruct cats[4];
 
   status = TdiGetArgs(opcode, narg, list, sig, uni, dat, cats);

--- a/tdishr/TdiSame.c
+++ b/tdishr/TdiSame.c
@@ -57,7 +57,7 @@ extern int TdiFaultHandler();
 int Tdi1Same(opcode_t opcode, int narg, struct descriptor *list[], struct descriptor_xd *out_ptr)
 {
   INIT_STATUS;
-  struct descriptor_xd sig[3], uni[3], dat[3];
+  struct descriptor_xd sig[3] = {EMPTY_XD}, uni[3] = {EMPTY_XD}, dat[3] = {EMPTY_XD};
   struct TdiCatStruct cats[4];
   struct TdiFunctionStruct *fun_ptr = (struct TdiFunctionStruct *)&TdiRefFunction[opcode];
   int cmode = -1, j, (*routine) () = fun_ptr->f3;

--- a/tdishr/TdiScalar.c
+++ b/tdishr/TdiScalar.c
@@ -63,7 +63,7 @@ extern int TdiPower();
 int Tdi1Scalar(opcode_t opcode, int narg, struct descriptor *list[], struct descriptor_xd *out_ptr)
 {
   INIT_STATUS;
-  struct descriptor_xd sig[2], uni[2], dat[2];
+  struct descriptor_xd sig[2] = {EMPTY_XD}, uni[2] = {EMPTY_XD}, dat[2] = {EMPTY_XD};
   struct TdiCatStruct cats[3];
   struct TdiFunctionStruct *fun_ptr = (struct TdiFunctionStruct *)&TdiRefFunction[opcode];
   int cmode = 0, j, (*routine) () = fun_ptr->f3;

--- a/tdishr/TdiSetRange.c
+++ b/tdishr/TdiSetRange.c
@@ -61,7 +61,7 @@ int Tdi1SetRange(opcode_t opcode, int narg, struct descriptor *list[], struct de
 {
   INIT_STATUS;
   STATIC_CONSTANT DESCRIPTOR_A(arr0, 1, DTYPE_BU, 0, 1);
-  struct descriptor_xd sig[1], uni[1], dat[1], tmp = EMPTY_XD;
+  struct descriptor_xd sig[1] = {EMPTY_XD}, uni[1] = {EMPTY_XD}, dat[1] = {EMPTY_XD}, tmp = EMPTY_XD;
   struct descriptor_range *prange;
   struct TdiCatStruct cats[2];
   array_bounds *pa = 0, arr = {0};

--- a/tdishr/TdiSort.c
+++ b/tdishr/TdiSort.c
@@ -273,7 +273,7 @@ int Tdi1Bsearch(opcode_t opcode, int narg, struct descriptor *list[], struct des
   int upcase = 0, cmode = -1, len, mode = 0, ni = 0, nt = 0;
   char *pinput, *ptable;
   int (*neq) () = 0, (*gtr) () = 0;
-  struct descriptor_xd sig[2], uni[2], dat[2];
+  struct descriptor_xd sig[2] = {EMPTY_XD}, uni[2] = {EMPTY_XD}, dat[2] = {EMPTY_XD};
   struct TdiCatStruct cats[3];
 
   status = TdiGetArgs(opcode, 2, list, sig, uni, dat, cats);
@@ -496,7 +496,7 @@ int Tdi1Sort(opcode_t opcode, int narg, struct descriptor *list[], struct descri
   int upcase = 0, cmode = -1, len, n = 0;
   int (*gtr) () = 0;
   char *pinput, *pkeep;
-  struct descriptor_xd sig[1], uni[1], dat[1];
+  struct descriptor_xd sig[1] = {EMPTY_XD}, uni[1] = {EMPTY_XD}, dat[1] = {EMPTY_XD};
   struct TdiCatStruct cats[2];
   int stack[64];
 

--- a/tdishr/TdiSubscript.c
+++ b/tdishr/TdiSubscript.c
@@ -112,7 +112,7 @@ int Tdi1Subscript(opcode_t opcode, int narg, struct descriptor *list[], struct d
   array_coeff arr = {1,DTYPE_B,CLASS_A,0,0,0,{0,1,1,1,0},MAX_DIMS,1,0,{0}};
   struct descriptor ddim = { sizeof(dim), DTYPE_L, CLASS_S, 0 };
   struct descriptor_xd ii[MAX_DIMS], xx[MAX_DIMS];
-  struct descriptor_xd sig[1], uni[1], dat[1];
+  struct descriptor_xd sig[1] = {EMPTY_XD}, uni[1] = {EMPTY_XD}, dat[1] = {EMPTY_XD};
   struct TdiCatStruct cats[2];
   ddim.pointer = (char *)&dim;
   status = TdiGetArgs(opcode, 1, list, sig, uni, dat, cats);
@@ -352,7 +352,7 @@ int Tdi1Map(opcode_t opcode, int narg __attribute__ ((unused)), struct descripto
 {
   INIT_STATUS;
   GET_TDITHREADSTATIC_P;
-  struct descriptor_xd dwu = EMPTY_XD, sig[1], uni[1], dat[1];
+  struct descriptor_xd dwu = EMPTY_XD, sig[1] = {EMPTY_XD}, uni[1] = {EMPTY_XD}, dat[1] = {EMPTY_XD};
   struct TdiCatStruct cats[2];
   struct descriptor_with_units *pwu;
   int cmode = -1, n = 0, len;

--- a/tdishr/TdiTrans.c
+++ b/tdishr/TdiTrans.c
@@ -114,7 +114,7 @@ int Tdi1Trans(int opcode, int narg, struct descriptor *list[], struct descriptor
   struct descriptor_signal *psig;
   signal_maxdim tmpsig;
   array_bounds arr, *pa, *pd;
-  struct descriptor_xd sig[3], uni[3], dat[3];
+  struct descriptor_xd sig[3] = {EMPTY_XD}, uni[3] = {EMPTY_XD}, dat[3] = {EMPTY_XD};
   struct TdiCatStruct cats[4];
   struct TdiFunctionStruct *pfun = (struct TdiFunctionStruct *)&TdiRefFunction[opcode];
   int cmode = -1, dim = -1, j, mul = 0, ncopies = 0, rank = 0, ndim;

--- a/tdishr/TdiTrim.c
+++ b/tdishr/TdiTrim.c
@@ -49,7 +49,7 @@ extern int TdiMasterData();
 int Tdi1Trim(opcode_t opcode, int narg, struct descriptor *list[], struct descriptor_xd *out_ptr)
 {
   INIT_STATUS;
-  struct descriptor_xd sig[1], uni[1], dat[1];
+  struct descriptor_xd sig[1] = {EMPTY_XD}, uni[1] = {EMPTY_XD}, dat[1] = {EMPTY_XD};
   struct TdiCatStruct cats[2];
   struct TdiFunctionStruct *fun_ptr = (struct TdiFunctionStruct *)&TdiRefFunction[opcode];
   int j, cmode = -1;


### PR DESCRIPTION
Several Tdishr code needed to have xds sig[], uni[] and dat[] initialized. This should fix an issue that we saw when using CULL().