### PR TITLE
Fix: trunc files when doing new on MDS_IO_OPEN_ONE

### DIFF
--- a/python/MDSplus/tests/treeUnitTest.py
+++ b/python/MDSplus/tests/treeUnitTest.py
@@ -70,7 +70,15 @@ class Tests(_UnitTest.TreeTests):
         self.assertEqual(exattr['ATT3'],'this is plasma current')
 
     def openTrees(self):
-        with Tree('pytree',self.shot+1,'new'): pass
+        with Tree('pytree',self.shot+1,'new') as pytree:
+            a = pytree.addNode('A','TEXT')
+            pytree.write()
+        pytree.open()
+        a.record = 'a'*64
+        self.assertEqual(pytree.getDatafileSize(),84)
+        pytree.close()
+        with Tree('pytree',self.shot+1,'new') as pytree:
+            self.assertEqual(pytree.getDatafileSize(),0) # new should clear datafile (O_TRUNC)
         filepath = ('%s/pytree_%03d.tree'%(self.tmpdir,self.shot+1)).replace(os.sep,'/')
         self.assertEqual(Tree.getFileName('pytree',self.shot+1), filepath)
         pytree = Tree('pytree',self.shot+1)

--- a/treeshr/RemoteAccess.c
+++ b/treeshr/RemoteAccess.c
@@ -1525,7 +1525,7 @@ inline static int io_open_one_request(int conid,size_t size,mdsio_t*mdsio,char*d
 
 static void getOptionsMode(int new,int edit,int*options,int*mode) {
   if (new){
-    *options = O_RDWR | O_CREAT;
+    *options = O_RDWR | O_CREAT | O_TRUNC;
     *mode = 0664;
   } else {
     *options = edit ? O_RDWR : O_RDONLY;


### PR DESCRIPTION
* if you did create pules or edit tree/new, the treefiles would not get truncated but hold the old data if the file existed.