### PR TITLE
Feature: allow to set default resample mode at runtime

### DIFF
--- a/python/MDSplus/_mdsshr.py
+++ b/python/MDSplus/_mdsshr.py
@@ -69,6 +69,12 @@ def setenv(name,value):
     pe=_mds.MdsPutEnv
     pe(_ver.tobytes("=".join([str(name),str(value)])))
 
+def set_default_resample_mode(mode):
+    """set MDSPLUS_DEFAULT_RESAMPLE_MODE environment variable
+    @param mode: name of resample mode: 'Average', 'MinMax', 'Interpolation', 'Closest', or 'Previous'
+    @type mode: str
+    """
+    setenv("MDSPLUS_DEFAULT_RESAMPLE_MODE",mode)
 
 def DateToQuad(date):
     ans=_C.c_ulonglong(0)
@@ -76,4 +82,5 @@ def DateToQuad(date):
     if not (status & 1):
         raise MdsshrException("Cannot parse %s as date. Use dd-mon-yyyy hh:mm:ss.hh format or \"now\",\"today\",\"yesterday\"." % (date,))
     return _dat.Data(_N.uint64(ans.value))
+
 

--- a/python/MDSplus/tests/segmentsUnitTest.py
+++ b/python/MDSplus/tests/segmentsUnitTest.py
@@ -31,8 +31,7 @@ def _mimport(name, level=1):
     except:
         return __import__(name, globals())
 _UnitTest=_mimport("_UnitTest")
-from MDSplus import setenv
-setenv("MDSPLUS_DEFAULT_RESAMPLE_MODE","interp")
+from MDSplus import setenv, set_default_resample_mode
 class Tests(_UnitTest.TreeTests):
     shotinc = 12
     tree    =  'segments'
@@ -250,7 +249,13 @@ class Tests(_UnitTest.TreeTests):
         self.assertEqual(Tree.getTimeContext(),(1,2,3))
         self.assertEqual(node.tree.getTimeContext(),(300,700,150))
 
-        sig = node.record # interp as set by env
+        set_default_resample_mode("m") # minmax
+        sig = node.record
+        self.assertEqual(sig.data().tolist(),[30,44,45,59,60,74])
+        self.assertEqual(sig.dim_of().data().tolist(),[375,375,525,525,675,675])
+
+        set_default_resample_mode("i") # interpolation
+        sig = node.record
         self.assertEqual(sig.data().tolist(),[30,45,60])
         self.assertEqual(sig.dim_of().data().tolist(),[300,450,600])
 

--- a/tdi/segments/SetTimeContext.fun
+++ b/tdi/segments/SetTimeContext.fun
@@ -1,5 +1,7 @@
-public fun SetTimeContext(optional _start, optional _end, optional _delta)
+public fun SetTimeContext(optional _start, optional _end, optional _delta, optional _resample_mode)
 {
+  if (present(_resample_mode))
+    setenv('MDSPLUS_DEFAULT_RESAMPLE_MODE='//_resample_mode);
   _exp="TreeShr->TreeSetTimeContext(";
   _exp=_exp//((present(_start))?"descr(_start),":"val(0),");
   _exp=_exp//((present(_end)) ? "descr(_end),":"val(0),");

--- a/xtreeshr/XTreeDefaultResample.c
+++ b/xtreeshr/XTreeDefaultResample.c
@@ -126,10 +126,11 @@ EXPORT mdsdsc_xd_t *XTreeResamplePrevious(mds_signal_t *inSignalD, mdsdsc_t*star
 }
 
 static res_mode_t default_mode = AVERAGE;
-static void get_default() {
+static inline void get_default() {
   char *resampleMode = TranslateLogical("MDSPLUS_DEFAULT_RESAMPLE_MODE");
-  if(!resampleMode) return;
-       if(!strcasecmp(resampleMode, "Average"))
+  if(!resampleMode)
+    default_mode = AVERAGE;
+  else if(!strcasecmp(resampleMode, "Average"))
     default_mode = AVERAGE;
   else if(!strcasecmp(resampleMode, "MinMax"))
     default_mode = MINMAX;
@@ -139,11 +140,14 @@ static void get_default() {
     default_mode = CLOSEST;
   else if(!strcasecmp(resampleMode, "Previous"))
     default_mode = PREVIOUS;
+  else {
+    fprintf(stderr,"Error: Resample mode must be one of 'Average', 'MinMax', 'Interp', 'Closest', or 'Previous' but was '%s'; using 'Average'.", resampleMode);
+    default_mode = AVERAGE;
+  }
   TranslateLogicalFree(resampleMode);
 }
 int XTreeDefaultResample(mds_signal_t *inSignalD, mdsdsc_t*startD, mdsdsc_t*endD, mdsdsc_t*deltaD, mdsdsc_xd_t *outSignalXd){
-  static pthread_once_t once = PTHREAD_ONCE_INIT;
-  pthread_once(&once,get_default);
+  get_default(); // get_env is cheap compared to what comming next, we can affort to reload it
   return XTreeDefaultResampleMode(inSignalD, startD, endD, deltaD, default_mode, outSignalXd);
 }
 

--- a/xtreeshr/XTreeDefaultResample.c
+++ b/xtreeshr/XTreeDefaultResample.c
@@ -128,20 +128,21 @@ EXPORT mdsdsc_xd_t *XTreeResamplePrevious(mds_signal_t *inSignalD, mdsdsc_t*star
 static res_mode_t default_mode = AVERAGE;
 static inline void get_default() {
   char *resampleMode = TranslateLogical("MDSPLUS_DEFAULT_RESAMPLE_MODE");
-  if(!resampleMode)
+  int len;
+  if(!resampleMode || (len=strlen(resampleMode)) == 0)
     default_mode = AVERAGE;
-  else if(!strcasecmp(resampleMode, "Average"))
+  else if(!strncasecmp(resampleMode, "Average", len))
     default_mode = AVERAGE;
-  else if(!strcasecmp(resampleMode, "MinMax"))
+  else if(!strncasecmp(resampleMode, "MinMax", len))
     default_mode = MINMAX;
-  else if(!strcasecmp(resampleMode, "Interp"))
+  else if(!strncasecmp(resampleMode, "Interpolation", len))
     default_mode = INTERPOLATION;
-  else if(!strcasecmp(resampleMode, "Closest"))
+  else if(!strncasecmp(resampleMode, "Closest", len))
     default_mode = CLOSEST;
-  else if(!strcasecmp(resampleMode, "Previous"))
+  else if(!strncasecmp(resampleMode, "Previous", len))
     default_mode = PREVIOUS;
   else {
-    fprintf(stderr,"Error: Resample mode must be one of 'Average', 'MinMax', 'Interp', 'Closest', or 'Previous' but was '%s'; using 'Average'.", resampleMode);
+    fprintf(stderr,"Error: Resample mode must be one of 'Average', 'MinMax', 'Interpolation', 'Closest', or 'Previous' but was '%s'; using 'Average'.\n", resampleMode);
     default_mode = AVERAGE;
   }
   TranslateLogicalFree(resampleMode);


### PR DESCRIPTION
* removed the once from get_default allowing updates to default_mode
* added _resample_mode to SetTimeContext for an easy switch
* allows abbreviations for resample mode, e.g. 'm' is sufficient for minmax
