### PR TITLE
Fix: fixed performance issues

### DIFF
--- a/tdishr/CvtConvertFloat.c
+++ b/tdishr/CvtConvertFloat.c
@@ -26,7 +26,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <mdsdescrip.h>
 #include <mdsplus/mdsplus.h>
 #include <inttypes.h>
-#include <STATICdef.h>
 
 /** Adapted from VMS V7.0 sources CvtConvertFloat.lis                      **/
 /******************************************************************************/
@@ -288,7 +287,7 @@ typedef UNPACKED_REAL *UNPACKED_REAL_PTR;
 ** Special floating point constant definitions
 **=============================================================================
 */
-STATIC_CONSTANT uint32_t const vax_c[] = {
+static const uint32_t vax_c[] = {
 
   0x00008000, 0x00000000, 0x00000000, 0x00000000,	/* ROPs */
   0x00000000, 0x00000000, 0x00000000, 0x00000000,	/* zeros */
@@ -296,7 +295,7 @@ STATIC_CONSTANT uint32_t const vax_c[] = {
   0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff,	/* -huge */
 };
 
-STATIC_CONSTANT uint32_t const ieee_s[] = {
+static const uint32_t ieee_s[] = {
 
   0x7fbfffff,			/* little endian ieee s nan */
   0xffffbf7f,			/* big endian ieee s nan */
@@ -314,7 +313,7 @@ STATIC_CONSTANT uint32_t const ieee_s[] = {
   0x000080ff,			/* be ieee s -infinity */
 };
 
-STATIC_CONSTANT uint32_t const ieee_t[] = {
+static const uint32_t ieee_t[] = {
 
   0xffffffff, 0x7ff7ffff,	/* le ieee t nan */
   0xfffff77f, 0xffffffff,	/* be ieee t nan */
@@ -332,7 +331,7 @@ STATIC_CONSTANT uint32_t const ieee_t[] = {
   0x0000f0ff, 0x00000000,	/* be ieee t -infinity */
 };
 
-STATIC_CONSTANT uint32_t const ieee_x[] = {
+static const uint32_t ieee_x[] = {
 
   0xffffffff, 0xffffffff, 0xffffffff, 0x7fff7fff,	/* le ieee x nan */
   0xff7fff7f, 0xffffffff, 0xffffffff, 0xffffffff,	/* be ieee x nan */
@@ -350,7 +349,7 @@ STATIC_CONSTANT uint32_t const ieee_x[] = {
   0x0000ffff, 0x00000000, 0x00000000, 0x00000000,	/* be ieee x -infinity */
 };
 
-STATIC_CONSTANT uint32_t const ibm_s[] = {
+static const uint32_t ibm_s[] = {
 
   0x000000ff,			/* ibm s invalid */
   0x00000000,			/* ibm s +zero */
@@ -362,7 +361,7 @@ STATIC_CONSTANT uint32_t const ibm_s[] = {
 
 };
 
-STATIC_CONSTANT uint32_t const ibm_l[] = {
+static const uint32_t ibm_l[] = {
 
   0x000000ff, 0x00000000,	/* ibm t invalid */
   0x00000000, 0x00000000,	/* ibm t +zero */
@@ -374,7 +373,7 @@ STATIC_CONSTANT uint32_t const ibm_l[] = {
 
 };
 
-STATIC_CONSTANT uint32_t const cray[] = {
+static const uint32_t cray[] = {
 
   0x00000060, 0x00000000,	/* cray invalid */
   0x00000000, 0x00000000,	/* cray +zero */
@@ -490,67 +489,67 @@ STATIC_CONSTANT uint32_t const cray[] = {
 ** Function Prototypes
 **-----------------------------------------------------------------------------
 */
-STATIC_ROUTINE CVT_STATUS pack_vax_f(UNPACKED_REAL intermediate_value,
+static CVT_STATUS pack_vax_f(UNPACKED_REAL intermediate_value,
 				     CVT_VAX_F output_value, uint32_t options __attribute__ ((unused)));
 
-STATIC_ROUTINE CVT_STATUS pack_vax_d(UNPACKED_REAL intermediate_value,
+static CVT_STATUS pack_vax_d(UNPACKED_REAL intermediate_value,
 				     CVT_VAX_D output_value, uint32_t options __attribute__ ((unused)));
 
-STATIC_ROUTINE CVT_STATUS pack_vax_g(UNPACKED_REAL intermediate_value,
+static CVT_STATUS pack_vax_g(UNPACKED_REAL intermediate_value,
 				     CVT_VAX_G output_value, uint32_t options __attribute__ ((unused)));
 
-STATIC_ROUTINE CVT_STATUS pack_vax_h(UNPACKED_REAL intermediate_value,
+static CVT_STATUS pack_vax_h(UNPACKED_REAL intermediate_value,
 				     CVT_VAX_H output_value, uint32_t options __attribute__ ((unused)));
 
-STATIC_ROUTINE CVT_STATUS pack_ieee_s(UNPACKED_REAL intermediate_value,
+static CVT_STATUS pack_ieee_s(UNPACKED_REAL intermediate_value,
 				      CVT_IEEE_S output_value, uint32_t options __attribute__ ((unused)));
 
-STATIC_ROUTINE CVT_STATUS pack_ieee_t(UNPACKED_REAL intermediate_value,
+static CVT_STATUS pack_ieee_t(UNPACKED_REAL intermediate_value,
 				      CVT_IEEE_T output_value, uint32_t options __attribute__ ((unused)));
 
-STATIC_ROUTINE CVT_STATUS pack_ieee_x(UNPACKED_REAL intermediate_value,
+static CVT_STATUS pack_ieee_x(UNPACKED_REAL intermediate_value,
 				      CVT_IEEE_X output_value, uint32_t options __attribute__ ((unused)));
 
-STATIC_ROUTINE CVT_STATUS pack_ibm_l(UNPACKED_REAL intermediate_value,
+static CVT_STATUS pack_ibm_l(UNPACKED_REAL intermediate_value,
 				     CVT_IBM_LONG output_value, uint32_t options __attribute__ ((unused)));
 
-STATIC_ROUTINE CVT_STATUS pack_ibm_s(UNPACKED_REAL intermediate_value,
+static CVT_STATUS pack_ibm_s(UNPACKED_REAL intermediate_value,
 				     CVT_IBM_SHORT output_value, uint32_t options __attribute__ ((unused)));
 
-STATIC_ROUTINE CVT_STATUS pack_cray(UNPACKED_REAL intermediate_value,
+static CVT_STATUS pack_cray(UNPACKED_REAL intermediate_value,
 				    CVT_CRAY output_value, uint32_t options __attribute__ ((unused)));
 
-STATIC_ROUTINE void _round(UNPACKED_REAL intermediate_value,
+static void _round(UNPACKED_REAL intermediate_value,
 			   uint32_t round_bit_position, uint32_t options __attribute__ ((unused)));
 
-STATIC_ROUTINE void unpack_vax_f(CVT_VAX_F input_value,
+static void unpack_vax_f(CVT_VAX_F input_value,
 				 UNPACKED_REAL intermediate_value, uint32_t options __attribute__ ((unused)));
 
-STATIC_ROUTINE void unpack_vax_d(CVT_VAX_D input_value,
+static void unpack_vax_d(CVT_VAX_D input_value,
 				 UNPACKED_REAL intermediate_value, uint32_t options __attribute__ ((unused)));
 
-STATIC_ROUTINE void unpack_vax_g(CVT_VAX_G input_value,
+static void unpack_vax_g(CVT_VAX_G input_value,
 				 UNPACKED_REAL output_value, uint32_t options __attribute__ ((unused)));
 
-STATIC_ROUTINE void unpack_vax_h(CVT_VAX_H input_value,
+static void unpack_vax_h(CVT_VAX_H input_value,
 				 UNPACKED_REAL intermediate_value, uint32_t options __attribute__ ((unused)));
 
-STATIC_ROUTINE void unpack_ieee_s(CVT_IEEE_S input_value,
+static void unpack_ieee_s(CVT_IEEE_S input_value,
 				  UNPACKED_REAL intermediate_value, uint32_t options __attribute__ ((unused)));
 
-STATIC_ROUTINE void unpack_ieee_t(CVT_IEEE_T input_value,
+static void unpack_ieee_t(CVT_IEEE_T input_value,
 				  UNPACKED_REAL intermediate_value, uint32_t options __attribute__ ((unused)));
 
-STATIC_ROUTINE void unpack_ieee_x(CVT_IEEE_X input_value,
+static void unpack_ieee_x(CVT_IEEE_X input_value,
 				  UNPACKED_REAL intermediate_value, uint32_t options __attribute__ ((unused)));
 
-STATIC_ROUTINE void unpack_ibm_l(CVT_IBM_LONG input_value,
+static void unpack_ibm_l(CVT_IBM_LONG input_value,
 				 UNPACKED_REAL intermediate_value, uint32_t options __attribute__ ((unused)));
 
-STATIC_ROUTINE void unpack_ibm_s(CVT_IBM_SHORT input_value,
+static void unpack_ibm_s(CVT_IBM_SHORT input_value,
 				 UNPACKED_REAL intermediate_value, uint32_t options __attribute__ ((unused)));
 
-STATIC_ROUTINE void unpack_cray(CVT_CRAY input_value,
+static void unpack_cray(CVT_CRAY input_value,
 				UNPACKED_REAL intermediate_value, uint32_t options __attribute__ ((unused)));
 
 extern EXPORT CVT_STATUS CvtConvertFloat(void *input_value,
@@ -820,14 +819,14 @@ extern EXPORT CVT_STATUS CvtConvertFloat(void *input_value,
   return return_status;
 }
 
-STATIC_ROUTINE void FlipDouble(int *in)
+static void FlipDouble(int *in)
 {
   int tmp = in[0];
   in[0] = in[1];
   in[1] = tmp;
 }
 
-STATIC_ROUTINE CVT_STATUS pack_vax_f(UNPACKED_REAL intermediate_value,
+static CVT_STATUS pack_vax_f(UNPACKED_REAL intermediate_value,
 				     CVT_VAX_F output_value, uint32_t options __attribute__ ((unused)))
 /*
 **=============================================================================
@@ -1003,7 +1002,7 @@ STATIC_ROUTINE CVT_STATUS pack_vax_f(UNPACKED_REAL intermediate_value,
 
 }
 
-STATIC_ROUTINE CVT_STATUS pack_vax_d(UNPACKED_REAL intermediate_value,
+static CVT_STATUS pack_vax_d(UNPACKED_REAL intermediate_value,
 				     CVT_VAX_D output_value, uint32_t options __attribute__ ((unused)))
 /*
 **=============================================================================
@@ -1191,7 +1190,7 @@ STATIC_ROUTINE CVT_STATUS pack_vax_d(UNPACKED_REAL intermediate_value,
 
 }
 
-STATIC_ROUTINE CVT_STATUS pack_vax_g(UNPACKED_REAL intermediate_value,
+static CVT_STATUS pack_vax_g(UNPACKED_REAL intermediate_value,
 				     CVT_VAX_G output_value, uint32_t options __attribute__ ((unused)))
 /*
 **=============================================================================
@@ -1372,7 +1371,7 @@ STATIC_ROUTINE CVT_STATUS pack_vax_g(UNPACKED_REAL intermediate_value,
 
 }
 
-STATIC_ROUTINE CVT_STATUS pack_vax_h(UNPACKED_REAL intermediate_value,
+static CVT_STATUS pack_vax_h(UNPACKED_REAL intermediate_value,
 				     CVT_VAX_H output_value, uint32_t options __attribute__ ((unused)))
 /*
 **=============================================================================
@@ -1555,7 +1554,7 @@ STATIC_ROUTINE CVT_STATUS pack_vax_h(UNPACKED_REAL intermediate_value,
 
 }
 
-STATIC_ROUTINE CVT_STATUS pack_ieee_s(UNPACKED_REAL intermediate_value,
+static CVT_STATUS pack_ieee_s(UNPACKED_REAL intermediate_value,
 				      CVT_IEEE_S output_value, uint32_t options __attribute__ ((unused)))
 /*
 **=============================================================================
@@ -1780,7 +1779,7 @@ STATIC_ROUTINE CVT_STATUS pack_ieee_s(UNPACKED_REAL intermediate_value,
 
 }
 
-STATIC_ROUTINE CVT_STATUS pack_ieee_t(UNPACKED_REAL intermediate_value,
+static CVT_STATUS pack_ieee_t(UNPACKED_REAL intermediate_value,
 				      CVT_IEEE_T output_value, uint32_t options __attribute__ ((unused)))
 /*
 **=============================================================================
@@ -1838,7 +1837,7 @@ STATIC_ROUTINE CVT_STATUS pack_ieee_t(UNPACKED_REAL intermediate_value,
   int round_bit_position;
   int i;
   CVT_STATUS return_status;
-  STATIC_CONSTANT double fliptest = 42.;
+  static const double fliptest = 42.;
   int flip = *(int *)&fliptest != 0;
 
   /*
@@ -2058,7 +2057,7 @@ STATIC_ROUTINE CVT_STATUS pack_ieee_t(UNPACKED_REAL intermediate_value,
 
 }
 
-STATIC_ROUTINE CVT_STATUS pack_ieee_x(UNPACKED_REAL intermediate_value,
+static CVT_STATUS pack_ieee_x(UNPACKED_REAL intermediate_value,
 				      CVT_IEEE_X output_value, uint32_t options __attribute__ ((unused)))
 /*
 **=============================================================================
@@ -2355,7 +2354,7 @@ STATIC_ROUTINE CVT_STATUS pack_ieee_x(UNPACKED_REAL intermediate_value,
 
 }
 
-STATIC_ROUTINE CVT_STATUS pack_ibm_l(UNPACKED_REAL intermediate_value,
+static CVT_STATUS pack_ibm_l(UNPACKED_REAL intermediate_value,
 				     CVT_IBM_LONG output_value, uint32_t options __attribute__ ((unused)))
 /*
 **=============================================================================
@@ -2565,7 +2564,7 @@ STATIC_ROUTINE CVT_STATUS pack_ibm_l(UNPACKED_REAL intermediate_value,
 
 }
 
-STATIC_ROUTINE CVT_STATUS pack_ibm_s(UNPACKED_REAL intermediate_value,
+static CVT_STATUS pack_ibm_s(UNPACKED_REAL intermediate_value,
 				     CVT_IBM_SHORT output_value, uint32_t options __attribute__ ((unused)))
 /*
 **=============================================================================
@@ -2763,7 +2762,7 @@ STATIC_ROUTINE CVT_STATUS pack_ibm_s(UNPACKED_REAL intermediate_value,
 
 }
 
-STATIC_ROUTINE CVT_STATUS pack_cray(UNPACKED_REAL intermediate_value,
+static CVT_STATUS pack_cray(UNPACKED_REAL intermediate_value,
 				    CVT_CRAY output_value, uint32_t options __attribute__ ((unused)))
 /*
 **=============================================================================
@@ -2956,7 +2955,7 @@ STATIC_ROUTINE CVT_STATUS pack_cray(UNPACKED_REAL intermediate_value,
 
 }
 
-STATIC_ROUTINE void _round(UNPACKED_REAL intermediate_value,
+static void _round(UNPACKED_REAL intermediate_value,
 			   uint32_t round_bit_position, uint32_t options __attribute__ ((unused)))
 /*
 **=============================================================================
@@ -3201,7 +3200,7 @@ STATIC_ROUTINE void _round(UNPACKED_REAL intermediate_value,
 
 }
 
-STATIC_ROUTINE void unpack_vax_f(CVT_VAX_F input_value,
+static void unpack_vax_f(CVT_VAX_F input_value,
 				 UNPACKED_REAL output_value, uint32_t options __attribute__ ((unused)))
 /*
 **=============================================================================
@@ -3319,7 +3318,7 @@ STATIC_ROUTINE void unpack_vax_f(CVT_VAX_F input_value,
 
 }
 
-STATIC_ROUTINE void unpack_vax_d(CVT_VAX_D input_value,
+static void unpack_vax_d(CVT_VAX_D input_value,
 				 UNPACKED_REAL output_value, uint32_t options __attribute__ ((unused)))
 /*
 **=============================================================================
@@ -3449,7 +3448,7 @@ STATIC_ROUTINE void unpack_vax_d(CVT_VAX_D input_value,
 
 }
 
-STATIC_ROUTINE void unpack_vax_g(CVT_VAX_G input_value,
+static void unpack_vax_g(CVT_VAX_G input_value,
 				 UNPACKED_REAL output_value, uint32_t options __attribute__ ((unused)))
 /*
 **=============================================================================
@@ -3580,7 +3579,7 @@ STATIC_ROUTINE void unpack_vax_g(CVT_VAX_G input_value,
 
 }
 
-STATIC_ROUTINE void unpack_vax_h(CVT_VAX_H input_value,
+static void unpack_vax_h(CVT_VAX_H input_value,
 				 UNPACKED_REAL output_value, uint32_t options __attribute__ ((unused)))
 /*
 **=============================================================================
@@ -3709,7 +3708,7 @@ STATIC_ROUTINE void unpack_vax_h(CVT_VAX_H input_value,
 
 }
 
-STATIC_ROUTINE void unpack_ieee_s(CVT_IEEE_S input_value,
+static void unpack_ieee_s(CVT_IEEE_S input_value,
 				  UNPACKED_REAL output_value, uint32_t options __attribute__ ((unused)))
 /*
 **=============================================================================
@@ -3897,7 +3896,7 @@ STATIC_ROUTINE void unpack_ieee_s(CVT_IEEE_S input_value,
 
 }
 
-STATIC_ROUTINE void unpack_ieee_t(CVT_IEEE_T input_value,
+static void unpack_ieee_t(CVT_IEEE_T input_value,
 				  UNPACKED_REAL output_value, uint32_t options __attribute__ ((unused)))
 /*
 **=============================================================================
@@ -3952,7 +3951,7 @@ STATIC_ROUTINE void unpack_ieee_t(CVT_IEEE_T input_value,
    ** ==========================================================================
    */
   int i;
-  STATIC_CONSTANT double fliptest = 42.;
+  static const double fliptest = 42.;
   int flip = *(int *)&fliptest != 0;
 
   /*
@@ -4121,7 +4120,7 @@ STATIC_ROUTINE void unpack_ieee_t(CVT_IEEE_T input_value,
 
 }
 
-STATIC_ROUTINE void unpack_ieee_x(CVT_IEEE_X input_value,
+static void unpack_ieee_x(CVT_IEEE_X input_value,
 				  UNPACKED_REAL output_value, uint32_t options __attribute__ ((unused)))
 /*
 **=============================================================================
@@ -4433,7 +4432,7 @@ STATIC_ROUTINE void unpack_ieee_x(CVT_IEEE_X input_value,
 
 }
 
-STATIC_ROUTINE void unpack_ibm_l(CVT_IBM_LONG input_value,
+static void unpack_ibm_l(CVT_IBM_LONG input_value,
 				 UNPACKED_REAL output_value, uint32_t options __attribute__ ((unused)))
 /*
 **=============================================================================
@@ -4595,7 +4594,7 @@ STATIC_ROUTINE void unpack_ibm_l(CVT_IBM_LONG input_value,
 
 }
 
-STATIC_ROUTINE void unpack_ibm_s(CVT_IBM_SHORT input_value,
+static void unpack_ibm_s(CVT_IBM_SHORT input_value,
 				 UNPACKED_REAL output_value, uint32_t options __attribute__ ((unused)))
 /*
 **=============================================================================
@@ -4751,7 +4750,7 @@ STATIC_ROUTINE void unpack_ibm_s(CVT_IBM_SHORT input_value,
 
 }
 
-STATIC_ROUTINE void unpack_cray(CVT_CRAY input_value, UNPACKED_REAL output_value, uint32_t options __attribute__ ((unused)))
+static void unpack_cray(CVT_CRAY input_value, UNPACKED_REAL output_value, uint32_t options __attribute__ ((unused)))
 /*
 **=============================================================================
 **

--- a/tdishr/IsRoprand.c
+++ b/tdishr/IsRoprand.c
@@ -28,7 +28,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 /*  CMS REPLACEMENT HISTORY, Element ISROPRAND.C */
 #include <mdstypes.h>
 #include <mdsdescrip.h>
-#include <STATICdef.h>
 
 #define f_float_exp(val) ((*(int *)val >> 7) & 0xff)
 #define f_float_sign(val) ((*(int *)val >> 15) &0x1)

--- a/tdishr/TdiAbs.c
+++ b/tdishr/TdiAbs.c
@@ -73,7 +73,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <mdsdescrip.h>
 #include <tdishr_messages.h>
 #include <math.h>
-#include <STATICdef.h>
 #include <int128.h>
 
 extern int TdiConvert();
@@ -84,7 +83,7 @@ extern int CvtConvertFloat();
 #define min(a,b) ((a)<(b)) ? (a) : (b)
 #define max(a,b) ((a)<(b)) ? (b) : (a)
 
-STATIC_CONSTANT const int roprand = 0x8000;
+static const int roprand = 0x8000;
 
 #define start_operate(type) {\
   type *in=(type *)(in_ptr->pointer); \

--- a/tdishr/TdiAdd.c
+++ b/tdishr/TdiAdd.c
@@ -57,7 +57,6 @@ int Tdi3Add(struct descriptor *in1, struct descriptor *in2, struct descriptor *o
 #include <mdsdescrip.h>
 #include <tdishr_messages.h>
 #include "roprand.h"
-#include <STATICdef.h>
 #include <int128.h>
 
 
@@ -105,7 +104,7 @@ extern int CvtConvertFloat();
   break;\
 }
 
-STATIC_CONSTANT const int roprand = 0x8000;
+static const int roprand = 0x8000;
 
 #define OperateFloatOne(type,dtype,native,operator,p1,p2) \
 { type a,b,ans;\

--- a/tdishr/TdiAnd.c
+++ b/tdishr/TdiAnd.c
@@ -75,7 +75,6 @@ int Tdi3And(struct descriptor *in1, struct descriptor *in2, struct descriptor *o
 #include <stdio.h>
 #include <mdsdescrip.h>
 #include <tdishr_messages.h>
-#include <STATICdef.h>
 
 static inline int Operate(struct descriptor *in1, struct descriptor *in2, struct descriptor *out,char operator(const char, const char)) {
   if (in1->dtype!=2) {

--- a/tdishr/TdiApd.c
+++ b/tdishr/TdiApd.c
@@ -27,7 +27,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 	Timo Schröder, IPP      2017
 */
 
-#include "STATICdef.h"
 #include "tdirefcat.h"
 #include "tdirefstandard.h"
 #include "tdinelements.h"

--- a/tdishr/TdiArray.c
+++ b/tdishr/TdiArray.c
@@ -51,7 +51,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "tdirefcat.h"
 #include "tdireffunction.h"
 #include "tdirefstandard.h"
-#include <STATICdef.h>
 #ifdef _WIN32
 #include <process.h>
 #endif
@@ -161,9 +160,9 @@ int Tdi3Array(/*int *out_ptr*/)
 int Tdi3Ramp(struct descriptor *out_ptr)
 {
   INIT_STATUS;
-  STATIC_CONSTANT int i0 = 0, i1 = 1;
-  STATIC_CONSTANT struct descriptor con0 = { sizeof(int), DTYPE_L, CLASS_S, (char *)&i0 };
-  STATIC_CONSTANT struct descriptor con1 = { sizeof(int), DTYPE_L, CLASS_S, (char *)&i1 };
+  static const int i0 = 0, i1 = 1;
+  static const struct descriptor con0 = { sizeof(int), DTYPE_L, CLASS_S, (char *)&i0 };
+  static const struct descriptor con1 = { sizeof(int), DTYPE_L, CLASS_S, (char *)&i1 };
   int i,n;
 
 #define LoadRamp(type) { type *ptr = (type *)out_ptr->pointer; for (i=0;i<n;i++) ptr[i] = (type)i; break;}
@@ -325,7 +324,7 @@ int Tdi3Random(struct descriptor_a *out_ptr){
 	Create an array of zeroes.
 */
 int Tdi3Zero(struct descriptor_a *out_ptr){
-  STATIC_CONSTANT int i0 = 0;
-  STATIC_CONSTANT struct descriptor con0 = { sizeof(int), DTYPE_L, CLASS_S, (char *)&i0 };
+  static const int i0 = 0;
+  static const struct descriptor con0 = { sizeof(int), DTYPE_L, CLASS_S, (char *)&i0 };
   return TdiConvert(&con0, out_ptr);
 }

--- a/tdishr/TdiBinary.c
+++ b/tdishr/TdiBinary.c
@@ -67,7 +67,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ------------------------------------------------------------------------------*/
 #include <mdsdescrip.h>
 #include <tdishr_messages.h>
-#include <STATICdef.h>
 
 
 

--- a/tdishr/TdiBound.c
+++ b/tdishr/TdiBound.c
@@ -47,7 +47,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "tdirefcat.h"
 #include "tdireffunction.h"
 #include "tdirefstandard.h"
-#include <STATICdef.h>
 
 
 extern struct descriptor *TdiItoXSpecial;
@@ -59,9 +58,9 @@ extern int TdiProduct();
 extern int TdiItoX();
 extern int Tdi3Subtract();
 
-STATIC_CONSTANT DESCRIPTOR_A(adsc0, sizeof(int), DTYPE_L, 0, 0);
-STATIC_CONSTANT dtype_t dtype_l = DTYPE_L;
-STATIC_CONSTANT length_t size_l = (length_t)sizeof(int);
+static const DESCRIPTOR_A(adsc0, sizeof(int), DTYPE_L, 0, 0);
+static const dtype_t dtype_l = DTYPE_L;
+static const length_t size_l = (length_t)sizeof(int);
 
 int Tdi1Bound(opcode_t opcode, int narg, struct descriptor *list[], struct descriptor_xd *out_ptr)
 {

--- a/tdishr/TdiBuild.c
+++ b/tdishr/TdiBuild.c
@@ -34,7 +34,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "tdirefstandard.h"
 #include <tdishr_messages.h>
 #include <mdsshr.h>
-#include <STATICdef.h>
 
 
 

--- a/tdishr/TdiCall.c
+++ b/tdishr/TdiCall.c
@@ -60,7 +60,7 @@ extern int TdiEvaluate();
 extern int TdiFaultHandler();
 extern int TdiFindImageSymbol();
 extern int TdiGetLong();
-extern int TdiPutIdent();
+extern int tdi_put_ident();
 
 #if defined __GNUC__ && 800 <= __GNUC__ * 100 + __GNUC_MINOR__
     _Pragma ("GCC diagnostic ignored \"-Wcast-function-type\"")
@@ -247,7 +247,7 @@ int TdiCall(dtype_t rtype, int narg, mdsdsc_t *list[], mdsdsc_xd_t *out_ptr)
       if (code == OPC_DESCR || code == OPC_REF || code == OPC_XD)
 	pfun = (mds_function_t *)pfun->arguments[0];
       if (pfun && pfun->dtype == DTYPE_IDENT)
-	TdiPutIdent(pfun, &tmp[j]);
+	tdi_put_ident(pfun, &tmp[j]);
     }
     if (tmp[j].pointer)
       MdsFree1Dx(&tmp[j], NULL);

--- a/tdishr/TdiCall.c
+++ b/tdishr/TdiCall.c
@@ -52,7 +52,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <strroutines.h>
 #include <tdishr_messages.h>
 #include <mdsshr.h>
-#include <STATICdef.h>
 
 extern int TdiConcat();
 extern int TdiData();
@@ -66,7 +65,7 @@ extern int tdi_put_ident();
     _Pragma ("GCC diagnostic ignored \"-Wcast-function-type\"")
 #endif
 
-STATIC_ROUTINE int TdiInterlude(dtype_t rtype, mdsdsc_t **newdsc,
+static int TdiInterlude(dtype_t rtype, mdsdsc_t **newdsc,
 				int (*routine) (), unsigned int *(*called) (),
 				void **result, int *max)
 {

--- a/tdishr/TdiChar.c
+++ b/tdishr/TdiChar.c
@@ -38,7 +38,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 
-extern int tdiHash();
+extern int tdi_hash();
 
 STATIC_CONSTANT char false = 0;
 STATIC_CONSTANT struct descriptor false_dsc = { 1, DTYPE_T, CLASS_S, (char *)&false };
@@ -376,7 +376,7 @@ int Tdi3StringOpcode(struct descriptor *in_ptr, struct descriptor *out_ptr)
       str_ptr += 4;
       len -= 4;
     }
-    *code_ptr++ = (short)tdiHash(len, str_ptr);
+    *code_ptr++ = (short)tdi_hash(len, str_ptr);
   }
   StrFree1Dx(&one_dsc);
   return status;

--- a/tdishr/TdiChar.c
+++ b/tdishr/TdiChar.c
@@ -34,14 +34,13 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <libroutines.h>
 #include <strroutines.h>
 #include <tdishr_messages.h>
-#include <STATICdef.h>
 
 
 
 extern int tdi_hash();
 
-STATIC_CONSTANT char false = 0;
-STATIC_CONSTANT struct descriptor false_dsc = { 1, DTYPE_T, CLASS_S, (char *)&false };
+static const char false = 0;
+static const struct descriptor false_dsc = { 1, DTYPE_T, CLASS_S, (char *)&false };
 
 /*------------------------------------------------------------------------------
 	F8X elemental, adjust string left, if there are blanks at left, and add blanks at right.
@@ -165,7 +164,7 @@ int Tdi3Element(struct descriptor *number_ptr,
   delim_dsc.class = CLASS_S;
   out_dsc.class = CLASS_S;
   for (; STATUS_OK && --n >= 0;) {
-    STATIC_CONSTANT unsigned short zero = 0;
+    static const unsigned short zero = 0;
     number = *(int *)pnumber, pnumber += number_step;
     status = StrElement(&out_dsc, &number, &delim_dsc, &source_dsc);
     if STATUS_NOT_OK

--- a/tdishr/TdiCompile.c
+++ b/tdishr/TdiCompile.c
@@ -50,7 +50,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #endif
 
 extern int Tdi1Evaluate();
-extern int TdiYacc();
+extern int tdi_yacc();
 /*-------------------------------------------------------
 	Interface to compiler/parser.
 	        expression = COMPILE(string, [arg1,...])
@@ -107,7 +107,7 @@ static inline void add_compile_info(int status,ThreadStatic * TdiThreadStatic_p)
   free(marker.pointer);
 }
 
-static inline int tdi_compile(ThreadStatic * TdiThreadStatic_p,mdsdsc_t * text_ptr, int narg, mdsdsc_t *list[], mdsdsc_xd_t *out_ptr) {
+static inline int compile(ThreadStatic * TdiThreadStatic_p,mdsdsc_t * text_ptr, int narg, mdsdsc_t *list[], mdsdsc_xd_t *out_ptr) {
   int status;
   TDI_COMPILE_REC = TRUE;
   pthread_cleanup_push((void*)cleanup_compile,(void*)TdiThreadStatic_p);
@@ -120,7 +120,7 @@ static inline int tdi_compile(ThreadStatic * TdiThreadStatic_p,mdsdsc_t * text_p
   TDI_REFZONE.l_narg   = narg - 1;
   TDI_REFZONE.l_iarg   = 0;
   TDI_REFZONE.a_list   = list;
-  if (IS_NOT_OK(TdiYacc()) && IS_OK(TDI_REFZONE.l_status))
+  if (IS_NOT_OK(tdi_yacc()) && IS_OK(TDI_REFZONE.l_status))
     status = TdiSYNTAX;
   else
     status = TDI_REFZONE.l_status;
@@ -138,7 +138,7 @@ static inline int tdi_compile(ThreadStatic * TdiThreadStatic_p,mdsdsc_t * text_p
   return status;
 }
 
-EXPORT int Tdi1Compile(opcode_t opcode, int narg, mdsdsc_t *list[], mdsdsc_xd_t *out_ptr){
+int Tdi1Compile(opcode_t opcode, int narg, mdsdsc_t *list[], mdsdsc_xd_t *out_ptr){
   int status;
   GET_TDITHREADSTATIC_P;
   if (TDI_COMPILE_REC) {
@@ -151,7 +151,7 @@ EXPORT int Tdi1Compile(opcode_t opcode, int narg, mdsdsc_t *list[], mdsdsc_xd_t 
   if (STATUS_OK && text_ptr->dtype != DTYPE_T)
     status = TdiINVDTYDSC;
   else if (STATUS_OK && text_ptr->length > 0)
-    status = tdi_compile(TdiThreadStatic_p,text_ptr,narg,list,out_ptr);
+    status = compile(TdiThreadStatic_p,text_ptr,narg,list,out_ptr);
   FREEXD_NOW(&tmp);
   if STATUS_NOT_OK MdsFree1Dx(out_ptr, NULL);
   return status;

--- a/tdishr/TdiCompile.c
+++ b/tdishr/TdiCompile.c
@@ -60,7 +60,7 @@ extern int tdi_yacc();
 	supports (`) on COMPILE
 */
 
-static void cleanup_compile(ThreadStatic * TdiThreadStatic_p){
+static void cleanup_compile(TDITHREADSTATIC_ARG){
   LibResetVmZone(&TDI_REFZONE.l_zone);
   if (TDI_REFZONE.a_begin) {
     free(TDI_REFZONE.a_begin);
@@ -69,7 +69,7 @@ static void cleanup_compile(ThreadStatic * TdiThreadStatic_p){
   TDI_COMPILE_REC = FALSE;
 }
 
-static inline void add_compile_info(int status,ThreadStatic * TdiThreadStatic_p) {
+static inline void add_compile_info(int status,TDITHREADSTATIC_ARG) {
   if(!(status==TdiSYNTAX
     || status==TdiEXTRANEOUS
     || status==TdiUNBALANCE
@@ -107,10 +107,10 @@ static inline void add_compile_info(int status,ThreadStatic * TdiThreadStatic_p)
   free(marker.pointer);
 }
 
-static inline int compile(ThreadStatic * TdiThreadStatic_p,mdsdsc_t * text_ptr, int narg, mdsdsc_t *list[], mdsdsc_xd_t *out_ptr) {
+static inline int compile(mdsdsc_t * text_ptr, int narg, mdsdsc_t *list[], mdsdsc_xd_t *out_ptr, TDITHREADSTATIC_ARG) {
   int status;
   TDI_COMPILE_REC = TRUE;
-  pthread_cleanup_push((void*)cleanup_compile,(void*)TdiThreadStatic_p);
+  pthread_cleanup_push((void*)cleanup_compile,(void*)TDITHREADSTATIC_PASS);
   if (!TDI_REFZONE.l_zone)
     status = LibCreateVmZone(&TDI_REFZONE.l_zone);
   TDI_REFZONE.l_status = TdiBOMB;  // In case we bomb out
@@ -120,7 +120,7 @@ static inline int compile(ThreadStatic * TdiThreadStatic_p,mdsdsc_t * text_ptr, 
   TDI_REFZONE.l_narg   = narg - 1;
   TDI_REFZONE.l_iarg   = 0;
   TDI_REFZONE.a_list   = list;
-  if (IS_NOT_OK(tdi_yacc()) && IS_OK(TDI_REFZONE.l_status))
+  if (IS_NOT_OK(tdi_yacc(TDITHREADSTATIC_PASS)) && IS_OK(TDI_REFZONE.l_status))
     status = TdiSYNTAX;
   else
     status = TDI_REFZONE.l_status;
@@ -133,7 +133,7 @@ static inline int compile(ThreadStatic * TdiThreadStatic_p,mdsdsc_t * text_ptr, 
     else
       status = MdsCopyDxXd((mdsdsc_t *)TDI_REFZONE.a_result, out_ptr);
   }
-  add_compile_info(status,TdiThreadStatic_p);
+  add_compile_info(status,TDITHREADSTATIC_PASS);
   pthread_cleanup_pop(1);
   return status;
 }
@@ -151,7 +151,7 @@ int Tdi1Compile(opcode_t opcode, int narg, mdsdsc_t *list[], mdsdsc_xd_t *out_pt
   if (STATUS_OK && text_ptr->dtype != DTYPE_T)
     status = TdiINVDTYDSC;
   else if (STATUS_OK && text_ptr->length > 0)
-    status = compile(TdiThreadStatic_p,text_ptr,narg,list,out_ptr);
+    status = compile(text_ptr,narg,list,out_ptr,TDITHREADSTATIC_PASS);
   FREEXD_NOW(&tmp);
   if STATUS_NOT_OK MdsFree1Dx(out_ptr, NULL);
   return status;

--- a/tdishr/TdiConstant.c
+++ b/tdishr/TdiConstant.c
@@ -25,7 +25,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 /*      Tdi1Constant.C
 	Get descriptor of a constant value.
 	Note $NARG (number of arguments) is in Tdi1Var.
-	Note $VALUE (raw of signal, data of param) is in TdiGetData.
+	Note $VALUE (raw of signal, data of param) is in tdi_get_data.
 	They are not constants, but context values.
 
 	Ken Klare, LANL P-4     (c)1989,1990,1992

--- a/tdishr/TdiConstant.c
+++ b/tdishr/TdiConstant.c
@@ -33,16 +33,15 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "tdireffunction.h"
 #include "tdirefstandard.h"
 #include <mdsshr.h>
-#include <STATICdef.h>
 #if defined __GNUC__ && 800 <= __GNUC__ * 100 + __GNUC_MINOR__
     _Pragma ("GCC diagnostic ignored \"-Wcast-function-type\"")
 #endif
 
 int Tdi1Constant(opcode_t opcode, int narg __attribute__ ((unused)),
-		 struct descriptor *list[] __attribute__ ((unused)), struct descriptor_xd *out_ptr)
+		 mdsdsc_t *list[] __attribute__ ((unused)), mdsdsc_xd_t *out_ptr)
 {
 
-  return MdsCopyDxXd(((struct descriptor * (*)())*TdiRefFunction[opcode].f3) (), out_ptr);
+  return MdsCopyDxXd(((mdsdsc_t * (*)())*TdiRefFunction[opcode].f3) (), out_ptr);
 }
 
 /*------------------------------------------------
@@ -92,68 +91,68 @@ typedef unsigned int FROP;
 #define DTYPE_FROP      DTYPE_F
 
 #define DATUM(type, x, data) \
-	STATIC_CONSTANT type                    d##x = data;\
-	STATIC_CONSTANT struct descriptor       Tdi##x##Constant = {sizeof(type), DTYPE_##type, CLASS_S, (char *)&d##x};\
-	struct descriptor *Tdi3##x(){return &Tdi##x##Constant;}
+	static const type     d##x = data;\
+	static const mdsdsc_t Tdi##x##Constant = {sizeof(type), DTYPE_##type, CLASS_S, (char *)&d##x};\
+	mdsdsc_t *Tdi3##x(){return (mdsdsc_t *)&Tdi##x##Constant;}
 
 #define DERR(type, x, data, error) \
-	STATIC_CONSTANT type                    d##x = data;\
-	STATIC_CONSTANT type                    e##x = error;\
-	STATIC_CONSTANT struct descriptor       dd##x = {sizeof(type), DTYPE_##type, CLASS_S, (char *)&d##x};\
-	STATIC_CONSTANT struct descriptor       de##x = {sizeof(type), DTYPE_##type, CLASS_S, (char *)&e##x};\
-	STATIC_CONSTANT DESCRIPTOR_WITH_ERROR(Tdi##x##Constant,&dd##x,&de##x);\
-	struct descriptor *Tdi3##x(){return (struct descriptor *)&Tdi##x##Constant;}
+	static const type     d##x = data;\
+	static const type     e##x = error;\
+	static const mdsdsc_t dd##x = {sizeof(type), DTYPE_##type, CLASS_S, (char *)&d##x};\
+	static const mdsdsc_t de##x = {sizeof(type), DTYPE_##type, CLASS_S, (char *)&e##x};\
+	static const DESCRIPTOR_WITH_ERROR(Tdi##x##Constant,&dd##x,&de##x);\
+	mdsdsc_t *Tdi3##x(){return (mdsdsc_t *)&Tdi##x##Constant;}
 
 #define UNITS(type, x, data, units) \
-	STATIC_CONSTANT type                    d##x = data;\
-	STATIC_CONSTANT struct descriptor       dd##x = {sizeof(type), DTYPE_##type, CLASS_S, (char *)&d##x};\
-	STATIC_CONSTANT DESCRIPTOR(             du##x, units);\
-	STATIC_CONSTANT DESCRIPTOR_WITH_UNITS(Tdi##x##Constant,&dd##x,&du##x);\
-	struct descriptor *Tdi3##x(){return (struct descriptor *)&Tdi##x##Constant;}
+	static const type     d##x = data;\
+	static const mdsdsc_t dd##x = {sizeof(type), DTYPE_##type, CLASS_S, (char *)&d##x};\
+	static const DESCRIPTOR(du##x, units);\
+	static const DESCRIPTOR_WITH_UNITS(Tdi##x##Constant,&dd##x,&du##x);\
+	mdsdsc_t *Tdi3##x(){return (mdsdsc_t *)&Tdi##x##Constant;}
 
 #define UERR(type, x, data, error, units) \
-	STATIC_CONSTANT type                    d##x = data;\
-	STATIC_CONSTANT type                    e##x = error;\
-	STATIC_CONSTANT DESCRIPTOR(du##x, units);\
-	STATIC_CONSTANT struct descriptor       dd##x = {sizeof(type), DTYPE_##type, CLASS_S, (char *)&d##x};\
-	STATIC_CONSTANT struct descriptor       de##x = {sizeof(type), DTYPE_##type, CLASS_S, (char *)&e##x};\
-	STATIC_CONSTANT DESCRIPTOR_WITH_ERROR(dwe##x,&dd##x,&de##x);\
-	STATIC_CONSTANT DESCRIPTOR_WITH_UNITS(Tdi##x##Constant,&dwe##x,&du##x);\
-	struct descriptor *Tdi3##x(){return (struct descriptor *)&Tdi##x##Constant;}
+	static const type     d##x = data;\
+	static const type     e##x = error;\
+	static const mdsdsc_t dd##x = {sizeof(type), DTYPE_##type, CLASS_S, (char *)&d##x};\
+	static const mdsdsc_t de##x = {sizeof(type), DTYPE_##type, CLASS_S, (char *)&e##x};\
+	static const DESCRIPTOR(du##x, units);\
+	static const DESCRIPTOR_WITH_ERROR(dwe##x,&dd##x,&de##x);\
+	static const DESCRIPTOR_WITH_UNITS(Tdi##x##Constant,&dwe##x,&du##x);\
+	mdsdsc_t *Tdi3##x(){return (mdsdsc_t *)&Tdi##x##Constant;}
 
 #define II {(float)0., (float)1.}
 #define RR 0x8000
 
 DATUM(FLOAT, 2Pi, (float)6.2831853072)	/* circumference/radius    */
-    UERR(FLOAT, A0, (float)5.29177249e-11, (float)0.00000024e-11, "m")	/*a0       Bohr radius             */
-    DERR(FLOAT, Alpha, (float)7.29735308e-3, (float)0.00000033e-3)	/* fine-structure constant */
-    UERR(FLOAT, Amu, (float)1.6605402e-27, (float)0.0000010e-27, "kg")	/* u atomic mass unit, unified */
-    UNITS(FLOAT, C, (float)299792458., "m/s")	/* c speed of light(exact) */
-    UNITS(FLOAT, Cal, (float)4.1868, "J")	/* calorie                 */
-    DATUM(FLOAT, Degree, (float).01745329252)	/* pi/180                  */
-    UNITS(FLOAT, Epsilon0, (float)8.854187817e-12, "F/m")	/* permitivity of vacuum(exact) */
-    UERR(FLOAT, Ev, (float)1.60217733e-19, (float)0.00000049e-19, "J/eV")	/* eV electron volt        */
-    DATUM(BU, False, 0)		/* logically false         */
-    UERR(FLOAT, Faraday, (float)9.6485309e4, (float)0.0000029e4, "C/mol")	/*F        Faraday constant        */
-    UERR(FLOAT, G, (float)6.67259e-11, (float)0.00085, "m^3/s^2/kg")	/*G gravitational constant */
-    UERR(FLOAT, Gas, (float)8.314510, (float)0.000070, "J/K/mol")	/*R       gas constant            */
-    UNITS(FLOAT, Gn, (float)9.80665, "m/s^2")	/*gn       acceleration of gravity(exact) */
-    UERR(FLOAT, H, (float)6.6260755e-34, (float)0.0000040, "J*s")	/*h        Planck constant         */
-    UERR(FLOAT, Hbar, (float)1.05457266e-34, (float)0.00000063, "J*s")	/*hbar h/(2pi)             */
-    DATUM(FLOAT_COMPLEX, I, II)	/*i        imaginary               */
-    UERR(FLOAT, K, (float)1.380658e-23, (float)0.000012e-23, "J/K")	/*k        Boltzmann constant      */
-    UERR(FLOAT, Me, (float)9.1093897e-31, (float)0.0000054e-31, "kg")	/*me       mass of electron        */
-    DATUM(MISSING, Missing, 0)	/* missing argument        */
-    UERR(FLOAT, Mp, (float)1.6726231e-27, (float)0.0000010e-27, "kg")	/*mp       mass of proton          */
-    UNITS(FLOAT, Mu0, (float)12.566370614e-7, "N/A^2")	/* permeability of vacuum(exact) */
-    UERR(FLOAT, N0, (float)2.686763e25, (float)0.000023e25, "/m^3")	/*n0       Loschmidt's number (STP) */
-    UERR(FLOAT, Na, (float)6.0221367e23, (float)0.0000036e23, "/mol")	/*NA or L Avogadro number  */
-    UNITS(FLOAT, P0, (float)1.01325e5, "Pa")	/*atm      atmospheric pressure(exact) */
-    DATUM(FLOAT, Pi, (float)3.1415926536)	/* circumference/diameter  */
-    UERR(FLOAT, Qe, (float)1.60217733e-19, (float)0.000000493e-19, "C")	/*e        charge on electron      */
-    UERR(FLOAT, Re, (float)2.81794092e-15, (float)0.00000038e-15, "m")	/*re       classical electron radius */
-    DATUM(FROP, Roprand, RR)	/* reserved operand        */
-    UERR(FLOAT, Rydberg, (float)1.0973731534e7, (float)0.0000000013e7, "/m")	/*Rinf Rydberg constant    */
-    UNITS(FLOAT, T0, (float)273.16, "K")	/*?        standard temperature    */
-    UNITS(FLOAT, Torr, (float)1.3332e2, "Pa")	/*?torr 1mm Hg pressure    */
-    DATUM(BU, True, 1)
+UERR(FLOAT, A0, (float)5.29177249e-11, (float)0.00000024e-11, "m")	/*a0       Bohr radius             */
+DERR(FLOAT, Alpha, (float)7.29735308e-3, (float)0.00000033e-3)	/* fine-structure constant */
+UERR(FLOAT, Amu, (float)1.6605402e-27, (float)0.0000010e-27, "kg")	/* u atomic mass unit, unified */
+UNITS(FLOAT, C, (float)299792458., "m/s")	/* c speed of light(exact) */
+UNITS(FLOAT, Cal, (float)4.1868, "J")	/* calorie                 */
+DATUM(FLOAT, Degree, (float).01745329252)	/* pi/180                  */
+UNITS(FLOAT, Epsilon0, (float)8.854187817e-12, "F/m")	/* permitivity of vacuum(exact) */
+UERR(FLOAT, Ev, (float)1.60217733e-19, (float)0.00000049e-19, "J/eV")	/* eV electron volt        */
+DATUM(BU, False, 0)		/* logically false         */
+UERR(FLOAT, Faraday, (float)9.6485309e4, (float)0.0000029e4, "C/mol")	/*F        Faraday constant        */
+UERR(FLOAT, G, (float)6.67259e-11, (float)0.00085, "m^3/s^2/kg")	/*G gravitational constant */
+UERR(FLOAT, Gas, (float)8.314510, (float)0.000070, "J/K/mol")	/*R       gas constant            */
+UNITS(FLOAT, Gn, (float)9.80665, "m/s^2")	/*gn       acceleration of gravity(exact) */
+UERR(FLOAT, H, (float)6.6260755e-34, (float)0.0000040, "J*s")	/*h        Planck constant         */
+UERR(FLOAT, Hbar, (float)1.05457266e-34, (float)0.00000063, "J*s")	/*hbar h/(2pi)             */
+DATUM(FLOAT_COMPLEX, I, II)	/*i        imaginary               */
+UERR(FLOAT, K, (float)1.380658e-23, (float)0.000012e-23, "J/K")	/*k        Boltzmann constant      */
+UERR(FLOAT, Me, (float)9.1093897e-31, (float)0.0000054e-31, "kg")	/*me       mass of electron        */
+DATUM(MISSING, Missing, 0)	/* missing argument        */
+UERR(FLOAT, Mp, (float)1.6726231e-27, (float)0.0000010e-27, "kg")	/*mp       mass of proton          */
+UNITS(FLOAT, Mu0, (float)12.566370614e-7, "N/A^2")	/* permeability of vacuum(exact) */
+UERR(FLOAT, N0, (float)2.686763e25, (float)0.000023e25, "/m^3")	/*n0       Loschmidt's number (STP) */
+UERR(FLOAT, Na, (float)6.0221367e23, (float)0.0000036e23, "/mol")	/*NA or L Avogadro number  */
+UNITS(FLOAT, P0, (float)1.01325e5, "Pa")	/*atm      atmospheric pressure(exact) */
+DATUM(FLOAT, Pi, (float)3.1415926536)	/* circumference/diameter  */
+UERR(FLOAT, Qe, (float)1.60217733e-19, (float)0.000000493e-19, "C")	/*e        charge on electron      */
+UERR(FLOAT, Re, (float)2.81794092e-15, (float)0.00000038e-15, "m")	/*re       classical electron radius */
+DATUM(FROP, Roprand, RR)	/* reserved operand        */
+UERR(FLOAT, Rydberg, (float)1.0973731534e7, (float)0.0000000013e7, "/m")	/*Rinf Rydberg constant    */
+UNITS(FLOAT, T0, (float)273.16, "K")	/*?        standard temperature    */
+UNITS(FLOAT, Torr, (float)1.3332e2, "Pa")	/*?torr 1mm Hg pressure    */
+DATUM(BU, True, 1)

--- a/tdishr/TdiConvert.c
+++ b/tdishr/TdiConvert.c
@@ -28,7 +28,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <mdsdescrip.h>
 #include <tdishr_messages.h>
 #include <math.h>
-#include <STATICdef.h>
 
 #define MAXTYPE (DTYPE_FTC + 1)
 
@@ -640,7 +639,7 @@ static void mem_shift(char *in, int offset, int num)
     *p1++ = *p2++;
 }
 
-STATIC_ROUTINE void FLOAT_TO_TEXT(int itype, char *pa, char *pb, int numb, int lenb, char sym)
+static void FLOAT_TO_TEXT(int itype, char *pa, char *pb, int numb, int lenb, char sym)
 {
   float *ip = (float *)pa;
   char *op = (char *)pb;
@@ -684,7 +683,7 @@ STATIC_ROUTINE void FLOAT_TO_TEXT(int itype, char *pa, char *pb, int numb, int l
   }
 }
 
-STATIC_ROUTINE void DOUBLE_TO_TEXT(int itype, char *pa, char *pb, int numb, int lenb, char sym)
+static void DOUBLE_TO_TEXT(int itype, char *pa, char *pb, int numb, int lenb, char sym)
 {
   double *ip = (double *)pa;
   char *op = (char *)pb;
@@ -734,7 +733,7 @@ STATIC_ROUTINE void DOUBLE_TO_TEXT(int itype, char *pa, char *pb, int numb, int 
   }
 }
 
-STATIC_ROUTINE void FLOATC_TO_TEXT(int itype, char *pa, char *pb, int numb, int lenb, char sym)
+static void FLOATC_TO_TEXT(int itype, char *pa, char *pb, int numb, int lenb, char sym)
 {
   float *ip = (float *)pa;
   char *op = (char *)pb;
@@ -786,7 +785,7 @@ STATIC_ROUTINE void FLOATC_TO_TEXT(int itype, char *pa, char *pb, int numb, int 
   }
 }
 
-STATIC_ROUTINE void DOUBLEC_TO_TEXT(int itype, char *pa, char *pb, int numb, int lenb, char sym)
+static void DOUBLEC_TO_TEXT(int itype, char *pa, char *pb, int numb, int lenb, char sym)
 {
   double *ip = (double *)pa;
   char *op = (char *)pb;

--- a/tdishr/TdiCull.c
+++ b/tdishr/TdiCull.c
@@ -48,7 +48,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 extern struct descriptor *TdiItoXSpecial;
 
-extern int TdiGetData();
+extern int tdi_get_data();
 extern int TdiUnits();
 extern int TdiData();
 extern int TdiCvtArgs();
@@ -199,11 +199,11 @@ STATIC_ROUTINE int work(int rroutine(struct descriptor *, struct descriptor_a *,
   struct TdiCatStruct cats[4];
   STATIC_CONSTANT unsigned char omits[] = { DTYPE_DIMENSION, DTYPE_SIGNAL, DTYPE_DIMENSION, 0 };
   STATIC_CONSTANT unsigned char omitd[] = { DTYPE_WITH_UNITS, DTYPE_DIMENSION, 0 };
-  status = TdiGetData(omits, list[0], &in);
+  status = tdi_get_data(omits, list[0], &in);
   if (STATUS_OK && in.pointer->dtype == DTYPE_WITH_UNITS) {
     status = TdiUnits(in.pointer, &units MDS_END_ARG);
     if STATUS_OK
-      status = TdiGetData(&omits[1], &in, &in);
+      status = tdi_get_data(&omits[1], &in, &in);
   }
   if (STATUS_OK && narg > 1 && list[1])
     status = TdiGetLong(list[1], &dim);
@@ -220,11 +220,11 @@ STATIC_ROUTINE int work(int rroutine(struct descriptor *, struct descriptor_a *,
     if (dim >= psig->ndesc - 2)
       status = TdiBAD_INDEX;
     else
-      status = TdiGetData(omitd, psig->dimensions[dim], &in);
+      status = tdi_get_data(omitd, psig->dimensions[dim], &in);
     if (STATUS_OK && in.pointer->dtype == DTYPE_WITH_UNITS) {
       status = TdiUnits(in.pointer, &units MDS_END_ARG);
       if STATUS_OK
-	status = TdiGetData(&omitd[1], &in, &in);
+	status = tdi_get_data(&omitd[1], &in, &in);
     } else
       MdsFree1Dx(&units, NULL);
     dim = 0;

--- a/tdishr/TdiCull.c
+++ b/tdishr/TdiCull.c
@@ -43,7 +43,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <tdishr_messages.h>
 #include <mdsshr_messages.h>
 #include <mdsshr.h>
-#include <STATICdef.h>
 
 
 extern struct descriptor *TdiItoXSpecial;
@@ -62,8 +61,8 @@ extern int TdiGetLong();
 extern int Tdi2Range();
 
 extern unsigned short OpcValue;
-STATIC_CONSTANT DESCRIPTOR_FUNCTION_0(value, &OpcValue);
-STATIC_CONSTANT DESCRIPTOR_RANGE(EMPTY_RANGE, 0, 0, (struct descriptor *)&value);
+static const DESCRIPTOR_FUNCTION_0(value, &OpcValue);
+static const DESCRIPTOR_RANGE(EMPTY_RANGE, 0, 0, (struct descriptor *)&value);
 
 /**********************************************
 	Redo culled array or scalar.
@@ -137,7 +136,7 @@ int TdiIextend(int left, int right, struct descriptor_a *px)
 /*---------------------------------------------
 	Remove elements not satisfying mask.
 */
-STATIC_ROUTINE int rcull(struct descriptor *pnew __attribute__ ((unused)),
+static int rcull(struct descriptor *pnew __attribute__ ((unused)),
 	struct descriptor_a *pmask, struct descriptor_a *px){
   INIT_STATUS;
   char *pm = pmask->pointer, *pi = px->pointer, *po = pi;
@@ -168,7 +167,7 @@ STATIC_ROUTINE int rcull(struct descriptor *pnew __attribute__ ((unused)),
 /*---------------------------------------------
 	Replace elements not in mask.
 */
-STATIC_ROUTINE int rextend(struct descriptor *pnew,
+static int rextend(struct descriptor *pnew,
 			   struct descriptor_a *pmask, struct descriptor_a *px) {
   INIT_STATUS;
   char *pn = pnew->pointer, *pm = pmask->pointer, *pi = px->pointer;
@@ -184,7 +183,7 @@ STATIC_ROUTINE int rextend(struct descriptor *pnew,
 /**********************************************
 	Going to find out who is naughty and nice.
 */
-STATIC_ROUTINE int work(int rroutine(struct descriptor *, struct descriptor_a *, struct descriptor_a *),
+static int work(int rroutine(struct descriptor *, struct descriptor_a *, struct descriptor_a *),
 		opcode_t opcode, int narg, struct descriptor *list[3], struct descriptor_xd *out_ptr) {
   INIT_STATUS;
   GET_TDITHREADSTATIC_P;
@@ -197,8 +196,8 @@ STATIC_ROUTINE int work(int rroutine(struct descriptor *, struct descriptor_a *,
   struct descriptor dx0, dx1;
   struct descriptor_xd sig[3] = {EMPTY_XD}, uni[3] = {EMPTY_XD}, dat[3] = {EMPTY_XD};
   struct TdiCatStruct cats[4];
-  STATIC_CONSTANT unsigned char omits[] = { DTYPE_DIMENSION, DTYPE_SIGNAL, DTYPE_DIMENSION, 0 };
-  STATIC_CONSTANT unsigned char omitd[] = { DTYPE_WITH_UNITS, DTYPE_DIMENSION, 0 };
+  static const unsigned char omits[] = { DTYPE_DIMENSION, DTYPE_SIGNAL, DTYPE_DIMENSION, 0 };
+  static const unsigned char omitd[] = { DTYPE_WITH_UNITS, DTYPE_DIMENSION, 0 };
   status = tdi_get_data(omits, list[0], &in);
   if (STATUS_OK && in.pointer->dtype == DTYPE_WITH_UNITS) {
     status = TdiUnits(in.pointer, &units MDS_END_ARG);

--- a/tdishr/TdiCvtArgs.c
+++ b/tdishr/TdiCvtArgs.c
@@ -34,7 +34,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "tdirefstandard.h"
 #include <tdishr_messages.h>
 #include <mdsshr.h>
-#include <STATICdef.h>
 
 #define SIGNEDNESS      (TdiCAT_B ^ TdiCAT_BU)
 #define FLOATMASK       (TdiCAT_FLOAT | TdiCAT_LENGTH)

--- a/tdishr/TdiCvtDxDx.c
+++ b/tdishr/TdiCvtDxDx.c
@@ -34,7 +34,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <mdsdescrip.h>
 #include <mdsshr.h>
 #include <status.h>
-#include <STATICdef.h>
 
 
 

--- a/tdishr/TdiDecompile.c
+++ b/tdishr/TdiDecompile.c
@@ -32,7 +32,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
 #include <tdishr_messages.h>
-#include <STATICdef.h>
 
 #include "tdirefcat.h"
 #include "tdirefstandard.h"
@@ -92,27 +91,27 @@ EXPORT int Tdi1Decompile(opcode_t opcode __attribute__ ((unused)), int narg, str
 	Precedence is used by function evaluation.
 */
 #define P_ARG   88
-//STATIC_CONSTANT unsigned char htab[16] =
+//static const unsigned char htab[16] =
 //    { '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e',
 //  'f'
 //};
 
-STATIC_CONSTANT DESCRIPTOR(BUILD_EVENT, "BuildEvent(\"");
-STATIC_CONSTANT DESCRIPTOR(CLASS, "??Class_");
-STATIC_CONSTANT DESCRIPTOR(CLOSE_EVENT, "\")");
-STATIC_CONSTANT DESCRIPTOR(COLON, ":");
-STATIC_CONSTANT DESCRIPTOR(COMMA, ",");
-STATIC_CONSTANT DESCRIPTOR(COMMA_SPACE, ", ");
-STATIC_CONSTANT DESCRIPTOR(CMPLX, "Cmplx(");
-STATIC_CONSTANT DESCRIPTOR(DTYPE, "??Dtype_");
-//STATIC_CONSTANT DESCRIPTOR(HEX, "0X");
-STATIC_CONSTANT DESCRIPTOR(LEFT_BRACKET, "[");
-STATIC_CONSTANT DESCRIPTOR(MISSING, "$Missing");
-STATIC_CONSTANT DESCRIPTOR(MORE, " /*** etc. ***/");
-STATIC_CONSTANT DESCRIPTOR(RIGHT_BRACKET, "]");
-STATIC_CONSTANT DESCRIPTOR(RIGHT_PAREN, ")");
-STATIC_CONSTANT DESCRIPTOR(SET_RANGE, "Set_Range(");
-STATIC_CONSTANT DESCRIPTOR(STAR, "*");
+static const DESCRIPTOR(BUILD_EVENT, "BuildEvent(\"");
+static const DESCRIPTOR(CLASS, "??Class_");
+static const DESCRIPTOR(CLOSE_EVENT, "\")");
+static const DESCRIPTOR(COLON, ":");
+static const DESCRIPTOR(COMMA, ",");
+static const DESCRIPTOR(COMMA_SPACE, ", ");
+static const DESCRIPTOR(CMPLX, "Cmplx(");
+static const DESCRIPTOR(DTYPE, "??Dtype_");
+//static const DESCRIPTOR(HEX, "0X");
+static const DESCRIPTOR(LEFT_BRACKET, "[");
+static const DESCRIPTOR(MISSING, "$Missing");
+static const DESCRIPTOR(MORE, " /*** etc. ***/");
+static const DESCRIPTOR(RIGHT_BRACKET, "]");
+static const DESCRIPTOR(RIGHT_PAREN, ")");
+static const DESCRIPTOR(SET_RANGE, "Set_Range(");
+static const DESCRIPTOR(STAR, "*");
 
 int TdiSingle(int val, struct descriptor_d *out_ptr)
 {
@@ -124,7 +123,7 @@ int TdiSingle(int val, struct descriptor_d *out_ptr)
 /*-------------------------------------------------------
 	Handle arrays and arrays of pointers to descriptors.
 */
-STATIC_ROUTINE int tdi_vector(struct descriptor *in_ptr,
+static int tdi_vector(struct descriptor *in_ptr,
 			      int level, char **item_ptr_ptr, struct descriptor_d *out_ptr)
 {
   array_bounds_desc *a_ptr = (array_bounds_desc *) in_ptr;
@@ -185,7 +184,7 @@ STATIC_ROUTINE int tdi_vector(struct descriptor *in_ptr,
 	/******************
 	Squeeze out spaces.
 	******************/
-STATIC_ROUTINE int noblanks(struct descriptor *cdsc_ptr)
+static int noblanks(struct descriptor *cdsc_ptr)
 {
   int n = cdsc_ptr->length;
   char *pwas = cdsc_ptr->pointer, *pnow = pwas;
@@ -202,7 +201,7 @@ STATIC_ROUTINE int noblanks(struct descriptor *cdsc_ptr)
 	/*****************************
 	Neater floating point numbers.
 	*****************************/
-STATIC_ROUTINE int closeup(char repl, struct descriptor *pfloat, struct descriptor *pdc)
+static int closeup(char repl, struct descriptor *pfloat, struct descriptor *pdc)
 {
   int status, sum, j, shift;
   char *pwas = pdc->pointer;

--- a/tdishr/TdiDecompile.c
+++ b/tdishr/TdiDecompile.c
@@ -56,7 +56,7 @@ extern int TdiDecompileDeindent();
 extern int Tdi0Decompile_R();
 extern int TdiConvert();
 extern int Tdi1Evaluate();
-extern int TdiTrace();
+extern int tdi_trace();
 
 int Tdi0Decompile(struct descriptor *in_ptr, int prec, struct descriptor_d *out_ptr);
 
@@ -770,6 +770,6 @@ complex: ;
     break;
   }	/*switch class */
   if STATUS_NOT_OK
-    TdiTrace(OPC_DECOMPILE, 1, in_ptr, out_ptr);
+    tdi_trace(out_ptr);
   return status;
 }

--- a/tdishr/TdiDecompileDependency.c
+++ b/tdishr/TdiDecompileDependency.c
@@ -39,7 +39,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define P_UNARY 12		/*unary: NEGATE(!) IGNORE_UNDEFINED(?) IGNORE_STATUS(~) */
 #define P_TIGHT 16		/*strongest: path <event> and parentheses */
 
-#include <STATICdef.h>
 #include <string.h>
 #include <mdsdescrip.h>
 #include "tdirefstandard.h"
@@ -51,18 +50,18 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 
-STATIC_CONSTANT DESCRIPTOR(AND, " & ");
-STATIC_CONSTANT DESCRIPTOR(OR, " | ");
-STATIC_CONSTANT DESCRIPTOR(NEGATE, "!");
-STATIC_CONSTANT DESCRIPTOR(IGNORE_UNDEFINED, "?");
-STATIC_CONSTANT DESCRIPTOR(IGNORE_STATUS, "~");
+static const DESCRIPTOR(AND, " & ");
+static const DESCRIPTOR(OR, " | ");
+static const DESCRIPTOR(NEGATE, "!");
+static const DESCRIPTOR(IGNORE_UNDEFINED, "?");
+static const DESCRIPTOR(IGNORE_STATUS, "~");
 
-STATIC_CONSTANT DESCRIPTOR(LEFT_ANGLE, "<");
-STATIC_CONSTANT DESCRIPTOR(RIGHT_ANGLE, ">");
-STATIC_CONSTANT DESCRIPTOR(LEFT_PAREN, "(");
-STATIC_CONSTANT DESCRIPTOR(RIGHT_PAREN, ")");
+static const DESCRIPTOR(LEFT_ANGLE, "<");
+static const DESCRIPTOR(RIGHT_ANGLE, ">");
+static const DESCRIPTOR(LEFT_PAREN, "(");
+static const DESCRIPTOR(RIGHT_PAREN, ")");
 
-STATIC_ROUTINE int DependencyGet(int prec, struct descriptor_r *pin, struct descriptor_d *pout)
+static int DependencyGet(int prec, struct descriptor_r *pin, struct descriptor_d *pout)
 {
   INIT_STATUS;
   int now = 0;

--- a/tdishr/TdiDecompileR.c
+++ b/tdishr/TdiDecompileR.c
@@ -30,7 +30,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 	Ken Klare, LANL P-4     (c)1989,1990,1991,1992
 */
 
-#include <STATICdef.h>
 #include <string.h>
 #include "tdirefcat.h"
 #include "tdireffunction.h"
@@ -46,7 +45,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 extern int Tdi0Decompile();
 extern int TdiSingle();
 
-STATIC_CONSTANT struct op_rec {
+static const struct op_rec {
   char *symbol;
   opcode_t opcode;
   char prec, lorr;
@@ -99,8 +98,8 @@ STATIC_CONSTANT struct op_rec {
   0, 0, 0, 0}
 };
 
-STATIC_CONSTANT DESCRIPTOR(ARROW, "->");
-STATIC_CONSTANT char *bname[] = {
+static const DESCRIPTOR(ARROW, "->");
+static const char *bname[] = {
   "Param",			/*194 */
   "Signal",			/*195 */
   "Dim",			/*196 dtype_dimension */
@@ -127,11 +126,10 @@ STATIC_CONSTANT char *bname[] = {
   "Opaque",			/*217 */
 };
 
-STATIC_ROUTINE int Append(char *pstr, struct descriptor_d *pd)
-{
+static int Append(const char *const pstr, struct descriptor_d *pd) {
   struct descriptor dstr = { 0, DTYPE_T, CLASS_S, 0 };
-  dstr.length = (unsigned short)strlen(pstr);
-  dstr.pointer = pstr;
+  dstr.length = (length_t)strlen(pstr);
+  dstr.pointer = (char*)pstr;
   return StrAppend(pd, &dstr);
 }
 
@@ -147,7 +145,7 @@ void TdiDecompileDeindent(struct descriptor_d *pout)
   return;
 }
 
-STATIC_ROUTINE int Indent(int step, struct descriptor_d *pout){
+static int Indent(int step, struct descriptor_d *pout){
   GET_TDITHREADSTATIC_P;
 #ifdef _WIN32
   const char* newline= "\r\n\t\t\t\t\t\t\t";
@@ -165,7 +163,7 @@ STATIC_ROUTINE int Indent(int step, struct descriptor_d *pout){
   return MDSplusSUCCESS;
 }
 
-STATIC_ROUTINE int OneStatement(struct descriptor_r *pin, struct descriptor_d *pout)
+static int OneStatement(struct descriptor_r *pin, struct descriptor_d *pout)
 {
   INIT_STATUS;
 
@@ -187,7 +185,7 @@ STATIC_ROUTINE int OneStatement(struct descriptor_r *pin, struct descriptor_d *p
   return status;
 }
 
-STATIC_ROUTINE int MultiStatement(int nstmt, struct descriptor_r *pin[], struct descriptor_d *pout)
+static int MultiStatement(int nstmt, struct descriptor_r *pin[], struct descriptor_d *pout)
 {
   int status = MDSplusSUCCESS, j;
 
@@ -201,7 +199,7 @@ STATIC_ROUTINE int MultiStatement(int nstmt, struct descriptor_r *pin[], struct 
   return status;
 }
 
-STATIC_ROUTINE int CompoundStatement(int nstmt,
+static int CompoundStatement(int nstmt,
 				     struct descriptor_r *pin[], struct descriptor_d *pout)
 {
   INIT_STATUS;
@@ -222,7 +220,7 @@ STATIC_ROUTINE int CompoundStatement(int nstmt,
   return status;
 }
 
-STATIC_ROUTINE int Arguments(int first,
+static int Arguments(int first,
 			     char *left,
 			     char *right, struct descriptor_r *pin, struct descriptor_d *pout)
 {
@@ -250,7 +248,7 @@ int Tdi0Decompile_R(struct descriptor_r *pin, int prec, struct descriptor_d *pou
   struct TdiFunctionStruct *fun_ptr;
   int narg = pin->ndesc;
   int m, lorr, newone;
-  struct op_rec *pop;
+  const struct op_rec *pop;
   unsigned int dtype;
   opcode_t opcode;
 

--- a/tdishr/TdiDecompress.c
+++ b/tdishr/TdiDecompress.c
@@ -36,7 +36,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 	Ken Klare, LANL P-4     (c)1989,1990,1992
 */
-#include <STATICdef.h>
 #include <stdlib.h>
 #include "tdirefstandard.h"
 #include "tdirefcat.h"

--- a/tdishr/TdiDefCat.c
+++ b/tdishr/TdiDefCat.c
@@ -37,7 +37,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 	Ken Klare, LANL CTR-7   (c)1989,1990
 */
-#include <STATICdef.h>
 #include "tdirefcat.h"
 
 #define F_SYM   "F"

--- a/tdishr/TdiDefFunction.c
+++ b/tdishr/TdiDefFunction.c
@@ -29,7 +29,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 	Ken Klare, LANL CTR-7   (c)1989,1990
 */
-#include <STATICdef.h>
 #include <mds_stdarg.h>
 #include <libroutines.h>
 #include <tdishr.h>

--- a/tdishr/TdiDim.c
+++ b/tdishr/TdiDim.c
@@ -83,7 +83,6 @@ int Tdi3xxxxx(struct descriptor *in1, struct descriptor *in2,
 #include <mdstypes.h>
 #include <mdsdescrip.h>
 #include <tdishr_messages.h>
-#include <STATICdef.h>
 #include <limits.h>
 #include <int128.h>
 
@@ -93,7 +92,7 @@ extern int TdiConvert();
 extern int Tdi3Subtract();
 extern int CvtConvertFloat();
 
-STATIC_CONSTANT int roprand = 0x8000;
+static const int roprand = 0x8000;
 typedef struct {
   int longword[4];
 } octaword;
@@ -559,7 +558,7 @@ int Tdi3Dim(struct descriptor *in1, struct descriptor *in2, struct descriptor *o
   typedef struct {
     double l[2];
   } octaword_aligned;
-  STATIC_CONSTANT octaword_aligned zero = { {0} };
+  static const octaword_aligned zero = { {0} };
 
   switch (in1->dtype) {
   default:break;

--- a/tdishr/TdiDivide.c
+++ b/tdishr/TdiDivide.c
@@ -52,7 +52,6 @@ int Tdi3Divide(struct descriptor *in1, struct descriptor *in2, struct descriptor
 
 ------------------------------------------------------------------------------*/
 
-#include <STATICdef.h>
 #include <mdsdescrip.h>
 #include <mdstypes.h>
 #include <tdishr_messages.h>
@@ -61,7 +60,7 @@ int Tdi3Divide(struct descriptor *in1, struct descriptor *in2, struct descriptor
 
 
 extern int CvtConvertFloat();
-STATIC_CONSTANT int roprand = 0x8000;
+static const int roprand = 0x8000;
 
 #define SetupArgs \
   struct descriptor_a *ina1 = (struct descriptor_a *)in1;\

--- a/tdishr/TdiDoTask.c
+++ b/tdishr/TdiDoTask.c
@@ -36,7 +36,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 	Ken Klare, LANL P-4     (c)1992
 */
-#include <STATICdef.h>
 #include <stdlib.h>
 #include <mdsdescrip.h>
 #include "tdirefstandard.h"
@@ -65,7 +64,7 @@ extern int TdiCall();
 	acmode  access mode
 ****/
 
-STATIC_ROUTINE int Doit(struct descriptor_routine *ptask, struct descriptor_xd *out_ptr){
+static int Doit(struct descriptor_routine *ptask, struct descriptor_xd *out_ptr){
   INIT_STATUS;
   int dtype, ndesc, j;
   void **arglist[256];
@@ -159,7 +158,7 @@ static int WorkerThread(void *args){
   return wc.wa->status;
 }
 
-STATIC_ROUTINE int StartWorker(struct descriptor_xd *task_xd, struct descriptor_xd *out_ptr, const float timeout){
+static int StartWorker(struct descriptor_xd *task_xd, struct descriptor_xd *out_ptr, const float timeout){
   INIT_STATUS;
 #ifdef _WIN32
   worker_args_t wa = {

--- a/tdishr/TdiDtypeRange.c
+++ b/tdishr/TdiDtypeRange.c
@@ -36,7 +36,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 	NEED faster code for longs and maybe floats.
 */
 
-#include <STATICdef.h>
 #include "tdinelements.h"
 #include "tdirefcat.h"
 #include "tdirefstandard.h"
@@ -47,9 +46,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 
-STATIC_CONSTANT DESCRIPTOR_A(arr0, 1, DTYPE_B, 0, 0);
-STATIC_CONSTANT int minus_one_value = -1;
-STATIC_CONSTANT struct descriptor minus_one =
+static const DESCRIPTOR_A(arr0, 1, DTYPE_B, 0, 0);
+static const int minus_one_value = -1;
+static const struct descriptor minus_one =
     { sizeof(int), DTYPE_L, CLASS_S, (char *)&minus_one_value };
 
 extern struct descriptor *TdiItoXSpecial;

--- a/tdishr/TdiEq.c
+++ b/tdishr/TdiEq.c
@@ -88,7 +88,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <mdsdescrip.h>
 #include <mdsdescrip.h>
 #include <tdishr_messages.h>
-#include <STATICdef.h>
 
 
 

--- a/tdishr/TdiEvaluate.c
+++ b/tdishr/TdiEvaluate.c
@@ -38,7 +38,6 @@ RULES OF THE GAME:
 	"out" must be an XD. It will be an XD-DSC, usually.
 */
 
-#include <STATICdef.h>
 #include "tdirefstandard.h"
 #include "tdishrp.h"
 #include <tdishr_messages.h>
@@ -50,7 +49,7 @@ RULES OF THE GAME:
 
 
 
-STATIC_CONSTANT struct descriptor missing = { 0, DTYPE_MISSING, CLASS_S, 0 };
+static const struct descriptor missing = { 0, DTYPE_MISSING, CLASS_S, 0 };
 
 extern int tdi_get_ident();
 extern int TdiEvaluate();

--- a/tdishr/TdiEvaluate.c
+++ b/tdishr/TdiEvaluate.c
@@ -52,7 +52,7 @@ RULES OF THE GAME:
 
 STATIC_CONSTANT struct descriptor missing = { 0, DTYPE_MISSING, CLASS_S, 0 };
 
-extern int TdiGetIdent();
+extern int tdi_get_ident();
 extern int TdiEvaluate();
 extern int TdiIntrinsic();
 extern int TdiCall();
@@ -118,7 +118,7 @@ EXPORT int Tdi1Evaluate(opcode_t opcode __attribute__ ((unused)),
       status = TdiEvaluate(list[0]->pointer, out_ptr MDS_END_ARG);
       break;
     case DTYPE_IDENT:
-      status = TdiGetIdent(list[0], out_ptr);
+      status = tdi_get_ident(list[0], out_ptr);
       break;
     case DTYPE_NID:
       pnid = (int *)list[0]->pointer;

--- a/tdishr/TdiExponent.c
+++ b/tdishr/TdiExponent.c
@@ -32,7 +32,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <mdsdescrip.h>
 #include "tdinelements.h"
 #include <tdishr_messages.h>
-#include <STATICdef.h>
 
 
 

--- a/tdishr/TdiExpt.c
+++ b/tdishr/TdiExpt.c
@@ -34,7 +34,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <libroutines.h>
 #include <mdsshr.h>
 #include <treeshr.h>
-#include <STATICdef.h>
 
 
 
@@ -44,7 +43,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 int Tdi3MdsDefault(struct descriptor *in_ptr __attribute__ ((unused)), struct descriptor_xd *out_ptr)
 {
   char value[4096];
-  STATIC_CONSTANT dtype_t dtype = DTYPE_T;
+  static const dtype_t dtype = DTYPE_T;
   int retlen, status;
   struct dbi_itm lst[] = { {sizeof(value), DbiDEFAULT, 0, 0} , {0, DbiEND_OF_LIST, 0, 0}
   };
@@ -68,7 +67,7 @@ int Tdi3Expt(struct descriptor *in_ptr __attribute__ ((unused)), struct descript
 {
   char value[39 - 7];
   int retlen, status;
-  STATIC_CONSTANT dtype_t dtype = DTYPE_T;
+  static const dtype_t dtype = DTYPE_T;
   struct dbi_itm lst[] = { {sizeof(value), DbiNAME, 0, 0}
 			   , {0, DbiEND_OF_LIST, 0, 0}
   };
@@ -92,7 +91,7 @@ int Tdi3Shot(struct descriptor *in_ptr __attribute__ ((unused)), struct descript
 {
   int value;
   int retlen, status;
-  STATIC_CONSTANT dtype_t dtype = DTYPE_L;
+  static const dtype_t dtype = DTYPE_L;
   struct dbi_itm lst[] = { {sizeof(value), DbiSHOTID, 0, 0}
 			   , {0, DbiEND_OF_LIST, 0,  0}
   };

--- a/tdishr/TdiExtFunction.c
+++ b/tdishr/TdiExtFunction.c
@@ -65,7 +65,7 @@ extern int TdiData();
 extern int TdiDoFun();
 extern int TdiGetLong();
 extern int TdiAllocated();
-extern int TdiPutIdent();
+extern int tdi_put_ident();
 extern int TdiCompile();
 extern int TdiEvaluate();
 
@@ -159,8 +159,9 @@ ident: ;
 	  struct descriptor dtest = { sizeof(test), DTYPE_BU, CLASS_S, 0 };
 	  dtest.pointer = (char *)&test;
 	  status = TdiAllocated(pfun, &dtest MDS_END_ARG);
-	  if (status && !test)
-	    status = TdiPutIdent(pfun, 0);
+	  if (status && !test) {
+	    status = tdi_put_ident(pfun, 0);
+	  }
 	}
       }
     }

--- a/tdishr/TdiExtFunction.c
+++ b/tdishr/TdiExtFunction.c
@@ -58,7 +58,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <stdlib.h>
 #include <mdsshr.h>
 #include <mds_stdarg.h>
-#include <STATICdef.h>
 
 extern int TdiFaultHandler();
 extern int TdiData();
@@ -69,7 +68,7 @@ extern int tdi_put_ident();
 extern int TdiCompile();
 extern int TdiEvaluate();
 
-STATIC_CONSTANT struct descriptor_d EMPTY_D = { 0, DTYPE_T, CLASS_D, 0 };
+static const struct descriptor_d EMPTY_D = { 0, DTYPE_T, CLASS_D, 0 };
 
 int TdiFindImageSymbol(struct descriptor_d *image, struct descriptor_d *entry, int (**symbol) ())
 {

--- a/tdishr/TdiGetArgs.c
+++ b/tdishr/TdiGetArgs.c
@@ -47,7 +47,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "tdirefstandard.h"
 #include "tdithreadstatic.h"
 
-extern int TdiGetData();
+extern int tdi_get_data();
 extern int TdiData();
 extern int TdiUnits();
 extern int Tdi2Keep();
@@ -66,7 +66,7 @@ int TdiGetSignalUnitsData(struct descriptor *in_ptr,
   INIT_STATUS;
   GET_TDITHREADSTATIC_P;
   MdsFree1Dx(signal_ptr, NULL);
-  status = TdiGetData(omitsu, in_ptr, data_ptr);
+  status = tdi_get_data(omitsu, in_ptr, data_ptr);
   if STATUS_OK
     switch (data_ptr->pointer->dtype) {
     case DTYPE_SIGNAL:
@@ -74,7 +74,7 @@ int TdiGetSignalUnitsData(struct descriptor *in_ptr,
       *data_ptr = EMPTY_XD;
       keep = TDI_SELF_PTR;
       TDI_SELF_PTR = (struct descriptor_xd *)signal_ptr->pointer;
-      status = TdiGetData(omitu, ((struct descriptor_signal *)signal_ptr->pointer)->data, data_ptr);
+      status = tdi_get_data(omitu, ((struct descriptor_signal *)signal_ptr->pointer)->data, data_ptr);
       if STATUS_OK
 	switch (data_ptr->pointer->dtype) {
 	case DTYPE_WITH_UNITS:
@@ -98,7 +98,7 @@ int TdiGetSignalUnitsData(struct descriptor *in_ptr,
       *data_ptr = EMPTY_XD;
       status = TdiUnits(tmp.pointer, units_ptr MDS_END_ARG);
       if STATUS_OK
-	status = TdiGetData(omits, tmp.pointer, data_ptr);
+	status = tdi_get_data(omits, tmp.pointer, data_ptr);
       if STATUS_OK
 	switch (data_ptr->pointer->dtype) {
 	case DTYPE_SIGNAL:

--- a/tdishr/TdiGetArgs.c
+++ b/tdishr/TdiGetArgs.c
@@ -34,7 +34,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 	Ken Klare, LANL CTR-7   (c)1989,1990
 */
-#include <STATICdef.h>
 #include <stdlib.h>
 #include <mdsdescrip.h>
 #include <tdishr_messages.h>
@@ -59,9 +58,9 @@ int TdiGetSignalUnitsData(struct descriptor *in_ptr,
 			  struct descriptor_xd *signal_ptr,
 			  struct descriptor_xd *units_ptr, struct descriptor_xd *data_ptr)
 {
-  STATIC_CONSTANT unsigned char omitsu[] = { DTYPE_SIGNAL, DTYPE_WITH_UNITS, 0 };
-  STATIC_CONSTANT unsigned char omits[] = { DTYPE_SIGNAL, 0 };
-  STATIC_CONSTANT unsigned char omitu[] = { DTYPE_WITH_UNITS, 0 };
+  static const unsigned char omitsu[] = { DTYPE_SIGNAL, DTYPE_WITH_UNITS, 0 };
+  static const unsigned char omits[] = { DTYPE_SIGNAL, 0 };
+  static const unsigned char omitu[] = { DTYPE_WITH_UNITS, 0 };
   struct descriptor_xd tmp, *keep;
   INIT_STATUS;
   GET_TDITHREADSTATIC_P;

--- a/tdishr/TdiGetData.c
+++ b/tdishr/TdiGetData.c
@@ -61,7 +61,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 int TdiGetRecord(int nid, mdsdsc_xd_t *out);
 
 extern int TdiEvaluate();
-extern int TdiGetIdent();
+extern int tdi_get_ident();
 extern int TdiItoX();
 extern int TdiIntrinsic();
 extern int TdiCall();
@@ -236,7 +236,7 @@ int TdiGetData(const unsigned char omits[], mdsdsc_t *their_ptr, mdsdsc_xd_t *ou
 	        Evaluate on these types.
 	        ***********************/
 	case DTYPE_IDENT:
-	  status = TdiGetIdent(pin, &hold);
+	  status = tdi_get_ident(pin, &hold);
  redo:	  if STATUS_OK
 	    status = TdiGetData(omits, (mdsdsc_t *)&hold, &hold);
 	  break;
@@ -766,7 +766,7 @@ EXPORT int TdiGetRecord(int nid, mdsdsc_xd_t *out)
     else if STATUS_OK {
       status = stat;
       if IS_OK(stat)
-	status = TdiGetIdent(&var_d, out);
+	status = tdi_get_ident(&var_d, out);
     }
   }
   if (!use_get_record_fun)

--- a/tdishr/TdiGetDbi.c
+++ b/tdishr/TdiGetDbi.c
@@ -65,7 +65,7 @@ STATIC_CONSTANT struct item {
 
 extern int TdiData();
 extern int TdiUpcase();
-extern int TdiGetData();
+extern int tdi_get_data();
 extern int TdiGetLong();
 extern int _TdiEvaluate();
 
@@ -214,7 +214,7 @@ int Tdi1Using(opcode_t opcode __attribute__ ((unused)),
   if (narg > 1 && STATUS_OK) {
     if (list[1]) {
       struct descriptor_xd xd = EMPTY_XD;
-      status = TdiGetData(omits, list[1], &xd);
+      status = tdi_get_data(omits, list[1], &xd);
       if (STATUS_OK && xd.pointer)
 	switch (xd.pointer->dtype) {
 	case DTYPE_T:

--- a/tdishr/TdiGetDbi.c
+++ b/tdishr/TdiGetDbi.c
@@ -31,7 +31,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 	Ken Klare, LANL P-4     (c)1990,1991
 */
-#include <STATICdef.h>
 #include "tdirefstandard.h"
 #include <dbidef.h>
 #include <strroutines.h>
@@ -41,10 +40,10 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <treeshr.h>
 #include <mdsshr.h>
 
-STATIC_CONSTANT DESCRIPTOR(coloncolon, "::");
+static const DESCRIPTOR(coloncolon, "::");
 #define EOL {0,DbiEND_OF_LIST,0,0}
 
-STATIC_CONSTANT struct item {
+static const struct item {
   char *item_name;
   char item_code;
   dtype_t item_dtype;
@@ -69,7 +68,7 @@ extern int tdi_get_data();
 extern int TdiGetLong();
 extern int _TdiEvaluate();
 
-STATIC_ROUTINE int compare(struct descriptor *s1, struct item s2[1])
+static int compare(struct descriptor *s1, struct item s2[1])
 {
   int cmp, len1 = s1->length, len2 = strlen(s2[0].item_name);
   char c0;
@@ -165,7 +164,7 @@ int Tdi1GetDbi(opcode_t opcode __attribute__ ((unused)),
 	        USING(expression, [DEFAULT], [SHOTID], [EXPT])
 	Note that DEFAULT may be NID/PATH and will not be data at same.
 */
-STATIC_ROUTINE int fixup_nid(int *pin, /* NID pointer */
+static int fixup_nid(int *pin, /* NID pointer */
 			     int arg __attribute__ ((unused)),
 			     struct descriptor_d *pout)
 {
@@ -179,7 +178,7 @@ STATIC_ROUTINE int fixup_nid(int *pin, /* NID pointer */
   return MDSplusERROR;
 }
 
-STATIC_ROUTINE int fixup_path(struct descriptor *pin,
+static int fixup_path(struct descriptor *pin,
 			      int arg __attribute__ ((unused)),
 			      struct descriptor_d *pout)
 {
@@ -233,7 +232,7 @@ int Tdi1Using(opcode_t opcode __attribute__ ((unused)),
       };
       status = TreeGetDbi(def_itm);
       if (def_itm[0].pointer == NULL) {
-	STATIC_CONSTANT DESCRIPTOR(top, "\\TOP");
+	static const DESCRIPTOR(top, "\\TOP");
 	StrCopyDx((struct descriptor *)&def, (struct descriptor *)&top);
 	status = MDSplusSUCCESS;
       } else {

--- a/tdishr/TdiGetNci.c
+++ b/tdishr/TdiGetNci.c
@@ -46,7 +46,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 	NEED parameter for sizeof(NODE_NAME).
 	NEED to be careful about any new names. They could take away uniqueness from existing code.
 */
-#include <STATICdef.h>
 #undef MAX
 #define EOL {0,NciEND_OF_LIST,0,0}
 #define NID_NUMBER -1
@@ -71,7 +70,7 @@ extern int TdiUpcase();
 extern int Tdi1Vector();
 int TdiGetRecord(int nid, struct descriptor_xd *out);
 
-STATIC_CONSTANT struct item {
+static const struct item {
   char *item_name;
   unsigned int item_mask;
   unsigned int item_test;
@@ -158,7 +157,7 @@ STATIC_CONSTANT struct item {
 #define siztab sizeof(struct item)
 #define numtab (sizeof(table)/siztab)
 
-STATIC_CONSTANT struct usage_item {
+static const struct usage_item {
   char *usage_name;
   usage_t usage_code;
 } usage_table[] = {
@@ -178,7 +177,7 @@ STATIC_CONSTANT struct usage_item {
   "TEXT", TreeUSAGE_TEXT,}, {
 "WINDOW", TreeUSAGE_WINDOW,},};
 
-STATIC_ROUTINE int compare(struct descriptor *s1, struct item s2[1])
+static int compare(struct descriptor *s1, struct item s2[1])
 {
   int cmp, len1 = s1->length, len2 = strlen(s2[0].item_name);
   char c0;
@@ -232,8 +231,8 @@ int Tdi1GetNci(opcode_t opcode __attribute__ ((unused)),
 	       struct descriptor_xd *out_ptr)
 {
   INIT_STATUS;
-  STATIC_CONSTANT struct descriptor_d EMPTY_D = { 0, DTYPE_T, CLASS_D, 0 };
-  STATIC_CONSTANT DESCRIPTOR_A(arr0, 1, DTYPE_B, 0, 960);
+  static const struct descriptor_d EMPTY_D = { 0, DTYPE_T, CLASS_D, 0 };
+  static const DESCRIPTOR_A(arr0, 1, DTYPE_B, 0, 960);
   struct descriptor_a *holda_ptr = 0;
   struct descriptor_d string = EMPTY_D;
   struct descriptor_xd nids = EMPTY_XD, tmp = EMPTY_XD, holdxd = EMPTY_XD;
@@ -309,7 +308,7 @@ int Tdi1GetNci(opcode_t opcode __attribute__ ((unused)),
       length = allow.length;
       allow.class = CLASS_S;
       for (; --nallow >= 0; allow.pointer += length) {
-	struct usage_item *puse = &usage_table[sizeof(usage_table) / sizeof(usage_table[0])];
+	const struct usage_item *puse = &usage_table[sizeof(usage_table) / sizeof(usage_table[0])];
 	allow.length = length;
 	while (((char *)allow.pointer)[allow.length - 1] == ' ')
 	  allow.length--;

--- a/tdishr/TdiGetNci.c
+++ b/tdishr/TdiGetNci.c
@@ -65,7 +65,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "tdirefstandard.h"
 #include "tdinelements.h"
 
-extern int TdiGetData();
+extern int tdi_get_data();
 extern int TdiData();
 extern int TdiUpcase();
 extern int Tdi1Vector();
@@ -249,7 +249,7 @@ int Tdi1GetNci(opcode_t opcode __attribute__ ((unused)),
   unsigned short maxlen = 0;
 
   if (list[0]) {
-    status = TdiGetData(omits, list[0], &nids);
+    status = tdi_get_data(omits, list[0], &nids);
     if STATUS_OK {
       len = nids.pointer->length;
       class = nids.pointer->class;

--- a/tdishr/TdiGetShape.c
+++ b/tdishr/TdiGetShape.c
@@ -35,7 +35,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 	Ken Klare LANL CTR-7    (c)1989,1990
 	NEED CHECKS: Dimensions must match except first one and the smaller first dimension is used.
 */
-#include <STATICdef.h>
 #include <tdishr_messages.h>
 #include <mdsdescrip.h>
 #include <mdsdescrip.h>

--- a/tdishr/TdiGetSlope.c
+++ b/tdishr/TdiGetSlope.c
@@ -35,7 +35,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 	NEED to watch for rounding/precision problems.
 */
 
-#include <STATICdef.h>
 #include <stdlib.h>
 #include <tdishr_messages.h>
 #include "tdirefstandard.h"

--- a/tdishr/TdiHash.c
+++ b/tdishr/TdiHash.c
@@ -49,7 +49,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
   static short TdiREF_HASH[TdiHASH_MAX];
 #endif
 
-int hash(const int len, const char *str) {
+int hash_one(const int len, const char *str) {
   // djb2 by dan bernstein (http://www.cse.yorku.ca/~oz/hash.html)
   unsigned int hash = 5381;
   if (len<0) {// len unknown
@@ -70,12 +70,12 @@ static void hash_all() {
   for (i = 0 ; i < TdiHASH_MAX ; i++)
     TdiREF_HASH[i] = -1;
  for (i = 0; i < TdiFUNCTION_MAX; i++)
-   TdiREF_HASH[hash(-1, TdiRefFunction[i].name)] = i;
+   TdiREF_HASH[hash_one(-1, TdiRefFunction[i].name)] = i;
 }
-int tdiHash(const int len, const char *const pstring) {
+int tdi_hash(const int len, const char *const pstring) {
   static pthread_once_t once = PTHREAD_ONCE_INIT;
   pthread_once(&once,hash_all);
-  const int jf = TdiREF_HASH[hash(len, pstring)];
+  const int jf = TdiREF_HASH[hash_one(len, pstring)];
   if (jf<0)			return -1; // pstring's hash did not match a buildin's
   const char *rf = TdiRefFunction[jf].name;
   const char *ps=pstring, *pe=pstring+len;
@@ -95,7 +95,7 @@ static int hash_all() {
     TdiREF_HASH[jh] = -1;
   for (jf = 0; jf < TdiFUNCTION_MAX; ++jf, pf++) {
     if (pf->name) {
-      jh = hash(-1, pf->name);
+      jh = hash_one(-1, pf->name);
       TdiREF_HASH[jh] = (short)jf;
       while (TdiREF_HASH[jh] >= 0) {
 	count++;
@@ -108,10 +108,10 @@ static int hash_all() {
   }
   return count;
 }
-int tdiHash(const int len, const char *const pstring) {
+int tdi_hash(const int len, const char *const pstring) {
   // used in TdiLex and TdiChar
   int i, jh, jf;
-  jh = hash(len, pstring);
+  jh = hash_one(len, pstring);
   while ((jf = TdiREF_HASH[jh]) >= 0) {
     for (i = 0 ; i<len && TdiRefFunction[jf].name[i] ; i++) {
       if (TdiRefFunction[jf].name[i] != toupper(pstring[i]))

--- a/tdishr/TdiIand.c
+++ b/tdishr/TdiIand.c
@@ -70,7 +70,6 @@ int Tdi3Iand(struct descriptor *in1, struct descriptor *in2, struct descriptor *
 
 ------------------------------------------------------------------------------*/
 
-#include <STATICdef.h>
 #include <string.h>
 #include <mdsdescrip.h>
 #include <tdishr_messages.h>

--- a/tdishr/TdiIntrinsic.c
+++ b/tdishr/TdiIntrinsic.c
@@ -50,7 +50,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define MINMAX(min, test, max) ((min) >= (test) ? (min) : (test) < (max) ? (test) : (max))
 #define OPC_ENUM
 
-#include <STATICdef.h>
 #include "tdithreadstatic.h"
 #include "tdirefcat.h"
 #include "tdireffunction.h"

--- a/tdishr/TdiIntrinsic.c
+++ b/tdishr/TdiIntrinsic.c
@@ -77,51 +77,47 @@ extern int Tdi0Decompile();
 extern int TdiConvert();
 extern int TdiGetLong();
 extern int SysGetMsg();
-STATIC_ROUTINE mdsdsc_t *FixedArray();
 
-STATIC_CONSTANT mdsdsc_t miss_dsc = { 0, DTYPE_MISSING, CLASS_S, 0 };
+static mdsdsc_t *fixed_array(mdsdsc_t *in){
+  array_coeff *a = (array_coeff *) in;
+  int dsize = sizeof(mdsdsc_a_t) + sizeof(int) + 3 * sizeof(int) * a->dimct;
+  int i;
+  BOUNDS *bounds = (BOUNDS *) & a->m[a->dimct];
+  array_coeff *answer = (array_coeff *) memcpy(malloc(dsize), a, dsize);
+  answer->class = CLASS_A;
+  answer->aflags.column = 1;
+  answer->aflags.coeff = 1;
+  answer->aflags.bounds = 1;
+  for (i = 0; i < a->dimct; i++)
+    answer->m[i] = bounds[i].u - bounds[i].l + 1;
+  return (mdsdsc_t *)answer;
+}
+
+static const mdsdsc_t miss_dsc = { 0, DTYPE_MISSING, CLASS_S, 0 };
 
 /****************************
 Explain in 300 words or less.
 ****************************/
 #define MAXMESS 1800
-#define ADD(text) add(text, TdiThreadStatic_p)
-STATIC_ROUTINE void add(char *const text, ThreadStatic *const TdiThreadStatic_p)
-{
-  struct descriptor_d new = { 0, DTYPE_T, CLASS_D, 0 };
+#define ADD(text) add(text, TDITHREADSTATIC_PASS)
+static void add(char *const text, TDITHREADSTATIC_ARG) {
+  mdsdsc_d_t new = { 0, DTYPE_T, CLASS_D, 0 };
   new.length = (length_t)strlen(text);
   new.pointer = text;
   if (TDI_INTRINSIC_MSG.length + new.length < MAXMESS)
     StrAppend(&TDI_INTRINSIC_MSG, (mdsdsc_t *)&new);
 }
-
-#define NUMB(count) numb(count, TdiThreadStatic_p)
-STATIC_ROUTINE void numb(int count, ThreadStatic *const TdiThreadStatic_p)
-{
-  STATIC_CONSTANT char blanks[] = "            ";
-  char val[sizeof(blanks)], *pval;
-  strcpy(val, blanks);
-  pval = &val[sizeof(val) - 1];
-  if (count < 0)
-    *--pval = '-';
-  else if (count == 0)
-    *--pval = '0';
-  else
-    for (; count > 0 && pval > val; count /= 10)
-      *--pval = (char)(count % 10 + '0');
-  if (pval > val)
-    *--pval = ' ';
-  ADD(pval);
+#define NUMB(count) numb(count, TDITHREADSTATIC_PASS)
+static void numb(int count, TDITHREADSTATIC_ARG) {
+  char val[16];
+  sprintf(val,"%-12d",count);
+  ADD(val);
 }
 
 /***************************************************
 Danger: this routine is used by DECOMPILE to report.
 ***************************************************/
-int TdiTrace(opcode_t opcode __attribute__ ((unused)),
-	     int narg __attribute__ ((unused)),
-	     mdsdsc_t *list[] __attribute__ ((unused)),
-	     struct descriptor_xd *out_ptr)
-{
+int tdi_trace(mdsdsc_xd_t *out_ptr) {
   GET_TDITHREADSTATIC_P;
   if (TDI_INTRINSIC_MSG.length > MAXMESS)
     return MDSplusERROR;
@@ -137,16 +133,16 @@ int TdiTrace(opcode_t opcode __attribute__ ((unused)),
   return MDSplusSUCCESS;
 }
 
-static inline void TRACE(opcode_t opcode, int narg,
-	  mdsdsc_t *list[],
-	  struct descriptor_xd *out_ptr __attribute__ ((unused)))
-{
-  GET_TDITHREADSTATIC_P;
+#define TRACE(opcode,narg,list) trace(opcode,narg,list,TDITHREADSTATIC_PASS)
+static inline void trace(
+	opcode_t opcode,
+	int narg, mdsdsc_t *list[],
+	TDITHREADSTATIC_ARG){
   if (TDI_INTRINSIC_MSG.length >= MAXMESS)
     return;
   unsigned short now = TDI_INTRINSIC_MSG.length;
   int j;
-  struct descriptor_d text = { 0, DTYPE_T, CLASS_D, 0 };
+  mdsdsc_d_t text = { 0, DTYPE_T, CLASS_D, 0 };
   if (opcode < TdiFUNCTION_MAX) {
     struct TdiFunctionStruct *pfun = (struct TdiFunctionStruct *)&TdiRefFunction[opcode];
     if (narg < pfun->m1 || narg > pfun->m2) {
@@ -192,18 +188,17 @@ struct _fixed {
   int n;
   char f[256];
   mdsdsc_t *a[256];
+  int* rec;
 };
-void cleanup_list(void* fixed_in) {
-  GET_TDITHREADSTATIC_P;
+static void cleanup_list(void* fixed_in) {
   struct _fixed* fixed = (struct _fixed*)fixed_in;
   for (; --fixed->n >= 0 ;)
     if (fixed->f[fixed->n])
       free(fixed->a[fixed->n]);
-  TDI_INTRINSIC_REC--;
+  (*fixed->rec)--;
 }
 
-EXPORT int TdiIntrinsic(opcode_t opcode, int narg, mdsdsc_t *list[], struct descriptor_xd *out_ptr)
-{
+EXPORT int TdiIntrinsic(opcode_t opcode, int narg, mdsdsc_t *list[], mdsdsc_xd_t *out_ptr) {
   int status;
   struct TdiFunctionStruct *fun_ptr = (struct TdiFunctionStruct *)&TdiRefFunction[opcode];
   GET_TDITHREADSTATIC_P;
@@ -222,10 +217,11 @@ EXPORT int TdiIntrinsic(opcode_t opcode, int narg, mdsdsc_t *list[], struct desc
     struct _fixed fixed = {0};
     TDI_INTRINSIC_REC++;
     pthread_cleanup_push(cleanup_list,&fixed);
+    fixed.rec = &TDI_INTRINSIC_REC;
     for (fixed.n = 0; fixed.n < narg; fixed.n++)
       if (list[fixed.n] != NULL && list[fixed.n]->class == CLASS_NCA) {
 	fixed.f[fixed.n] = 1;
-	fixed.a[fixed.n] = FixedArray(list[fixed.n]);
+	fixed.a[fixed.n] = fixed_array(list[fixed.n]);
       } else {
 	fixed.f[fixed.n] = 0;
 	fixed.a[fixed.n] = list[fixed.n];
@@ -255,7 +251,7 @@ EXPORT int TdiIntrinsic(opcode_t opcode, int narg, mdsdsc_t *list[], struct desc
 	MdsFree1Dx(out_ptr, NULL);
       else if (out_ptr->l_length) {
 	ADD("%TDI DANGER, part of old output descriptor was input to below.\n");
-	TRACE(opcode, narg, list, out_ptr);
+	trace(opcode, narg, list,TDITHREADSTATIC_PASS);
       }
       if (tmp.class == CLASS_XD)
 	*out_ptr = tmp;
@@ -273,13 +269,13 @@ EXPORT int TdiIntrinsic(opcode_t opcode, int narg, mdsdsc_t *list[], struct desc
       else
 	dsc_ptr = (mdsdsc_t *)&tmp;
       if (dsc_ptr == 0)
-	stat1 = StrFree1Dx((struct descriptor_d *)out_ptr);
+	stat1 = StrFree1Dx((mdsdsc_d_t *)out_ptr);
       else
 	switch (dsc_ptr->class) {
 	case CLASS_S:
 	case CLASS_D:
 	  if (out_ptr->length != dsc_ptr->length) {
-	    stat1 = StrGet1Dx(&dsc_ptr->length, (struct descriptor_d *)out_ptr);
+	    stat1 = StrGet1Dx(&dsc_ptr->length, (mdsdsc_d_t *)out_ptr);
 	  }
 	  if IS_OK(stat1) {
 	    out_ptr->dtype = dsc_ptr->dtype;
@@ -310,7 +306,7 @@ EXPORT int TdiIntrinsic(opcode_t opcode, int narg, mdsdsc_t *list[], struct desc
       break;
     case CLASS_NCA:
       {
-	mdsdsc_t *fixed_out_ptr = FixedArray(out_ptr);
+	mdsdsc_t *fixed_out_ptr = fixed_array((mdsdsc_t *)out_ptr);
 	if (tmp.class == CLASS_XD)
 	  dsc_ptr = tmp.pointer;
 	else
@@ -329,7 +325,7 @@ EXPORT int TdiIntrinsic(opcode_t opcode, int narg, mdsdsc_t *list[], struct desc
     status = stat1;
   }
   if (TDI_INTRINSIC_REC>=0)
-    TRACE(opcode, narg, list, out_ptr);
+    trace(opcode, narg, list, TDITHREADSTATIC_PASS);
   if (out_ptr)
     MdsFree1Dx(out_ptr, NULL);
  notmp:MdsFree1Dx(&tmp, NULL);
@@ -340,7 +336,7 @@ EXPORT int TdiIntrinsic(opcode_t opcode, int narg, mdsdsc_t *list[], struct desc
   FREE_CANCEL(out_ptr);
   return status;
 }
-EXPORT int _TdiIntrinsic(void** ctx, opcode_t opcode, int narg, mdsdsc_t *list[], struct descriptor_xd *out_ptr){
+EXPORT int _TdiIntrinsic(void** ctx, opcode_t opcode, int narg, mdsdsc_t *list[], mdsdsc_xd_t *out_ptr){
   int status;
   CTX_PUSH(ctx);
   status = TdiIntrinsic(opcode, narg, list, out_ptr);
@@ -360,8 +356,7 @@ EXPORT int _TdiIntrinsic(void** ctx, opcode_t opcode, int narg, mdsdsc_t *list[]
 int Tdi1Debug(opcode_t opcode __attribute__ ((unused)),
 	      int narg,
 	      mdsdsc_t *list[],
-	      struct descriptor_xd *out_ptr)
-{
+	      mdsdsc_xd_t *out_ptr) {
   INIT_STATUS;
   GET_TDITHREADSTATIC_P;
   int option = -1;
@@ -389,20 +384,4 @@ int Tdi1Debug(opcode_t opcode __attribute__ ((unused)),
     }
   }
   return MdsCopyDxXd((mdsdsc_t *)&TDI_INTRINSIC_MSG, out_ptr);
-}
-
-STATIC_ROUTINE mdsdsc_t *FixedArray(mdsdsc_t *in)
-{
-  array_coeff *a = (array_coeff *) in;
-  int dsize = sizeof(mdsdsc_a_t) + sizeof(int) + 3 * sizeof(int) * a->dimct;
-  int i;
-  BOUNDS *bounds = (BOUNDS *) & a->m[a->dimct];
-  array_coeff *answer = (array_coeff *) memcpy(malloc(dsize), a, dsize);
-  answer->class = CLASS_A;
-  answer->aflags.column = 1;
-  answer->aflags.coeff = 1;
-  answer->aflags.bounds = 1;
-  for (i = 0; i < a->dimct; i++)
-    answer->m[i] = bounds[i].u - bounds[i].l + 1;
-  return (mdsdsc_t *)answer;
 }

--- a/tdishr/TdiIntrinsic.c
+++ b/tdishr/TdiIntrinsic.c
@@ -183,15 +183,15 @@ static inline void trace(
   ADD(")\n");
 }
 
-struct _fixed {
+typedef struct {
   int n;
   char f[256];
   mdsdsc_t *a[256];
   int* rec;
-};
+} fixed_t;
 static void cleanup_list(void* fixed_in) {
-  struct _fixed* fixed = (struct _fixed*)fixed_in;
-  for (; --fixed->n >= 0 ;)
+  fixed_t *const fixed = (fixed_t*)fixed_in;
+  while ( --fixed->n >= 0 )
     if (fixed->f[fixed->n])
       free(fixed->a[fixed->n]);
   (*fixed->rec)--;
@@ -213,7 +213,7 @@ EXPORT int TdiIntrinsic(opcode_t opcode, int narg, mdsdsc_t *list[], mdsdsc_xd_t
   else if (TDI_INTRINSIC_REC > 1800)
     status = TdiRECURSIVE;
   else {
-    struct _fixed fixed = {0};
+    fixed_t fixed;
     TDI_INTRINSIC_REC++;
     pthread_cleanup_push(cleanup_list,&fixed);
     fixed.rec = &TDI_INTRINSIC_REC;

--- a/tdishr/TdiIo.c
+++ b/tdishr/TdiIo.c
@@ -30,7 +30,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 #include <status.h>
 #include <mdsplus/mdsplus.h>
-#include <STATICdef.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include "tdirefstandard.h"
@@ -41,10 +40,10 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 
-STATIC_CONSTANT struct descriptor_d EMPTY_D = { 0, DTYPE_T, CLASS_D, 0 };
+static const struct descriptor_d EMPTY_D = { 0, DTYPE_T, CLASS_D, 0 };
 
-STATIC_CONSTANT DESCRIPTOR(dNUL, "\0");
-STATIC_CONSTANT DESCRIPTOR(dBAD, "/*bad*/");
+static const DESCRIPTOR(dNUL, "\0");
+static const DESCRIPTOR(dBAD, "/*bad*/");
 
 /*----------------------------------------------
 	A kludge to get stdout.
@@ -66,8 +65,8 @@ extern int TdiDecompile();
 int TdiPutLong(int *data, struct descriptor_xd *out_ptr)
 {
   INIT_STATUS;
-  STATIC_CONSTANT dtype_t dtype = DTYPE_L;
-  STATIC_CONSTANT length_t len = (length_t)sizeof(int);
+  static const dtype_t dtype = DTYPE_L;
+  static const length_t len = (length_t)sizeof(int);
 
   if (out_ptr == 0)
     return 1;
@@ -80,7 +79,7 @@ int TdiPutLong(int *data, struct descriptor_xd *out_ptr)
 /*----------------------------------------------
 	Internal routine to output a unit
 */
-STATIC_ROUTINE int TdiPutUnit(FILE * unit, struct descriptor_xd *out_ptr)
+static int TdiPutUnit(FILE * unit, struct descriptor_xd *out_ptr)
 {
   if (!unit) return MdsCopyDxXd(NULL, out_ptr);
   struct descriptor unit_d = { sizeof(void*), DTYPE_POINTER, CLASS_S, (char*)&unit };
@@ -90,7 +89,7 @@ STATIC_ROUTINE int TdiPutUnit(FILE * unit, struct descriptor_xd *out_ptr)
 /*----------------------------------------------
 	Internal routine to input a unit
 */
-STATIC_ROUTINE int TdiGetOutUnit(struct descriptor *in_ptr, FILE ** unit)
+static int TdiGetOutUnit(struct descriptor *in_ptr, FILE ** unit)
 {
   int status;
   INIT_AND_FREEXD_ON_EXIT(xd);
@@ -113,7 +112,7 @@ STATIC_ROUTINE int TdiGetOutUnit(struct descriptor *in_ptr, FILE ** unit)
 /*----------------------------------------------
 	Internal routine to input a unit
 */
-STATIC_ROUTINE int TdiGetInUnit(struct descriptor *in_ptr, FILE ** unit)
+static int TdiGetInUnit(struct descriptor *in_ptr, FILE ** unit)
 {
   int status;
   INIT_AND_FREEXD_ON_EXIT(xd);
@@ -139,8 +138,8 @@ int Tdi1DateTime(opcode_t opcode __attribute__ ((unused)),
   INIT_STATUS;
   int time[2] = { 0, 0 }, *ptime;
   length_t len;
-  STATIC_CONSTANT dtype_t dtype = DTYPE_T;
-  STATIC_CONSTANT length_t length = 23;
+  static const dtype_t dtype = DTYPE_T;
+  static const length_t length = 23;
 
   if (narg > 0 && list[0]) {
     struct descriptor dtime = { sizeof(time), DTYPE_Q, CLASS_S, 0 };
@@ -321,7 +320,7 @@ int Tdi1Write(opcode_t opcode __attribute__ ((unused)),
   char *pt, *plim;
   EMPTYXD(tmp);
 
-  STATIC_CONSTANT int width = 132;
+  static const int width = 132;
 
   status = TdiGetOutUnit(list[0], &unit);
   if STATUS_OK

--- a/tdishr/TdiItoX.c
+++ b/tdishr/TdiItoX.c
@@ -70,7 +70,7 @@ extern int IsRoprand();
 STATIC_CONSTANT struct descriptor tdiItoXSpecial;
 struct descriptor *TdiItoXSpecial = &tdiItoXSpecial;
 
-extern int TdiGetData();
+extern int tdi_get_data();
 extern int TdiGetLong();
 extern int TdiUnits();
 extern int TdiData();
@@ -157,14 +157,14 @@ int Tdi1ItoX(opcode_t opcode, int narg, struct descriptor *list[], struct descri
 	Previously allowed BUILD_DIM(,BUILD_WITH_UNITS(range,units)).
 	 ************************************************************/
   if (!flag)
-    status = TdiGetData(&omits[1], list[0], &dimen);
+    status = tdi_get_data(&omits[1], list[0], &dimen);
   else {
-    status = TdiGetData(omits, list[0], &dimen);
+    status = tdi_get_data(omits, list[0], &dimen);
 
     if (STATUS_OK && dimen.pointer->dtype == DTYPE_WITH_UNITS) {
       status = TdiUnits(dimen.pointer, &units MDS_END_ARG);
       if STATUS_OK
-	status = TdiGetData(&omits[1], &dimen, &dimen);
+	status = tdi_get_data(&omits[1], &dimen, &dimen);
     }
   }
   if STATUS_OK

--- a/tdishr/TdiItoX.c
+++ b/tdishr/TdiItoX.c
@@ -44,7 +44,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 	KK      21-Oct-1992     Text requires exact match.
  */
 #include <mdsplus/mdsplus.h>
-#include <STATICdef.h>
 #define beg     0
 #define end     1
 #define delta   2
@@ -63,12 +62,8 @@ extern int IsRoprand();
 #include <mdsshr.h>
 #include <string.h>
 
-
-
-#define _MOVC3(a,b,c) memcpy(c,b,a)
-
-STATIC_CONSTANT struct descriptor tdiItoXSpecial;
-struct descriptor *TdiItoXSpecial = &tdiItoXSpecial;
+static const mdsdsc_t tdiItoXSpecial;
+const mdsdsc_t *TdiItoXSpecial = &tdiItoXSpecial;
 
 extern int tdi_get_data();
 extern int TdiGetLong();
@@ -99,53 +94,51 @@ extern int TdiFloor();
 extern int TdiMax();
 extern int TdiMultiply();
 
-extern unsigned short OpcValue;
-STATIC_CONSTANT DESCRIPTOR_FUNCTION_0(value, &OpcValue);
-STATIC_CONSTANT float big = (float)1.e37;
-STATIC_CONSTANT float mbig = (float)-1.e37;
-STATIC_CONSTANT int mhuge = -HUGE;
-STATIC_CONSTANT int lhuge = HUGE;
-STATIC_CONSTANT int mone = -1;
-STATIC_CONSTANT int one = 1;
-STATIC_CONSTANT struct descriptor dmbig = { sizeof(mbig), DTYPE_F, CLASS_S, (char *)&mbig };
-STATIC_CONSTANT struct descriptor dbig = { sizeof(big), DTYPE_F, CLASS_S, (char *)&big };
-STATIC_CONSTANT struct descriptor dmhuge = { sizeof(mhuge), DTYPE_L, CLASS_S, (char *)&mhuge };
-STATIC_CONSTANT struct descriptor dhuge = { sizeof(lhuge), DTYPE_L, CLASS_S, (char *)&lhuge };
-STATIC_CONSTANT struct descriptor dmone = { sizeof(mone), DTYPE_L, CLASS_S, (char *)&mone };
-STATIC_CONSTANT struct descriptor done = { sizeof(one), DTYPE_L, CLASS_S, (char *)&one };
+static const float big = (float)1.e37;
+static const float mbig= (float)-1.e37;
+static const int mhuge = -HUGE;
+static const int lhuge = HUGE;
+static const int mone  = -1;
+static const int one   = 1;
+static mdsdsc_t dmbig  = { sizeof(mbig), DTYPE_FS, CLASS_S, (char *)&mbig };
+static mdsdsc_t dbig   = { sizeof(big), DTYPE_FS, CLASS_S, (char *)&big };
+static mdsdsc_t dmhuge = { sizeof(mhuge), DTYPE_L, CLASS_S, (char *)&mhuge };
+static mdsdsc_t dhuge  = { sizeof(lhuge), DTYPE_L, CLASS_S, (char *)&lhuge };
+static mdsdsc_t dmone  = { sizeof(mone), DTYPE_L, CLASS_S, (char *)&mone };
+static mdsdsc_t done   = { sizeof(one), DTYPE_L, CLASS_S, (char *)&one };
 
-STATIC_CONSTANT DESCRIPTOR_A(duo, sizeof(int), DTYPE_L, 0, 2 * sizeof(int));
-STATIC_CONSTANT DESCRIPTOR_RANGE(fake0, 0, 0, 0);
-extern unsigned short OpcVector;
-STATIC_CONSTANT DESCRIPTOR_FUNCTION_0(vector0, &OpcVector);
-int Tdi1ItoX(opcode_t opcode, int narg, struct descriptor *list[], struct descriptor_xd *out_ptr)
-{
+extern unsigned short OpcValue, OpcVector;
+static DESCRIPTOR_FUNCTION_0(value,   &OpcValue);
+static DESCRIPTOR_FUNCTION_0(vector0, &OpcVector);
+static DESCRIPTOR_A(duo, sizeof(int), DTYPE_L, 0, 2 * sizeof(int));
+static DESCRIPTOR_RANGE(fake0, 0, 0, 0);
+int Tdi1ItoX(opcode_t opcode, int narg, mdsdsc_t *list[], mdsdsc_xd_t *out_ptr) {
   INIT_STATUS;
   GET_TDITHREADSTATIC_P;
+  static const dtype_t omits[] = { DTYPE_WITH_UNITS, DTYPE_DIMENSION, 0 };
   int j1, left, right, *pcnt = 0, *ptest;
   int k0, k1;
   int special = narg > 1 && list[1] == TdiItoXSpecial;
   int arg1 = narg > 1 && list[1] && list[1] != TdiItoXSpecial;
   int big_beg, big_end, nran, tslo;
   int nseg, jseg, kseg;
-  struct descriptor *pmode;
+  const mdsdsc_t *pmode;
   int cmode = -1, flag = (opcode == OPC_I_TO_X);
   char *plogical;
-  struct descriptor_dimension *pdim;
-  struct descriptor_window *pwin = 0;
-  struct descriptor_range *paxis = 0, fake;
-  struct descriptor_slope *pslope;
-  struct descriptor dk0 = { sizeof(int), DTYPE_L, CLASS_S, 0 };
-  struct descriptor dk1 = { sizeof(int), DTYPE_L, CLASS_S, 0 };
-  struct descriptor *keep[3];
-  struct descriptor tst1, del1, int1;
-  struct descriptor_xd dimen = EMPTY_XD, window = EMPTY_XD, axis = EMPTY_XD, xat0 = EMPTY_XD;
-  struct descriptor_xd cnt = EMPTY_XD, tmp = EMPTY_XD, units = EMPTY_XD;
-  struct descriptor_xd sig[3] = {EMPTY_XD}, uni[3] = {EMPTY_XD}, dat[3] = {EMPTY_XD};
-  struct descriptor_xd sig1 = EMPTY_XD, uni1 = EMPTY_XD;
+  mds_dimension_t *pdim;
+  mds_window_t *pwin = 0;
+  mds_range_t *paxis = 0, fake;
+  mds_slope_t *pslope;
+  mdsdsc_t dk0 = { sizeof(int), DTYPE_L, CLASS_S, 0 };
+  mdsdsc_t dk1 = { sizeof(int), DTYPE_L, CLASS_S, 0 };
+  mdsdsc_t *keep[3];
+  mdsdsc_t tst1, del1, int1;
+  mdsdsc_xd_t dimen = EMPTY_XD, window = EMPTY_XD, axis = EMPTY_XD, xat0 = EMPTY_XD;
+  mdsdsc_xd_t cnt = EMPTY_XD, tmp = EMPTY_XD, units = EMPTY_XD;
+  mdsdsc_xd_t sig[3] = {EMPTY_XD}, uni[3] = {EMPTY_XD}, dat[3] = {EMPTY_XD};
+  mdsdsc_xd_t sig1 = EMPTY_XD, uni1 = EMPTY_XD;
   struct TdiCatStruct cats[4];
   FUNCTION(255 / 3) vec[3];
-  unsigned char omits[] = { DTYPE_WITH_UNITS, DTYPE_DIMENSION, 0 };
   dk0.pointer = (char *)&k0;
   dk1.pointer = (char *)&k1;
   keep[0] = TDI_RANGE_PTRS[0];
@@ -181,24 +174,24 @@ int Tdi1ItoX(opcode_t opcode, int narg, struct descriptor *list[], struct descri
       status = TdiData(0, &xat0 MDS_END_ARG);
       goto plain;
     case DTYPE_DIMENSION:
-      pdim = (struct descriptor_dimension *)dimen.pointer;
+      pdim = (mds_dimension_t *)dimen.pointer;
       status = TdiEvaluate(pdim->window, &window MDS_END_ARG);
-      pwin = (struct descriptor_window *)window.pointer;
+      pwin = (mds_window_t *)window.pointer;
       if (STATUS_OK && pwin && pwin->dtype == DTYPE_WITH_UNITS) {
-	status = TdiEvaluate(((struct descriptor_with_units *)pwin)->data, &tmp MDS_END_ARG);
+	status = TdiEvaluate(((mds_with_units_t *)pwin)->data, &tmp MDS_END_ARG);
 	if STATUS_OK
-	  status = MdsCopyDxXd((struct descriptor *)&tmp, &window);
+	  status = MdsCopyDxXd((mdsdsc_t *)&tmp, &window);
       }
       if STATUS_OK
 	status = TdiEvaluate(pdim->axis, &axis MDS_END_ARG);
-      paxis = (struct descriptor_range *)axis.pointer;
+      paxis = (mds_range_t *)axis.pointer;
       if (STATUS_OK && paxis && paxis->dtype == DTYPE_WITH_UNITS) {
-	status = TdiEvaluate(((struct descriptor_with_units *)paxis)->data, &tmp MDS_END_ARG);
+	status = TdiEvaluate(((mds_with_units_t *)paxis)->data, &tmp MDS_END_ARG);
 	if STATUS_OK
-	  status = MdsCopyDxXd((struct descriptor *)&tmp, &axis);
+	  status = MdsCopyDxXd((mdsdsc_t *)&tmp, &axis);
       }
-      paxis = (struct descriptor_range *)axis.pointer;
-      pwin = (struct descriptor_window *)window.pointer;
+      paxis = (mds_range_t *)axis.pointer;
+      pwin = (mds_window_t *)window.pointer;
       break;
     }
   if (STATUS_OK && pwin && pwin->dtype == DTYPE_WINDOW) ;
@@ -222,7 +215,7 @@ int Tdi1ItoX(opcode_t opcode, int narg, struct descriptor *list[], struct descri
   if STATUS_OK {
     switch (paxis->dtype) {
     case DTYPE_SLOPE:
-      pslope = (struct descriptor_slope *)paxis;
+      pslope = (mds_slope_t *)paxis;
       paxis = &fake;
       fake = fake0;
       switch (pslope->ndesc) {
@@ -239,23 +232,22 @@ int Tdi1ItoX(opcode_t opcode, int narg, struct descriptor *list[], struct descri
 	status = TdiINVDTYDSC;
 	break;
       default:
-	*(struct descriptor_function *)(fake.begin = (struct descriptor *)&vec[0]) = vector0;
-	*(struct descriptor_function *)(fake.ending = (struct descriptor *)&vec[1]) = vector0;
-	*(struct descriptor_function *)(fake.deltaval = (struct descriptor *)&vec[2]) = vector0;
+	*(mds_function_t *)(fake.begin = (mdsdsc_t *)&vec[0]) = vector0;
+	*(mds_function_t *)(fake.ending = (mdsdsc_t *)&vec[1]) = vector0;
+	*(mds_function_t *)(fake.deltaval = (mdsdsc_t *)&vec[2]) = vector0;
 	nseg = ((pslope->ndesc + 1) / 3);
 	vec[0].ndesc = (unsigned char)nseg;
 	vec[1].ndesc = (unsigned char)nseg;
 	vec[2].ndesc = (unsigned char)nseg;
 	for (jseg = nseg; --jseg >= 0;)
-	  if ((vec[0].arguments[jseg] = pslope->segment[jseg].begin) == 0) {
-	    vec[0].arguments[jseg] = &dmbig;
-	  }
+	  if ((vec[0].arguments[jseg] = pslope->segment[jseg].begin) == 0)
+	    vec[0].arguments[jseg] = (mdsdsc_t*)&dmbig;
 	for (jseg = nseg; --jseg >= 0;)
 	  if ((vec[1].arguments[jseg] = pslope->segment[jseg].ending) == 0)
-	    vec[1].arguments[jseg] = &dbig;
+	    vec[1].arguments[jseg] = (mdsdsc_t*)&dbig;
 	for (jseg = nseg; --jseg >= 0;)
 	  if ((vec[2].arguments[jseg] = pslope->segment[jseg].slope) == 0)
-	    vec[1].arguments[jseg] = &done;
+	    vec[1].arguments[jseg] = (mdsdsc_t*)&done;
 	break;
       }
       if (STATUS_NOT_OK)
@@ -270,7 +262,7 @@ int Tdi1ItoX(opcode_t opcode, int narg, struct descriptor *list[], struct descri
       if STATUS_OK {		/*bug 2/26/91 include status set in bracket */
 	for (j1 = nran; --j1 >= 0;)
 	  if (dat[j1].pointer->class == CLASS_A) {
-	    jseg = ((struct descriptor_a *)dat[j1].pointer)->arsize / (int)dat[j1].pointer->length;
+	    jseg = ((mdsdsc_a_t *)dat[j1].pointer)->arsize / (int)dat[j1].pointer->length;
 	    if (nseg > jseg)
 	      nseg = jseg;
 	  }
@@ -287,7 +279,7 @@ int Tdi1ItoX(opcode_t opcode, int narg, struct descriptor *list[], struct descri
       if STATUS_OK
 	status = Tdi2Range(nran, uni, dat, cats, 0);
       if (flag && units.pointer == 0 && uni[0].pointer && STATUS_OK)
-	status = MdsCopyDxXd((struct descriptor *)&uni[0], &units);
+	status = MdsCopyDxXd((mdsdsc_t *)&uni[0], &units);
       if (STATUS_NOT_OK)
 	goto firstbad;
       tslo = nran > 2 && cats[2].in_dtype != DTYPE_MISSING;
@@ -428,7 +420,7 @@ int Tdi1ItoX(opcode_t opcode, int narg, struct descriptor *list[], struct descri
 	  big_beg = 1;
 	  right = left + HUGE;
 	  *pcnt = 1;
-	  _MOVC3(dat[end].pointer->length, dat[end].pointer->pointer, dat[beg].pointer->pointer);
+	  memcpy(dat[beg].pointer->pointer, dat[end].pointer->pointer,dat[end].pointer->length);
 	} else
 	  right = left + *pcnt;
       }
@@ -501,9 +493,9 @@ int Tdi1ItoX(opcode_t opcode, int narg, struct descriptor *list[], struct descri
 	  limits[0] = k0;
 	  limits[1] = k1;
 	  dlimits.pointer = limits;
-	  status = MdsCopyDxXd((struct descriptor *)&dlimits, out_ptr);
+	  status = MdsCopyDxXd((mdsdsc_t *)&dlimits, out_ptr);
 	} else if (arg1) {
-	  struct descriptor_range *rptr = (struct descriptor_range *)list[1];
+	  mds_range_t *rptr = (mds_range_t *)list[1];
 	  MdsFree1Dx(out_ptr, NULL);
 	  TDI_RANGE_PTRS[0] = &dk0;
 	  TDI_RANGE_PTRS[1] = &dk1;
@@ -517,7 +509,7 @@ int Tdi1ItoX(opcode_t opcode, int narg, struct descriptor *list[], struct descri
 	    DESCRIPTOR_RANGE(fake_range, 0, 0, 0);
 	    fake_range.begin = rptr->begin;
 	    fake_range.ending = rptr->ending;
-	    fake_range.deltaval = (struct descriptor *)&value;
+	    fake_range.deltaval = (mdsdsc_t *)&value;
 	    rptr = &fake_range;
 	    status = TdiGetArgs(opcode, 1, &rptr, &sig1, &uni1, out_ptr, cats);
 	  } else
@@ -622,8 +614,8 @@ int Tdi1ItoX(opcode_t opcode, int narg, struct descriptor *list[], struct descri
 				 **************************************/
     default:
  plain:status = TdiData(&axis, &axis MDS_END_ARG);
-      paxis = (struct descriptor_range *)axis.pointer;
-      pmode = paxis->dtype == DTYPE_T ? 0 : &dmone;
+      paxis = (mds_range_t *)axis.pointer;
+      pmode = paxis->dtype == DTYPE_T ? NULL : &dmone;
       j1 = paxis->length;
       if STATUS_OK
 	status = TdiSort(paxis, &tmp MDS_END_ARG);
@@ -654,12 +646,10 @@ int Tdi1ItoX(opcode_t opcode, int narg, struct descriptor *list[], struct descri
 	if (special) {
 	  if (flag) {
 	    unsigned short num = (unsigned short)j1;
-	    status = MdsGet1DxA((struct descriptor_a *)&duo, &num, &paxis->dtype, out_ptr);
+	    status = MdsGet1DxA((mdsdsc_a_t *)&duo, &num, &paxis->dtype, out_ptr);
 	    if STATUS_OK {
-	      _MOVC3(j1, (char *)window.pointer->pointer, out_ptr->pointer->pointer);
-	      _MOVC3(j1,
-		     (char *)window.pointer->pointer + j1 * (k1 -
-							     k0), out_ptr->pointer->pointer + j1);
+	      memcpy(out_ptr->pointer->pointer   ,(char *)window.pointer->pointer           ,j1);
+	      memcpy(out_ptr->pointer->pointer+j1,(char *)window.pointer->pointer+j1*(k1-k0),j1);
 	    }
 	  } else {
 	    int limits[2];
@@ -667,11 +657,11 @@ int Tdi1ItoX(opcode_t opcode, int narg, struct descriptor *list[], struct descri
 	    limits[0] = k0;
 	    limits[1] = k1;
 	    dlimits.pointer = limits;
-	    status = MdsCopyDxXd((struct descriptor *)&dlimits, out_ptr);
+	    status = MdsCopyDxXd((mdsdsc_t *)&dlimits, out_ptr);
 	  }
 	} else if (!arg1) {
 	  if (flag)
-	    status = MdsCopyDxXd((struct descriptor *)&axis, out_ptr);	/*unsorted values */
+	    status = MdsCopyDxXd((mdsdsc_t *)&axis, out_ptr);	/*unsorted values */
 	  else
 	    status = TdiDtypeRange(&dk0, &dk1, out_ptr MDS_END_ARG);	/*plain indexes */
 	} else {

--- a/tdishr/TdiLex.c
+++ b/tdishr/TdiLex.c
@@ -419,7 +419,7 @@ static void upcase(char *const str, int len){
 
 #define UNPUT()		--TDI_REFZONE.a_cur
 #define SET_POS()	(lvalPtr->w_ok = TDI_REFZONE.a_cur - TDI_REFZONE.a_begin)
-static inline char lex_input(ThreadStatic *const TdiThreadStatic_p) {
+static inline char lex_input(TDITHREADSTATIC_ARG) {
   int tchar;
   if (TDI_REFZONE.a_cur < TDI_REFZONE.a_end)
     tchar = *TDI_REFZONE.a_cur++;
@@ -429,7 +429,7 @@ static inline char lex_input(ThreadStatic *const TdiThreadStatic_p) {
     return '\0';
   return (char)tchar;
 }
-#define INPUT()	lex_input(TdiThreadStatic_p)
+#define INPUT()	lex_input(TDITHREADSTATIC_PASS)
 
 /*--------------------------------------------------------
 	Remove comment from the Lex input stream.
@@ -440,8 +440,7 @@ static int lex_comment(
 	int len __attribute__ ((unused)),
 	char *str __attribute__ ((unused)),
 	struct marker *mark_ptr __attribute__ ((unused)),
-	ThreadStatic *const TdiThreadStatic_p)
-{
+	TDITHREADSTATIC_ARG) {
   char c, c1;
   int count = 1;
   while (count) {
@@ -501,7 +500,7 @@ static int lex_float(
 	int len,
 	char *str,
 	struct marker *mark_ptr,
-	ThreadStatic *const TdiThreadStatic_p) {
+	TDITHREADSTATIC_ARG) {
   struct descriptor_s str_dsc = { len, DTYPE_T, CLASS_S, str };
   int bad, idx, status, tst, type;
   static const struct {
@@ -579,7 +578,7 @@ static int lex_float(
 	Note must be acceptable in written form also: a<=b, a LE b, LE(a,b).
 	Binary a<=(b,c) is OK, but unary <=(b,c) should not be.
 */
-static int lex_bin_eq(int token, ThreadStatic *const TdiThreadStatic_p) {
+static int lex_bin_eq(int token, TDITHREADSTATIC_ARG) {
   char cx;
   while ((cx = INPUT()) == ' ' || cx == '\t') ;
   if (cx == '=')
@@ -597,7 +596,7 @@ static inline int lex_ident(
 	int len,
 	char *str,
 	struct marker *mark_ptr,
-	ThreadStatic *const TdiThreadStatic_p) {
+	TDITHREADSTATIC_ARG) {
   int j, token;
   mark_ptr->builtin = -1;
   MAKE_S(DTYPE_T, len, mark_ptr->rptr);
@@ -640,7 +639,7 @@ static inline int lex_ident(
 	|| token == LEX_LAND
 	|| token == LEX_LEQ
 	|| token == LEX_LEQV || token == LEX_LGE || token == LEX_LOR || token == LEX_MUL)
-      return lex_bin_eq(token, TdiThreadStatic_p);
+      return lex_bin_eq(token, TDITHREADSTATIC_PASS);
     return token;
   }
   return (LEX_IDENT);
@@ -683,7 +682,7 @@ static int lex_integer(
 	int len,
 	char *str,
 	struct marker *mark_ptr,
-	ThreadStatic *const TdiThreadStatic_p) {
+	TDITHREADSTATIC_ARG) {
   const struct {
    length_t length;
    dtype_t  udtype, sdtype;
@@ -905,7 +904,7 @@ int tdi_lex_path(
 	int len,
 	char *str,
 	struct marker *mark_ptr,
-	ThreadStatic *const TdiThreadStatic_p) {
+	TDITHREADSTATIC_ARG) {
   int nid, token = LEX_VALUE;
   char *str_l;
   str_l = strncpy((char *)malloc(len + 1), str, len);
@@ -944,7 +943,7 @@ static inline int lex_point(
 	int len,
 	char *str,
 	struct marker *mark_ptr,
-	ThreadStatic *const TdiThreadStatic_p) {
+	TDITHREADSTATIC_ARG) {
   int lenx = len - 2;
   while (str[lenx + 1] == '.' || str[lenx + 1] == ':')
     --lenx;
@@ -958,7 +957,7 @@ static inline int lex_punct(
 	int len __attribute__ ((unused)),
 	char *str,
 	struct marker *mark_ptr,
-	ThreadStatic *const TdiThreadStatic_p) {
+	TDITHREADSTATIC_ARG) {
   char c0 = str[0], c1 = INPUT();
 
   mark_ptr->rptr = 0;
@@ -970,19 +969,19 @@ static inline int lex_punct(
   case '!':
     if (c1 == '=') {
       mark_ptr->builtin = OPC_NE;
-      return lex_bin_eq(LEX_LEQS, TdiThreadStatic_p);
+      return lex_bin_eq(LEX_LEQS, TDITHREADSTATIC_PASS);
     }
     break;
   case '&':
     if (c1 == '&') {
       mark_ptr->builtin = OPC_AND;
-      return lex_bin_eq(LEX_LANDS, TdiThreadStatic_p);
+      return lex_bin_eq(LEX_LANDS, TDITHREADSTATIC_PASS);
     }
     break;
   case '*':
     if (c1 == '*') {
       mark_ptr->builtin = OPC_POWER;
-      return lex_bin_eq(LEX_POWER, TdiThreadStatic_p);
+      return lex_bin_eq(LEX_POWER, TDITHREADSTATIC_PASS);
     }
     break;
   case '+':
@@ -1007,43 +1006,43 @@ static inline int lex_punct(
   case '/':
     if (c1 == '/') {
       mark_ptr->builtin = OPC_CONCAT;
-      return lex_bin_eq(LEX_CONCAT, TdiThreadStatic_p);
+      return lex_bin_eq(LEX_CONCAT, TDITHREADSTATIC_PASS);
     }
     break;
   case '<':
     if (c1 == '<') {
       mark_ptr->builtin = OPC_SHIFT_LEFT;
-      return lex_bin_eq(LEX_SHIFT, TdiThreadStatic_p);
+      return lex_bin_eq(LEX_SHIFT, TDITHREADSTATIC_PASS);
     }
     if (c1 == '=') {
       mark_ptr->builtin = OPC_LE;
-      return lex_bin_eq(LEX_LGES, TdiThreadStatic_p);
+      return lex_bin_eq(LEX_LGES, TDITHREADSTATIC_PASS);
     }
     if (c1 == '>') {
       mark_ptr->builtin = OPC_NE;
-      return lex_bin_eq(LEX_LEQS, TdiThreadStatic_p);
+      return lex_bin_eq(LEX_LEQS, TDITHREADSTATIC_PASS);
     }
     break;
   case '=':
     if (c1 == '=') {
       mark_ptr->builtin = OPC_EQ;
-      return lex_bin_eq(LEX_LEQS, TdiThreadStatic_p);
+      return lex_bin_eq(LEX_LEQS, TDITHREADSTATIC_PASS);
     }
     break;
   case '>':
     if (c1 == '=') {
       mark_ptr->builtin = OPC_GE;
-      return lex_bin_eq(LEX_LGES, TdiThreadStatic_p);
+      return lex_bin_eq(LEX_LGES, TDITHREADSTATIC_PASS);
     }
     if (c1 == '>') {
       mark_ptr->builtin = OPC_SHIFT_RIGHT;
-      return lex_bin_eq(LEX_SHIFT, TdiThreadStatic_p);
+      return lex_bin_eq(LEX_SHIFT, TDITHREADSTATIC_PASS);
     }
     break;
   case '|':
     if (c1 == '|') {
       mark_ptr->builtin = OPC_OR;
-      return lex_bin_eq(LEX_LORS, TdiThreadStatic_p);
+      return lex_bin_eq(LEX_LORS, TDITHREADSTATIC_PASS);
     }
     break;
   }
@@ -1058,40 +1057,40 @@ static inline int lex_punct(
     return (LEX_UNARYS);
   case '%':
     mark_ptr->builtin = OPC_MOD;
-    return lex_bin_eq(LEX_MULS, TdiThreadStatic_p);
+    return lex_bin_eq(LEX_MULS, TDITHREADSTATIC_PASS);
   case '&':
     mark_ptr->builtin = OPC_IAND;
-    return lex_bin_eq(LEX_IAND, TdiThreadStatic_p);
+    return lex_bin_eq(LEX_IAND, TDITHREADSTATIC_PASS);
   case '*':
     mark_ptr->builtin = OPC_MULTIPLY;
-    return lex_bin_eq('*', TdiThreadStatic_p);
+    return lex_bin_eq('*', TDITHREADSTATIC_PASS);
   case '+':
     mark_ptr->builtin = OPC_ADD;
-    return lex_bin_eq(LEX_ADD, TdiThreadStatic_p);
+    return lex_bin_eq(LEX_ADD, TDITHREADSTATIC_PASS);
   case '-':
     mark_ptr->builtin = OPC_SUBTRACT;
-    return lex_bin_eq(LEX_ADD, TdiThreadStatic_p);
+    return lex_bin_eq(LEX_ADD, TDITHREADSTATIC_PASS);
   case '/':
     mark_ptr->builtin = OPC_DIVIDE;
-    return lex_bin_eq(LEX_MULS, TdiThreadStatic_p);
+    return lex_bin_eq(LEX_MULS, TDITHREADSTATIC_PASS);
   case ':':
     mark_ptr->builtin = OPC_DTYPE_RANGE;
     return (LEX_RANGE);
   case '<':
     mark_ptr->builtin = OPC_LT;
-    return lex_bin_eq(LEX_LGES, TdiThreadStatic_p);
+    return lex_bin_eq(LEX_LGES, TDITHREADSTATIC_PASS);
   case '>':
     mark_ptr->builtin = OPC_GT;
-    return lex_bin_eq(LEX_LGES, TdiThreadStatic_p);
+    return lex_bin_eq(LEX_LGES, TDITHREADSTATIC_PASS);
   case '@':
     mark_ptr->builtin = OPC_PROMOTE;
     return (LEX_PROMO);
   case '^':
     mark_ptr->builtin = OPC_POWER;
-    return lex_bin_eq(LEX_POWER, TdiThreadStatic_p);
+    return lex_bin_eq(LEX_POWER, TDITHREADSTATIC_PASS);
   case '|':
     mark_ptr->builtin = OPC_IOR;
-    return lex_bin_eq(LEX_IOR, TdiThreadStatic_p);
+    return lex_bin_eq(LEX_IOR, TDITHREADSTATIC_PASS);
   case '~':
     mark_ptr->builtin = OPC_INOT;
     return (LEX_UNARYS);
@@ -1113,7 +1112,7 @@ static inline int lex_quote(
 	int len __attribute__ ((unused)),
 	char *str,
 	struct marker *mark_ptr,
-	ThreadStatic *const TdiThreadStatic_p) {
+	TDITHREADSTATIC_ARG) {
   char c, c1, *cptr = TDI_REFZONE.a_cur;
   int cur = 0, limit;
 
@@ -1213,7 +1212,7 @@ static inline int lex_back(const int *p, const int m) {
   return 0;
 }
 
-static int lex_look(int *leng, char *previous, char*const text, const svf_t **lstate, ThreadStatic *const TdiThreadStatic_p) {
+static int lex_look(int *leng, char *previous, char*const text, const svf_t **lstate, TDITHREADSTATIC_ARG) {
   const svf_t *state, **lsp;
   const work_t *t;
   const svf_t *z;
@@ -1358,14 +1357,13 @@ static int lex_look(int *leng, char *previous, char*const text, const svf_t **ls
   }
 }
 
-int tdi_lex(struct marker *lvalPtr) {
-  GET_TDITHREADSTATIC_P;
+int tdi_lex(struct marker *lvalPtr, TDITHREADSTATIC_ARG) {
   int nstr, leng;
   char previous = NEWLINE;
   char text[MAX_TOKEN_LEN];
   memset(text,127,MAX_TOKEN_LEN);
   const svf_t *lstate[MAX_TOKEN_LEN];
-  while ((nstr = lex_look(&leng, &previous, text, lstate, TdiThreadStatic_p)) >= 0) {
+  while ((nstr = lex_look(&leng, &previous, text, lstate, TDITHREADSTATIC_PASS)) >= 0) {
     switch (nstr) {
       case 0:
 	return 0;
@@ -1375,34 +1373,34 @@ int tdi_lex(struct marker *lvalPtr) {
 	break;
       case 3:
 	SET_POS();
-	return (lex_float(leng, text, lvalPtr, TdiThreadStatic_p));
+	return (lex_float(leng, text, lvalPtr, TDITHREADSTATIC_PASS));
       case 4:
 	SET_POS();
-	return (lex_float(leng, text, lvalPtr, TdiThreadStatic_p));
+	return (lex_float(leng, text, lvalPtr, TDITHREADSTATIC_PASS));
       case 5:
 	SET_POS();
-	return (lex_integer(leng, text, lvalPtr, TdiThreadStatic_p));
+	return (lex_integer(leng, text, lvalPtr, TDITHREADSTATIC_PASS));
       case 6:
 	SET_POS();
-	return (lex_ident(leng, text, lvalPtr, TdiThreadStatic_p));
+	return (lex_ident(leng, text, lvalPtr, TDITHREADSTATIC_PASS));
       case 7:
 	SET_POS();
-	return (tdi_lex_path(leng, text, lvalPtr, TdiThreadStatic_p));
+	return (tdi_lex_path(leng, text, lvalPtr, TDITHREADSTATIC_PASS));
       case 8:
 	SET_POS();
-	return (lex_quote(leng, text, lvalPtr, TdiThreadStatic_p));
+	return (lex_quote(leng, text, lvalPtr, TDITHREADSTATIC_PASS));
       case 9:
 	SET_POS();
-	return (lex_point(leng, text, lvalPtr, TdiThreadStatic_p));
+	return (lex_point(leng, text, lvalPtr, TDITHREADSTATIC_PASS));
       case 10:
 	SET_POS();
-	if (lex_comment(leng, text, lvalPtr, TdiThreadStatic_p))
+	if (lex_comment(leng, text, lvalPtr, TDITHREADSTATIC_PASS))
 	  return (LEX_ERROR);
 	else
 	  break;
       case 11:
 	SET_POS();
-	return (lex_punct(leng, text, lvalPtr, TdiThreadStatic_p));
+	return (lex_punct(leng, text, lvalPtr, TDITHREADSTATIC_PASS));
       case -1:
 	break;
       default:

--- a/tdishr/TdiLex.c
+++ b/tdishr/TdiLex.c
@@ -599,7 +599,6 @@ static inline int lex_ident(
 	struct marker *mark_ptr,
 	ThreadStatic *const TdiThreadStatic_p) {
   int j, token;
-  char *str_l;
   mark_ptr->builtin = -1;
   MAKE_S(DTYPE_T, len, mark_ptr->rptr);
   memcpy(mark_ptr->rptr->pointer, str, mark_ptr->rptr->length);
@@ -622,10 +621,7 @@ static inline int lex_ident(
 	/**********************
 	Search of initial list.
 	**********************/
-  str_l = (char *)strncpy((char *)malloc(len + 1), (char *)str, len);
-  str_l[len] = 0;
-  j = tdi_hash(len, str_l);
-  free(str_l);
+  j = tdi_hash(len, str);
   if (j < 0) {
     if (str[0] == '$')
       return (LEX_VBL);

--- a/tdishr/TdiLex.c
+++ b/tdishr/TdiLex.c
@@ -35,7 +35,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "tdirefzone.h"
 #include "tdireffunction.h"
 #include "tdithreadstatic.h"
-extern int tdiHash();
+extern int tdi_hash();
 extern int TdiConvert();
 
 #define NEWLINE 10
@@ -378,7 +378,7 @@ static void upcase(char *const str, int len){
     *pc = (char)toupper(*pc);
 }
 
-/*      TdiLex
+/*      tdiLex
    Lexical analysis to parse tokens for TdiYacc.y.
    Definition section precedes rule section.
    Lex regular expression operators:
@@ -419,26 +419,24 @@ static void upcase(char *const str, int len){
 
 #define UNPUT()		--TDI_REFZONE.a_cur
 #define SET_POS()	(lvalPtr->w_ok = TDI_REFZONE.a_cur - TDI_REFZONE.a_begin)
-static inline char input_fun(ThreadStatic *const TdiThreadStatic_p) {
+static inline char lex_input(ThreadStatic *const TdiThreadStatic_p) {
   int tchar;
   if (TDI_REFZONE.a_cur < TDI_REFZONE.a_end)
     tchar = *TDI_REFZONE.a_cur++;
   else
     return TDI_REFZONE.a_cur++ == TDI_REFZONE.a_end ? ';' : 0;
-  if      (tchar==NEWLINE)
-    ;//lineno++;
-  else if (tchar==EOF)
+  if (tchar==EOF)
     return '\0';
   return (char)tchar;
 }
-#define INPUT()	input_fun(TdiThreadStatic_p)
+#define INPUT()	lex_input(TdiThreadStatic_p)
 
 /*--------------------------------------------------------
 	Remove comment from the Lex input stream.
 	Nested comments allowed. Len is not used.
 	Limitation:     Not ANSI C standard use of delimiters.
 */
-static int tdiLexComment(
+static int lex_comment(
 	int len __attribute__ ((unused)),
 	char *str __attribute__ ((unused)),
 	struct marker *mark_ptr __attribute__ ((unused)),
@@ -479,8 +477,7 @@ ing
 static const DESCRIPTOR(dfghst_dsc, "DFGHSTVdfghstv");
 static const DESCRIPTOR(valid_dsc, "+-.0123456789DEFGHSTV \t");
 
-static int convertFloating(struct descriptor_s *str, struct descriptor_r *out_d)
-{
+static int lex_convert_floating(struct descriptor_s *str, struct descriptor_r *out_d) {
   char str_c[64];
   int len = str->length > 63 ? 63 : str->length;
   strncpy(str_c, str->pointer, len);
@@ -500,7 +497,7 @@ static int convertFloating(struct descriptor_s *str, struct descriptor_r *out_d)
   }
 }
 
-static int tdiLexFloat(
+static int lex_float(
 	int len,
 	char *str,
 	struct marker *mark_ptr,
@@ -566,7 +563,7 @@ static int tdiLexFloat(
 
   MAKE_S(table[type].dtype, table[type].length, mark_ptr->rptr);
 
-  status = convertFloating(&str_dsc, mark_ptr->rptr);
+  status = lex_convert_floating(&str_dsc, mark_ptr->rptr);
   if (STATUS_OK && bad > 0 && str[bad - 1] != '\0')
     status = TdiEXTRANEOUS;
 
@@ -582,7 +579,7 @@ static int tdiLexFloat(
 	Note must be acceptable in written form also: a<=b, a LE b, LE(a,b).
 	Binary a<=(b,c) is OK, but unary <=(b,c) should not be.
 */
-static int tdiLexBinEq(int token, ThreadStatic *const TdiThreadStatic_p) {
+static int lex_bin_eq(int token, ThreadStatic *const TdiThreadStatic_p) {
   char cx;
   while ((cx = INPUT()) == ' ' || cx == '\t') ;
   if (cx == '=')
@@ -596,7 +593,7 @@ static int tdiLexBinEq(int token, ThreadStatic *const TdiThreadStatic_p) {
 	Clobbers string with upcase. IDENT token returns name.
 	Note, Lex strings are NUL terminated.
 */
-static inline int tdiLexIdent(
+static inline int lex_ident(
 	int len,
 	char *str,
 	struct marker *mark_ptr,
@@ -627,7 +624,7 @@ static inline int tdiLexIdent(
 	**********************/
   str_l = (char *)strncpy((char *)malloc(len + 1), (char *)str, len);
   str_l[len] = 0;
-  j = tdiHash(len, str_l);
+  j = tdi_hash(len, str_l);
   free(str_l);
   if (j < 0) {
     if (str[0] == '$')
@@ -647,7 +644,7 @@ static inline int tdiLexIdent(
 	|| token == LEX_LAND
 	|| token == LEX_LEQ
 	|| token == LEX_LEQV || token == LEX_LGE || token == LEX_LOR || token == LEX_MUL)
-      return tdiLexBinEq(token, TdiThreadStatic_p);
+      return lex_bin_eq(token, TdiThreadStatic_p);
     return token;
   }
   return (LEX_IDENT);
@@ -686,7 +683,7 @@ static inline int tdiLexIdent(
 #define len1 8			/*length of a word in bits */
 #define num1 16			/*number of words to accumulate, octaword */
 
-static int tdiLexInteger(
+static int lex_integer(
 	int len,
 	char *str,
 	struct marker *mark_ptr,
@@ -908,7 +905,7 @@ static int tdiLexInteger(
 /*--------------------------------------------------------
 	Convert Lex input to NID or absolute PATH.
 */ // used in TdiYacc.c
-int TdiLexPath(
+int tdi_lex_path(
 	int len,
 	char *str,
 	struct marker *mark_ptr,
@@ -947,7 +944,7 @@ int TdiLexPath(
 /*--------------------------------------------------------
 	Remove arrow and trailing punctation.
 */
-static inline int tdiLexPoint(
+static inline int lex_point(
 	int len,
 	char *str,
 	struct marker *mark_ptr,
@@ -961,7 +958,7 @@ static inline int tdiLexPoint(
   return LEX_POINT;
 }
 
-static inline int tdiLexPunct(
+static inline int lex_punct(
 	int len __attribute__ ((unused)),
 	char *str,
 	struct marker *mark_ptr,
@@ -977,19 +974,19 @@ static inline int tdiLexPunct(
   case '!':
     if (c1 == '=') {
       mark_ptr->builtin = OPC_NE;
-      return tdiLexBinEq(LEX_LEQS, TdiThreadStatic_p);
+      return lex_bin_eq(LEX_LEQS, TdiThreadStatic_p);
     }
     break;
   case '&':
     if (c1 == '&') {
       mark_ptr->builtin = OPC_AND;
-      return tdiLexBinEq(LEX_LANDS, TdiThreadStatic_p);
+      return lex_bin_eq(LEX_LANDS, TdiThreadStatic_p);
     }
     break;
   case '*':
     if (c1 == '*') {
       mark_ptr->builtin = OPC_POWER;
-      return tdiLexBinEq(LEX_POWER, TdiThreadStatic_p);
+      return lex_bin_eq(LEX_POWER, TdiThreadStatic_p);
     }
     break;
   case '+':
@@ -1014,43 +1011,43 @@ static inline int tdiLexPunct(
   case '/':
     if (c1 == '/') {
       mark_ptr->builtin = OPC_CONCAT;
-      return tdiLexBinEq(LEX_CONCAT, TdiThreadStatic_p);
+      return lex_bin_eq(LEX_CONCAT, TdiThreadStatic_p);
     }
     break;
   case '<':
     if (c1 == '<') {
       mark_ptr->builtin = OPC_SHIFT_LEFT;
-      return tdiLexBinEq(LEX_SHIFT, TdiThreadStatic_p);
+      return lex_bin_eq(LEX_SHIFT, TdiThreadStatic_p);
     }
     if (c1 == '=') {
       mark_ptr->builtin = OPC_LE;
-      return tdiLexBinEq(LEX_LGES, TdiThreadStatic_p);
+      return lex_bin_eq(LEX_LGES, TdiThreadStatic_p);
     }
     if (c1 == '>') {
       mark_ptr->builtin = OPC_NE;
-      return tdiLexBinEq(LEX_LEQS, TdiThreadStatic_p);
+      return lex_bin_eq(LEX_LEQS, TdiThreadStatic_p);
     }
     break;
   case '=':
     if (c1 == '=') {
       mark_ptr->builtin = OPC_EQ;
-      return tdiLexBinEq(LEX_LEQS, TdiThreadStatic_p);
+      return lex_bin_eq(LEX_LEQS, TdiThreadStatic_p);
     }
     break;
   case '>':
     if (c1 == '=') {
       mark_ptr->builtin = OPC_GE;
-      return tdiLexBinEq(LEX_LGES, TdiThreadStatic_p);
+      return lex_bin_eq(LEX_LGES, TdiThreadStatic_p);
     }
     if (c1 == '>') {
       mark_ptr->builtin = OPC_SHIFT_RIGHT;
-      return tdiLexBinEq(LEX_SHIFT, TdiThreadStatic_p);
+      return lex_bin_eq(LEX_SHIFT, TdiThreadStatic_p);
     }
     break;
   case '|':
     if (c1 == '|') {
       mark_ptr->builtin = OPC_OR;
-      return tdiLexBinEq(LEX_LORS, TdiThreadStatic_p);
+      return lex_bin_eq(LEX_LORS, TdiThreadStatic_p);
     }
     break;
   }
@@ -1065,40 +1062,40 @@ static inline int tdiLexPunct(
     return (LEX_UNARYS);
   case '%':
     mark_ptr->builtin = OPC_MOD;
-    return tdiLexBinEq(LEX_MULS, TdiThreadStatic_p);
+    return lex_bin_eq(LEX_MULS, TdiThreadStatic_p);
   case '&':
     mark_ptr->builtin = OPC_IAND;
-    return tdiLexBinEq(LEX_IAND, TdiThreadStatic_p);
+    return lex_bin_eq(LEX_IAND, TdiThreadStatic_p);
   case '*':
     mark_ptr->builtin = OPC_MULTIPLY;
-    return tdiLexBinEq('*', TdiThreadStatic_p);
+    return lex_bin_eq('*', TdiThreadStatic_p);
   case '+':
     mark_ptr->builtin = OPC_ADD;
-    return tdiLexBinEq(LEX_ADD, TdiThreadStatic_p);
+    return lex_bin_eq(LEX_ADD, TdiThreadStatic_p);
   case '-':
     mark_ptr->builtin = OPC_SUBTRACT;
-    return tdiLexBinEq(LEX_ADD, TdiThreadStatic_p);
+    return lex_bin_eq(LEX_ADD, TdiThreadStatic_p);
   case '/':
     mark_ptr->builtin = OPC_DIVIDE;
-    return tdiLexBinEq(LEX_MULS, TdiThreadStatic_p);
+    return lex_bin_eq(LEX_MULS, TdiThreadStatic_p);
   case ':':
     mark_ptr->builtin = OPC_DTYPE_RANGE;
     return (LEX_RANGE);
   case '<':
     mark_ptr->builtin = OPC_LT;
-    return tdiLexBinEq(LEX_LGES, TdiThreadStatic_p);
+    return lex_bin_eq(LEX_LGES, TdiThreadStatic_p);
   case '>':
     mark_ptr->builtin = OPC_GT;
-    return tdiLexBinEq(LEX_LGES, TdiThreadStatic_p);
+    return lex_bin_eq(LEX_LGES, TdiThreadStatic_p);
   case '@':
     mark_ptr->builtin = OPC_PROMOTE;
     return (LEX_PROMO);
   case '^':
     mark_ptr->builtin = OPC_POWER;
-    return tdiLexBinEq(LEX_POWER, TdiThreadStatic_p);
+    return lex_bin_eq(LEX_POWER, TdiThreadStatic_p);
   case '|':
     mark_ptr->builtin = OPC_IOR;
-    return tdiLexBinEq(LEX_IOR, TdiThreadStatic_p);
+    return lex_bin_eq(LEX_IOR, TdiThreadStatic_p);
   case '~':
     mark_ptr->builtin = OPC_INOT;
     return (LEX_UNARYS);
@@ -1116,7 +1113,7 @@ static inline int tdiLexPunct(
 	NEED overflow check on octal and hex. Watch sign extend of char.
 */
 
-static inline int tdiLexQuote(
+static inline int lex_quote(
 	int len __attribute__ ((unused)),
 	char *str,
 	struct marker *mark_ptr,
@@ -1211,7 +1208,7 @@ static inline int tdiLexQuote(
   return (LEX_ERROR);
 }
 
-static inline int back(const int *p, const int m) {
+static inline int lex_back(const int *p, const int m) {
   if (p == 0) return 0;
   while (*p) {
     if (*p++ == m)
@@ -1220,7 +1217,7 @@ static inline int back(const int *p, const int m) {
   return 0;
 }
 
-int look(int *leng, char *previous, char*const text, const svf_t **lstate, ThreadStatic *const TdiThreadStatic_p) {
+static int lex_look(int *leng, char *previous, char*const text, const svf_t **lstate, ThreadStatic *const TdiThreadStatic_p) {
   const svf_t *state, **lsp;
   const work_t *t;
   const svf_t *z;
@@ -1333,7 +1330,7 @@ int look(int *leng, char *previous, char*const text, const svf_t **lstate, Threa
       const int *fnd;
       if (*lsp != 0 && (fnd = (*lsp)->stops) && *fnd > 0) {
 	if (extra[*fnd]) {	/* must backup */
-	  while (back((*lsp)->stops, -*fnd) != 1 && lsp > lstate) {
+	  while (lex_back((*lsp)->stops, -*fnd) != 1 && lsp > lstate) {
 	    lsp--;
 	    --lastch;
 	    UNPUT();
@@ -1365,14 +1362,14 @@ int look(int *leng, char *previous, char*const text, const svf_t **lstate, Threa
   }
 }
 
-int TdiLex(struct marker *lvalPtr) {
+int tdi_lex(struct marker *lvalPtr) {
   GET_TDITHREADSTATIC_P;
   int nstr, leng;
   char previous = NEWLINE;
   char text[MAX_TOKEN_LEN];
   memset(text,127,MAX_TOKEN_LEN);
   const svf_t *lstate[MAX_TOKEN_LEN];
-  while ((nstr = look(&leng, &previous, text, lstate, TdiThreadStatic_p)) >= 0) {
+  while ((nstr = lex_look(&leng, &previous, text, lstate, TdiThreadStatic_p)) >= 0) {
     switch (nstr) {
       case 0:
 	return 0;
@@ -1382,34 +1379,34 @@ int TdiLex(struct marker *lvalPtr) {
 	break;
       case 3:
 	SET_POS();
-	return (tdiLexFloat(leng, text, lvalPtr, TdiThreadStatic_p));
+	return (lex_float(leng, text, lvalPtr, TdiThreadStatic_p));
       case 4:
 	SET_POS();
-	return (tdiLexFloat(leng, text, lvalPtr, TdiThreadStatic_p));
+	return (lex_float(leng, text, lvalPtr, TdiThreadStatic_p));
       case 5:
 	SET_POS();
-	return (tdiLexInteger(leng, text, lvalPtr, TdiThreadStatic_p));
+	return (lex_integer(leng, text, lvalPtr, TdiThreadStatic_p));
       case 6:
 	SET_POS();
-	return (tdiLexIdent(leng, text, lvalPtr, TdiThreadStatic_p));
+	return (lex_ident(leng, text, lvalPtr, TdiThreadStatic_p));
       case 7:
 	SET_POS();
-	return (TdiLexPath(leng, text, lvalPtr, TdiThreadStatic_p));
+	return (tdi_lex_path(leng, text, lvalPtr, TdiThreadStatic_p));
       case 8:
 	SET_POS();
-	return (tdiLexQuote(leng, text, lvalPtr, TdiThreadStatic_p));
+	return (lex_quote(leng, text, lvalPtr, TdiThreadStatic_p));
       case 9:
 	SET_POS();
-	return (tdiLexPoint(leng, text, lvalPtr, TdiThreadStatic_p));
+	return (lex_point(leng, text, lvalPtr, TdiThreadStatic_p));
       case 10:
 	SET_POS();
-	if (tdiLexComment(leng, text, lvalPtr, TdiThreadStatic_p))
+	if (lex_comment(leng, text, lvalPtr, TdiThreadStatic_p))
 	  return (LEX_ERROR);
 	else
 	  break;
       case 11:
 	SET_POS();
-	return (tdiLexPunct(leng, text, lvalPtr, TdiThreadStatic_p));
+	return (lex_punct(leng, text, lvalPtr, TdiThreadStatic_p));
       case -1:
 	break;
       default:

--- a/tdishr/TdiMakeFunctionTable.c
+++ b/tdishr/TdiMakeFunctionTable.c
@@ -32,7 +32,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 /*  *2    25-OCT-1994 08:21:07 TWF "Add TdiMAX_FUNCTION" */
 /*  *1    25-OCT-1994 08:18:33 TWF "Make TdiRefFunction table" */
 /*  CMS REPLACEMENT HISTORY, Element TDI$$MAKE_FUNCTION_TABLE.C */
-#include <STATICdef.h>
 #include <mdsdescrip.h>
 #define COM
 

--- a/tdishr/TdiMasterData.c
+++ b/tdishr/TdiMasterData.c
@@ -37,7 +37,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 	Ken Klare LANL P-4      (c)1989,1990,1991
 */
-#include <STATICdef.h>
 #include <status.h>
 #include "tdirefstandard.h"
 #include <mdsshr.h>
@@ -45,7 +44,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 
-STATIC_CONSTANT EMPTYXD(emptyxd);
+static const EMPTYXD(emptyxd);
 
 int TdiMasterData(int nsig,
 		  struct descriptor_xd sig[1],

--- a/tdishr/TdiMath1.c
+++ b/tdishr/TdiMath1.c
@@ -58,7 +58,6 @@ int Tdi3xxx(struct descriptor *in, struct descriptor *out)
 
 ------------------------------------------------------------------------------*/
 
-#include <STATICdef.h>
 #include <stdlib.h>
 #include <mdsdescrip.h>
 #include <mdsdescrip.h>
@@ -70,7 +69,7 @@ int Tdi3xxx(struct descriptor *in, struct descriptor *out)
 
 extern int CvtConvertFloat();
 
-STATIC_CONSTANT int roprand = 0x8000;
+static const int roprand = 0x8000;
 #define radians_to_degrees 57.295778
 #define degrees_to_radians 0.017453293
 
@@ -203,7 +202,7 @@ int Tdi3##name(struct descriptor *in, struct descriptor *out)\
   return 1;\
 }
 
-STATIC_ROUTINE double anint(double val)
+static double anint(double val)
 {
   int tmp;
   val += (val > 0.0) ? .5 : -.5;
@@ -211,26 +210,26 @@ STATIC_ROUTINE double anint(double val)
   return (double)tmp;
 }
 
-STATIC_ROUTINE double trunc_Static(double val)
+static double trunc_Static(double val)
 {
   return (double)((int)val);
 }
 
-STATIC_ROUTINE void cos_complex(double *in, double *out)
+static void cos_complex(double *in, double *out)
 {
   out[0] = cos(in[0]) * cosh(in[1]);
   out[1] = -sin(in[0]) * sinh(in[1]);
   return;
 }
 
-STATIC_ROUTINE void sin_complex(double *in, double *out)
+static void sin_complex(double *in, double *out)
 {
   out[0] = sin(in[0]) * cosh(in[1]);
   out[1] = cos(in[0]) * sinh(in[1]);
   return;
 }
 
-STATIC_ROUTINE void exp_complex(double *in, double *out)
+static void exp_complex(double *in, double *out)
 {
   out[0] = exp(in[0]);
   out[1] = out[0] * sin(in[1]);
@@ -238,7 +237,7 @@ STATIC_ROUTINE void exp_complex(double *in, double *out)
   return;
 }
 
-STATIC_ROUTINE double cabs_d(double in1, double in2)
+static double cabs_d(double in1, double in2)
 {
   double x = (in1 > 0) ? in1 : -in1;
   double y = (in2 > 0) ? in2 : -in2;
@@ -252,7 +251,7 @@ STATIC_ROUTINE double cabs_d(double in1, double in2)
     return y * sqrt(1 + pow((x / y), 2.0));
 }
 
-STATIC_ROUTINE void sqrt_complex(double *in, double *out)
+static void sqrt_complex(double *in, double *out)
 {
   if (in[0] == (double)0.0 && in[1] == (double)0.0) {
     out[0] = (double)0.0;
@@ -269,7 +268,7 @@ STATIC_ROUTINE void sqrt_complex(double *in, double *out)
   return;
 }
 
-STATIC_ROUTINE void log_complex(double *in, double *out)
+static void log_complex(double *in, double *out)
 {
   double theta = 0;
   if (in[0] > 0.0)
@@ -296,47 +295,47 @@ STATIC_ROUTINE void log_complex(double *in, double *out)
   return;
 }
 
-STATIC_ROUTINE double acosd_Static(double in)
+static double acosd_Static(double in)
 {
   return radians_to_degrees * acos(in);
 }
 
-STATIC_ROUTINE double asind_Static(double in)
+static double asind_Static(double in)
 {
   return radians_to_degrees * asin(in);
 }
 
-STATIC_ROUTINE double atand_Static(double in)
+static double atand_Static(double in)
 {
   return radians_to_degrees * atan(in);
 }
 
-STATIC_ROUTINE double cosd_Static(double in)
+static double cosd_Static(double in)
 {
   return cos(degrees_to_radians * in);
 }
 
-STATIC_ROUTINE double log2_Static(double in)
+static double log2_Static(double in)
 {
   return log10(in) / log10(2.);
 }
 
-STATIC_ROUTINE double sind_Static(double in)
+static double sind_Static(double in)
 {
   return sin(degrees_to_radians * in);
 }
 
-STATIC_ROUTINE double tand_Static(double in)
+static double tand_Static(double in)
 {
   return tan(degrees_to_radians * in);
 }
 
-STATIC_ROUTINE double atand2_Static(double in1, double in2)
+static double atand2_Static(double in1, double in2)
 {
   return radians_to_degrees * atan2(in1, in2);
 }
 
-STATIC_ROUTINE double atanh_Static(double in)
+static double atanh_Static(double in)
 {
   double ans;
   if (in <= -1.0 || in >= 1.)

--- a/tdishr/TdiMath2.c
+++ b/tdishr/TdiMath2.c
@@ -59,7 +59,6 @@ int Tdi3Mod(struct descriptor *in1, struct descriptor *in2, struct descriptor *o
 
 ------------------------------------------------------------------------------*/
 
-#include <STATICdef.h>
 #include <math.h>
 #include <mdsdescrip.h>
 #include <mdsdescrip.h>
@@ -115,9 +114,9 @@ extern void DoubleToWideInt();
   break;\
 }
 
-STATIC_CONSTANT const int roprand = 0x8000;
+static const int roprand = 0x8000;
 
-STATIC_ROUTINE double mod_d(double in1, double in2)
+static double mod_d(double in1, double in2)
 {
   double intpart;
   modf((in2 != 0.0) ? in1 / in2 : 0., &intpart);
@@ -145,7 +144,7 @@ STATIC_ROUTINE double mod_d(double in1, double in2)
   break;\
 }
 
-STATIC_ROUTINE void mod_bin(int size, int is_signed, char *in1, char *in2, char *out)
+static void mod_bin(int size, int is_signed, char *in1, char *in2, char *out)
 {
   double in1_d = WideIntToDouble(in1, size/sizeof(int), is_signed);
   double in2_d = WideIntToDouble(in2, size/sizeof(int), is_signed);

--- a/tdishr/TdiMatrix.c
+++ b/tdishr/TdiMatrix.c
@@ -30,9 +30,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 	Ken Klare, LANL CTR-7   (c)1990
 */
 
-#include <STATICdef.h>
 #define _MOVC3(a,b,c) memcpy(c,b,a)
-#include "STATICdef.h"
 #include "tdirefstandard.h"
 #include "tdirefcat.h"
 #include "tdinelements.h"
@@ -48,12 +46,12 @@ extern int TdiData();
 extern int TdiConvert();
 extern int TdiMasterData();
 
-STATIC_CONSTANT struct descriptor missing = { 0, DTYPE_MISSING, CLASS_S, 0 };
+static const struct descriptor missing = { 0, DTYPE_MISSING, CLASS_S, 0 };
 
 typedef struct {
   int q[2];
 } quadw;
-STATIC_ROUTINE int copy(int len, int n, char *x, int incx, char *y, int incy)
+static int copy(int len, int n, char *x, int incx, char *y, int incy)
 {
   switch (len) {
   case 1:

--- a/tdishr/TdiMaxVal.c
+++ b/tdishr/TdiMaxVal.c
@@ -72,7 +72,6 @@ int Tdi3xxxxx(struct descriptor *in, struct descriptor *mask,
 extern int Tdi3Lt();
 extern int Tdi3Gt();
 extern int Tdi3Divide();
-#include <STATICdef.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/tdishr/TdiMinMax.c
+++ b/tdishr/TdiMinMax.c
@@ -28,7 +28,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 	Ken Klare, LANL CTR-7   (c)1989,1990
 */
-#include <STATICdef.h>
 #include <status.h>
 #include "tdirefstandard.h"
 #include <stdlib.h>

--- a/tdishr/TdiPack.c
+++ b/tdishr/TdiPack.c
@@ -41,7 +41,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 	Ken Klare, LANL CTR-7   (c)1990
 */
 
-#include <STATICdef.h>
 #include "tdirefcat.h"
 #include "tdirefstandard.h"
 #include <tdishr_messages.h>

--- a/tdishr/TdiPower.c
+++ b/tdishr/TdiPower.c
@@ -30,7 +30,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 	WARNING accuracy of float base not as good as OTS$ routines, which use double.
 	Ken Klare, LANL P-4     (c)1990,1991
 */
-#include <STATICdef.h>
 #include <string.h>
 #define _MOVC3(a,b,c) memcpy(c,b,a)
 #include <mdsdescrip.h>
@@ -39,8 +38,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 
-STATIC_CONSTANT int one = 1;
-STATIC_CONSTANT struct descriptor one_dsc = { sizeof(one), DTYPE_L, CLASS_S, (char *)&one };
+static const int one = 1;
+static const struct descriptor one_dsc = { sizeof(one), DTYPE_L, CLASS_S, (char *)&one };
 
 extern int Tdi3Log();
 extern int TdiConvert();

--- a/tdishr/TdiSame.c
+++ b/tdishr/TdiSame.c
@@ -34,7 +34,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 	Ken Klare, LANL CTR-7   (c)1989,1990
 */
-#include <STATICdef.h>
 #include <status.h>
 #include <stdlib.h>
 #include <mdsdescrip.h>

--- a/tdishr/TdiScalar.c
+++ b/tdishr/TdiScalar.c
@@ -34,7 +34,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #define _MOVC3(a,b,c) memcpy(c,b,a)
 #include <mdsplus/mdsplus.h>
-#include <STATICdef.h>
 #include "tdirefcat.h"
 #include "tdireffunction.h"
 #include "tdirefstandard.h"
@@ -219,8 +218,8 @@ int Tdi3Epsilon(struct descriptor *x_ptr, struct descriptor *out_ptr)
   digits.pointer = (char *)&digits_d;
   status = TdiDigits(x_ptr, &digits MDS_END_ARG);
   if STATUS_OK {
-    STATIC_CONSTANT double two_d = 2.;
-    STATIC_CONSTANT struct descriptor two =
+    static const double two_d = 2.;
+    static const struct descriptor two =
 	{ sizeof(two_d), DTYPE_NATIVE_DOUBLE, CLASS_S, (char *)&two_d };
     digits_d = 1. - digits_d;
     status = TdiPower(&two, &digits, out_ptr MDS_END_ARG);
@@ -234,26 +233,26 @@ int Tdi3Epsilon(struct descriptor *x_ptr, struct descriptor *out_ptr)
 	HUGE(3.0) is 2**(+127)*(1-2**(-24)).
 	        real = HUGE(real)
 */
-STATIC_CONSTANT const unsigned int BU_HUGE[] = { 0xff };
-STATIC_CONSTANT const unsigned int B_HUGE[] = { 0x7f };
-STATIC_CONSTANT const unsigned int WU_HUGE[] = { 0xffff };
-STATIC_CONSTANT const unsigned int W_HUGE[] = { 0x7fff };
-STATIC_CONSTANT const unsigned int LU_HUGE[] = { 0xffffffff };
-STATIC_CONSTANT const unsigned int L_HUGE[] = { 0x7fffffff };
-STATIC_CONSTANT const unsigned int QU_HUGE[] = { 0xffffffff, 0xffffffff };
-STATIC_CONSTANT const unsigned int Q_HUGE[] = { 0xffffffff, 0x7fffffff };
-STATIC_CONSTANT const unsigned int OU_HUGE[] = { 0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff };
-STATIC_CONSTANT const unsigned int O_HUGE[] = { 0xffffffff, 0xffffffff, 0xffffffff, 0x7fffffff };
-STATIC_CONSTANT const unsigned int F_HUGE[] = { 0xFFFF7FFF };
-STATIC_CONSTANT const unsigned int FC_HUGE[] = { 0xFFFF7FFF };
-STATIC_CONSTANT const unsigned int D_HUGE[] = { 0xFFFF7FFF, 0xFFFFFFFF };
-STATIC_CONSTANT const unsigned int DC_HUGE[] = { 0xFFFF7FFF, 0xFFFFFFFF };
-STATIC_CONSTANT const unsigned int G_HUGE[] = { 0xFFFF7FFF, 0xFFFFFFFF };
-STATIC_CONSTANT const unsigned int GC_HUGE[] = { 0xFFFF7FFF, 0xFFFFFFFF };
-STATIC_CONSTANT const unsigned int FS_HUGE[] = { 0x7F7FFFFF };
-STATIC_CONSTANT const unsigned int FSC_HUGE[] = { 0x7F7FFFFF };
-STATIC_CONSTANT const unsigned int FT_HUGE[] = { 0xFFFFFFFF, 0x7FF7FFFF };
-STATIC_CONSTANT const unsigned int FTC_HUGE[] = { 0xFFFFFFFF, 0x7FF7FFFF };
+static const unsigned int BU_HUGE[] = { 0xff };
+static const unsigned int B_HUGE[] = { 0x7f };
+static const unsigned int WU_HUGE[] = { 0xffff };
+static const unsigned int W_HUGE[] = { 0x7fff };
+static const unsigned int LU_HUGE[] = { 0xffffffff };
+static const unsigned int L_HUGE[] = { 0x7fffffff };
+static const unsigned int QU_HUGE[] = { 0xffffffff, 0xffffffff };
+static const unsigned int Q_HUGE[] = { 0xffffffff, 0x7fffffff };
+static const unsigned int OU_HUGE[] = { 0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff };
+static const unsigned int O_HUGE[] = { 0xffffffff, 0xffffffff, 0xffffffff, 0x7fffffff };
+static const unsigned int F_HUGE[] = { 0xFFFF7FFF };
+static const unsigned int FC_HUGE[] = { 0xFFFF7FFF };
+static const unsigned int D_HUGE[] = { 0xFFFF7FFF, 0xFFFFFFFF };
+static const unsigned int DC_HUGE[] = { 0xFFFF7FFF, 0xFFFFFFFF };
+static const unsigned int G_HUGE[] = { 0xFFFF7FFF, 0xFFFFFFFF };
+static const unsigned int GC_HUGE[] = { 0xFFFF7FFF, 0xFFFFFFFF };
+static const unsigned int FS_HUGE[] = { 0x7F7FFFFF };
+static const unsigned int FSC_HUGE[] = { 0x7F7FFFFF };
+static const unsigned int FT_HUGE[] = { 0xFFFFFFFF, 0x7FF7FFFF };
+static const unsigned int FTC_HUGE[] = { 0xFFFFFFFF, 0x7FF7FFFF };
 
 #define CASE(dtype) case DTYPE_##dtype : memcpy(out_ptr->pointer,dtype##_HUGE,sizeof(dtype##_HUGE)); break;
 
@@ -608,11 +607,11 @@ int Tdi3SizeOf(struct descriptor *in_ptr, struct descriptor *out_ptr)
 	TINY(3.0) is 2**(-127), TINY(4G0) is 2**(-1023).
 	        real = TINY(real)
 */
-STATIC_CONSTANT unsigned int F_TINY[] = { 0x80 };
-STATIC_CONSTANT unsigned int D_TINY[] = { 0x80, 0 };
-STATIC_CONSTANT unsigned int G_TINY[] = { 0x10, 0 };
-STATIC_CONSTANT unsigned int FS_TINY[] = { 0x800000 };
-STATIC_CONSTANT unsigned int FT_TINY[] = { 0, 0x100000 };
+static const unsigned int F_TINY[] = { 0x80 };
+static const unsigned int D_TINY[] = { 0x80, 0 };
+static const unsigned int G_TINY[] = { 0x10, 0 };
+static const unsigned int FS_TINY[] = { 0x800000 };
+static const unsigned int FT_TINY[] = { 0, 0x100000 };
 
 int Tdi3Tiny(struct descriptor *in_ptr, struct descriptor *out_ptr)
 {

--- a/tdishr/TdiSetRange.c
+++ b/tdishr/TdiSetRange.c
@@ -41,7 +41,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 	NEED way to specify character string subscript range
 */
 
-#include <STATICdef.h>
 #include "tdirefcat.h"
 #include "tdirefstandard.h"
 #include <tdishr_messages.h>
@@ -60,7 +59,7 @@ extern int TdiMasterData();
 int Tdi1SetRange(opcode_t opcode, int narg, struct descriptor *list[], struct descriptor_xd *out_ptr)
 {
   INIT_STATUS;
-  STATIC_CONSTANT DESCRIPTOR_A(arr0, 1, DTYPE_BU, 0, 1);
+  static const DESCRIPTOR_A(arr0, 1, DTYPE_BU, 0, 1);
   struct descriptor_xd sig[1] = {EMPTY_XD}, uni[1] = {EMPTY_XD}, dat[1] = {EMPTY_XD}, tmp = EMPTY_XD;
   struct descriptor_range *prange;
   struct TdiCatStruct cats[2];

--- a/tdishr/TdiSetRange.c
+++ b/tdishr/TdiSetRange.c
@@ -52,7 +52,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 extern int TdiGetArgs();
-extern int TdiGetData();
+extern int tdi_get_data();
 extern int TdiGetLong();
 extern int TdiConvert();
 extern int TdiMasterData();
@@ -120,7 +120,7 @@ int Tdi1SetRange(opcode_t opcode, int narg, struct descriptor *list[], struct de
     else {
       unsigned char omits[] = {(unsigned char)DTYPE_RANGE,0};
       if STATUS_OK
-	status = TdiGetData(omits, list[j], &tmp);
+	status = tdi_get_data(omits, list[j], &tmp);
       if (STATUS_NOT_OK)
 	break;
       prange = (struct descriptor_range *)tmp.pointer;

--- a/tdishr/TdiShowVm.c
+++ b/tdishr/TdiShowVm.c
@@ -29,7 +29,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 	Ken Klare, LANL CTR-7   (c)1989,1990
 */
 
-#include <STATICdef.h>
 #include "tdirefstandard.h"
 #include <libroutines.h>
 #include <mdsshr_messages.h>

--- a/tdishr/TdiSort.c
+++ b/tdishr/TdiSort.c
@@ -46,7 +46,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 	Ken Klare, LANL P-4     (c)1990,1992
 	KK      21-Oct-1992     upcase options for BSEARCH/SORT/SORTVAL
 */
-#include <STATICdef.h>
 #include "tdinelements.h"
 #include "tdirefcat.h"
 #include "tdirefstandard.h"
@@ -83,31 +82,31 @@ extern int TdiSortVal();
 	Equality test where different.
 */
 #define NEQ_BU GTR_BU
-STATIC_ROUTINE int GTR_BU(unsigned char *a, unsigned char *b)
+static int GTR_BU(unsigned char *a, unsigned char *b)
 {
   return *a - *b;
 }
 
 #define NEQ_WU GTR_WU
-STATIC_ROUTINE int GTR_WU(unsigned short *a, unsigned short *b)
+static int GTR_WU(unsigned short *a, unsigned short *b)
 {
   return *a - *b;
 }
 
 #define NEQ_LU NEQ_L
-STATIC_ROUTINE int GTR_LU(unsigned int *a, unsigned int *b)
+static int GTR_LU(unsigned int *a, unsigned int *b)
 {
   return *a > *b;
 }
 
 #define NEQ_QU NEQ_Q
-STATIC_ROUTINE int GTR_QU(unsigned int a[2], unsigned int b[2])
+static int GTR_QU(unsigned int a[2], unsigned int b[2])
 {
   return a[1] > b[1] || (a[1] == b[1] && a[0] > b[0]);
 }
 
 #define NEQ_OU NEQ_O
-STATIC_ROUTINE int GTR_OU(unsigned int a[4], unsigned int b[4])
+static int GTR_OU(unsigned int a[4], unsigned int b[4])
 {
   return a[3] > b[3] ||
       (a[3] == b[3] &&
@@ -115,43 +114,43 @@ STATIC_ROUTINE int GTR_OU(unsigned int a[4], unsigned int b[4])
 }
 
 #define NEQ_B GTR_B
-STATIC_ROUTINE int GTR_B(char *a, char *b)
+static int GTR_B(char *a, char *b)
 {
   return *a - *b;
 }
 
 #define NEQ_W GTR_W
-STATIC_ROUTINE int GTR_W(short *a, short *b)
+static int GTR_W(short *a, short *b)
 {
   return *a - *b;
 }
 
-STATIC_ROUTINE int NEQ_L(int *a, int *b)
+static int NEQ_L(int *a, int *b)
 {
   return *a != *b;
 }
 
-STATIC_ROUTINE int GTR_L(int *a, int *b)
+static int GTR_L(int *a, int *b)
 {
   return *a > *b;
 }
 
-STATIC_ROUTINE int NEQ_Q(unsigned int a[2], unsigned int b[2])
+static int NEQ_Q(unsigned int a[2], unsigned int b[2])
 {
   return a[0] != b[0] || a[1] != b[1];
 }
 
-STATIC_ROUTINE int GTR_Q(unsigned int a[2], unsigned int b[2])
+static int GTR_Q(unsigned int a[2], unsigned int b[2])
 {
   return (int)a[1] > (int)b[1] || (a[1] == b[1] && a[0] > b[0]);
 }
 
-STATIC_ROUTINE int NEQ_O(unsigned int a[4], unsigned int b[4])
+static int NEQ_O(unsigned int a[4], unsigned int b[4])
 {
   return a[0] != b[0] || a[1] != b[1] || a[2] != b[2] || a[3] != b[3];
 }
 
-STATIC_ROUTINE int GTR_O(unsigned int a[4], unsigned int b[4])
+static int GTR_O(unsigned int a[4], unsigned int b[4])
 {
   return (int)a[3] > (int)b[3] || (a[3] == b[3]
 				   && (a[2] > b[2]
@@ -163,7 +162,7 @@ STATIC_ROUTINE int GTR_O(unsigned int a[4], unsigned int b[4])
 
 extern int CvtConvertFloat();
 
-STATIC_ROUTINE int GtrFloat(int dtype, void *a, void *b)
+static int GtrFloat(int dtype, void *a, void *b)
 {
   int ans=0;
   float a_local;
@@ -174,7 +173,7 @@ STATIC_ROUTINE int GtrFloat(int dtype, void *a, void *b)
   return ans;
 }
 
-STATIC_ROUTINE int GtrDouble(int dtype, void *a, void *b)
+static int GtrDouble(int dtype, void *a, void *b)
 {
   int ans=0;
   double a_local;
@@ -186,37 +185,37 @@ STATIC_ROUTINE int GtrDouble(int dtype, void *a, void *b)
 }
 
 #define NEQ_F NEQ_L
-STATIC_ROUTINE int GTR_F(void *a, void *b)
+static int GTR_F(void *a, void *b)
 {
   return GtrFloat(DTYPE_F, a, b);
 }
 
 #define NEQ_FS NEQ_L
-STATIC_ROUTINE int GTR_FS(void *a, void *b)
+static int GTR_FS(void *a, void *b)
 {
   return GtrFloat(DTYPE_FS, a, b);
 }
 
 #define NEQ_D NEQ_Q
-STATIC_ROUTINE int GTR_D(void *a, void *b)
+static int GTR_D(void *a, void *b)
 {
   return GtrDouble(DTYPE_D, a, b);
 }
 
 #define NEQ_G NEQ_Q
-STATIC_ROUTINE int GTR_G(void *a, void *b)
+static int GTR_G(void *a, void *b)
 {
   return GtrDouble(DTYPE_G, a, b);
 }
 
 #define NEQ_FT NEQ_Q
-STATIC_ROUTINE int GTR_FT(void *a, void *b)
+static int GTR_FT(void *a, void *b)
 {
   return GtrDouble(DTYPE_FT, a, b);
 }
 
 #define NEQ_FC NEQ_Q
-STATIC_ROUTINE int GTR_FC(float *a, float *b)
+static int GTR_FC(float *a, float *b)
 {
   if (NEQ_F((int *)a, (int *)b))
     return GTR_F(&a[0], &b[0]);
@@ -224,7 +223,7 @@ STATIC_ROUTINE int GTR_FC(float *a, float *b)
 }
 
 #define NEQ_FSC NEQ_Q
-STATIC_ROUTINE int GTR_FSC(float *a, float *b)
+static int GTR_FSC(float *a, float *b)
 {
   if (NEQ_FS((int *)a, (int *)b))
     return GTR_FS(&a[0], &b[0]);
@@ -232,7 +231,7 @@ STATIC_ROUTINE int GTR_FSC(float *a, float *b)
 }
 
 #define NEQ_DC NEQ_O
-STATIC_ROUTINE int GTR_DC(double *a, double *b)
+static int GTR_DC(double *a, double *b)
 {
   if (NEQ_D((unsigned int *)a, (unsigned int *)b))
     return GTR_D(&a[0], &b[0]);
@@ -240,7 +239,7 @@ STATIC_ROUTINE int GTR_DC(double *a, double *b)
 }
 
 #define NEQ_GC NEQ_O
-STATIC_ROUTINE int GTR_GC(double *a, double *b)
+static int GTR_GC(double *a, double *b)
 {
   if (NEQ_G((unsigned int *)a, (unsigned int *)b))
     return GTR_G(&a[0], &b[0]);
@@ -248,7 +247,7 @@ STATIC_ROUTINE int GTR_GC(double *a, double *b)
 }
 
 #define NEQ_FTC NEQ_O
-STATIC_ROUTINE int GTR_FTC(double *a, double *b)
+static int GTR_FTC(double *a, double *b)
 {
   if (NEQ_FT((unsigned int *)a, (unsigned int *)b))
     return GTR_FT(&a[0], &b[0]);
@@ -256,7 +255,7 @@ STATIC_ROUTINE int GTR_FTC(double *a, double *b)
 }
 
 #define NEQ_T GTR_T
-STATIC_ROUTINE int GTR_T(unsigned char *a, unsigned char *b, int len)
+static int GTR_T(unsigned char *a, unsigned char *b, int len)
 {
   register char *pa = (char *)a, *pb = (char *)b;
   register int n = len;
@@ -491,7 +490,7 @@ int Tdi1Bsearch(opcode_t opcode, int narg, struct descriptor *list[], struct des
 int Tdi1Sort(opcode_t opcode, int narg, struct descriptor *list[], struct descriptor_xd *out_ptr)
 {
   INIT_STATUS;
-  STATIC_THREADSAFE int64_t ran = 0;
+  static int64_t ran = 0;
   int i, j, keep, l, r, jstack, *ndx;
   int upcase = 0, cmode = -1, len, n = 0;
   int (*gtr) () = 0;

--- a/tdishr/TdiSql.c
+++ b/tdishr/TdiSql.c
@@ -700,8 +700,7 @@ int Tdi1IsqlSet()
   return 0;
 }
 #else				/* no sybase support */
-static const DESCRIPTOR(const msg,
-			   "Sybase support not compiled into TDI.  Did you want to MDSConnect ?");
+static const DESCRIPTOR(msg, "Sybase support not compiled into TDI.  Did you want to MDSConnect ?");
 
 int Tdi1Dsql(opcode_t opcode __attribute__ ((unused)), int narg __attribute__ ((unused)), const struct descriptor *list[] __attribute__ ((unused)), struct descriptor_xd *out_ptr)
 {

--- a/tdishr/TdiSql.c
+++ b/tdishr/TdiSql.c
@@ -44,7 +44,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 #include <mdstypes.h>
 #define _MOVC3(a,b,c) memcpy(c,b,a)
-#include <STATICdef.h>
 #include <string.h>
 #include <stdlib.h>
 #include <stdio.h>
@@ -79,7 +78,7 @@ extern int TdiText();
 /* MUST match declaration in DYNAMIC_SYB.C ( ../idlsql/dyanamic_syb.c ) */
 #define MAXPARSE 16384
 
-STATIC_CONSTANT DESCRIPTOR(dunderscore, "_");
+static const DESCRIPTOR(dunderscore, "_");
 typedef struct {
   unsigned int l0;
   int l1;
@@ -89,30 +88,30 @@ typedef struct {
   int c;
   struct descriptor **v;
 } ARGLIST;
-STATIC_CONSTANT double HUGE_D = 1.7e+38;
-STATIC_CONSTANT float HUGE_F = (float)1.7e+38;
-//STATIC_CONSTANT quadw HUGE_Q = { 0xffffffff, 0x7fffffff };
+static const double HUGE_D = 1.7e+38;
+static const float HUGE_F = (float)1.7e+38;
+//static const quadw HUGE_Q = { 0xffffffff, 0x7fffffff };
 
-STATIC_CONSTANT int HUGE_L = 0x7fffffff;
-STATIC_CONSTANT short HUGE_W = 0x7fff;
-STATIC_CONSTANT char HUGE_B = 0x7f;
+static const int HUGE_L = 0x7fffffff;
+static const short HUGE_W = 0x7fff;
+static const char HUGE_B = 0x7f;
 
 /*
-STATIC_CONSTANT  unsigned int nan_f_bits =  0x7fbfffff;
-STATIC_CONSTANT unsigned long long nan_d_bits = 0xffffffff7ff7ffff;
+static const  unsigned int nan_f_bits =  0x7fbfffff;
+static const unsigned long long nan_d_bits = 0xffffffff7ff7ffff;
 */
-STATIC_CONSTANT unsigned int nan_f_bits = 0x7fc00000;
+static const unsigned int nan_f_bits = 0x7fc00000;
 
 #if defined(_MSC_VER) && _MSC_VER <= 1300
-STATIC_CONSTANT uint64_t nan_d_bits = 0x7ff8000000000000U i64;
+static const uint64_t nan_d_bits = 0x7ff8000000000000U i64;
 #else
-STATIC_CONSTANT uint64_t nan_d_bits = 0x7ff8000000000000ULL;
+static const uint64_t nan_d_bits = 0x7ff8000000000000ULL;
 #endif
 
 static double d_null = 0;
 //static float f_null = 0;
 
-STATIC_CONSTANT const char *default_date = "Jan 01 1970 12:00:00:000AM";
+static const char *default_date = "Jan 01 1970 12:00:00:000AM";
 //static DESCRIPTOR(ddate, "dd-mmm-yyyy hh:mm:ss.cc");
 //static int (*USERSQL_ERRORS) () = 0;
 //static int (*USERSQL_GETS) () = 0;
@@ -155,11 +154,11 @@ typedef const LPBYTE LPCBYTE;
 #endif
 
 /*********************************************************/
-STATIC_ROUTINE int TDISQL_LINK(char *name, int (**routine) ())
+static int TDISQL_LINK(char *name, int (**routine) ())
 {
-  STATIC_CONSTANT DESCRIPTOR(dimage, "MdsSql");
+  static const DESCRIPTOR(dimage, "MdsSql");
 #ifdef __APPLE__
-  STATIC_CONSTANT DESCRIPTOR(dimage2, "sybdb");
+  static const DESCRIPTOR(dimage2, "sybdb");
 #endif
   DESCRIPTOR_FROM_CSTRING(dname,name);
   int status = TdiFindImageSymbol(&dimage, &dname, routine);
@@ -171,11 +170,11 @@ STATIC_ROUTINE int TDISQL_LINK(char *name, int (**routine) ())
 }
 
 /*********************************************************/
-STATIC_ROUTINE int TDISQL_LINKCPTR(char *name, char *(**routine) ())
+static int TDISQL_LINKCPTR(char *name, char *(**routine) ())
 {
-  STATIC_CONSTANT DESCRIPTOR(dimage, "MdsSql");
+  static const DESCRIPTOR(dimage, "MdsSql");
 #ifdef __APPLE__
-  STATIC_CONSTANT DESCRIPTOR(dimage2, "sybdb");
+  static const DESCRIPTOR(dimage2, "sybdb");
 #endif
   DESCRIPTOR_FROM_CSTRING(dname,name);
   int status = TdiFindImageSymbol(&dimage, &dname, routine);
@@ -215,7 +214,7 @@ static void FreeBuffers()
 
 #define INITIAL_GUESS 32767
 
-STATIC_ROUTINE void AppendAnswer(int idx, void *buffer, int len, int dtype)
+static void AppendAnswer(int idx, void *buffer, int len, int dtype)
 {
   int needed = len;
   /*
@@ -246,7 +245,7 @@ STATIC_ROUTINE void AppendAnswer(int idx, void *buffer, int len, int dtype)
   }
 }
 
-STATIC_ROUTINE void StoreAnswer(int idx, struct descriptor *dst, int type)
+static void StoreAnswer(int idx, struct descriptor *dst, int type)
 {
   INIT_STATUS;
   DESCRIPTOR_A(src, 0, 0, 0, 0);
@@ -318,7 +317,7 @@ STATIC_ROUTINE void StoreAnswer(int idx, struct descriptor *dst, int type)
   bufs[idx].size = 0;
 }
 
-STATIC_ROUTINE int Puts(dbproc, prows, arg)
+static int Puts(dbproc, prows, arg)
 DBPROCESS *dbproc;
 int *prows;
 ARGLIST *arg;
@@ -455,8 +454,8 @@ ARGLIST *arg;
 				       SYBCHAR, (unsigned char *)ddate,
 				       sizeof(ddate) - 1);
 
-	    STATIC_CONSTANT char *moname = "JanFebMarAprMayJunJulAugSepOctNovDec";
-	    STATIC_CONSTANT int day[] = { 0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304,
+	    static const char *moname = "JanFebMarAprMayJunJulAugSepOctNovDec";
+	    static const int day[] = { 0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304,
 	      334
 	    };
 	    char mon[4], *moptr, ampm[3];
@@ -556,7 +555,7 @@ if (pout == pout_end) {\
   return 0;\
 }
 
-STATIC_ROUTINE int Gets(pin, pout, nmarks, arg)
+static int Gets(pin, pout, nmarks, arg)
 char *pin, *pout;
 int *nmarks;
 ARGLIST *arg;
@@ -615,7 +614,7 @@ int Tdi1Dsql(opcode_t opcode __attribute__ ((unused)), int narg, struct descript
   struct descriptor_d dtext = { 0, DTYPE_T, CLASS_D, 0 };
   struct descriptor_d dq_text = { 0, DTYPE_T, CLASS_D, 0 };
   struct descriptor drows = { sizeof(rows), DTYPE_L, CLASS_S, 0 };
-  STATIC_CONSTANT DESCRIPTOR(zero, "\0");
+  static const DESCRIPTOR(zero, "\0");
   drows.pointer = (char *)&rows;
   user_args.c = narg - 1;
   user_args.v = &list[1];
@@ -701,7 +700,7 @@ int Tdi1IsqlSet()
   return 0;
 }
 #else				/* no sybase support */
-STATIC_CONSTANT DESCRIPTOR(const msg,
+static const DESCRIPTOR(const msg,
 			   "Sybase support not compiled into TDI.  Did you want to MDSConnect ?");
 
 int Tdi1Dsql(opcode_t opcode __attribute__ ((unused)), int narg __attribute__ ((unused)), const struct descriptor *list[] __attribute__ ((unused)), struct descriptor_xd *out_ptr)

--- a/tdishr/TdiSql.c
+++ b/tdishr/TdiSql.c
@@ -70,8 +70,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 extern int stat;
 extern int TdiFindImageSymbol();
 extern int TdiGetLong();
-extern int TdiGetIdent();
-extern int TdiPutIdent();
+extern int tdi_get_ident();
+extern int tdi_put_ident();
 extern int TdiData();
 extern int TdiVector();
 extern int TdiText();
@@ -310,9 +310,9 @@ STATIC_ROUTINE void StoreAnswer(int idx, struct descriptor *dst, int type)
     status = MDSplusERROR;
   }
   if STATUS_OK
-    status = TdiPutIdent(dst, &xs);
+    status = tdi_put_ident(dst, &xs);
   else
-    status = TdiPutIdent(dst, &xd);
+    status = tdi_put_ident(dst, &xd);
   free(bufs[idx].vptr);
   bufs[idx].vptr = 0;
   bufs[idx].size = 0;
@@ -382,7 +382,7 @@ ARGLIST *arg;
 	  bufs[j].len = SYB_dbdatlen(dbproc, j + 1);
 	}
 	/*
-	   if (rows == -1) status = TdiPutIdent(dst, &tmp);
+	   if (rows == -1) status = tdi_put_ident(dst, &tmp);
 	 */
 /*
 	                        len = SYB_dbdatlen(dbproc, j+1);

--- a/tdishr/TdiSquare.c
+++ b/tdishr/TdiSquare.c
@@ -29,7 +29,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 #include <mdsdescrip.h>
 #include <status.h>
-#include <STATICdef.h>
 
 
 

--- a/tdishr/TdiStatement.c
+++ b/tdishr/TdiStatement.c
@@ -30,7 +30,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 	Ken Klare, LANL P-24    (c)1989,1990,1995
 */
 
-#include <STATICdef.h>
 #include "tdirefstandard.h"
 #include <strroutines.h>
 #include <tdishr_messages.h>
@@ -46,7 +45,7 @@ extern int TdiGe();
 extern int TdiLe();
 extern int TdiEq();
 
-STATIC_ROUTINE int goto1(int, struct descriptor *[], struct descriptor_xd *);
+static int goto1(int, struct descriptor *[], struct descriptor_xd *);
 
 /*-----------------------------------------------------------------
 	ABORT processing.
@@ -279,7 +278,7 @@ int Tdi1Return(opcode_t opcode __attribute__ ((unused)), int narg, struct descri
 	WHERE (exp) stmt ELSEWHERE stmt
 	{stmt ...}
 */
-STATIC_ROUTINE int goto1(int narg, struct descriptor *list[], struct descriptor_xd *out_ptr)
+static int goto1(int narg, struct descriptor *list[], struct descriptor_xd *out_ptr)
 {
   int status = SsINTERNAL;
   int j = 0, off, opcode;
@@ -347,7 +346,7 @@ int Tdi1Statement(opcode_t opcode __attribute__ ((unused)), int narg, struct des
 	        FOR IF ELSE SWITCH WHERE ELSEWHERE or WHILE.
 	NEED to handle vector cases and stepped ranges, NEED IS_IN.
 */
-STATIC_ROUTINE int switch1(struct descriptor *ptest,
+static int switch1(struct descriptor *ptest,
 			   int *jdefault,
 			   struct descriptor_function ***pdefault,
 			   int narg,

--- a/tdishr/TdiSubscript.c
+++ b/tdishr/TdiSubscript.c
@@ -56,7 +56,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 	Ken Klare, LANL P-4     (c)1990,1991
 */
-#include <STATICdef.h>
 #include "tdirefcat.h"
 #include "tdirefstandard.h"
 #include "tdinelements.h"

--- a/tdishr/TdiThreadStatic.c
+++ b/tdishr/TdiThreadStatic.c
@@ -25,7 +25,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define _GNU_SOURCE
 #include <mdsplus/mdsconfig.h>
 #include <libroutines.h>
-#include <STATICdef.h>
 #include "tdithreadstatic.h"
 #include <stdlib.h>
 #include <mdsshr.h>

--- a/tdishr/TdiTrim.c
+++ b/tdishr/TdiTrim.c
@@ -27,7 +27,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 	Ken Klare, LANL P-4     (c)1989,1990,1991
 */
-#include <STATICdef.h>
 #include "tdinelements.h"
 #include "tdirefcat.h"
 #include "tdireffunction.h"
@@ -103,7 +102,7 @@ int Tdi3OpcodeBuiltin(struct descriptor *in_ptr, struct descriptor_xd *out_ptr)
 {
   int ind = TdiFUNCTION_MAX;
   INIT_STATUS;
-  STATIC_CONSTANT dtype_t dtype = DTYPE_T;
+  static const dtype_t dtype = DTYPE_T;
   status = TdiGetLong(in_ptr, &ind);
   if (STATUS_OK && ind < (int)TdiFUNCTION_MAX) {
     char *name_ptr = TdiRefFunction[ind].name;
@@ -123,10 +122,10 @@ int Tdi3OpcodeBuiltin(struct descriptor *in_ptr, struct descriptor_xd *out_ptr)
 */
 int Tdi3OpcodeString(struct descriptor *in_ptr, struct descriptor_xd *out_ptr)
 {
-  STATIC_CONSTANT DESCRIPTOR(str1, "OPC" "$");
+  static const DESCRIPTOR(str1, "OPC" "$");
   int ind = TdiFUNCTION_MAX;
   INIT_STATUS;
-  STATIC_CONSTANT dtype_t dtype = DTYPE_T;
+  static const dtype_t dtype = DTYPE_T;
   status = TdiGetLong(in_ptr, &ind);
   if (STATUS_OK && ind < TdiFUNCTION_MAX) {
     char *name_ptr = TdiRefFunction[ind].name;

--- a/tdishr/TdiUnary.c
+++ b/tdishr/TdiUnary.c
@@ -56,7 +56,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
        use without specific written approval of MIT Plasma Fusion Center
        Management.
 ------------------------------------------------------------------------------*/
-#include <STATICdef.h>
 #include <mdsdescrip.h>
 #include <tdishr_messages.h>
 

--- a/tdishr/TdiUndef.c
+++ b/tdishr/TdiUndef.c
@@ -28,7 +28,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
 #include <tdishr_messages.h>
-#include <STATICdef.h>
 
 
 #define UNDEF(x) int x() {return TdiNO_OPC;}

--- a/tdishr/TdiVar.c
+++ b/tdishr/TdiVar.c
@@ -44,9 +44,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 	        [PRIVATE|PUBLIC] var --         post-decrement
 	        DEALLOCATE (var...)             free data field
 	Utilities:
-	        TdiFindIdent(search, var, [key], [node_ptr], [block_ptr])
-	        TdiGetIdent(var, data)  fetch variable
-	        TdiPutIdent(var, data)  store variable
+	        find_ident(search, var, [key], [node_ptr], [block_ptr])
+	        tdi_get_ident(var, data)  fetch variable
+	        tdi_put_ident(var, data)  store variable
 	        RESET_PRIVATE() RESET_PUBLIC()  release variables
 	        SHOW_PRIVATE([text],...)
 	        SHOW_PUBLIC([text],...)         display variables
@@ -147,22 +147,22 @@ mdsdsc_t *Tdi3Narg(){
 /*--------------------------------------------------------------
 	Put a byte to output.
 */
-int TdiPutLogical(unsigned char data, mdsdsc_xd_t *out_ptr){
+int tdi_put_logical(uint8_t data, mdsdsc_xd_t *const out_ptr){
   INIT_STATUS;
-  length_t len = (length_t)sizeof(unsigned char);
+  length_t len = (length_t)sizeof(uint8_t);
   dtype_t dtype = DTYPE_BU;
   if (!out_ptr)
     return TdiNULL_PTR;
   status = MdsGet1DxS(&len, &dtype, out_ptr);
   if STATUS_OK
-    *(unsigned char *)out_ptr->pointer->pointer = data;
+    *(uint8_t *)out_ptr->pointer->pointer = data;
   return status;
 }
 
 /*--------------------------------------------------------------
 	Comparison routine.
 */
-static int compare(mdsdsc_t *key_ptr, node_type * node_ptr, block_type * block_ptr __attribute__ ((unused))){
+static int compare(const mdsdsc_t *const key_ptr, const node_type *const node_ptr, const block_type *const block_ptr __attribute__ ((unused))){
   return StrCaseBlindCompare(key_ptr, &node_ptr->name_dsc);
 }
 
@@ -170,7 +170,7 @@ static int compare(mdsdsc_t *key_ptr, node_type * node_ptr, block_type * block_p
 	Allocation routine, does not set data field.
 	ASSUMED called only once per node.
 */
-static int allocate(mdsdsc_t *key_ptr, node_type ** node_ptr_ptr, block_type * block_ptr){
+static int allocate(const mdsdsc_t *const key_ptr, node_type **const node_ptr_ptr, block_type *const block_ptr){
   INIT_STATUS;
   unsigned int len = sizeof(struct link) - 1 + key_ptr->length;
 
@@ -199,13 +199,14 @@ static int allocate(mdsdsc_t *key_ptr, node_type ** node_ptr_ptr, block_type * b
 	if block_ptr is returned and public public_lock is acquired
 */
 #define _private (*(block_type*)&TDI_VAR_PRIVATE)
-static int TdiFindIdent(int search,
-	                        mdsdsc_r_t *ident_ptr,
-	                        mdsdsc_t *key_ptr,
-	                        node_type ** node_ptr_ptr, block_type ** block_ptr_ptr)
-{
+static int find_ident(
+	const int search,
+	const mdsdsc_r_t *const ident_ptr,
+	mdsdsc_t *const key_ptr,
+	node_type **const node_ptr_ptr,
+	block_type **const block_ptr_ptr,
+	TDITHREADSTATIC_ARG) {
   INIT_STATUS;
-  GET_TDITHREADSTATIC_P;
   mdsdsc_t key_dsc;
   mdsdsc_d_t name_dsc;
   node_type *node_ptr;
@@ -281,29 +282,29 @@ static int TdiFindIdent(int search,
 	        So strip ++ and += and use public.
 	        ***************************************/
       if (code == OPC_PUBLIC)
-	status = TdiFindIdent(search & ~1,
+	status = find_ident(search & ~1,
 	                 (mdsdsc_r_t *)ident_ptr->dscptrs[0],
-	                 &key_dsc, &node_ptr, block_ptr_ptr);
+	                 &key_dsc, &node_ptr, block_ptr_ptr,TDITHREADSTATIC_PASS);
       else if (code == OPC_PRIVATE)
-	status = TdiFindIdent(search & ~2,
+	status = find_ident(search & ~2,
 	                 (mdsdsc_r_t *)ident_ptr->dscptrs[0],
-	                 &key_dsc, &node_ptr, block_ptr_ptr);
+	                 &key_dsc, &node_ptr, block_ptr_ptr,TDITHREADSTATIC_PASS);
       else if (code == OPC_EQUALS || code == OPC_EQUALS_FIRST
 	       || code == OPC_POST_DEC || code == OPC_PRE_DEC
 	       || code == OPC_POST_INC || code == OPC_PRE_INC) {
 	INIT_AND_FREEXD_ON_EXIT(tmp);
 	status = TdiEvaluate(ident_ptr, &tmp MDS_END_ARG);
 	if STATUS_OK
-	  status = TdiFindIdent(search,
+	  status = find_ident(search,
 	                   (mdsdsc_r_t *)ident_ptr->dscptrs[0],
-			   &key_dsc, &node_ptr, block_ptr_ptr);
+			   &key_dsc, &node_ptr, block_ptr_ptr,TDITHREADSTATIC_PASS);
 	FREEXD_NOW(tmp);
       } else if (code == OPC_VAR) {
 	name_dsc = EMPTY_D;
 	status = TdiData(ident_ptr->dscptrs[0], &name_dsc MDS_END_ARG);
 	if STATUS_OK
-	  status = TdiFindIdent(search, (mdsdsc_r_t *)&name_dsc,
-	                   &key_dsc, &node_ptr, block_ptr_ptr);
+	  status = find_ident(search, (mdsdsc_r_t *)&name_dsc,
+	                   &key_dsc, &node_ptr, block_ptr_ptr,TDITHREADSTATIC_PASS);
 	StrFree1Dx((mdsdsc_d_t *)&name_dsc);
       } else
 	status = TdiINV_OPC;
@@ -324,26 +325,15 @@ static int TdiFindIdent(int search,
   return status;
 }
 
-int TdiFindSymbol(char* name){
-  mdsdsc_s_t ident_ptr = { strlen(name), DTYPE_T, CLASS_S, name };
-  node_type *node_ptr;
-  block_type *block_ptr = NULL;
-  int status;
-  UNLOCK_PUBLIC_PUSH;
-  status = TdiFindIdent(7, (mdsdsc_r_t *)&ident_ptr, 0, &node_ptr, &block_ptr);
-  UNLOCK_IF_PUBLIC(block_ptr);
-  return STATUS_OK ? (block_ptr==&_public ? 2 : 1) : (status==TdiUNKNOWN_VAR ? 0 : -1);
-}
-
 /*--------------------------------------------------------------
 	Get active variable for VAR and EVALUATE. Copies to MDSSHR space.
 */
-int TdiGetIdent(mdsdsc_t *ident_ptr, mdsdsc_xd_t *data_ptr){
+static int get_ident(const mdsdsc_t *const ident_ptr, mdsdsc_xd_t *const data_ptr,TDITHREADSTATIC_ARG){
   node_type *node_ptr;
   block_type *block_ptr = NULL;
   INIT_STATUS;
   UNLOCK_PUBLIC_PUSH;
-  status = TdiFindIdent(7, (mdsdsc_r_t *)ident_ptr, 0, &node_ptr, &block_ptr);
+  status = find_ident(7, (mdsdsc_r_t *)ident_ptr, 0, &node_ptr, &block_ptr,TDITHREADSTATIC_PASS);
 #ifdef DEBUG
   char string[64];
   memcpy(string,ident_ptr->pointer,ident_ptr->length);string[ident_ptr->length] = '\0';
@@ -356,24 +346,26 @@ int TdiGetIdent(mdsdsc_t *ident_ptr, mdsdsc_xd_t *data_ptr){
   UNLOCK_IF_PUBLIC(block_ptr);
   return status;
 }
+int tdi_get_ident(const mdsdsc_t *const ident_ptr, mdsdsc_xd_t *const data_ptr) {
+  GET_TDITHREADSTATIC_P;
+  return get_ident(ident_ptr,data_ptr,TDITHREADSTATIC_PASS);
+}
 
 /*--------------------------------------------------------------
 	Keep an XD-DSC of whatever.
 	Assumes we are given XD or class-0.
 */
-int TdiPutIdent(mdsdsc_r_t *ident_ptr, mdsdsc_xd_t *data_ptr){
+static inline int put_ident_inner(const mdsdsc_r_t *const ident_ptr, mdsdsc_xd_t *const data_ptr,TDITHREADSTATIC_ARG){
+  INIT_STATUS;
+  block_type *block_ptr = NULL;
+  UNLOCK_PUBLIC_PUSH;
   mdsdsc_t key_dsc = EMPTDY_S;
   node_type *node_ptr;
-  block_type *block_ptr = NULL;
   mdsdsc_d_t upstr = { 0, DTYPE_T, CLASS_D, 0 };
-  INIT_STATUS;
-  if (ident_ptr->dtype == DTYPE_DSC)
-    return TdiPutIdent((mdsdsc_r_t *)ident_ptr->pointer, data_ptr);
 	/************************************
 	Find where we should place the stuff.
 	************************************/
-  UNLOCK_PUBLIC_PUSH;
-  status = TdiFindIdent(3, ident_ptr, &key_dsc, 0, &block_ptr);
+  status = find_ident(3, ident_ptr, &key_dsc, 0, &block_ptr,TDITHREADSTATIC_PASS);
   StrUpcase((mdsdsc_t *)&upstr, &key_dsc);
 #ifdef DEBUG
   char string[64];
@@ -400,16 +392,28 @@ int TdiPutIdent(mdsdsc_r_t *ident_ptr, mdsdsc_xd_t *data_ptr){
   UNLOCK_IF_PUBLIC(block_ptr);
   return status;
 }
+static int put_ident(const mdsdsc_r_t *ident_ptr, mdsdsc_xd_t *const data_ptr,TDITHREADSTATIC_ARG){
+  while (ident_ptr->dtype == DTYPE_DSC)
+    ident_ptr = (mdsdsc_r_t *)ident_ptr->pointer;
+  return put_ident_inner(ident_ptr, data_ptr, TDITHREADSTATIC_PASS);
+}
+int tdi_put_ident(const mdsdsc_r_t *ident_ptr, mdsdsc_xd_t *const data_ptr) {
+  GET_TDITHREADSTATIC_P;
+  while (ident_ptr->dtype == DTYPE_DSC)
+    ident_ptr = (mdsdsc_r_t *)ident_ptr->pointer;
+  return put_ident_inner(ident_ptr, data_ptr, TDITHREADSTATIC_PASS);
+}
+
 
 /***************************************************************
 	Display/free wildcarded variables.
 	IDENT names are not evaluated.
 	PUBLIC or PRIVATE(ident or text) overrides block_ptr.
 */
-static int wild_loop(int (*doit) (),mdsdsc_t *arg,user_type* user_p) {
+static int wild_loop(int (*const doit) (), const mdsdsc_t *const arg, user_type *const user_p,TDITHREADSTATIC_ARG) {
   int status;
   UNLOCK_PUBLIC_PUSH;
-  status = TdiFindIdent(3, (mdsdsc_r_t *)arg, &user_p->match, 0, &user_p->block_ptr);
+  status = find_ident(3, (mdsdsc_r_t *)arg, &user_p->match, 0, &user_p->block_ptr,TDITHREADSTATIC_PASS);
   if STATUS_OK
     status = StrUpcase(&user_p->match, &user_p->match);
   if STATUS_OK {
@@ -428,11 +432,13 @@ static int wild_loop(int (*doit) (),mdsdsc_t *arg,user_type* user_p) {
   UNLOCK_IF_PUBLIC(user_p->block_ptr);
   return status;
 }
-static int wild(int (*doit) (),
-			int narg,
-			mdsdsc_t *list[],
-			block_type * block_ptr, mdsdsc_xd_t *out_ptr)
-{
+static int wild(
+	int (*const doit) (),
+	const int narg,
+	mdsdsc_t *const list[],
+	block_type *const block_ptr,
+	mdsdsc_xd_t *const out_ptr,
+	TDITHREADSTATIC_ARG) {
   INIT_STATUS;
   user_type user = { {0, DTYPE_T, CLASS_D, 0}, 0, 0 };
   user.block_ptr = block_ptr;
@@ -441,7 +447,7 @@ static int wild(int (*doit) (),
   else {
     int j;
     for (j = 0; STATUS_OK && j < narg; ++j)
-      status = wild_loop(doit,list[j],&user);
+      status = wild_loop(doit,list[j],&user,TDITHREADSTATIC_PASS);
   }
   if (user.match.class == CLASS_D)
     StrFree1Dx((mdsdsc_d_t *)&user.match);
@@ -453,8 +459,7 @@ static int wild(int (*doit) (),
 /*--------------------------------------------------------------
 	Release variables.
 */
-static int free_one(node_type * node_ptr, user_type * user_ptr)
-{
+static int free_one(node_type *const node_ptr, user_type *const user_ptr) {
   block_type *block_ptr = user_ptr->block_ptr;
   INIT_STATUS;
 
@@ -481,20 +486,18 @@ static int free_one(node_type * node_ptr, user_type * user_ptr)
 	Release all variables under a header and the headers too.
 	Used to release the FUN variables.
 */
-static int free_all(node_type ** pnode)
-{
+static int free_all(node_type **const pnode,TDITHREADSTATIC_ARG) {
   INIT_STATUS, stat2;
-  GET_TDITHREADSTATIC_P;
   unsigned int len;
   if ((*pnode)->xd.l_length)
     status = LibFreeVm(&(*pnode)->xd.l_length, (void *)&(*pnode)->xd.pointer, &_private.data_zone);
   if ((*pnode)->left) {
-    stat2 = free_all(&((*pnode)->left));
+    stat2 = free_all(&((*pnode)->left),TDITHREADSTATIC_PASS);
     if STATUS_OK
       status = stat2;
   }
   if ((*pnode)->right) {
-    stat2 = free_all(&((*pnode)->right));
+    stat2 = free_all(&((*pnode)->right),TDITHREADSTATIC_PASS);
     if STATUS_OK
       status = stat2;
   }
@@ -509,30 +512,29 @@ static int free_all(node_type ** pnode)
 /*--------------------------------------------------------------
 	Release variables.
 */
-int Tdi1Deallocate(opcode_t opcode __attribute__ ((unused)), int narg, mdsdsc_t *list[], mdsdsc_xd_t *out_ptr)
-{
+int Tdi1Deallocate(opcode_t opcode __attribute__ ((unused)), int narg, mdsdsc_t *list[], mdsdsc_xd_t *out_ptr) {
   INIT_STATUS;
   GET_TDITHREADSTATIC_P;
   if (narg == 0 && _private.head) {
-    status = free_all(&_private.head);
+    status = free_all(&_private.head,TDITHREADSTATIC_PASS);
     _private.head = NULL;
     return status;
   }
-  return wild((int (*)())free_one, narg, list, &_private, out_ptr); // runs on public and private, or clears private if no args
+  return wild((int (*)())free_one, narg, list, &_private, out_ptr,TDITHREADSTATIC_PASS); // runs on public and private, or clears private if no args
 }
 
 /*--------------------------------------------------------------
 	Check for allocated variable, private only by default.
 */
-int Tdi1Allocated(opcode_t opcode __attribute__ ((unused)), int narg __attribute__ ((unused)), mdsdsc_t *list[], mdsdsc_xd_t *out_ptr)
-{
+int Tdi1Allocated(opcode_t opcode __attribute__ ((unused)), int narg __attribute__ ((unused)), mdsdsc_t *list[], mdsdsc_xd_t *out_ptr) {
   INIT_STATUS;
+  GET_TDITHREADSTATIC_P;
   mdsdsc_t key_dsc = EMPTDY_S;
   node_type *node_ptr;
   block_type *block_ptr;
   int found;
   UNLOCK_PUBLIC_PUSH;
-  status = TdiFindIdent(3, (mdsdsc_r_t *)list[0], &key_dsc, 0, &block_ptr);
+  status = find_ident(3, (mdsdsc_r_t *)list[0], &key_dsc, 0, &block_ptr,TDITHREADSTATIC_PASS);
   if STATUS_OK
     status = LibLookupTree((void **)&block_ptr->head, (void *)&key_dsc, compare, (void **)&node_ptr);
   UNLOCK_IF_PUBLIC(block_ptr);
@@ -542,7 +544,7 @@ int Tdi1Allocated(opcode_t opcode __attribute__ ((unused)), int narg __attribute
   else if (status == LibKEYNOTFOU || status == TdiUNKNOWN_VAR)
     status = MDSplusSUCCESS;
   if STATUS_OK
-    status = TdiPutLogical((unsigned char)found, out_ptr);
+    status = tdi_put_logical((unsigned char)found, out_ptr);
   return status;
 }
 
@@ -552,12 +554,13 @@ int Tdi1Allocated(opcode_t opcode __attribute__ ((unused)), int narg __attribute
 int Tdi1Present(opcode_t opcode __attribute__ ((unused)), int narg __attribute__ ((unused)), mdsdsc_t *list[], mdsdsc_xd_t *out_ptr)
 {
   INIT_STATUS;
+  GET_TDITHREADSTATIC_P;
   mdsdsc_t key_dsc = EMPTDY_S;
   node_type *node_ptr;
   block_type *block_ptr;
   int found;
   UNLOCK_PUBLIC_PUSH;
-  status = TdiFindIdent(3, (mdsdsc_r_t *)list[0], &key_dsc, 0, &block_ptr);
+  status = find_ident(3, (mdsdsc_r_t *)list[0], &key_dsc, 0, &block_ptr,TDITHREADSTATIC_PASS);
   if STATUS_OK
     status = LibLookupTree((void **)&block_ptr->head, (void *)&key_dsc, compare, (void **)&node_ptr);
   UNLOCK_IF_PUBLIC(block_ptr);
@@ -566,7 +569,7 @@ int Tdi1Present(opcode_t opcode __attribute__ ((unused)), int narg __attribute__
   else if (status == LibKEYNOTFOU || status == TdiUNKNOWN_VAR)
     status = MDSplusSUCCESS;
   if STATUS_OK
-    status = TdiPutLogical((unsigned char)found, out_ptr);
+    status = tdi_put_logical((unsigned char)found, out_ptr);
   return status;
 }
 
@@ -577,7 +580,7 @@ typedef enum {
 EXT_NONE,EXT_FUN,EXT_PY
 } ext_t;
 
-static inline ext_t matchext(const mdsdsc_d_t* file){
+static inline ext_t matchext(const mdsdsc_d_t *const file){
   if (file->length<4) return EXT_NONE;
   char* p = file->pointer+file->length-4;
   char ext[5] = {p[0],toupper(p[1]),toupper(p[2]),toupper(p[3]),'\0'};
@@ -585,7 +588,7 @@ static inline ext_t matchext(const mdsdsc_d_t* file){
   if (strcmp(ext+1,".PY")==0) return EXT_PY;
   return EXT_NONE;
 }
-static inline int findfile_fun(mdsdsc_t *entry, char**funfile,char** pyfile) {
+static inline int findfile_fun(const mdsdsc_t *const entry, char **const funfile,char **const pyfile) {
   int status;
   INIT_AND_FREED_ON_EXIT(bufd,DTYPE_T);
   ext_t isext = EXT_NONE;
@@ -633,7 +636,7 @@ static inline int findfile_fun(mdsdsc_t *entry, char**funfile,char** pyfile) {
 }
 
 extern int TdiCompile();
-int compile_fun(mdsdsc_t *entry,char *file) {
+static int compile_fun(const mdsdsc_t *const entry,const char *const file) {
   if (!file) return  TdiUNKNOWN_VAR;
   int status;
   INIT_AND_FREEXD_ON_EXIT(tmp);
@@ -679,10 +682,10 @@ int compile_fun(mdsdsc_t *entry,char *file) {
   return status;
 }
 
-extern int loadPyFunction(const char*filepath,char**funname);
-extern int callPyFunction(const char*filename,int nargs,mdsdsc_r_t **args,mdsdsc_xd_t *out_ptr);
-static int findFun(mdsdsc_t *ident_ptr, node_type **node_ptr) {
-  int status = TdiFindIdent(7, (mdsdsc_r_t *)ident_ptr, 0, node_ptr, 0);
+extern int tdi_load_python_fun(const char *const filepath,char **const funname);
+extern int tdi_call_python_fun(const char *const filename,const int nargs,const mdsdsc_r_t *const *const args,mdsdsc_xd_t *const out_ptr);
+static int find_fun(const mdsdsc_t *const ident_ptr, node_type **const node_ptr,TDITHREADSTATIC_ARG) {
+  int status = find_ident(7, (mdsdsc_r_t *)ident_ptr, 0, node_ptr, 0,TDITHREADSTATIC_PASS);
   if (status==TdiUNKNOWN_VAR) {
     INIT_AND_FREE_ON_EXIT(char*,pyfile);
     INIT_AND_FREE_ON_EXIT(char*,funfile);
@@ -690,14 +693,14 @@ static int findFun(mdsdsc_t *ident_ptr, node_type **node_ptr) {
     status = findfile_fun(ident_ptr, &funfile, &pyfile);
     if (pyfile) {
       char *funname;
-      status = loadPyFunction(pyfile,&funname);
+      status = tdi_load_python_fun(pyfile,&funname);
       if STATUS_OK {
 	mdsdsc_t function = {strlen(funname),DTYPE_T,CLASS_S,funname};
 	mdsdsc_xd_t tmp = EMPTY_XD;
 	status = MdsCopyDxXd((mdsdsc_t *)&function, &tmp);
 	free(funname);
 	if STATUS_OK {
-	  status = TdiPutIdent((mdsdsc_r_t *)ident_ptr, &tmp);
+	  status = put_ident((mdsdsc_r_t *)ident_ptr, &tmp,TDITHREADSTATIC_PASS);
 	  MdsFree1Dx(&tmp, NULL);
 	}
       }
@@ -707,18 +710,17 @@ static int findFun(mdsdsc_t *ident_ptr, node_type **node_ptr) {
       status = compile_fun(ident_ptr,funfile);
     FREE_NOW(funfile);
     FREE_NOW(pyfile);
-    if STATUS_OK status = TdiFindIdent(7, (mdsdsc_r_t *)ident_ptr, 0, node_ptr, 0);
+    if STATUS_OK status = find_ident(7, (mdsdsc_r_t *)ident_ptr, 0, node_ptr, 0,TDITHREADSTATIC_PASS);
   }
   return status;
 }
 
 static pthread_mutex_t lock;
-static void unlock(void *p) {
-  ThreadStatic *const TdiThreadStatic_p = (ThreadStatic *)p;
+static void unlock(TDITHREADSTATIC_ARG) {
   TDI_VAR_REC = FALSE;
   pthread_mutex_unlock(&lock);
 }
-int TdiDoFun(mdsdsc_t *ident_ptr, int nactual, mdsdsc_r_t *actual_arg_ptr[], mdsdsc_xd_t *out_ptr) {
+int TdiDoFun(const mdsdsc_t *const ident_ptr, const int nactual, const mdsdsc_r_t *const actual_arg_ptr[], mdsdsc_xd_t *const out_ptr) {
   GET_TDITHREADSTATIC_P;
   node_type *node_ptr;
 /******************************************
@@ -727,22 +729,22 @@ Get name of function to do. Check its type.
   int status;
   // look up method: check cached, check python, or load
   if (TDI_VAR_REC)
-    status = findFun(ident_ptr,&node_ptr);
+    status = find_fun(ident_ptr,&node_ptr,TDITHREADSTATIC_PASS);
   else {
     pthread_mutex_lock(&lock);
     TDI_VAR_REC = TRUE;
-    pthread_cleanup_push(unlock,(void*)TdiThreadStatic_p);
-    status = findFun(ident_ptr,&node_ptr);
+    pthread_cleanup_push((void*)unlock,(void*)TDITHREADSTATIC_PASS);
+    status = find_fun(ident_ptr,&node_ptr,TDITHREADSTATIC_PASS);
     pthread_cleanup_pop(1);
   }
   if STATUS_NOT_OK return status;
-  mdsdsc_r_t *formal_ptr = 0, *formal_arg_ptr, *actual_ptr;
+  const mdsdsc_r_t *formal_ptr = 0, *formal_arg_ptr, *actual_ptr;
   if ((formal_ptr = (mdsdsc_r_t *)node_ptr->xd.pointer) == 0) return TdiUNKNOWN_VAR;
   if (formal_ptr->dtype == DTYPE_T) {
     char *funname = malloc(formal_ptr->length+1);
     FREE_ON_EXIT(funname);
     memcpy(funname,formal_ptr->pointer,formal_ptr->length);funname[formal_ptr->length]='\0';
-    status = callPyFunction(funname,nactual,actual_arg_ptr,out_ptr);
+    status = tdi_call_python_fun(funname,nactual,actual_arg_ptr,out_ptr);
     FREE_NOW(funname);
     return status;
   }
@@ -807,14 +809,14 @@ Get name of function to do. Check its type.
     } else if (code == OPC_OUT) {
       old_head = _private.head;
       _private.head = new_head;
-      status = TdiPutIdent(formal_arg_ptr, 0);
+      status = put_ident(formal_arg_ptr, 0,TDITHREADSTATIC_PASS);
       new_head = _private.head;
       _private.head = old_head;
     } else {
       if (code == OPC_AS_IS) {
 	status = MdsCopyDxXd((mdsdsc_t *)actual_ptr, &tmp);
       } else if (actual_ptr->dtype == DTYPE_IDENT) {
-	status = TdiGetIdent((mdsdsc_t *)actual_ptr, &tmp);
+	status = get_ident((mdsdsc_t *)actual_ptr, &tmp,TDITHREADSTATIC_PASS);
 	if (opt && status == TdiUNKNOWN_VAR)
 	  status = MDSplusSUCCESS;
       } else {
@@ -828,7 +830,7 @@ Get name of function to do. Check its type.
       old_head = _private.head;
       _private.head = new_head;
       if STATUS_OK
-	status = TdiPutIdent(formal_arg_ptr, &tmp);
+	status = put_ident(formal_arg_ptr, &tmp,TDITHREADSTATIC_PASS);
       new_head = _private.head;
       _private.head = old_head;
     }
@@ -860,14 +862,14 @@ Get name of function to do. Check its type.
       }
       if (code == OPC_INOUT || code == OPC_OUT) {
 	status =
-	    TdiFindIdent(7, (mdsdsc_r_t *)formal_arg_ptr->dscptrs[0], 0, &node_ptr, 0);
+	    find_ident(7, (mdsdsc_r_t *)formal_arg_ptr->dscptrs[0], 0, &node_ptr, 0, TDITHREADSTATIC_PASS);
 				/**************************
 	                        Do this with old variables.
 	                        **************************/
 	new_head = _private.head;
 	_private.head = old_head;
 	if STATUS_OK
-	  status = TdiPutIdent(actual_arg_ptr[j], &node_ptr->xd);
+	  status = put_ident(actual_arg_ptr[j], &node_ptr->xd, TDITHREADSTATIC_PASS);
 	old_head = _private.head;
 	_private.head = new_head;
       }
@@ -886,15 +888,15 @@ Get name of function to do. Check its type.
 int Tdi1Equals(opcode_t opcode __attribute__ ((unused)), int narg __attribute__ ((unused)), mdsdsc_t *list[], mdsdsc_xd_t *out_ptr)
 {
   INIT_STATUS;
-
+  GET_TDITHREADSTATIC_P;
   status = TdiEvaluate(list[1], out_ptr MDS_END_ARG);
 	/************************************
 	Place the data or clear the variable.
 	************************************/
   if STATUS_OK
-    status = TdiPutIdent((mdsdsc_r_t *)list[0], out_ptr);
+    status = put_ident((mdsdsc_r_t *)list[0], out_ptr, TDITHREADSTATIC_PASS);
   else
-    TdiPutIdent((mdsdsc_r_t *)list[0], 0);
+    put_ident((mdsdsc_r_t *)list[0], NULL, TDITHREADSTATIC_PASS);
   return status;
 }
 
@@ -918,39 +920,33 @@ int Tdi1EqualsFirst(opcode_t opcode __attribute__ ((unused)), int narg __attribu
 int Tdi1PreDec(opcode_t opcode __attribute__ ((unused)), int narg __attribute__ ((unused)), mdsdsc_t *list[], mdsdsc_xd_t *out_ptr)
 {
   INIT_STATUS;
-
   status = TdiSubtract(list[0], &true_dsc, out_ptr MDS_END_ARG);
   if STATUS_OK
-    status = TdiPutIdent((mdsdsc_r_t *)list[0], out_ptr);
+    status = tdi_put_ident((mdsdsc_r_t *)list[0], out_ptr);
   return status;
 }
 
 /*--------------------------------------------------------------
 	Increment a variable before use.
 */
-int Tdi1PreInc(opcode_t opcode __attribute__ ((unused)), int narg __attribute__ ((unused)), mdsdsc_t *list[], mdsdsc_xd_t *out_ptr)
-{
-  INIT_STATUS;
-
-  status = TdiAdd(list[0], &true_dsc, out_ptr MDS_END_ARG);
+int Tdi1PreInc(opcode_t opcode __attribute__ ((unused)), int narg __attribute__ ((unused)), mdsdsc_t *list[], mdsdsc_xd_t *out_ptr) {
+  int status = TdiAdd(list[0], &true_dsc, out_ptr MDS_END_ARG);
   if STATUS_OK
-    status = TdiPutIdent((mdsdsc_r_t *)list[0], out_ptr);
+    status = tdi_put_ident((mdsdsc_r_t *)list[0], out_ptr);
   return status;
 }
 
 /*--------------------------------------------------------------
 	Decrement a variable after use.
 */
-int Tdi1PostDec(opcode_t opcode __attribute__ ((unused)), int narg __attribute__ ((unused)), mdsdsc_t *list[], mdsdsc_xd_t *out_ptr)
-{
-  INIT_STATUS;
-  mdsdsc_xd_t tmp = EMPTY_XD;
-
-  status = TdiGetIdent(list[0], out_ptr);
+int Tdi1PostDec(opcode_t opcode __attribute__ ((unused)), int narg __attribute__ ((unused)), mdsdsc_t *list[], mdsdsc_xd_t *out_ptr) {
+  GET_TDITHREADSTATIC_P;
+  EMPTYXD(tmp);
+  int status = get_ident(list[0], out_ptr, TDITHREADSTATIC_PASS);
   if STATUS_OK
     status = TdiSubtract(out_ptr->pointer, &true_dsc, &tmp MDS_END_ARG);
   if STATUS_OK
-    status = TdiPutIdent((mdsdsc_r_t *)list[0], &tmp);
+    status = put_ident((mdsdsc_r_t *)list[0], &tmp, TDITHREADSTATIC_PASS);
   MdsFree1Dx(&tmp, NULL);
   return status;
 }
@@ -960,13 +956,13 @@ int Tdi1PostDec(opcode_t opcode __attribute__ ((unused)), int narg __attribute__
 */
 int Tdi1PostInc(opcode_t opcode __attribute__ ((unused)), int narg __attribute__ ((unused)), mdsdsc_t *list[], mdsdsc_xd_t *out_ptr)
 {
-  INIT_STATUS;
-  mdsdsc_xd_t tmp = EMPTY_XD;
-  status = TdiGetIdent(list[0], out_ptr);
+  GET_TDITHREADSTATIC_P;
+  EMPTYXD(tmp);
+  int status = get_ident(list[0], out_ptr, TDITHREADSTATIC_PASS);
   if STATUS_OK
     status = TdiAdd(out_ptr->pointer, &true_dsc, &tmp MDS_END_ARG);
   if STATUS_OK
-    status = TdiPutIdent((mdsdsc_r_t *)list[0], &tmp);
+    status = put_ident((mdsdsc_r_t *)list[0], &tmp, TDITHREADSTATIC_PASS);
   MdsFree1Dx(&tmp, NULL);
   return status;
 }
@@ -978,10 +974,9 @@ int Tdi1PostInc(opcode_t opcode __attribute__ ((unused)), int narg __attribute__
 */
 int Tdi1Private(opcode_t opcode __attribute__ ((unused)), int narg __attribute__ ((unused)), mdsdsc_t *list[], mdsdsc_xd_t *out_ptr)
 {
-  INIT_STATUS;
   GET_TDITHREADSTATIC_P;
   node_type *node_ptr;
-  status = LibLookupTree((void **)&_private.head, (void *)list[0], compare, (void **)&node_ptr);
+  int status = LibLookupTree((void **)&_private.head, (void *)list[0], compare, (void **)&node_ptr);
   if STATUS_OK
     status = MdsCopyDxXd(node_ptr->xd.pointer, out_ptr);
   else if (status == LibKEYNOTFOU)
@@ -1012,12 +1007,12 @@ int Tdi1Public(opcode_t opcode __attribute__ ((unused)), int narg __attribute__(
 */
 int Tdi1Var(opcode_t opcode __attribute__ ((unused)), int narg, mdsdsc_t *list[], mdsdsc_xd_t *out_ptr)
 {
-  INIT_STATUS;
+  int status;
   INIT_AND_FREEXD_ON_EXIT(tmp);
   status = TdiData(list[0], &tmp MDS_END_ARG);
   if STATUS_OK {
     if (narg < 2 || list[1] == 0)
-      status = TdiGetIdent(tmp.pointer, out_ptr);
+      status = tdi_get_ident(tmp.pointer, out_ptr);
     else
       status = TdiEquals(tmp.pointer, list[1], out_ptr MDS_END_ARG);
   }
@@ -1028,9 +1023,7 @@ int Tdi1Var(opcode_t opcode __attribute__ ((unused)), int narg, mdsdsc_t *list[]
 /***************************************************************
 	Define a function by reconstruction.
 */
-int Tdi1Fun(opcode_t opcode, int narg, mdsdsc_t *list[], mdsdsc_xd_t *out_ptr)
-{
-  INIT_STATUS;
+int Tdi1Fun(opcode_t opcode, int narg, mdsdsc_t *list[], mdsdsc_xd_t *out_ptr) {
   DESCRIPTOR_FUNCTION(hold, 0, 255);
   int j;
   unsigned short opcode_s = (unsigned short)opcode;
@@ -1039,9 +1032,9 @@ int Tdi1Fun(opcode_t opcode, int narg, mdsdsc_t *list[], mdsdsc_xd_t *out_ptr)
   for (j = narg; --j >= 0;)
     if ((hold.arguments[j] = list[j]) == 0)
       return TdiNULL_PTR;
-  status = MdsCopyDxXd((mdsdsc_t *)&hold, out_ptr);
+  int status = MdsCopyDxXd((mdsdsc_t *)&hold, out_ptr);
   if STATUS_OK
-    status = TdiPutIdent((mdsdsc_r_t *)list[0], out_ptr);
+    status = tdi_put_ident((mdsdsc_r_t *)list[0], out_ptr);
   return status;
 }
 
@@ -1049,8 +1042,7 @@ int Tdi1Fun(opcode_t opcode, int narg, mdsdsc_t *list[], mdsdsc_xd_t *out_ptr)
 	Release the private variables.
 	This to be used by functions.
 */
-int Tdi1ResetPrivate()
-{
+int Tdi1ResetPrivate() {
   INIT_STATUS;
   GET_TDITHREADSTATIC_P;
   _private.head = 0;
@@ -1082,8 +1074,7 @@ int Tdi1ResetPublic()
 /***************************************************************
 	Display a variable.
 */
-static int show_one(node_type * node_ptr, user_type * user_ptr)
-{
+static int show_one(const node_type *const node_ptr, user_type *const user_ptr) {
   INIT_STATUS;
   mdsdsc_d_t tmp = EMPTY_D;
   mdsdsc_r_t *rptr = (mdsdsc_r_t *)node_ptr->xd.pointer;
@@ -1123,7 +1114,7 @@ static int show_one(node_type * node_ptr, user_type * user_ptr)
 int Tdi1ShowPrivate(opcode_t opcode __attribute__ ((unused)), int narg, mdsdsc_t *list[], mdsdsc_xd_t *out_ptr){
   GET_TDITHREADSTATIC_P;
   DBG("TdiShowPrivate: %"PRIxPTR"\n",(uintptr_t)(void*)_private.head);
-  return wild((int (*)())show_one, narg, list, &_private, out_ptr);
+  return wild((int (*)())show_one, narg, list, &_private, out_ptr,TDITHREADSTATIC_PASS);
 }
 
 /*--------------------------------------------------------------
@@ -1132,7 +1123,8 @@ int Tdi1ShowPrivate(opcode_t opcode __attribute__ ((unused)), int narg, mdsdsc_t
 int Tdi1ShowPublic(opcode_t opcode __attribute__ ((unused)), int narg, mdsdsc_t *list[], mdsdsc_xd_t *out_ptr){
   int status;
   LOCK_PUBLIC_PUSH;
-  status = wild((int (*)())show_one, narg, list, &_public, out_ptr);
+  GET_TDITHREADSTATIC_P;
+  status = wild((int (*)())show_one, narg, list, &_public, out_ptr,TDITHREADSTATIC_PASS);
   UNLOCK_PUBLIC;
   return status;
 }
@@ -1170,7 +1162,7 @@ extern EXPORT int TdiDeleteContext(void *ptr[6]){
 /*-------------------------------------------------------------
 	Restore variable context
 */
-extern EXPORT int TdiRestoreContext(void *ptr[6]){
+extern EXPORT int TdiRestoreContext(void *const ptr[6]){
   GET_TDITHREADSTATIC_P;
   DBG("TdiRestoreContext: %"PRIxPTR"\n",(uintptr_t)ptr[0]);
   _private.head = (node_type *) ptr[0];

--- a/tdishr/TdiVar.c
+++ b/tdishr/TdiVar.c
@@ -1056,17 +1056,15 @@ int Tdi1ResetPrivate() {
 /*--------------------------------------------------------------
 	Release the public variables.
 */
-int Tdi1ResetPublic()
-{
+int Tdi1ResetPublic() {
   int status;
   LOCK_PUBLIC_PUSH;
+  status = MDSplusSUCCESS;
   _public.head = 0;
-  TdiResetGetRecord();
   if (_public.data_zone)
     status = LibResetVmZone(&_public.data_zone);
-  else if (_public.head_zone)
+  if (_public.head_zone)
     status = LibResetVmZone(&_public.head_zone);
-  else status = MDSplusSUCCESS;
   UNLOCK_PUBLIC;
   return status;
 }

--- a/tdishr/TdiVector.c
+++ b/tdishr/TdiVector.c
@@ -33,7 +33,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 	Ken Klare, LANL P-4     (c)1989,1990,1991
 */
 
-#include "STATICdef.h"
 #include "tdirefcat.h"
 #include "tdirefstandard.h"
 #include "tdinelements.h"

--- a/tdishr/TdiXxx.c
+++ b/tdishr/TdiXxx.c
@@ -27,7 +27,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 	Ken Klare, LANL P-4     (c)1989,1990,1991
 */
-#include <STATICdef.h>
 #include "tdirefcat.h"
 #include "tdirefstandard.h"
 #include <strroutines.h>
@@ -41,17 +40,17 @@ extern int TdiConcat();
 extern int TdiTranslate();
 extern int TdiGetLong();
 
-STATIC_CONSTANT DESCRIPTOR(asterisk, "*");
-STATIC_CONSTANT DESCRIPTOR(slash, "/");
-STATIC_CONSTANT DESCRIPTOR(slash_star, "/*");
-STATIC_CONSTANT DESCRIPTOR(star_slash, "*/");
-STATIC_CONSTANT DESCRIPTOR(bad, "?");
-STATIC_CONSTANT struct descriptor_xd BAD = { 0, DTYPE_DSC, CLASS_XS, (struct descriptor *)&bad, 0 };
+static const DESCRIPTOR(asterisk, "*");
+static const DESCRIPTOR(slash, "/");
+static const DESCRIPTOR(slash_star, "/*");
+static const DESCRIPTOR(star_slash, "*/");
+static const DESCRIPTOR(bad, "?");
+static const struct descriptor_xd BAD = { 0, DTYPE_DSC, CLASS_XS, (struct descriptor *)&bad, 0 };
 
 /********************************
 Units must match or one be empty.
 ********************************/
-STATIC_ROUTINE int either(struct descriptor_xd uni[2])
+static int either(struct descriptor_xd uni[2])
 {
 
   if (uni[0].pointer == 0) {
@@ -69,7 +68,7 @@ STATIC_ROUTINE int either(struct descriptor_xd uni[2])
 /*******************************
 Discard units unless mismatched.
 *******************************/
-STATIC_ROUTINE int only_mismatch(struct descriptor_xd uni[2])
+static int only_mismatch(struct descriptor_xd uni[2])
 {
 
   either(uni);
@@ -81,7 +80,7 @@ STATIC_ROUTINE int only_mismatch(struct descriptor_xd uni[2])
 /*****************
 Concatenate units.
 *****************/
-STATIC_ROUTINE void multiply(struct descriptor_xd *left_ptr, struct descriptor_xd *right_ptr)
+static void multiply(struct descriptor_xd *left_ptr, struct descriptor_xd *right_ptr)
 {
   INIT_STATUS;
 
@@ -99,7 +98,7 @@ STATIC_ROUTINE void multiply(struct descriptor_xd *left_ptr, struct descriptor_x
 /*****************
 Reciprocate units.
 *****************/
-STATIC_ROUTINE void divide(struct descriptor_xd *left_ptr, struct descriptor_xd *right_ptr)
+static void divide(struct descriptor_xd *left_ptr, struct descriptor_xd *right_ptr)
 {
   INIT_STATUS;
 

--- a/tdishr/TdiXxxOf.c
+++ b/tdishr/TdiXxxOf.c
@@ -37,7 +37,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 extern int TdiGetData();
 extern int TdiGetLong();
-extern int TdiPutLogical();
+extern int tdi_put_logical();
 extern int TdiEvaluate();
 extern int TdiDispatchOf();
 extern int TdiBuildRange();
@@ -208,7 +208,7 @@ int Tdi1ClassOf(opcode_t opcode __attribute__ ((unused)), int narg __attribute__
     class = px->class;
   else
     class = DTYPE_MISSING;
-  status = TdiPutLogical(class, out_ptr);
+  status = tdi_put_logical(class, out_ptr);
   return status;
 }
 
@@ -496,7 +496,7 @@ int Tdi1KindOf(opcode_t opcode __attribute__ ((unused)), int narg __attribute__ 
     dtype = px->dtype;
   else
     dtype = DTYPE_MISSING;
-  status = TdiPutLogical(dtype, out_ptr);
+  status = tdi_put_logical(dtype, out_ptr);
   return status;
 }
 
@@ -859,7 +859,7 @@ int Tdi1NdescOf(opcode_t opcode __attribute__ ((unused)), int narg __attribute__
     switch (pr->class) {
     case CLASS_R:
       ndesc = pr->ndesc;
-      status = TdiPutLogical(ndesc, out_ptr);
+      status = tdi_put_logical(ndesc, out_ptr);
       break;
     default:
       status = TdiINVCLADSC;

--- a/tdishr/TdiXxxOf.c
+++ b/tdishr/TdiXxxOf.c
@@ -35,7 +35,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 
-extern int TdiGetData();
+extern int tdi_get_data();
 extern int TdiGetLong();
 extern int tdi_put_logical();
 extern int TdiEvaluate();
@@ -55,7 +55,7 @@ int Tdi1ArgOf(opcode_t opcode __attribute__ ((unused)), int narg, struct descrip
   INIT_STATUS;
   struct descriptor_xd tmp = EMPTY_XD;
   unsigned int iarg = 0;
-  STATIC_CONSTANT unsigned char omits[] = {
+  static const dtype_t omits[] = {
     DTYPE_CALL,
     DTYPE_CONDITION,
     DTYPE_DEPENDENCY,
@@ -66,7 +66,7 @@ int Tdi1ArgOf(opcode_t opcode __attribute__ ((unused)), int narg, struct descrip
     0
   };
 
-  status = TdiGetData(omits, list[0], &tmp);
+  status = tdi_get_data(omits, list[0], &tmp);
   if (STATUS_OK && narg > 1)
     status = TdiGetLong(list[1], &iarg);
   if (STATUS_OK && tmp.pointer->class != CLASS_R)
@@ -117,14 +117,14 @@ int Tdi1AxisOf(opcode_t opcode __attribute__ ((unused)), int narg __attribute__ 
 {
   INIT_STATUS;
   struct descriptor_xd tmp = EMPTY_XD;
-  STATIC_CONSTANT unsigned char omits[] = {
+  static const dtype_t omits[] = {
     DTYPE_DIMENSION,
     DTYPE_SLOPE,
     DTYPE_RANGE,
     0
   };
 
-  status = TdiGetData(omits, list[0], &tmp);
+  status = tdi_get_data(omits, list[0], &tmp);
   if STATUS_OK
     switch (tmp.pointer->dtype) {
     case DTYPE_DIMENSION:
@@ -154,14 +154,14 @@ int Tdi1BeginOf(opcode_t opcode __attribute__ ((unused)), int narg, struct descr
   INIT_STATUS;
   struct descriptor_xd tmp = EMPTY_XD;
   unsigned int n = 0;
-  STATIC_CONSTANT unsigned char omits[] = {
+  static const dtype_t omits[] = {
     DTYPE_RANGE,
     DTYPE_SLOPE,
     DTYPE_WINDOW,
     0
   };
 
-  status = TdiGetData(omits, list[0], &tmp);
+  status = tdi_get_data(omits, list[0], &tmp);
   if STATUS_OK
     switch (tmp.pointer->dtype) {
     case DTYPE_RANGE:
@@ -251,12 +251,12 @@ int Tdi1CompletionMessageOf(opcode_t opcode __attribute__ ((unused)), int narg _
 {
   INIT_STATUS;
   struct descriptor_xd tmp = EMPTY_XD;
-  STATIC_CONSTANT unsigned char omits[] = {
+  static const dtype_t omits[] = {
     DTYPE_ACTION,
     0
   };
 
-  status = TdiGetData(omits, list[0], &tmp);
+  status = tdi_get_data(omits, list[0], &tmp);
   if STATUS_OK
     switch (tmp.pointer->dtype) {
     case DTYPE_ACTION:
@@ -281,12 +281,12 @@ int Tdi1ConditionOf(opcode_t opcode __attribute__ ((unused)), int narg __attribu
 {
   INIT_STATUS;
   struct descriptor_xd tmp = EMPTY_XD;
-  STATIC_CONSTANT unsigned char omits[] = {
+  static const dtype_t omits[] = {
     DTYPE_CONDITION,
     0
   };
 
-  status = TdiGetData(omits, list[0], &tmp);
+  status = tdi_get_data(omits, list[0], &tmp);
   if STATUS_OK
     switch (tmp.pointer->dtype) {
     case DTYPE_CONDITION:
@@ -315,7 +315,7 @@ int Tdi1DimOf(opcode_t opcode __attribute__ ((unused)), int narg, struct descrip
   int dimct;
   int l, u;
   int index = 0;
-  STATIC_CONSTANT unsigned char omits[] = {
+  static const dtype_t omits[] = {
     DTYPE_SIGNAL,
     DTYPE_DIMENSION,
     0
@@ -324,7 +324,7 @@ int Tdi1DimOf(opcode_t opcode __attribute__ ((unused)), int narg, struct descrip
 	/**************************************
 	For array of signals, give array range.
 	**************************************/
-  status = TdiGetData(omits, list[0], &tmp);
+  status = tdi_get_data(omits, list[0], &tmp);
   if (STATUS_OK && narg > 1)
     status = TdiGetLong(list[1], &index);
 
@@ -370,7 +370,7 @@ int Tdi1DimOf(opcode_t opcode __attribute__ ((unused)), int narg, struct descrip
 	    || ((struct descriptor_signal *)pa)->dimensions[index] == 0) {
 	  struct descriptor_s index_dsc = { sizeof(int), DTYPE_L, CLASS_S, 0 };
 	  index_dsc.pointer = (char *)&index;
-	  status = TdiGetData(&omits[1], &tmp, &tmp);
+	  status = tdi_get_data(&omits[1], &tmp, &tmp);
 	  if STATUS_OK
 	    status = TdiDimOf(&tmp, &index_dsc, out_ptr MDS_END_ARG);
 	} else
@@ -398,13 +398,13 @@ int Tdi1DispatchOf(opcode_t opcode __attribute__ ((unused)), int narg __attribut
 {
   INIT_STATUS;
   struct descriptor_xd tmp = EMPTY_XD;
-  STATIC_CONSTANT unsigned char omits[] = {
+  static const dtype_t omits[] = {
     DTYPE_ACTION,
     DTYPE_DISPATCH,
     0
   };
 
-  status = TdiGetData(omits, list[0], &tmp);
+  status = tdi_get_data(omits, list[0], &tmp);
   if STATUS_OK
     switch (tmp.pointer->dtype) {
     case DTYPE_ACTION:
@@ -525,14 +525,14 @@ int Tdi1EndOf(opcode_t opcode __attribute__ ((unused)), int narg, struct descrip
   INIT_STATUS;
   struct descriptor_xd tmp = EMPTY_XD;
   unsigned int n = 0;
-  STATIC_CONSTANT unsigned char omits[] = {
+  static const dtype_t omits[] = {
     DTYPE_RANGE,
     DTYPE_SLOPE,
     DTYPE_WINDOW,
     0
   };
 
-  status = TdiGetData(omits, list[0], &tmp);
+  status = tdi_get_data(omits, list[0], &tmp);
   if STATUS_OK
     switch (tmp.pointer->dtype) {
     case DTYPE_RANGE:
@@ -572,12 +572,12 @@ int Tdi1ErrorOf(opcode_t opcode __attribute__ ((unused)), int narg __attribute__
   INIT_STATUS;
   STATIC_CONSTANT DESCRIPTOR(none, "");
   struct descriptor_xd tmp = EMPTY_XD;
-  STATIC_CONSTANT unsigned char omits[] = {
+  static const dtype_t omits[] = {
     DTYPE_WITH_ERROR,
     0
   };
 
-  status = TdiGetData(omits, list[0], &tmp);
+  status = tdi_get_data(omits, list[0], &tmp);
   if STATUS_OK
     switch (tmp.pointer->dtype) {
     case DTYPE_WITH_ERROR:
@@ -599,11 +599,11 @@ int Tdi1ErrorlogsOf(opcode_t opcode __attribute__ ((unused)), int narg __attribu
 {
   INIT_STATUS;
   struct descriptor_xd tmp = EMPTY_XD;
-  STATIC_CONSTANT unsigned char omits[] = {
+  static const dtype_t omits[] = {
     DTYPE_ACTION,
     0
   };
-  status = TdiGetData(omits, list[0], &tmp);
+  status = tdi_get_data(omits, list[0], &tmp);
   if STATUS_OK
     switch (tmp.pointer->dtype) {
     case DTYPE_ACTION:
@@ -628,12 +628,12 @@ int Tdi1HelpOf(opcode_t opcode __attribute__ ((unused)), int narg __attribute__ 
 {
   INIT_STATUS;
   struct descriptor_xd tmp = EMPTY_XD;
-  STATIC_CONSTANT unsigned char omits[] = {
+  static const dtype_t omits[] = {
     DTYPE_PARAM,
     0
   };
 
-  status = TdiGetData(omits, list[0], &tmp);
+  status = tdi_get_data(omits, list[0], &tmp);
   if STATUS_OK
     switch (tmp.pointer->dtype) {
     case DTYPE_PARAM:
@@ -673,14 +673,14 @@ int Tdi1ImageOf(opcode_t opcode __attribute__ ((unused)), int narg __attribute__
 {
   INIT_STATUS;
   struct descriptor_xd tmp = EMPTY_XD;
-  STATIC_CONSTANT unsigned char omits[] = {
+  static const dtype_t omits[] = {
     DTYPE_CALL,
     DTYPE_CONGLOM,
     DTYPE_ROUTINE,
     0
   };
 
-  status = TdiGetData(omits, list[0], &tmp);
+  status = tdi_get_data(omits, list[0], &tmp);
   if STATUS_OK
     switch (tmp.pointer->dtype) {
     case DTYPE_CALL:
@@ -718,7 +718,7 @@ int Tdi1InterruptOf(opcode_t opcode __attribute__ ((unused)), int narg __attribu
   if STATUS_OK {
     pd = (struct descriptor_dispatch *)tmp.pointer;
     if (*(char *)pd->pointer != TreeSCHED_ASYNC) {
-      status = TdiGetData(omits, pd->when, out_ptr);
+      status = tdi_get_data(omits, pd->when, out_ptr);
       if STATUS_OK {
 	if (out_ptr->pointer == 0 || out_ptr->pointer->dtype != DTYPE_T)
 	  status = TdiINVDTYDSC;
@@ -739,12 +739,12 @@ int Tdi1LanguageOf(opcode_t opcode __attribute__ ((unused)), int narg __attribut
 {
   INIT_STATUS;
   struct descriptor_xd tmp = EMPTY_XD;
-  STATIC_CONSTANT unsigned char omits[] = {
+  static const dtype_t omits[] = {
     DTYPE_PROCEDURE,
     0
   };
 
-  status = TdiGetData(omits, list[0], &tmp);
+  status = tdi_get_data(omits, list[0], &tmp);
   if STATUS_OK
     switch (tmp.pointer->dtype) {
     case DTYPE_PROCEDURE:
@@ -766,13 +766,13 @@ int Tdi1MethodOf(opcode_t opcode __attribute__ ((unused)), int narg __attribute_
 {
   INIT_STATUS;
   struct descriptor_xd tmp = EMPTY_XD;
-  STATIC_CONSTANT unsigned char omits[] = {
+  static const dtype_t omits[] = {
     DTYPE_METHOD,
     DTYPE_OPAQUE,
     0
   };
 
-  status = TdiGetData(omits, list[0], &tmp);
+  status = tdi_get_data(omits, list[0], &tmp);
   if STATUS_OK
     switch (tmp.pointer->dtype) {
     case DTYPE_METHOD:
@@ -797,12 +797,12 @@ int Tdi1ModelOf(opcode_t opcode __attribute__ ((unused)), int narg __attribute__
 {
   INIT_STATUS;
   struct descriptor_xd tmp = EMPTY_XD;
-  STATIC_CONSTANT unsigned char omits[] = {
+  static const dtype_t omits[] = {
     DTYPE_CONGLOM,
     0
   };
 
-  status = TdiGetData(omits, list[0], &tmp);
+  status = tdi_get_data(omits, list[0], &tmp);
   if STATUS_OK
     switch (tmp.pointer->dtype) {
     case DTYPE_CONGLOM:
@@ -824,12 +824,12 @@ int Tdi1NameOf(opcode_t opcode __attribute__ ((unused)), int narg __attribute__ 
 {
   INIT_STATUS;
   struct descriptor_xd tmp = EMPTY_XD;
-  STATIC_CONSTANT unsigned char omits[] = {
+  static const dtype_t omits[] = {
     DTYPE_CONGLOM,
     0
   };
 
-  status = TdiGetData(omits, list[0], &tmp);
+  status = tdi_get_data(omits, list[0], &tmp);
   if STATUS_OK
     switch (tmp.pointer->dtype) {
     case DTYPE_CONGLOM:
@@ -892,12 +892,12 @@ int Tdi1ObjectOf(opcode_t opcode __attribute__ ((unused)), int narg __attribute_
 {
   INIT_STATUS;
   struct descriptor_xd tmp = EMPTY_XD;
-  STATIC_CONSTANT unsigned char omits[] = {
+  static const dtype_t omits[] = {
     DTYPE_METHOD,
     0
   };
 
-  status = TdiGetData(omits, list[0], &tmp);
+  status = tdi_get_data(omits, list[0], &tmp);
   if STATUS_OK
     switch (tmp.pointer->dtype) {
     case DTYPE_METHOD:
@@ -920,12 +920,12 @@ int Tdi1PerformanceOf(opcode_t opcode __attribute__ ((unused)), int narg __attri
 {
   INIT_STATUS;
   struct descriptor_xd tmp = EMPTY_XD;
-  STATIC_CONSTANT unsigned char omits[] = {
+  static const dtype_t omits[] = {
     DTYPE_ACTION,
     0
   };
 
-  status = TdiGetData(omits, list[0], &tmp);
+  status = tdi_get_data(omits, list[0], &tmp);
   if STATUS_OK
     switch (tmp.pointer->dtype) {
     case DTYPE_ACTION:
@@ -966,12 +966,12 @@ int Tdi1ProcedureOf(opcode_t opcode __attribute__ ((unused)), int narg __attribu
 {
   INIT_STATUS;
   struct descriptor_xd tmp = EMPTY_XD;
-  STATIC_CONSTANT unsigned char omits[] = {
+  static const dtype_t omits[] = {
     DTYPE_PROCEDURE,
     0
   };
 
-  status = TdiGetData(omits, list[0], &tmp);
+  status = tdi_get_data(omits, list[0], &tmp);
   if STATUS_OK
     switch (tmp.pointer->dtype) {
     case DTYPE_PROCEDURE:
@@ -993,12 +993,12 @@ int Tdi1ProgramOf(opcode_t opcode __attribute__ ((unused)), int narg __attribute
 {
   INIT_STATUS;
   struct descriptor_xd tmp = EMPTY_XD;
-  STATIC_CONSTANT unsigned char omits[] = {
+  static const dtype_t omits[] = {
     DTYPE_PROGRAM,
     0
   };
 
-  status = TdiGetData(omits, list[0], &tmp);
+  status = tdi_get_data(omits, list[0], &tmp);
   if STATUS_OK
     switch (tmp.pointer->dtype) {
     case DTYPE_PROGRAM:
@@ -1026,7 +1026,7 @@ int Tdi1QualifiersOf(opcode_t opcode __attribute__ ((unused)), int narg __attrib
   INIT_STATUS;
   struct descriptor_xd tmp = EMPTY_XD;
   struct descriptor *pd;
-  STATIC_CONSTANT unsigned char omits[] = {
+  static const dtype_t omits[] = {
     DTYPE_CALL,
     DTYPE_CONDITION,
     DTYPE_CONGLOM,
@@ -1036,7 +1036,7 @@ int Tdi1QualifiersOf(opcode_t opcode __attribute__ ((unused)), int narg __attrib
     0
   };
 
-  status = TdiGetData(omits, list[0], &tmp);
+  status = tdi_get_data(omits, list[0], &tmp);
   pd = tmp.pointer;
   if STATUS_OK
     switch (pd->dtype) {
@@ -1073,12 +1073,12 @@ int Tdi1RawOf(opcode_t opcode __attribute__ ((unused)), int narg __attribute__ (
 {
   INIT_STATUS;
   struct descriptor_xd tmp = EMPTY_XD;
-  STATIC_CONSTANT unsigned char omits[] = {
+  static const dtype_t omits[] = {
     DTYPE_SIGNAL,
     0
   };
 
-  status = TdiGetData(omits, list[0], &tmp);
+  status = tdi_get_data(omits, list[0], &tmp);
   if STATUS_OK
     switch (tmp.pointer->dtype) {
     case DTYPE_SIGNAL:
@@ -1102,13 +1102,13 @@ int Tdi1RoutineOf(opcode_t opcode __attribute__ ((unused)), int narg __attribute
 {
   INIT_STATUS;
   struct descriptor_xd tmp = EMPTY_XD;
-  STATIC_CONSTANT unsigned char omits[] = {
+  static const dtype_t omits[] = {
     DTYPE_CALL,
     DTYPE_ROUTINE,
     0
   };
 
-  status = TdiGetData(omits, list[0], &tmp);
+  status = tdi_get_data(omits, list[0], &tmp);
   if STATUS_OK
     switch (tmp.pointer->dtype) {
     case DTYPE_CALL:
@@ -1133,19 +1133,19 @@ int Tdi1RoutineOf(opcode_t opcode __attribute__ ((unused)), int narg __attribute
 int Tdi1SlopeOf(opcode_t opcode __attribute__ ((unused)), int narg, struct descriptor *list[], struct descriptor_xd *out_ptr)
 {
   INIT_STATUS;
-  STATIC_CONSTANT unsigned char one_val = 1;
+  static const dtype_t one_val = 1;
   STATIC_CONSTANT struct descriptor one =
       { sizeof(unsigned char), DTYPE_BU, CLASS_S, (char *)&one_val };
 
   struct descriptor_xd tmp = EMPTY_XD;
   unsigned int n = 0;
-  STATIC_CONSTANT unsigned char omits[] = {
+  static const dtype_t omits[] = {
     DTYPE_RANGE,
     DTYPE_SLOPE,
     0
   };
 
-  status = TdiGetData(omits, list[0], &tmp);
+  status = tdi_get_data(omits, list[0], &tmp);
   if (STATUS_OK && narg > 1)
     status = TdiGetLong(list[1], &n);
   if STATUS_OK
@@ -1184,7 +1184,7 @@ int Tdi1TaskOf(opcode_t opcode __attribute__ ((unused)), int narg __attribute__ 
 {
   INIT_STATUS;
   struct descriptor_xd tmp = EMPTY_XD;
-  STATIC_CONSTANT unsigned char omits[] = {
+  static const dtype_t omits[] = {
     DTYPE_ACTION,
     DTYPE_METHOD,
     DTYPE_PROCEDURE,
@@ -1193,7 +1193,7 @@ int Tdi1TaskOf(opcode_t opcode __attribute__ ((unused)), int narg __attribute__ 
     0
   };
 
-  status = TdiGetData(omits, list[0], &tmp);
+  status = tdi_get_data(omits, list[0], &tmp);
   if STATUS_OK
     switch (tmp.pointer->dtype) {
     case DTYPE_ACTION:
@@ -1231,7 +1231,7 @@ int Tdi1TimeoutOf(opcode_t opcode __attribute__ ((unused)), int narg __attribute
 {
   INIT_STATUS;
   struct descriptor_xd tmp = EMPTY_XD;
-  STATIC_CONSTANT unsigned char omits[] = {
+  static const dtype_t omits[] = {
     DTYPE_METHOD,
     DTYPE_PROCEDURE,
     DTYPE_PROGRAM,
@@ -1239,7 +1239,7 @@ int Tdi1TimeoutOf(opcode_t opcode __attribute__ ((unused)), int narg __attribute
     0
   };
 
-  status = TdiGetData(omits, list[0], &tmp);
+  status = tdi_get_data(omits, list[0], &tmp);
   if STATUS_OK
     switch (tmp.pointer->dtype) {
     case DTYPE_METHOD:
@@ -1273,12 +1273,12 @@ int Tdi1UnitsOf(opcode_t opcode __attribute__ ((unused)), int narg __attribute__
   INIT_STATUS;
   STATIC_CONSTANT DESCRIPTOR(none, " ");
   struct descriptor_xd tmp = EMPTY_XD;
-  STATIC_CONSTANT unsigned char omits[] = {
+  static const dtype_t omits[] = {
     DTYPE_WITH_UNITS,
     0
   };
 
-  status = TdiGetData(omits, list[0], &tmp);
+  status = tdi_get_data(omits, list[0], &tmp);
   if STATUS_OK
     switch (tmp.pointer->dtype) {
     case DTYPE_WITH_UNITS:
@@ -1300,12 +1300,12 @@ int Tdi1ValidationOf(opcode_t opcode __attribute__ ((unused)), int narg __attrib
 {
   INIT_STATUS;
   struct descriptor_xd tmp = EMPTY_XD;
-  STATIC_CONSTANT unsigned char omits[] = {
+  static const dtype_t omits[] = {
     DTYPE_PARAM,
     0
   };
 
-  status = TdiGetData(omits, list[0], &tmp);
+  status = tdi_get_data(omits, list[0], &tmp);
   if STATUS_OK
     switch (tmp.pointer->dtype) {
     case DTYPE_PARAM:
@@ -1331,7 +1331,7 @@ int Tdi1ValueOf(opcode_t opcode __attribute__ ((unused)), int narg __attribute__
 {
   INIT_STATUS;
   struct descriptor_xd tmp = EMPTY_XD;
-  STATIC_CONSTANT unsigned char omits[] = {
+  static const dtype_t omits[] = {
     DTYPE_DIMENSION,
     DTYPE_PARAM,
     DTYPE_SIGNAL,
@@ -1341,7 +1341,7 @@ int Tdi1ValueOf(opcode_t opcode __attribute__ ((unused)), int narg __attribute__
     0
   };
 
-  status = TdiGetData(omits, list[0], &tmp);
+  status = tdi_get_data(omits, list[0], &tmp);
   if STATUS_OK
     switch (tmp.pointer->dtype) {
     case DTYPE_DIMENSION:
@@ -1397,13 +1397,13 @@ int Tdi1WindowOf(opcode_t opcode __attribute__ ((unused)), int narg __attribute_
 {
   INIT_STATUS;
   struct descriptor_xd tmp = EMPTY_XD;
-  STATIC_CONSTANT unsigned char omits[] = {
+  static const dtype_t omits[] = {
     DTYPE_DIMENSION,
     DTYPE_WINDOW,
     0
   };
 
-  status = TdiGetData(omits, list[0], &tmp);
+  status = tdi_get_data(omits, list[0], &tmp);
   if STATUS_OK
     switch (tmp.pointer->dtype) {
     case DTYPE_DIMENSION:

--- a/tdishr/TdiXxxOf.c
+++ b/tdishr/TdiXxxOf.c
@@ -27,7 +27,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 	Ken Klare, LANL P-4     (c)1989,1990,1991,1992
 */
-#include "STATICdef.h"
 #include <tdishr_messages.h>
 #include "tdirefstandard.h"
 #include <stdlib.h>
@@ -570,7 +569,7 @@ int Tdi1EndOf(opcode_t opcode __attribute__ ((unused)), int narg, struct descrip
 int Tdi1ErrorOf(opcode_t opcode __attribute__ ((unused)), int narg __attribute__ ((unused)), struct descriptor *list[], struct descriptor_xd *out_ptr)
 {
   INIT_STATUS;
-  STATIC_CONSTANT DESCRIPTOR(none, "");
+  static const DESCRIPTOR(none, "");
   struct descriptor_xd tmp = EMPTY_XD;
   static const dtype_t omits[] = {
     DTYPE_WITH_ERROR,
@@ -1134,7 +1133,7 @@ int Tdi1SlopeOf(opcode_t opcode __attribute__ ((unused)), int narg, struct descr
 {
   INIT_STATUS;
   static const dtype_t one_val = 1;
-  STATIC_CONSTANT struct descriptor one =
+  static const struct descriptor one =
       { sizeof(unsigned char), DTYPE_BU, CLASS_S, (char *)&one_val };
 
   struct descriptor_xd tmp = EMPTY_XD;
@@ -1271,7 +1270,7 @@ int Tdi1TimeoutOf(opcode_t opcode __attribute__ ((unused)), int narg __attribute
 int Tdi1UnitsOf(opcode_t opcode __attribute__ ((unused)), int narg __attribute__ ((unused)), struct descriptor *list[], struct descriptor_xd *out_ptr)
 {
   INIT_STATUS;
-  STATIC_CONSTANT DESCRIPTOR(none, " ");
+  static const DESCRIPTOR(none, " ");
   struct descriptor_xd tmp = EMPTY_XD;
   static const dtype_t omits[] = {
     DTYPE_WITH_UNITS,

--- a/tdishr/TdiYacc.c
+++ b/tdishr/TdiYacc.c
@@ -23,11 +23,11 @@ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-/*      TdiYacc.Y
-	YACC converts this to TdiYacc.C to compile TDI statements.
+/*      tdiYacc.Y
+	YACC converts this to tdiYacc.C to compile TDI statements.
 	Each YACC-LEX symbol has a returned token and a tdiyylval value.
 	Precedence is associated with a token and is set left and right below.
-	TdiLex_... routines and TdiRefFunction depend on tokens from TdiYacc.
+	tdi_lex_... routines and TdiRefFunction depend on tokens from tdiYacc.
 	Tdi0Decompile depends on TdiRefFunction and precedence.
 
 	Josh Stillerman and Thomas W. Fredian, MIT PFC, TDI$PARSE.Y.
@@ -70,28 +70,28 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 extern unsigned short OpcSubscript, OpcExtFunction, OpcFun, OpcUsing;
 
-extern int TdiYacc_RESOLVE();
-extern int TdiLex();
-extern int TdiYacc_IMMEDIATE();
-extern int TdiYacc_BUILD();
-extern int TdiYacc_ARG();
-extern int TdiLexPath();
+extern int tdi_lex();
+extern int tdi_lex_path();
+extern int tdi_yacc_RESOLVE();
+extern int tdi_yacc_IMMEDIATE();
+extern int tdi_yacc_BUILD();
+extern int tdi_yacc_ARG();
 
 #define YYMAXDEPTH      250
 #define __RUN(method) do{if IS_NOT_OK(method) tdiyyerror(0); else TDI_REFZONE.l_ok = TDI_REFZONE.a_cur - TDI_REFZONE.a_begin;}while(0)
 
-#define _RESOLVE(arg)   			__RUN(TdiYacc_RESOLVE(&arg.rptr))
+#define _RESOLVE(arg)   			__RUN(tdi_yacc_RESOLVE(&arg.rptr))
 
-#define _FULL1(opcode,arg1,out)                 __RUN(TdiYacc_BUILD(255, 1, opcode, &out, &arg1, NULL , NULL , NULL ))
-#define _FULL2(opcode,arg1,arg2,out)            __RUN(TdiYacc_BUILD(255, 2, opcode, &out, &arg1, &arg2, NULL , NULL ))
+#define _FULL1(opcode,arg1,out)                 __RUN(tdi_yacc_BUILD(255, 1, opcode, &out, &arg1, NULL , NULL , NULL ))
+#define _FULL2(opcode,arg1,arg2,out)            __RUN(tdi_yacc_BUILD(255, 2, opcode, &out, &arg1, &arg2, NULL , NULL ))
 	/*****************************
 	Two args for image->routine.
 	*****************************/
-#define _JUST0(opcode,out)                      __RUN(TdiYacc_BUILD(  2, 0, opcode, &out, NULL , NULL , NULL , NULL ))
-#define _JUST1(opcode,arg1,out)                 __RUN(TdiYacc_BUILD(  3, 1, opcode, &out, &arg1, NULL , NULL , NULL ))
-#define _JUST2(opcode,arg1,arg2,out)            __RUN(TdiYacc_BUILD(  2, 2, opcode, &out, &arg1, &arg2, NULL , NULL ))
-#define _JUST3(opcode,arg1,arg2,arg3,out)       __RUN(TdiYacc_BUILD(  3, 3, opcode, &out, &arg1, &arg2, &arg3, NULL ))
-#define _JUST4(opcode,arg1,arg2,arg3,arg4,out)  __RUN(TdiYacc_BUILD(  4, 4, opcode, &out, &arg1, &arg2, &arg3, &arg4))
+#define _JUST0(opcode,out)                      __RUN(tdi_yacc_BUILD(  2, 0, opcode, &out, NULL , NULL , NULL , NULL ))
+#define _JUST1(opcode,arg1,out)                 __RUN(tdi_yacc_BUILD(  3, 1, opcode, &out, &arg1, NULL , NULL , NULL ))
+#define _JUST2(opcode,arg1,arg2,out)            __RUN(tdi_yacc_BUILD(  2, 2, opcode, &out, &arg1, &arg2, NULL , NULL ))
+#define _JUST3(opcode,arg1,arg2,arg3,out)       __RUN(tdi_yacc_BUILD(  3, 3, opcode, &out, &arg1, &arg2, &arg3, NULL ))
+#define _JUST4(opcode,arg1,arg2,arg3,arg4,out)  __RUN(tdi_yacc_BUILD(  4, 4, opcode, &out, &arg1, &arg2, &arg3, &arg4))
 
 static const struct marker _EMPTY_MARKER = { 0 };
 
@@ -651,9 +651,9 @@ static void free_stacks();
 /*
 ** tdiyyparse - return 0 if worked, 1 if syntax error not recovered from
 */
-// TdiYacc aka tdiyyparse         TdiYacc
+// tdi_yacc aka tdiyyparse         tdi_yacc
 
-int TdiYacc(){
+int tdi_yacc(){
   YYSTYPE tdiyylval;
   YYSTYPE tdiyyval;
   GET_TDITHREADSTATIC_P;
@@ -737,7 +737,7 @@ int TdiYacc(){
  tdiyy_newstate:
     if ((tdiyy_n = tdiyypact[tdiyy_state]) <= YYFLAG)
       goto tdiyy_default;		/* simple state */
-    if ((tdiyychar < 0) && ((tdiyychar = TdiLex(&tdiyylval)) < 0))
+    if ((tdiyychar < 0) && ((tdiyychar = tdi_lex(&tdiyylval)) < 0))
       tdiyychar = 0;		/* reached EOF */
     YYDEBUG_("Received token ")
     if (((tdiyy_n += tdiyychar) < 0) || (tdiyy_n >= YYLAST))
@@ -753,7 +753,7 @@ int TdiYacc(){
 
  tdiyy_default:
     if ((tdiyy_n = tdiyydef[tdiyy_state]) == -2) {
-      if ((tdiyychar < 0) && ((tdiyychar = TdiLex(&tdiyylval)) < 0))
+      if ((tdiyychar < 0) && ((tdiyychar = tdi_lex(&tdiyylval)) < 0))
 	tdiyychar = 0;		/* reached EOF */
       YYDEBUG_("received token ")
       /*
@@ -884,7 +884,7 @@ int TdiYacc(){
     {
       tdiyyval.mark.rptr = tdiyypvt[-0].mark.rptr;
       tdiyyval.mark.builtin = -2;
-      TDI_REFZONE.l_status = TdiYacc_IMMEDIATE(&tdiyyval.mark.rptr);
+      TDI_REFZONE.l_status = tdi_yacc_IMMEDIATE(&tdiyyval.mark.rptr);
       if (!(TDI_REFZONE.l_status & 1))
 	tdiyyerror(0);
     }
@@ -1262,7 +1262,7 @@ int TdiYacc(){
 	  tdiyyval.mark.rptr->dtype = DTYPE_IDENT;
 	} else {
 	  if ((TdiRefFunction[tdiyyval.mark.builtin].token & LEX_M_TOKEN) == LEX_ARG) {
-	    if (!((TDI_REFZONE.l_status = TdiYacc_ARG(&tdiyyval.mark)) & 1))
+	    if (!((TDI_REFZONE.l_status = tdi_yacc_ARG(&tdiyyval.mark)) & 1))
 	      tdiyyerror(0);
 	  } else {
 	    if ((TdiRefFunction[tdiyyval.mark.builtin].token & LEX_M_TOKEN) == LEX_CONST)
@@ -1271,7 +1271,7 @@ int TdiYacc(){
 	}
       } else if (*tdiyyval.mark.rptr->pointer == '_')
 	tdiyyval.mark.rptr->dtype = DTYPE_IDENT;
-      else if (TdiLexPath(tdiyypvt[-0].mark.rptr->length, tdiyypvt[-0].mark.rptr->pointer, &tdiyyval.mark, TdiThreadStatic_p) == LEX_ERROR) {
+      else if (tdi_lex_path(tdiyypvt[-0].mark.rptr->length, tdiyypvt[-0].mark.rptr->pointer, &tdiyyval.mark, TdiThreadStatic_p) == LEX_ERROR) {
 	TDI_REFZONE.l_ok = tdiyypvt[-1].mark.w_ok;
 	TDI_REFZONE.a_cur = TDI_REFZONE.a_begin + TDI_REFZONE.l_ok + tdiyypvt[-0].mark.rptr->length;
 	return MDSplusERROR;
@@ -1385,7 +1385,7 @@ int TdiYacc(){
     {
       tdiyyval.mark.rptr = tdiyypvt[-0].mark.rptr;
       tdiyyval.mark.builtin = -2;
-      TDI_REFZONE.l_status = TdiYacc_IMMEDIATE(&tdiyyval.mark.rptr);
+      TDI_REFZONE.l_status = tdi_yacc_IMMEDIATE(&tdiyyval.mark.rptr);
       if (!(TDI_REFZONE.l_status & 1))
 	tdiyyerror(0);
     }

--- a/tdishr/TdiYacc.c
+++ b/tdishr/TdiYacc.c
@@ -103,14 +103,14 @@ static const struct marker _EMPTY_MARKER = { 0 };
 
 /* __YYSCLASS defines the scoping/storage class for global objects
  * that are NOT renamed by the -p option.  By default these names
- * are going to be 'STATIC_THREADSAFE' so that multi-definition errors
+ * are going to be 'static' so that multi-definition errors
  * will not occur with multiple parsers.
  * If you want (unsupported) access to internal names you need
  * to define this to be null so it implies 'extern' scope.
  * This should not be used in conjunction with -p.
  */
 #ifndef __YYSCLASS
-#define __YYSCLASS STATIC_THREADSAFE
+#define __YYSCLASS static
 #endif
 typedef int tdiyytabelem;
 #define YYERRCODE 256
@@ -1442,7 +1442,7 @@ int tdi_yacc(TDITHREADSTATIC_ARG){
 
 #ifdef __RUNTIME_YYMAXDEPTH
 
-STATIC_ROUTINE int allocate_stacks(const long size)
+static int allocate_stacks(const long size)
 {
   /* allocate the tdiyys and tdiyyv stacks */
   tdiyys = (int *)malloc(size * sizeof(int));
@@ -1456,7 +1456,7 @@ STATIC_ROUTINE int allocate_stacks(const long size)
 
 }
 
-STATIC_ROUTINE void free_stacks()
+static void free_stacks()
 {
   if (tdiyys != 0)
     free(tdiyys);

--- a/tdishr/TdiYaccSubs.c
+++ b/tdishr/TdiYaccSubs.c
@@ -61,12 +61,10 @@ int tdi_yacc_RESOLVE();
 	$nnn is nnn-th argument.
 	$0 is then the compile string itself.
 */
-int tdi_yacc_ARG(struct marker *mark_ptr)
-{
+int tdi_yacc_ARG(struct marker *mark_ptr, TDITHREADSTATIC_ARG) {
   INIT_STATUS;
-  GET_TDITHREADSTATIC_P;
-  struct descriptor *ptr;
-  struct descriptor_xd junk = EMPTY_XD;
+  mdsdsc_t *ptr;
+  mdsdsc_xd_t junk = EMPTY_XD;
   unsigned int len = mark_ptr->rptr->length;
   unsigned char *c_ptr;
 
@@ -88,7 +86,7 @@ int tdi_yacc_ARG(struct marker *mark_ptr)
 	*******************************/
   status = MdsCopyDxXdZ(ptr, &junk, &TDI_REFZONE.l_zone, NULL, NULL, NULL, NULL);
   if (status & 1)
-    mark_ptr->rptr = (struct descriptor_r *)junk.pointer;
+    mark_ptr->rptr = (mdsdsc_r_t *)junk.pointer;
   return status;
 }
 
@@ -98,16 +96,18 @@ int tdi_yacc_ARG(struct marker *mark_ptr)
 */
 static const DESCRIPTOR_FUNCTION_0(EMPTY_FUN, 0);
 
-int tdi_yacc_BUILD(int ndesc,
-		  int nused,
-		  opcode_t opcode,
-		  struct marker *out,
-		  struct marker *arg1,
-		  struct marker *arg2, struct marker *arg3, struct marker *arg4)
-{
-  GET_TDITHREADSTATIC_P;
-  struct descriptor_function *tmp;
-  int dsc_size = sizeof(struct descriptor_function) + sizeof(struct descriptor *) * (ndesc - 1);
+int tdi_yacc_BUILD(
+	int ndesc,
+	int nused,
+	opcode_t opcode,
+	struct marker *out,
+	struct marker *arg1,
+	struct marker *arg2,
+	struct marker *arg3,
+	struct marker *arg4,
+	TDITHREADSTATIC_ARG) {
+  mds_function_t *tmp;
+  int dsc_size = sizeof(mds_function_t) + sizeof(mdsdsc_t *) * (ndesc - 1);
   unsigned int vm_size = dsc_size + sizeof(unsigned short);
   struct TdiFunctionStruct *this_ptr = (struct TdiFunctionStruct *)&TdiRefFunction[opcode];
 
@@ -115,7 +115,7 @@ int tdi_yacc_BUILD(int ndesc,
   if IS_NOT_OK(TDI_REFZONE.l_status)
     return MDSplusERROR;
   out->builtin = -1;
-  out->rptr = (struct descriptor_r *)tmp;
+  out->rptr = (mdsdsc_r_t *)tmp;
 
   *tmp = EMPTY_FUN;		/* clears ndesc upper bits */
   tmp->pointer = (unsigned char *)((char *)tmp + dsc_size);
@@ -126,16 +126,16 @@ int tdi_yacc_BUILD(int ndesc,
     TDI_REFZONE.l_status = TdiEXTRA_ARG;
     return MDSplusERROR;
   case 4:
-    tmp->arguments[3] = (struct descriptor *)arg4->rptr;
+    tmp->arguments[3] = (mdsdsc_t *)arg4->rptr;
     MDS_ATTR_FALLTHROUGH
   case 3:
-    tmp->arguments[2] = (struct descriptor *)arg3->rptr;
+    tmp->arguments[2] = (mdsdsc_t *)arg3->rptr;
     MDS_ATTR_FALLTHROUGH
   case 2:
-    tmp->arguments[1] = (struct descriptor *)arg2->rptr;
+    tmp->arguments[1] = (mdsdsc_t *)arg2->rptr;
     MDS_ATTR_FALLTHROUGH
   case 1:
-    tmp->arguments[0] = (struct descriptor *)arg1->rptr;
+    tmp->arguments[0] = (mdsdsc_t *)arg1->rptr;
     MDS_ATTR_FALLTHROUGH
   case 0:
     break;
@@ -147,16 +147,16 @@ int tdi_yacc_BUILD(int ndesc,
 	If resolved, can change record pointer.
 	*******************************************/
   if (nused > this_ptr->m2) {
-    TDI_REFZONE.l_status = tdi_yacc_IMMEDIATE(&out->rptr);
+    TDI_REFZONE.l_status = tdi_yacc_IMMEDIATE(&out->rptr, TDITHREADSTATIC_PASS);
     return MDSplusERROR;
   }				/*Force an error */
   if (ndesc >= 254)
     return MDSplusSUCCESS;
   if (nused < this_ptr->m1) {
-    TDI_REFZONE.l_status = tdi_yacc_IMMEDIATE(&out->rptr);
+    TDI_REFZONE.l_status = tdi_yacc_IMMEDIATE(&out->rptr, TDITHREADSTATIC_PASS);
     return MDSplusERROR;
   }				/*Force an error */
-  return tdi_yacc_RESOLVE(&out->rptr);
+  return tdi_yacc_RESOLVE(&out->rptr, TDITHREADSTATIC_PASS);
 }
 
 /*--------------------------------------------------------------
@@ -164,20 +164,19 @@ int tdi_yacc_BUILD(int ndesc,
 	WARNING the pointer is changed.
 	We do not free small stuff because we will throw it all away later.
 */
-int tdi_yacc_IMMEDIATE(struct descriptor_xd **dsc_ptr_ptr)
-{
-  GET_TDITHREADSTATIC_P;
+int tdi_yacc_IMMEDIATE(mdsdsc_xd_t **dsc_ptr_ptr, TDITHREADSTATIC_ARG) {
   if (TDI_STACK_IDX >= TDI_STACK_SIZE-1) {
     fprintf(stderr, "Error: Too many recursive calls using '`': only %d supported\n",TDI_STACK_SIZE);
     return TdiRECURSIVE;
   }
-  struct descriptor_xd xd = EMPTY_XD, junk = EMPTY_XD, *ptr = *dsc_ptr_ptr;
+  mdsdsc_xd_t xd = EMPTY_XD, junk = EMPTY_XD, *ptr = *dsc_ptr_ptr;
   /*********************************************************
   Must not send compile XD-DSC to MDS, it may give it back.
   And if we release it below, we have trouble.
   *********************************************************/
   while (ptr && ptr->class == CLASS_XD && ptr->dtype == DTYPE_DSC)
-    ptr = (struct descriptor_xd *)ptr->pointer;
+    ptr = (mdsdsc_xd_t *)ptr->pointer;
+
   ++TDI_STACK_IDX;DBG("TDI_STACK_IDX = %d\n",TDI_STACK_IDX);
   int status = TdiEvaluate(ptr, &xd MDS_END_ARG);
   --TDI_STACK_IDX;DBG("TDI_STACK_IDX = %d\n",TDI_STACK_IDX);
@@ -188,7 +187,7 @@ int tdi_yacc_IMMEDIATE(struct descriptor_xd **dsc_ptr_ptr)
   if STATUS_OK
     status = MdsCopyDxXdZ(xd.pointer, &junk, &TDI_REFZONE.l_zone, NULL, NULL, NULL, NULL);
   if STATUS_OK
-    *dsc_ptr_ptr = (struct descriptor_xd *)junk.pointer;
+    *dsc_ptr_ptr = (mdsdsc_xd_t *)junk.pointer;
   MdsFree1Dx(&xd, NULL);
   return status;
 }
@@ -221,10 +220,8 @@ int tdi_yacc_IMMEDIATE(struct descriptor_xd **dsc_ptr_ptr)
 	What about DTYPE_MISSING? It is generated only by evaluation.
 */
 
-int tdi_yacc_RESOLVE(struct descriptor_function **out_ptr_ptr)
-{
-  GET_TDITHREADSTATIC_P;
-  struct descriptor_function *out_ptr = *out_ptr_ptr;
+int tdi_yacc_RESOLVE(mds_function_t **out_ptr_ptr, TDITHREADSTATIC_ARG) {
+  mds_function_t *out_ptr = *out_ptr_ptr;
   struct TdiFunctionStruct *this_ptr;
   int j, ndesc, opcode;
 
@@ -245,9 +242,9 @@ int tdi_yacc_RESOLVE(struct descriptor_function **out_ptr_ptr)
 	******************/
   if (this_ptr->f1 != Tdi1Build)
     for (j = ndesc; --j >= 0;) {
-      struct descriptor *tst = out_ptr->arguments[j];
+      mdsdsc_t *tst = out_ptr->arguments[j];
       while (tst != 0 && tst->dtype == DTYPE_DSC)
-	tst = (struct descriptor *)tst->pointer;
+	tst = (mdsdsc_t *)tst->pointer;
       if (opcode == OPC_SET_RANGE) {	/*Set_Range(value,range,...,array) */
 	if (j != ndesc - 1) {
 	  if (tst == 0 || tst->dtype == DTYPE_RANGE)
@@ -259,7 +256,8 @@ int tdi_yacc_RESOLVE(struct descriptor_function **out_ptr_ptr)
 	return MDSplusSUCCESS;
     }
  doit:
-  if IS_OK(TDI_REFZONE.l_status = tdi_yacc_IMMEDIATE((struct descriptor_xd **)out_ptr_ptr))
+  TDI_REFZONE.l_status = tdi_yacc_IMMEDIATE((mdsdsc_xd_t **)out_ptr_ptr, TDITHREADSTATIC_PASS);
+  if IS_OK(TDI_REFZONE.l_status)
     return MDSplusSUCCESS;
   return MDSplusERROR;
 }

--- a/tdishr/TdiYaccSubs.c
+++ b/tdishr/TdiYaccSubs.c
@@ -22,7 +22,7 @@ CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
-/*      TdiYacc_SUBS.C
+/*      TdiYaccSubs.c
 	Subroutines for the expression parser.
 
 	Ken Klare, LANL CTR-7   (c)1989,1990
@@ -49,8 +49,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 extern int Tdi1Build();
 extern int TdiEvaluate();
 
-int TdiYacc_IMMEDIATE();
-int TdiYacc_RESOLVE();
+int tdi_yacc_IMMEDIATE();
+int tdi_yacc_RESOLVE();
 
 /*--------------------------------------------------------------
 	Allow precomputed expressions to be included in the compile string.
@@ -61,7 +61,7 @@ int TdiYacc_RESOLVE();
 	$nnn is nnn-th argument.
 	$0 is then the compile string itself.
 */
-int TdiYacc_ARG(struct marker *mark_ptr)
+int tdi_yacc_ARG(struct marker *mark_ptr)
 {
   INIT_STATUS;
   GET_TDITHREADSTATIC_P;
@@ -98,7 +98,7 @@ int TdiYacc_ARG(struct marker *mark_ptr)
 */
 static const DESCRIPTOR_FUNCTION_0(EMPTY_FUN, 0);
 
-int TdiYacc_BUILD(int ndesc,
+int tdi_yacc_BUILD(int ndesc,
 		  int nused,
 		  opcode_t opcode,
 		  struct marker *out,
@@ -147,16 +147,16 @@ int TdiYacc_BUILD(int ndesc,
 	If resolved, can change record pointer.
 	*******************************************/
   if (nused > this_ptr->m2) {
-    TDI_REFZONE.l_status = TdiYacc_IMMEDIATE(&out->rptr);
+    TDI_REFZONE.l_status = tdi_yacc_IMMEDIATE(&out->rptr);
     return MDSplusERROR;
   }				/*Force an error */
   if (ndesc >= 254)
     return MDSplusSUCCESS;
   if (nused < this_ptr->m1) {
-    TDI_REFZONE.l_status = TdiYacc_IMMEDIATE(&out->rptr);
+    TDI_REFZONE.l_status = tdi_yacc_IMMEDIATE(&out->rptr);
     return MDSplusERROR;
   }				/*Force an error */
-  return TdiYacc_RESOLVE(&out->rptr);
+  return tdi_yacc_RESOLVE(&out->rptr);
 }
 
 /*--------------------------------------------------------------
@@ -164,7 +164,7 @@ int TdiYacc_BUILD(int ndesc,
 	WARNING the pointer is changed.
 	We do not free small stuff because we will throw it all away later.
 */
-int TdiYacc_IMMEDIATE(struct descriptor_xd **dsc_ptr_ptr)
+int tdi_yacc_IMMEDIATE(struct descriptor_xd **dsc_ptr_ptr)
 {
   GET_TDITHREADSTATIC_P;
   if (TDI_STACK_IDX >= TDI_STACK_SIZE-1) {
@@ -221,7 +221,7 @@ int TdiYacc_IMMEDIATE(struct descriptor_xd **dsc_ptr_ptr)
 	What about DTYPE_MISSING? It is generated only by evaluation.
 */
 
-int TdiYacc_RESOLVE(struct descriptor_function **out_ptr_ptr)
+int tdi_yacc_RESOLVE(struct descriptor_function **out_ptr_ptr)
 {
   GET_TDITHREADSTATIC_P;
   struct descriptor_function *out_ptr = *out_ptr_ptr;
@@ -259,7 +259,7 @@ int TdiYacc_RESOLVE(struct descriptor_function **out_ptr_ptr)
 	return MDSplusSUCCESS;
     }
  doit:
-  if IS_OK(TDI_REFZONE.l_status = TdiYacc_IMMEDIATE((struct descriptor_xd **)out_ptr_ptr))
+  if IS_OK(TDI_REFZONE.l_status = tdi_yacc_IMMEDIATE((struct descriptor_xd **)out_ptr_ptr))
     return MDSplusSUCCESS;
   return MDSplusERROR;
 }

--- a/tdishr/tdishrp.h
+++ b/tdishr/tdishrp.h
@@ -23,5 +23,4 @@ int Tdi3Multiply(struct descriptor *in1, struct descriptor *in2, struct descript
 int TdiSubtractOctaword(unsigned int *a, unsigned int *b, unsigned int *ans);
 int TdiUnary(struct descriptor *in_ptr, struct descriptor *out_ptr, unsigned int *out_count);
 void UseNativeFloat(struct TdiCatStruct *cat);
-void TdiResetGetRecord();
 #endif

--- a/tdishr/tdithreadstatic.h
+++ b/tdishr/tdithreadstatic.h
@@ -6,6 +6,8 @@
 #include <pthread_port.h>
 
 #define GET_TDITHREADSTATIC_P ThreadStatic *const TdiThreadStatic_p = TdiThreadStatic(NULL)
+#define TDITHREADSTATIC_ARG   ThreadStatic *const TdiThreadStatic_p
+#define TDITHREADSTATIC_PASS  TdiThreadStatic_p
 
 #define TDI_STACK_SIZE	3
 #define TDI_STACK_IDX	TdiThreadStatic_p->stack_idx

--- a/tdishr/tdithreadstatic.h
+++ b/tdishr/tdithreadstatic.h
@@ -21,6 +21,7 @@
 #define TDI_VAR_NEW_NARG	TdiThreadStatic_p->var_new_narg
 #define TDI_VAR_NEW_NARG_D	TdiThreadStatic_p->var_new_narg_d
 #define TDI_VAR_REC		TdiThreadStatic_p->var_rec
+#define TDI_USE_GET_RECORD_FUN  TdiThreadStatic_p->use_get_record_fun
 
 #define TDI_DECOMPILE_MAX	TDI_STACK.decompile_max
 #define TDI_COMPILE_REC		TDI_STACK.compile_rec
@@ -51,6 +52,7 @@ typedef struct {
   mdsdsc_d_t	 intrinsic_msg;	// TdiIntrinsic
   int intrinsic_rec;		// TdiIntrinsic
   int intrinsic_stat;		// TdiIntrinsic
+  int use_get_record_fun;	// TdiGetData, TdiVar
 } ThreadStatic;
 
 typedef struct {

--- a/treeshr/TreeFindNode.c
+++ b/treeshr/TreeFindNode.c
@@ -50,20 +50,18 @@ EXPORT int _TreeFindNodeEnd(void *dbid, void **ctx);
 /*
  * Static internal routines
  */
-STATIC_ROUTINE inline int IsWild(char *str);
-STATIC_ROUTINE NODELIST *Search(PINO_DATABASE *dblist, SEARCH_CTX *ctx, SEARCH_TERM *term, NODE *start, NODELIST **tail);
-STATIC_ROUTINE NODELIST *Find(PINO_DATABASE *dblist, SEARCH_TERM *term, NODE *start, NODELIST **tail);
-STATIC_ROUTINE NODELIST *AddNodeList(NODELIST *list, NODELIST **tail, NODE *node);
-STATIC_ROUTINE void FreeNodeList(NODELIST *list);
-STATIC_ROUTINE int match(char *first, char *second);
-STATIC_ROUTINE void FreeSearchCtx(SEARCH_CTX *ctx);
-STATIC_ROUTINE NODELIST  *ConcatenateNodeLists(NODELIST *start_list, NODELIST **tail, NODELIST *end_list, NODELIST *end_tail);
-STATIC_ROUTINE char *Trim(char *str, size_t len);
-STATIC_ROUTINE NODELIST *FindChildren(PINO_DATABASE *dblist, SEARCH_TERM *term, NODE *start, NODELIST **tail);
-STATIC_ROUTINE NODELIST *FindMembers(PINO_DATABASE *dblist, SEARCH_TERM *term, NODE *start, NODELIST **tail);
-STATIC_ROUTINE NODELIST *FindMembersOrChildren(PINO_DATABASE *dblist, SEARCH_TERM *term, NODE *start, NODELIST **tail);
-STATIC_ROUTINE NODELIST *FindTagWild(PINO_DATABASE *dblist, SEARCH_TERM *term, NODELIST **tail);
-STATIC_ROUTINE NODELIST *Filter(NODELIST *list, int mask);
+static NODELIST *Search(PINO_DATABASE *dblist, SEARCH_CTX *ctx, SEARCH_TERM *term, NODE *start, NODELIST **tail);
+static NODELIST *Find(PINO_DATABASE *dblist, SEARCH_TERM *term, NODE *start, NODELIST **tail);
+static NODELIST *AddNodeList(NODELIST *list, NODELIST **tail, NODE *node);
+static void FreeNodeList(NODELIST *list);
+static int match(char *first, char *second);
+static void FreeSearchCtx(SEARCH_CTX *ctx);
+static NODELIST  *ConcatenateNodeLists(NODELIST *start_list, NODELIST **tail, NODELIST *end_list, NODELIST *end_tail);
+static NODELIST *FindChildren(PINO_DATABASE *dblist, SEARCH_TERM *term, NODE *start, NODELIST **tail);
+static NODELIST *FindMembers(PINO_DATABASE *dblist, SEARCH_TERM *term, NODE *start, NODELIST **tail);
+static NODELIST *FindMembersOrChildren(PINO_DATABASE *dblist, SEARCH_TERM *term, NODE *start, NODELIST **tail);
+static NODELIST *FindTagWild(PINO_DATABASE *dblist, SEARCH_TERM *term, NODELIST **tail);
+static NODELIST *Filter(NODELIST *list, int mask);
 /*
  * External routines (not exported) defined here
  */
@@ -73,6 +71,30 @@ STATIC_ROUTINE NODELIST *Filter(NODELIST *list, int mask);
 extern int WildParse(char const *path, SEARCH_CTX *ctx, int *wild);
 extern void FreeSearchTerms(SEARCH_TERM *terms);
 extern char *_TreeGetPath(void *dbid, int nid_in);
+
+/* trim trailing space form str into buf
+ */
+static size_t trim_cpy(char *buf, char *str, size_t len) {
+  size_t i;
+  for (i=0; i<len; i++) {
+    if (str[i] == ' ')
+      break;
+    else
+      buf[i] = str[i];
+  }
+  buf[i] = '\0';
+  return i;
+}
+static inline int is_wild2(const char *const str) {
+  const char *p = str;
+  while (*p!='\0' && *p!='*' && *p!='%') p++;
+  return *p;
+}
+static inline int is_wild3(const char *const str) {
+  const char *p = str;
+  while (*p!='\0' && *p!='*' && *p!='?' && *p!='%') p++;
+  return *p;
+}
 
 EXPORT int TreeFindNode(char const *path, int *outnid)
 {
@@ -222,12 +244,12 @@ EXPORT int _TreeFindNodeEnd(void *dbid __attribute__ ((unused)), void **ctx)
   return TreeSUCCESS;
 }
 
-STATIC_ROUTINE void FreeSearchCtx(SEARCH_CTX *ctx)
+static void FreeSearchCtx(SEARCH_CTX *ctx)
 {
   free(ctx->wildcard);
   FreeSearchTerms(ctx->terms);
 }
-STATIC_ROUTINE NODELIST *Search(PINO_DATABASE *dblist, SEARCH_CTX *ctx, SEARCH_TERM *term, NODE *start, NODELIST **tail)
+static NODELIST *Search(PINO_DATABASE *dblist, SEARCH_CTX *ctx, SEARCH_TERM *term, NODE *start, NODELIST **tail)
 {
   NODELIST *nodes = term ? Find(dblist, term, start, tail) : NULL;
   if (nodes) {
@@ -256,56 +278,44 @@ STATIC_ROUTINE NODELIST *Search(PINO_DATABASE *dblist, SEARCH_CTX *ctx, SEARCH_T
   }
 }
 
-STATIC_ROUTINE inline int Wild(char *term)
-{
-  return (strchr(term, '*') || strchr(term, '?') || strchr(term, '%'));
-}
-
-STATIC_ROUTINE NODELIST *Find(PINO_DATABASE *dblist, SEARCH_TERM *term, NODE *start, NODELIST **tail)
+static NODELIST *Find(PINO_DATABASE *dblist, SEARCH_TERM *term, NODE *start, NODELIST **tail)
 {
   NODELIST *answer = NULL;
-  if (((term->search_type==CHILD) || (term->search_type==MEMBER)) && (! Wild(term->term))) {
+  if (((term->search_type==CHILD) || (term->search_type==MEMBER)) && (! is_wild3(term->term))) {
     term->search_type = CHILD_OR_MEMBER;
   }
+  char trimmed[sizeof(NODE_NAME)+1];
   switch (term->search_type) {
     case (CHILD) : {
       NODE *n=child_of(dblist, start);
       for (; n; n = brother_of(dblist, n)) {
-        char *trimmed = Trim(n->name,sizeof(NODE_NAME));
-        if (match(term->term, trimmed)) {
+        trim_cpy(trimmed,n->name,sizeof(NODE_NAME));
+        if (match(term->term, trimmed))
           answer = AddNodeList(answer, tail, n);
-        }
-        free(trimmed);
       }
       break;
     }
     case (MEMBER) : {
       NODE *n;
       for (n=member_of(start); n; n = brother_of(dblist, n)) {
-        char *trimmed = Trim(n->name, sizeof(NODE_NAME));
-        if (match(term->term, trimmed)) {
+        trim_cpy(trimmed,n->name,sizeof(NODE_NAME));
+        if (match(term->term, trimmed))
           answer = AddNodeList(answer, tail, n);
-        }
-        free(trimmed);
       }
       break;
     }
     case (CHILD_OR_MEMBER) : {
       NODE *n;
       for (n=member_of(start); n; n = brother_of(dblist, n)) {
-        char *trimmed = Trim(n->name, sizeof(NODE_NAME));
-        if (match(term->term, trimmed)) {
+        trim_cpy(trimmed,n->name,sizeof(NODE_NAME));
+        if (match(term->term, trimmed))
           answer = AddNodeList(answer, tail, n);
-        }
-        free(trimmed);
       }
       n=child_of(dblist, start);
       for (; n; n = brother_of(dblist, n)) {
-        char *trimmed = Trim(n->name, sizeof(NODE_NAME));
-        if (match(term->term, trimmed)) {
+        trim_cpy(trimmed,n->name,sizeof(NODE_NAME));
+        if (match(term->term, trimmed))
           answer = AddNodeList(answer, tail, n);
-        }
-        free(trimmed);
       }
       break;
     }
@@ -334,22 +344,20 @@ STATIC_ROUTINE NODELIST *Find(PINO_DATABASE *dblist, SEARCH_TERM *term, NODE *st
     case (ANCESTOR): {
       NODE *parent = parent_of(dblist, start);
       if (parent) {
-        char *trimmed = Trim(parent->name, sizeof(NODE_NAME));
+	trim_cpy(trimmed,parent->name,sizeof(NODE_NAME));
         char *search_term = (strlen(term->term)) ? term->term : "*";
         if (match(search_term, trimmed))
           answer = AddNodeList(answer, tail, parent);
-        free(trimmed);
       }
       break;
     }
     case (ANCESTOR_SEARCH): {
       NODE *parent = parent_of(dblist, start);
       while (parent) {
-        char *trimmed = Trim(parent->name, sizeof(NODE_NAME));
+	trim_cpy(trimmed,parent->name,sizeof(NODE_NAME));
         char *search_term = (strlen(term->term)) ? term->term : "*";
         if (match(search_term, trimmed))
           answer = AddNodeList(answer, tail, parent);
-        free(trimmed);
         parent = parent_of(dblist, parent);
       }
       break;
@@ -364,52 +372,41 @@ STATIC_ROUTINE NODELIST *Find(PINO_DATABASE *dblist, SEARCH_TERM *term, NODE *st
   return(answer);
 }
 
-STATIC_ROUTINE NODELIST *FindTags(PINO_DATABASE *dblist, TREE_INFO *info, int treenum, char *tagname, NODELIST **tail)
+static NODELIST *FindTags(PINO_DATABASE *dblist, TREE_INFO *info, int treenum, char *tagname, NODELIST **tail)
 {
   NODELIST *answer = NULL;
   TAG_INFO *tptr = info->tag_info;
   int i;
   NID nid;
-  int tag_wild = IsWild(tagname);
+  int tag_wild = is_wild2(tagname);
   *tail = NULL;
-
+  NODE *n;
   nid.tree = treenum;
   if(match(tagname, "TOP")) {
     nid.node = 0;
-    NODE *n = nid_to_node(dblist, &nid);
-    if (n->usage == TreeUSAGE_SUBTREE_REF) {
+    n = nid_to_node(dblist, &nid);
+    if (n->usage == TreeUSAGE_SUBTREE_REF)
       n = child_of(dblist, n);
-    }
     answer = AddNodeList(answer, tail, n);
-  }
-  else {
+  } else {
+    char trimmed[sizeof(TAG_NAME)+1];
     for (i=0; i<info->header->tags; i++) {
-      char *trimmed = Trim(tptr[i].name, sizeof(TAG_NAME));
+      trim_cpy(trimmed,tptr[i].name, sizeof(TAG_NAME));
       if(match(tagname, trimmed)) {
-        NODE *n;
         nid.node = tptr[i].node_idx;
         n = nid_to_node(dblist, &nid);
-        if (n->usage == TreeUSAGE_SUBTREE_REF) {
+        if (n->usage == TreeUSAGE_SUBTREE_REF)
           n = child_of(dblist, n);
-        }
         answer = AddNodeList(answer, tail, n);
-        if (! tag_wild) {
-          free(trimmed);
+        if (! tag_wild)
           break;
-        }
       }
-      free(trimmed);
     }
   }
   return(answer);
 }
 
-STATIC_ROUTINE inline int IsWild(char *str)
-{
-  return (strchr(str, '*') || strchr(str, '%'));
-}
-
-STATIC_ROUTINE TREE_INFO *GetDefaultTreeInfo(PINO_DATABASE *dblist, int *treenum)
+static TREE_INFO *GetDefaultTreeInfo(PINO_DATABASE *dblist, int *treenum)
 {
   TREE_INFO *info;
   int  i = 0;
@@ -421,7 +418,7 @@ STATIC_ROUTINE TREE_INFO *GetDefaultTreeInfo(PINO_DATABASE *dblist, int *treenum
 
 }
 
-STATIC_ROUTINE NODELIST *FindTagWild(PINO_DATABASE *dblist, SEARCH_TERM *term, NODELIST **tail)
+static NODELIST *FindTagWild(PINO_DATABASE *dblist, SEARCH_TERM *term, NODELIST **tail)
 {
   NODELIST *answer = NULL;
   TREE_INFO *tinfo;
@@ -432,7 +429,7 @@ STATIC_ROUTINE NODELIST *FindTagWild(PINO_DATABASE *dblist, SEARCH_TERM *term, N
     char *treename=tag_term;
     char *tagname = strstr(tag_term, "::")+2;
     *(strstr(tag_term, "::")) = '\0';
-    tree_wild = IsWild(treename);
+    tree_wild = is_wild2(treename);
     if (treename[0] == '\\') treename++;
     for (treenum = 0, tinfo=dblist->tree_info; tinfo; tinfo = tinfo->next_info, treenum++) {
       if(match(treename, tinfo->treenam)) {
@@ -448,7 +445,7 @@ STATIC_ROUTINE NODELIST *FindTagWild(PINO_DATABASE *dblist, SEARCH_TERM *term, N
     char *tagname = tag_term;
     int tag_wild;
     if (tagname[0] == '\\') tagname++;
-    tag_wild = IsWild(tagname);
+    tag_wild = is_wild2(tagname);
     answer = FindTags(dblist, default_tinfo, treenum, tagname, tail);
     if ((!answer) || tag_wild) {
       for (treenum=0, tinfo=dblist->tree_info; tinfo; tinfo = tinfo->next_info) {
@@ -466,29 +463,28 @@ STATIC_ROUTINE NODELIST *FindTagWild(PINO_DATABASE *dblist, SEARCH_TERM *term, N
   return answer;
 }
 
-STATIC_ROUTINE NODELIST *FindMembers(PINO_DATABASE *dblist, SEARCH_TERM *term, NODE *start, NODELIST **tail)
+static NODELIST *FindMembers(PINO_DATABASE *dblist, SEARCH_TERM *term, NODE *start, NODELIST **tail)
 {
   NODELIST *answer = NULL;
   NODELIST *queue = NULL;
   NODELIST *que_tail = NULL;
-
+  char trimmed[sizeof(NODE_NAME)+1];
   *tail = NULL;
   queue = AddNodeList(queue, &que_tail, start);
+  NODE *n;
+  NODELIST *this;
   while (queue) {
-    NODE *n;
-    NODELIST *this = queue;
+    this = queue;
     queue = queue->next;
     if (! queue)
       que_tail=NULL;
     if ((n = member_of(this->node))) {
       for(; n; n = brother_of(dblist, n)) {
-        char *trimmed = Trim(n->name, sizeof(NODE_NAME));
+        trim_cpy(trimmed, n->name, sizeof(NODE_NAME));
         char *search_term = (strlen(term->term)) ? term->term : "*";
         queue = AddNodeList(queue, &que_tail, n);
-        if (match(search_term, trimmed)) {
+        if (match(search_term, trimmed))
           answer = AddNodeList(answer, tail, n);
-        }
-        free(trimmed);
       }
     }
     free(this);
@@ -496,29 +492,28 @@ STATIC_ROUTINE NODELIST *FindMembers(PINO_DATABASE *dblist, SEARCH_TERM *term, N
   return answer;
 }
 
-STATIC_ROUTINE NODELIST *FindChildren(PINO_DATABASE *dblist, SEARCH_TERM *term, NODE *start, NODELIST **tail)
+static NODELIST *FindChildren(PINO_DATABASE *dblist, SEARCH_TERM *term, NODE *start, NODELIST **tail)
 {
   NODELIST *answer = NULL;
   NODELIST *queue = NULL;
   NODELIST *que_tail = NULL;
-
+  char trimmed[sizeof(NODE_NAME)+1];
   *tail = NULL;
   queue = AddNodeList(queue, &que_tail, start);
+  NODE *n;
+  NODELIST *this;
   while (queue) {
-    NODE *n;
-    NODELIST *this = queue;
+    this = queue;
     queue = queue->next;
     if (! queue)
       que_tail=NULL;
     if ((n = child_of(dblist, this->node))) {
       for(; n; n = brother_of(dblist, n)) {
-        char *trimmed = Trim(n->name, sizeof(NODE_NAME));
+	trim_cpy(trimmed, n->name, sizeof(NODE_NAME));
         char *search_term = (strlen(term->term)) ? term->term : "*";
         queue = AddNodeList(queue, &que_tail, n);
-        if (match(search_term, trimmed)) {
+        if (match(search_term, trimmed))
           answer = AddNodeList(answer, tail, n);
-        }
-        free(trimmed);
       }
     }
     free(this);
@@ -526,30 +521,29 @@ STATIC_ROUTINE NODELIST *FindChildren(PINO_DATABASE *dblist, SEARCH_TERM *term, 
   return answer;
 }
 
-STATIC_ROUTINE NODELIST *FindMembersOrChildren(PINO_DATABASE *dblist, SEARCH_TERM *term, NODE *start, NODELIST **tail)
+static NODELIST *FindMembersOrChildren(PINO_DATABASE *dblist, SEARCH_TERM *term, NODE *start, NODELIST **tail)
 {
   NODELIST *answer = NULL;
   NODELIST *queue = NULL;
   NODELIST *que_tail = NULL;
-
+  char trimmed[sizeof(NODE_NAME)+1];
   *tail = NULL;
   queue = AddNodeList(queue, &que_tail, start);
   answer = AddNodeList(answer, tail, start);
+  NODE *n;
+  NODELIST *this;
   while (queue) {
-    NODE *n;
-    NODELIST *this = queue;
+    this = queue;
     queue = queue->next;
     if (! queue)
       que_tail=NULL;
     if ((n = descendant_of(dblist, this->node))) {
       for(; n; n = sibling_of(dblist, n)) {
-        char *trimmed = Trim(n->name, sizeof(NODE_NAME));
+        trim_cpy(trimmed, n->name, sizeof(NODE_NAME));
         char *search_term = (strlen(term->term)) ? term->term : "*";
         queue = AddNodeList(queue, &que_tail, n);
-        if (match(search_term, trimmed)) {
+        if (match(search_term, trimmed))
           answer = AddNodeList(answer, tail, n);
-        }
-        free(trimmed);
       }
     }
     free(this);
@@ -557,7 +551,7 @@ STATIC_ROUTINE NODELIST *FindMembersOrChildren(PINO_DATABASE *dblist, SEARCH_TER
   return answer;
 }
 
-STATIC_ROUTINE NODELIST *AddNodeList(NODELIST *head, NODELIST **tail,  NODE *node)
+static NODELIST *AddNodeList(NODELIST *head, NODELIST **tail,  NODE *node)
 {
   NODELIST *this_one = malloc(sizeof(NODELIST));
   this_one->node = node;
@@ -572,7 +566,7 @@ STATIC_ROUTINE NODELIST *AddNodeList(NODELIST *head, NODELIST **tail,  NODE *nod
   return (head);
 }
 
-STATIC_ROUTINE void FreeNodeList(NODELIST *list)
+static void FreeNodeList(NODELIST *list)
 {
   NODELIST *ptr;
   for (ptr=list; ptr;)
@@ -582,27 +576,8 @@ STATIC_ROUTINE void FreeNodeList(NODELIST *list)
     ptr=nxt;
   }
 }
-/*
- * Trim trailing spaces from input nodename
- *
- * Note there will not be a \0
- * so allocate 12+1 and copy it in first
- */
-STATIC_ROUTINE char *Trim(char *str, size_t len)
-{
-  char *ans = calloc(len+1, 1);
-  char *p;
-  strncpy(ans, str, len);
-  for (p=ans; *p; p++) {
-    if (isspace(*p)) {
-      *p='\0';
-      break;
-    }
-  }
-  return ans;
-}
 
-STATIC_ROUTINE int match(char *first, char *second)
+static int match(char *first, char *second)
 {
     // If we reach at the end of both strings, we are done
     if (*first == '\0' && *second == '\0')
@@ -627,7 +602,7 @@ STATIC_ROUTINE int match(char *first, char *second)
     return 0;
 }
 
-STATIC_ROUTINE NODELIST  *ConcatenateNodeLists(NODELIST *start_list, NODELIST **tail, NODELIST *end_list, NODELIST *end_tail)
+static NODELIST  *ConcatenateNodeLists(NODELIST *start_list, NODELIST **tail, NODELIST *end_list, NODELIST *end_tail)
 {
   NODELIST *answer;
 
@@ -646,7 +621,7 @@ STATIC_ROUTINE NODELIST  *ConcatenateNodeLists(NODELIST *start_list, NODELIST **
   return answer;
 }
 
-STATIC_ROUTINE NODELIST *Filter(NODELIST *list, int usage_mask) {
+static NODELIST *Filter(NODELIST *list, int usage_mask) {
   NODELIST *ptr;
   NODELIST *previous=list;
   NODELIST *answer=list;

--- a/treeshr/TreeSegments.c
+++ b/treeshr/TreeSegments.c
@@ -1134,10 +1134,9 @@ static int get_compressed_segment_rows(TREE_INFO *tinfo, const int64_t offset, i
     return TreeFAILURE;
   char dimct = buffer[11];
   if (dimct == 1) {
-    loadint32(rows, &buffer[12]);       // arsize
-    *rows = *rows / swapint16(buffer);  // length
+    *rows = swapint32(&buffer[12]) / swapint16(buffer);  // arsize / length
   } else
-    loadint32(rows, &buffer[16 + dimct * 4]);  // last dim
+    loadint32(rows,&buffer[16 + dimct * 4]);  // last dim
   return TreeSUCCESS;
 }
 
@@ -1819,8 +1818,7 @@ static int get_segment_limits(vars_t *vars, mdsdsc_xd_t *retStart, mdsdsc_xd_t *
           const int filled_rows = get_filled_rows_ts(
               &vars->shead, vars->sinfo, vars->idx, (int64_t *)buffer);
           if (filled_rows > 0) {
-            loadint64(&timestamp,
-                      buffer + (filled_rows - 1) * sizeof(int64_t));
+            loadint64(&timestamp, buffer + (filled_rows - 1) * sizeof(int64_t));
             MdsCopyDxXd(&q_d, retEnd);
           } else
             MdsFree1Dx(retEnd, 0);

--- a/treeshr/treeshrp.h
+++ b/treeshr/treeshrp.h
@@ -133,41 +133,15 @@ typedef struct named_attributes_index {
 
 // #define WORDS_BIGENDIAN // use for testing
 #ifdef WORDS_BIGENDIAN
-static inline void SWP(void* out, const void* in, const int a, const int b) {
- char t=((char*)out)[O];	// in and out could be the same
-	((char*)in )[O]=((char*)out)[I];
-	                ((char*)in )[I]=t;
-}
-static inline void loadint16(void* out, const void* in) {
- SWP(out,in,0,1);
-}
-static inline void loadint32(void* out, const void* in) {
- SWP(out,in,0,3);
- SWP(out,in,2,1);
-}
-static inline void loadint64(void* out, const void* in) {
- SWP(out,in,0,7);
- SWP(out,in,2,5);
- SWP(out,in,4,3);
- SWP(out,in,6,1);
-}
+#define SWP(out, in, a, b) ((char*)(out))[a]=((char*)(in ))[b];((char*)(out))[b]=((char*)(in ))[a];
+#define loadint16(out,in) do{SWP(out,in,0,1);}while(0)
+#define loadint32(out,in) do{SWP(out,in,0,3);SWP(out,in,2,1);}while(0)
+#define loadint64(out,in) do{SWP(out,in,0,7);SWP(out,in,2,5);SWP(out,in,4,3);SWP(out,in,6,1);}while(0)
+#undef SWP
 #else
-static inline void CPY(void* out, const void* in, const int idx) {
-  ((char*)out)[idx] = ((char*)in)[idx];
-}
-static inline void loadint16(void* out, const void* in) {
- CPY(out,in,0);CPY(out,in,1);
-}
-static inline void loadint32(void* out, const void* in) {
- CPY(out,in,0);CPY(out,in,1);
- CPY(out,in,2);CPY(out,in,3);
-}
-static inline void loadint64(void* out, const void* in) {
- CPY(out,in,0);CPY(out,in,1);
- CPY(out,in,2);CPY(out,in,3);
- CPY(out,in,4);CPY(out,in,5);
- CPY(out,in,6);CPY(out,in,7);
-}
+#define loadint16(out,in) memcpy((char*)(out),(char*)(in ),2)
+#define loadint32(out,in) memcpy((char*)(out),(char*)(in ),4)
+#define loadint64(out,in) memcpy((char*)(out),(char*)(in ),8)
 #endif
 static inline int16_t swapint16(const void *buf) {
   int16_t ans;
@@ -214,7 +188,6 @@ static inline void putint32(char **buf, const void *ans) {
 static inline void putint64(char **buf, const void *ans) {
   loadint64(*buf,ans);*buf+=sizeof(int64_t);
 }
-
 
 #define bitassign(bool,value,mask)   value = (bool) ? (value) | (unsigned)(mask) : (value) & ~(unsigned)(mask)
 #define bitassign_c(bool,value,mask) value = (unsigned char)(( (bool) ? (value) |  (unsigned)(mask) : (value) & ~(unsigned)(mask) )&0xFF)


### PR DESCRIPTION
* performance of tdicompile increased
  - GET_TDITHREADSTATIC_P if costly so we pass the pointer to statics when we can.
  - LibResetVmZone and LibVmGet were slow
  - removed broken old code that is obviously not needed anymore (e.g. use_get_record_fun)
test case
```bash
time for i in `seq 1 100`; do tditest /git/mdsplus/tditest/testing/test-tdishr.tdi >/dev/null; done
```
before
```
real    0m10.142s
user    0m8.580s
sys     0m0.380s
```
after
```
real    0m8.115s
user    0m6.548s
sys     0m0.368s
```