### PR TITLE
Fix: split pthread into logical sections

### DIFF
--- a/deploy/packaging/debian/devel.noarch
+++ b/deploy/packaging/debian/devel.noarch
@@ -30,10 +30,12 @@
 ./usr/local/mdsplus/include/camshr.h
 ./usr/local/mdsplus/include/camshr_messages.h
 ./usr/local/mdsplus/include/classdef.h
+./usr/local/mdsplus/include/condition.h
 ./usr/local/mdsplus/include/coz.h
 ./usr/local/mdsplus/include/dbidef.h
 ./usr/local/mdsplus/include/dcl.h
 ./usr/local/mdsplus/include/dtypedef.h
+./usr/local/mdsplus/include/getusername.h
 ./usr/local/mdsplus/include/int128.h
 ./usr/local/mdsplus/include/ipdesc.h
 ./usr/local/mdsplus/include/libroutines.h
@@ -66,6 +68,7 @@
 ./usr/local/mdsplus/include/rtevents.h
 ./usr/local/mdsplus/include/servershr.h
 ./usr/local/mdsplus/include/servershr_messages.h
+./usr/local/mdsplus/include/socket_port.h
 ./usr/local/mdsplus/include/sqldb.h
 ./usr/local/mdsplus/include/sqlfront.h
 ./usr/local/mdsplus/include/status.h

--- a/deploy/packaging/redhat/devel.noarch
+++ b/deploy/packaging/redhat/devel.noarch
@@ -32,10 +32,12 @@
 ./usr/local/mdsplus/include/camshr.h
 ./usr/local/mdsplus/include/camshr_messages.h
 ./usr/local/mdsplus/include/classdef.h
+./usr/local/mdsplus/include/condition.h
 ./usr/local/mdsplus/include/coz.h
 ./usr/local/mdsplus/include/dbidef.h
 ./usr/local/mdsplus/include/dcl.h
 ./usr/local/mdsplus/include/dtypedef.h
+./usr/local/mdsplus/include/getusername.h
 ./usr/local/mdsplus/include/int128.h
 ./usr/local/mdsplus/include/ipdesc.h
 ./usr/local/mdsplus/include/libroutines.h
@@ -69,6 +71,7 @@
 ./usr/local/mdsplus/include/rtevents.h
 ./usr/local/mdsplus/include/servershr.h
 ./usr/local/mdsplus/include/servershr_messages.h
+./usr/local/mdsplus/include/socket_port.h
 ./usr/local/mdsplus/include/sqldb.h
 ./usr/local/mdsplus/include/sqlfront.h
 ./usr/local/mdsplus/include/status.h

--- a/include/condition.h
+++ b/include/condition.h
@@ -1,0 +1,92 @@
+#ifndef CONDITION_H
+#define CONDITION_H
+#include <pthread_port.h>
+
+typedef struct _Condition {
+  pthread_cond_t  cond;
+  pthread_mutex_t mutex;
+  int             value;
+} Condition;
+
+typedef struct _Condition_p {
+  pthread_cond_t  cond;
+  pthread_mutex_t mutex;
+  void*           value;
+} Condition_p;
+
+#define CONDITION_INITIALIZER {PTHREAD_COND_INITIALIZER,PTHREAD_MUTEX_INITIALIZER,B_FALSE}
+
+#define CONDITION_INIT(input) do{\
+(input)->value = 0;\
+pthread_cond_init(&(input)->cond, pthread_condattr_default);\
+pthread_mutex_init(&(input)->mutex, pthread_mutexattr_default);\
+} while(0)
+#define _CONDITION_LOCK(input)   pthread_mutex_lock(&(input)->mutex)
+#define _CONDITION_UNLOCK(input) pthread_mutex_unlock(&(input)->mutex)
+#define _CONDITION_SIGNAL(input) pthread_cond_signal(&(input)->cond)
+#define _CONDITION_WAIT(input)   pthread_cond_wait(&(input)->cond,&(input)->mutex)
+#define _CONDITION_WAIT_SET(input)   while (!(input)->value) _CONDITION_WAIT(input)
+#define _CONDITION_WAIT_RESET(input) while ( (input)->value) _CONDITION_WAIT(input)
+#define _CONDITION_WAIT_1SEC(input,status) do{\
+struct timespec tp;\
+clock_gettime(CLOCK_REALTIME, &tp);\
+tp.tv_sec++;\
+status pthread_cond_timedwait(&(input)->cond,&(input)->mutex,&tp);\
+} while(0)
+#define CONDITION_SET_TO(input,value_in) do{\
+_CONDITION_LOCK(input);\
+(input)->value = value_in;\
+_CONDITION_SIGNAL(input);\
+_CONDITION_UNLOCK(input);\
+} while(0)
+#define CONDITION_SET(input)   CONDITION_SET_TO(input,B_TRUE)
+#define CONDITION_RESET(input) CONDITION_SET_TO(input,0)
+#define CONDITION_WAIT_SET(input) do{\
+_CONDITION_LOCK(input);\
+_CONDITION_WAIT_SET(input);\
+_CONDITION_UNLOCK(input);\
+} while(0)
+#define CONDITION_WAIT_1SEC(input) do{\
+_CONDITION_LOCK(input);\
+_CONDITION_WAIT_1SEC(input,);\
+_CONDITION_UNLOCK(input);\
+} while(0)
+#define CONDITION_DESTROY(input,destroy_lock) do{\
+pthread_mutex_lock(destroy_lock);\
+pthread_cond_destroy(&(input)->cond);\
+pthread_mutex_destroy(&(input)->mutex);\
+pthread_mutex_unlock(destroy_lock);\
+} while(0)
+#define CONDITION_DESTROY_PTR(input,destroy_lock) do{\
+pthread_mutex_lock(destroy_lock);\
+if (input){\
+pthread_cond_destroy(&(input)->cond);\
+pthread_mutex_destroy(&(input)->mutex);\
+free(input);(input)=NULL;}\
+pthread_mutex_unlock(destroy_lock);\
+} while(0)
+#define CREATE_THREAD(thread, stacksize, target, args)\
+pthread_attr_t attr;\
+pthread_attr_init(&attr);\
+pthread_attr_setstacksize(&attr, DEFAULT_STACKSIZE stacksize);\
+int c_status = pthread_create(&thread, &attr, (void *)target, (void*)args);\
+pthread_attr_destroy(&attr)
+#define CREATE_DETACHED_THREAD(thread, stacksize, target, args)\
+CREATE_THREAD(thread, stacksize, target, args);if (!c_status) pthread_detach(thread);
+
+#define CONDITION_START_THREAD(input, thread, stacksize, target, args) do{\
+_CONDITION_LOCK(input);\
+if (!(input)->value) {\
+  CREATE_DETACHED_THREAD(thread, stacksize, target, args);\
+  if (c_status) {\
+    perror("Error creating pthread");\
+    status = MDSplusERROR;\
+  } else {\
+    _CONDITION_WAIT_SET(input);\
+    status = MDSplusSUCCESS;\
+  }\
+}\
+_CONDITION_UNLOCK(input);\
+} while(0)//"
+
+#endif// CONDITION_H

--- a/include/getusername.h
+++ b/include/getusername.h
@@ -1,0 +1,55 @@
+#ifndef GETUSERNAME_H
+#define GETUSERNAME_H
+#ifdef HAVE_UNISTD_H
+ #include <unistd.h>
+#endif
+#ifdef _WIN32
+ #include <io.h>
+#else
+ #include <pwd.h>
+#endif
+#include <pthread_port.h>
+
+#define GETUSERNAME(user_p) GETUSERNAME_BEGIN(user_p);GETUSERNAME_END;
+
+#define GETUSERNAME_BEGIN(user_p) {\
+static pthread_mutex_t username_mutex = PTHREAD_MUTEX_INITIALIZER;\
+pthread_mutex_lock(&username_mutex);\
+if (!user_p) {\
+  user_p = _getUserName()
+
+#define GETUSERNAME_END }\
+pthread_mutex_unlock(&username_mutex);\
+}
+static char* _getUserName(){
+  char *user_p;
+#ifdef _WIN32
+    static char user[128];
+    DWORD bsize = 128;
+    user_p = GetUserName(user, &bsize) ? user : "Windows User";
+#elif __MWERKS__
+    ans.pointer = "Macintosh User";
+#else
+    static char user[256];
+    struct passwd *pwd = getpwuid(geteuid());
+    if (pwd) {
+      strcpy(user,pwd->pw_name);
+      user_p = user;
+    } else
+#ifdef __APPLE__
+      user_p = "Apple User";
+#else
+    {
+      user_p = getlogin();
+      if (user_p && strlen(user_p)>0){
+	strcpy(user,user_p);
+	user_p = user;
+      } else
+	user_p = "Linux User";
+    }
+#endif
+#endif
+  return user_p;
+}
+
+#endif// GETUSERNAME_H

--- a/include/pthread_port.h
+++ b/include/pthread_port.h
@@ -1,5 +1,6 @@
 #ifndef PTHREAD_PORT_H
 #define PTHREAD_PORT_H
+#define _GNU_SOURCE
 #include <stdlib.h>
 #include <status.h>
 #include <STATICdef.h>

--- a/include/pthread_port.h
+++ b/include/pthread_port.h
@@ -1,14 +1,10 @@
 #ifndef PTHREAD_PORT_H
 #define PTHREAD_PORT_H
-#define _GNU_SOURCE
 #include <stdlib.h>
 #include <status.h>
 #include <STATICdef.h>
 #ifdef _WIN32
  #ifndef NO_WINDOWS_H
-  #ifdef LOAD_INITIALIZESOCKETS
-   #include <winsock2.h>
-  #endif
   #include <windows.h>
  #endif
 #endif
@@ -62,18 +58,6 @@ int rv = gettimeofday(&now, NULL);\
 }
 #endif
 
-typedef struct _Condition {
-  pthread_cond_t  cond;
-  pthread_mutex_t mutex;
-  int             value;
-} Condition;
-
-typedef struct _Condition_p {
-  pthread_cond_t  cond;
-  pthread_mutex_t mutex;
-  void*           value;
-} Condition_p;
-
 // FREE
 static void __attribute__((unused)) free_if(void *ptr){
   free(*(void**)ptr);
@@ -97,149 +81,8 @@ static void __attribute__((unused)) fclose_if(void *ptr){
 #define INIT_AS_AND_FCLOSE_ON_EXIT(ptr,value)	FILE *ptr = value;FCLOSE_ON_EXIT(ptr)
 #define INIT_AND_FCLOSE_ON_EXIT(ptr)		INIT_AS_AND_FCLOSE_ON_EXIT(ptr,NULL)
 
-#define CONDITION_INITIALIZER {PTHREAD_COND_INITIALIZER,PTHREAD_MUTEX_INITIALIZER,B_FALSE}
+#define INIT_SHARED_FUNCTION_ONCE(fun) static pthread_once_t __##fun##__once = PTHREAD_ONCE_INIT
+#define RUN_SHARED_FUNCTION_ONCE(fun)  pthread_once(& __##fun##__once,(void*)fun)
+#define RUN_FUNCTION_ONCE(fun) do{INIT_SHARED_FUNCTION_ONCE(fun);RUN_SHARED_FUNCTION_ONCE(fun);}while(0)
 
-#define CONDITION_INIT(input) do{\
-(input)->value = 0;\
-pthread_cond_init(&(input)->cond, pthread_condattr_default);\
-pthread_mutex_init(&(input)->mutex, pthread_mutexattr_default);\
-} while(0)
-#define _CONDITION_LOCK(input)   pthread_mutex_lock(&(input)->mutex)
-#define _CONDITION_UNLOCK(input) pthread_mutex_unlock(&(input)->mutex)
-#define _CONDITION_SIGNAL(input) pthread_cond_signal(&(input)->cond)
-#define _CONDITION_WAIT(input)   pthread_cond_wait(&(input)->cond,&(input)->mutex)
-#define _CONDITION_WAIT_SET(input)   while (!(input)->value) _CONDITION_WAIT(input)
-#define _CONDITION_WAIT_RESET(input) while ( (input)->value) _CONDITION_WAIT(input)
-#define _CONDITION_WAIT_1SEC(input,status) do{\
-struct timespec tp;\
-clock_gettime(CLOCK_REALTIME, &tp);\
-tp.tv_sec++;\
-status pthread_cond_timedwait(&(input)->cond,&(input)->mutex,&tp);\
-} while(0)
-#define CONDITION_SET_TO(input,value_in) do{\
-_CONDITION_LOCK(input);\
-(input)->value = value_in;\
-_CONDITION_SIGNAL(input);\
-_CONDITION_UNLOCK(input);\
-} while(0)
-#define CONDITION_SET(input)   CONDITION_SET_TO(input,B_TRUE)
-#define CONDITION_RESET(input) CONDITION_SET_TO(input,0)
-#define CONDITION_WAIT_SET(input) do{\
-_CONDITION_LOCK(input);\
-_CONDITION_WAIT_SET(input);\
-_CONDITION_UNLOCK(input);\
-} while(0)
-#define CONDITION_WAIT_1SEC(input) do{\
-_CONDITION_LOCK(input);\
-_CONDITION_WAIT_1SEC(input,);\
-_CONDITION_UNLOCK(input);\
-} while(0)
-#define CONDITION_DESTROY(input,destroy_lock) do{\
-pthread_mutex_lock(destroy_lock);\
-pthread_cond_destroy(&(input)->cond);\
-pthread_mutex_destroy(&(input)->mutex);\
-pthread_mutex_unlock(destroy_lock);\
-} while(0)
-#define CONDITION_DESTROY_PTR(input,destroy_lock) do{\
-pthread_mutex_lock(destroy_lock);\
-if (input){\
-pthread_cond_destroy(&(input)->cond);\
-pthread_mutex_destroy(&(input)->mutex);\
-free(input);(input)=NULL;}\
-pthread_mutex_unlock(destroy_lock);\
-} while(0)
-#define CREATE_THREAD(thread, stacksize, target, args)\
-pthread_attr_t attr;\
-pthread_attr_init(&attr);\
-pthread_attr_setstacksize(&attr, DEFAULT_STACKSIZE stacksize);\
-int c_status = pthread_create(&thread, &attr, (void *)target, (void*)args);\
-pthread_attr_destroy(&attr)
-#define CREATE_DETACHED_THREAD(thread, stacksize, target, args)\
-CREATE_THREAD(thread, stacksize, target, args);if (!c_status) pthread_detach(thread);
-
-#define CONDITION_START_THREAD(input, thread, stacksize, target, args) do{\
-_CONDITION_LOCK(input);\
-if (!(input)->value) {\
-  CREATE_DETACHED_THREAD(thread, stacksize, target, args);\
-  if (c_status) {\
-    perror("Error creating pthread");\
-    status = MDSplusERROR;\
-  } else {\
-    _CONDITION_WAIT_SET(input);\
-    status = MDSplusSUCCESS;\
-  }\
-}\
-_CONDITION_UNLOCK(input);\
-} while(0)//"
-#ifdef LOAD_INITIALIZESOCKETS
- #ifndef _WIN32
-  #define INITIALIZESOCKETS
- #else
-  #define SHUT_RDWR 2
-  static pthread_once_t InitializeSockets_once = PTHREAD_ONCE_INIT;
-  static void InitializeSockets() {
-    WSADATA wsaData;
-    WORD wVersionRequested;
-    wVersionRequested = MAKEWORD(1, 1);
-    WSAStartup(wVersionRequested, &wsaData);
-  }
-  #define INITIALIZESOCKETS pthread_once(&InitializeSockets_once,InitializeSockets)
- #endif
-#endif
-
-#ifdef LOAD_GETUSERNAME
-#define GETUSERNAME(user_p) GETUSERNAME_BEGIN(user_p);GETUSERNAME_END;
-
-#define GETUSERNAME_BEGIN(user_p) {\
-static pthread_mutex_t username_mutex = PTHREAD_MUTEX_INITIALIZER;\
-pthread_mutex_lock(&username_mutex);\
-if (!user_p) {\
-  user_p = _getUserName()
-
-#define GETUSERNAME_END }\
-pthread_mutex_unlock(&username_mutex);\
-}
-static char* _getUserName(){
-  char *user_p;
-#ifdef _WIN32
-    static char user[128];
-    DWORD bsize = 128;
-    user_p = GetUserName(user, &bsize) ? user : "Windows User";
-#elif __MWERKS__
-    ans.pointer = "Macintosh User";
-#else
-    static char user[256];
-    struct passwd *pwd;
-    pwd = getpwuid(geteuid());
-    if (pwd) {
-      strcpy(user,pwd->pw_name);
-      user_p = user;
-    } else
-#ifdef __APPLE__
-      user_p = "Apple User";
-#else
-    {
-      user_p = getlogin();
-      if (user_p && strlen(user_p)>0){
-	strcpy(user,user_p);
-	user_p = user;
-      } else
-	user_p = "Linux User";
-    }
-#endif
-#endif
-  return user_p;
-}
-#endif
-
-#define RUN_FUNCTION_ONCE(fun) do{ \
-  static pthread_once_t RUN_FUNCTION_once = PTHREAD_ONCE_INIT; \
-  static pthread_mutex_t RUN_FUNCTION_lock = PTHREAD_MUTEX_INITIALIZER; \
-  pthread_mutex_lock(&RUN_FUNCTION_lock); \
-  pthread_cleanup_push((void*)pthread_mutex_unlock,&RUN_FUNCTION_lock); \
-  pthread_once(&RUN_FUNCTION_once,fun); \
-  pthread_cleanup_pop(1); \
-}while(0)
-
-
-#endif//nPTHREAD_PORT_H
+#endif// PTHREAD_PORT_H

--- a/include/socket_port.h
+++ b/include/socket_port.h
@@ -1,0 +1,61 @@
+#ifndef SOCKET_PORT_H
+#define SOCKET_PORT_H
+#ifdef _WIN32
+ #ifdef _WIN32_WINNT
+  #undef _WIN32_WINNT
+ #endif
+ #define _WIN32_WINNT _WIN32_WINNT_WIN8 // Windows 8.0
+ #ifndef NO_WINDOWS_H
+  #include <winsock2.h>
+ #endif
+ #include <ws2tcpip.h>
+ #include <io.h>
+ #include <process.h>
+ typedef int socklen_t;
+ #define close closesocket
+ #define ioctl ioctlsocket
+ #define FIONREAD_TYPE u_long
+ #define snprintf _snprintf
+ #define getpid _getpid
+ #define SHUT_RDWR 2
+#else
+ #define INVALID_SOCKET -1
+ #define FIONREAD_TYPE int
+ #include <sys/socket.h>
+ #include <netdb.h>
+ #include <netinet/in.h>
+ #include <arpa/inet.h>
+ #include <sys/ioctl.h>
+ #include <sys/wait.h>
+ #include <poll.h>
+ #include <ifaddrs.h>
+#endif
+#include <pthread_port.h>
+
+#ifndef MSG_NOSIGNAL
+ #define MSG_NOSIGNAL 0
+#endif
+#ifndef MSG_DONTWAIT
+ #define MSG_DONTWAIT 0
+#endif
+
+#define SEND_BUF_SIZE 32768
+#define RECV_BUF_SIZE 32768
+
+
+#ifdef _WIN32
+  #define DEFINE_INITIALIZESOCKETS \
+  static void InitializeSockets() {\
+    WSADATA wsaData;\
+    WORD wVersionRequested;\
+    wVersionRequested = MAKEWORD(1, 1);\
+    WSAStartup(wVersionRequested, &wsaData);\
+  }\
+  INIT_SHARED_FUNCTION_ONCE(InitializeSockets)
+  #define INITIALIZESOCKETS RUN_SHARED_FUNCTION_ONCE(InitializeSockets)
+#else
+  #define DEFINE_INITIALIZESOCKETS
+  #define INITIALIZESOCKETS
+#endif
+
+#endif// SOCKET_PORT_H

--- a/mdsmisc/whoami.c
+++ b/mdsmisc/whoami.c
@@ -23,20 +23,11 @@ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 #include <mdsplus/mdsconfig.h>
-#include <mdsdescrip.h>
-#include <mdsplus/mdsconfig.h>
+
 #include <string.h>
-#ifdef HAVE_UNISTD_H
-#include <unistd.h>
-#endif
-#ifdef _WIN32
-#include <io.h>
-#include <windows.h>
-#else
-#include <pwd.h>
-#endif
-#define LOAD_GETUSERNAME
-#include <pthread_port.h>
+
+#include <mdsdescrip.h>
+#include <getusername.h>
 
 EXPORT struct descriptor *whoami()
 {

--- a/mdsshr/UdpEventSettings.c
+++ b/mdsshr/UdpEventSettings.c
@@ -28,17 +28,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <libxml/xpath.h>
 #include <libxml/xpathInternals.h>
 #include <strings.h>
-#define LOAD_INITIALIZESOCKETS
+#include <socket_port.h>
 #include "mdsshrthreadsafe.h"
-#ifdef _WIN32
-#include <ws2tcpip.h>
-#else
-#include <sys/socket.h>
-#include <netinet/in.h>
-#include <arpa/inet.h>
-#include <netdb.h>
-#include <ifaddrs.h>
-#endif
 #include <stdlib.h>
 #include <string.h>
 #include <sys/types.h>
@@ -244,11 +235,11 @@ inline static void xmlInitParser_supp() {
   // so it can targeted for valgrind suppression
   xmlInitParser();
 }
-EXPORT void InitializeEventSettings()
-{
+DEFINE_INITIALIZESOCKETS;
+EXPORT void InitializeEventSettings() {
+  INITIALIZESOCKETS;
   pthread_mutex_lock(&init_lock);
   pthread_cleanup_push((void*)pthread_mutex_unlock,&init_lock);
-  INITIALIZESOCKETS;
   int i, missing=0;
   xmlInitParser_supp();
   for (i=0;i<NUM_SETTINGS;i++) {

--- a/mdsshr/librtl.c
+++ b/mdsshr/librtl.c
@@ -24,19 +24,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 #define _XOPEN_SOURCE_EXTENDED
 #define _GNU_SOURCE		/* glibc2 needs this */
-#define LOAD_INITIALIZESOCKETS
-#include <pthread_port.h>
-
-#ifdef _WIN32
-#include <ws2tcpip.h>
-#else
-#include <netinet/in.h>
-#include <netdb.h>
-#include <arpa/inet.h>
-#include <netinet/tcp.h>
-#endif
-
 #include <mdsplus/mdsconfig.h>
+#include <ctype.h>
 #include <sys/time.h>
 #include <time.h>
 #include <string.h>
@@ -49,6 +38,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <dirent.h>
 #include <errno.h>
 #include <signal.h>
+#include <socket_port.h>
 
 // #define DEBUG
 #ifdef DEBUG
@@ -58,26 +48,25 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #endif
 
 #ifdef _WIN32
-#include <windows.h>
-#include <process.h>
-#define setenv(name,value,overwrite) _putenv_s(name,value)
-#define unsetenv(name)               _putenv_s(name,"")
-#define localtime_r(time,tm)         localtime_s(tm,time)
-#define ctime_r(tm,buf)              ctime_s(buf,32,tm)
+ #include <process.h>
+ #define setenv(name,value,overwrite) _putenv_s(name,value)
+ #define unsetenv(name)               _putenv_s(name,"")
+ #define localtime_r(time,tm)         localtime_s(tm,time)
+ #define ctime_r(tm,buf)              ctime_s(buf,32,tm)
 #else
-#include <sys/wait.h>
+ #include <sys/wait.h>
 #endif
 
+#include <STATICdef.h>
 #include <mdstypes.h>
 #include <mdsdescrip.h>
 #include <strroutines.h>
 #include <mds_stdarg.h>
 #include <mdsshr_messages.h>
 #include <mdsshr.h>
-#include <STATICdef.h>
-#include <ctype.h>
-#include "mdsshrthreadsafe.h"
 #include <release.h>
+
+#include "mdsshrthreadsafe.h"
 #define LIBRTL_SRC
 
 typedef struct {
@@ -107,8 +96,8 @@ typedef struct node {
   void *right;
   short bal;
 } LibTreeNode;
-
 #include <libroutines.h>
+
 
 #ifndef USE_TM_GMTOFF
 /* tzset() sets the global statics daylight and timezone.
@@ -257,6 +246,7 @@ EXPORT void *LibCallg(void **const a, void* (*const routine)()) {
   return 0;
 }
 
+DEFINE_INITIALIZESOCKETS;
 EXPORT uint32_t LibGetHostAddr(const char *const name){
   INITIALIZESOCKETS;
   uint32_t addr = 0;

--- a/mdstcpip/ConnectToMds.c
+++ b/mdstcpip/ConnectToMds.c
@@ -27,18 +27,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <string.h>
 #include <stdio.h>
 #include <status.h>
-#ifdef HAVE_UNISTD_H
-#include <unistd.h>
-#endif
-#ifdef _WIN32
- #include <winsock2.h>
-#else
- #include <pwd.h>
- #define INVALID_SOCKET -1
-#endif
 
-#define LOAD_GETUSERNAME
-#include <pthread_port.h>
+#include <socket_port.h>
+#include <getusername.h>
 #include "mdsip_connections.h"
 #include "mdsIo.h"
 

--- a/mdstcpip/Connections.c
+++ b/mdstcpip/Connections.c
@@ -26,11 +26,11 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <stdio.h>
 #include <string.h>
 
+#include <pthread_port.h>
 #include <treeshr.h>
 #include <mdsshr.h>
 #include "mdsip_connections.h"
 #include "mdsIo.h"
-#include <pthread_port.h>
 
 #ifdef DEBUG
  #define DBG(...) fprintf(stderr,__VA_ARGS__)

--- a/mdstcpip/ProcessMessage.c
+++ b/mdstcpip/ProcessMessage.c
@@ -22,16 +22,22 @@ CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
+#include <mdsplus/mdsconfig.h>
+
 #if defined(linux) && !defined(_LARGEFILE_SOURCE)
 # define _LARGEFILE_SOURCE
 # define _FILE_OFFSET_BITS 64
 # define __USE_FILE_OFFSET64
 #endif
-#include "mdsip_connections.h"
-#include <pthread_port.h>
-#include <mdstypes.h>
+#include <errno.h>
+#include <fcntl.h>
 #include <inttypes.h>
 #include <signal.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdio.h>
 #ifdef _WIN32
 # include <io.h>
 #else
@@ -39,22 +45,21 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 # include <unistd.h>
 # endif
 #endif
-#include <fcntl.h>
-#include "mdsIo.h"
-#include <sys/types.h>
-#include <sys/stat.h>
-#include <stdlib.h>
-#include <string.h>
-#include <stdio.h>
+
+#include <condition.h>
+#include <condition.h>
+#include <mdstypes.h>
 #include <mdsshr.h>
-#include <treeshr.h>
 #include "../tdishr/tdithreadstatic.h"
 #include <tdishr.h>
+#include "../treeshr/treeshrp.h"
+#include <treeshr.h>
 #include <libroutines.h>
 #include <strroutines.h>
-#include <errno.h>
+
+#include "mdsIo.h"
+#include "mdsip_connections.h"
 #include "cvtdef.h"
-#include "../treeshr/treeshrp.h"
 
 extern int TdiRestoreContext();
 extern void** TreeCtx();

--- a/mdstcpip/RemoveConnection.c
+++ b/mdstcpip/RemoveConnection.c
@@ -22,9 +22,10 @@ CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
-#include "mdsip_connections.h"
 #include <stdlib.h>
+
 #include <treeshr.h>
+#include "mdsip_connections.h"
 
 extern int TdiSaveContext();
 extern int TdiDeleteContext();

--- a/mdstcpip/ioroutines.h
+++ b/mdstcpip/ioroutines.h
@@ -8,15 +8,13 @@
 #define _INADDR_ANY INADDR_ANY
 #define GET_IPHOST(sin) char *iphost = inet_ntoa(sin.sin_addr)
 
-#include "mdsip_connections.h"
-#include <status.h>
-#include <STATICdef.h>
+#include <mdsplus/mdsconfig.h>
+
+#include <errno.h>
 #include <fcntl.h>
 #include <stdlib.h>
-#include <string.h>
-#include <errno.h>
 #include <stdio.h>
-#include <mdsplus/mdsconfig.h>
+#include <string.h>
 #include <time.h>
 #ifdef HAVE_UNISTD_H
  #include <unistd.h>
@@ -24,38 +22,11 @@
 #ifdef HAVE_SYS_FILIO_H
  #include <sys/filio.h>
 #endif
-#ifdef _WIN32
- #ifdef _WIN32_WINNT
-  #undef _WIN32_WINNT
- #endif
- #define _WIN32_WINNT _WIN32_WINNT_WIN8 // Windows 8.0
- #include <winsock2.h>
- #include <ws2tcpip.h>
- #define ioctl ioctlsocket
- #define FIONREAD_TYPE u_long
- typedef int socklen_t;
- #define snprintf _snprintf
- #define MSG_DONTWAIT 0
- #include <io.h>
- #include <process.h>
- #define getpid _getpid
-#else
- #define INVALID_SOCKET -1
- #define FIONREAD_TYPE int
- #include <sys/socket.h>
- #include <netdb.h>
- #include <netinet/in.h>
- #include <arpa/inet.h>
- #include <sys/ioctl.h>
- #include <sys/wait.h>
-#endif
-#define SEND_BUF_SIZE 32768
-#define RECV_BUF_SIZE 32768
-#ifndef MSG_NOSIGNAL
- #define MSG_NOSIGNAL 0
-#endif
-#define LOAD_INITIALIZESOCKETS
-#include <pthread_port.h>
+
+#include <STATICdef.h>
+#include <socket_port.h>
+
+#include "mdsip_connections.h"
 
 static int GetHostAndPort(char *hostin, struct sockaddr_in *sin);
 

--- a/mdstcpip/ioroutinesV6.h
+++ b/mdstcpip/ioroutinesV6.h
@@ -10,15 +10,13 @@
 char iphost[INET6_ADDRSTRLEN];\
 inet_ntop(AF_INET6, &sin.sin6_addr, iphost, INET6_ADDRSTRLEN)
 
-#include "mdsip_connections.h"
-#include <STATICdef.h>
-#include <signal.h>
+#include <mdsplus/mdsconfig.h>
+
+#include <errno.h>
 #include <fcntl.h>
 #include <stdlib.h>
-#include <string.h>
-#include <errno.h>
 #include <stdio.h>
-#include <mdsplus/mdsconfig.h>
+#include <string.h>
 #include <time.h>
 #ifdef HAVE_UNISTD_H
  #include <unistd.h>
@@ -26,39 +24,10 @@ inet_ntop(AF_INET6, &sin.sin6_addr, iphost, INET6_ADDRSTRLEN)
 #ifdef HAVE_SYS_FILIO_H
  #include <sys/filio.h>
 #endif
-#ifdef _WIN32
- #ifdef _WIN32_WINNT
-  #undef _WIN32_WINNT
- #endif
- #define _WIN32_WINNT _WIN32_WINNT_WIN8 // Windows 8.0
- #include <winsock2.h>
- #include <ws2tcpip.h>
- #define ioctl ioctlsocket
- #define FIONREAD_TYPE u_long
- typedef int socklen_t;
- #define snprintf _snprintf
- #define MSG_DONTWAIT 0
- #include <io.h>
- #include <process.h>
- #define getpid _getpid
-#else
- #define INVALID_SOCKET -1
- #define FIONREAD_TYPE int
- #include <sys/socket.h>
- #include <netdb.h>
- #include <netinet/in.h>
- #include <netinet/tcp.h>
- #include <arpa/inet.h>
- #include <sys/ioctl.h>
- #include <sys/wait.h>
-#endif
-#define SEND_BUF_SIZE 32768
-#define RECV_BUF_SIZE 32768
-#ifndef MSG_NOSIGNAL
- #define MSG_NOSIGNAL 0
-#endif
-#define LOAD_INITIALIZESOCKETS
-#include <pthread_port.h>
+
+#include <STATICdef.h>
+#include <socket_port.h>
+#include "mdsip_connections.h"
 
 static int GetHostAndPort(char *hostin, struct sockaddr_in6 *sin);
 

--- a/mdstcpip/ioroutinestcp.h
+++ b/mdstcpip/ioroutinestcp.h
@@ -1,4 +1,5 @@
 #define _TCP
+DEFINE_INITIALIZESOCKETS;
 #ifdef _WIN32
  static void socketerror(){
   int err;

--- a/mdstcpip/ioroutinesx.h
+++ b/mdstcpip/ioroutinesx.h
@@ -16,14 +16,8 @@ static IoRoutines io_routines = {
   io_connect, io_send, io_recv, io_flush, io_listen, io_authorize, io_reuseCheck, io_disconnect, io_recv_to, io_check
 };
 #include <mdsshr.h>
+
 #include <inttypes.h>
-#ifdef _TCP
- #ifdef _WIN32
-  #define close closesocket
- #endif
-#else
- #include <poll.h>
-#endif
 
 #define IP(addr)   ((uint8_t*)&addr)
 #define ADDR2IP(a) IP(a)[0],IP(a)[1],IP(a)[2],IP(a)[3]

--- a/mdstcpip/mdsip_connections.h
+++ b/mdstcpip/mdsip_connections.h
@@ -2,20 +2,12 @@
 #define __MDSIP_H__
 #define MdsLib_H
 #define _GNU_SOURCE /* glibc2 needs this */
-#include <mdsplus/mdsconfig.h>
+
 #include <mdsdescrip.h>
 #include <status.h>
-#ifdef _WIN32
- #ifndef __SIZE_TYPE__
- typedef int ssize_t;
- #endif
- #include <winsock2.h>
-#else
- #include <sys/types.h>
-#endif
 #include <ipdesc.h>
 #include <mds_stdarg.h>
-#include <pthread.h>
+#include <pthread_port.h>
 #define MDSIP_MAX_ARGS 256
 #define MDSIP_MAX_COMPRESS 9
 

--- a/mdstcpip/mdsip_service.c
+++ b/mdstcpip/mdsip_service.c
@@ -22,14 +22,14 @@ CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
-#define LOAD_INITIALIZESOCKETS
-#include <pthread_port.h>
-#include <stdlib.h>
 #include <mdsplus/mdsconfig.h>
+#include <stdlib.h>
 #include <process.h>
 #include <stdio.h>
 #include <io.h>
 #include <fcntl.h>
+
+#include <socket_port.h>
 #include "mdsip_connections.h"
 
 static int shut = 0;
@@ -306,6 +306,7 @@ static int ServiceMain(int argc, char **argv)
   }
 }
 
+DEFINE_INITIALIZESOCKETS;
 int main(int argc, char **argv)
 {
   int x_argc;

--- a/servershr/ServerDispatchPhase.c
+++ b/servershr/ServerDispatchPhase.c
@@ -53,25 +53,28 @@ int SERVER$DISPATCH_PHASE(int efn, DispatchTable *table, struct descriptor *phas
 
 ------------------------------------------------------------------------------*/
 
+#include <mdsplus/mdsconfig.h>
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/time.h>
+#include <time.h>
+
 #include <STATICdef.h>
+#include <condition.h>
 #include <mdsdescrip.h>
 #include <ipdesc.h>
 #include <servershr.h>
-#include "servershrp.h"
 #include <ncidef.h>
-#include <stdio.h>
-#include <string.h>
-#include <stdlib.h>
 #include <libroutines.h>
 #include <strroutines.h>
-#include <time.h>
 #include <treeshr.h>
 #include <mdsshr.h>
 #include <servershr.h>
 #include <mds_stdarg.h>
 #include <tdishr_messages.h>
-#include <errno.h>
-#include <sys/time.h>
+#include "servershrp.h"
 
 extern int TdiCompletionOf();
 extern int TdiExecute();

--- a/servershr/ServerQAction.c
+++ b/servershr/ServerQAction.c
@@ -23,19 +23,19 @@ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 #include <mdsplus/mdsconfig.h>
-#include <servershr.h>
-#include "servershrp.h"
 #include <stdlib.h>
 #include <string.h>
 #include <stdio.h>
 #include <time.h>
 #include <errno.h>
+#include <servershr.h>
+#include "servershrp.h"
 #include <mds_stdarg.h>
 #include <mdsdescrip.h>
 #include <mdsshr.h>
 #include <strroutines.h>
 #include <treeshr.h>
-#include <pthread_port.h>
+#include <condition.h>
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif

--- a/servershr/ServerSendMessage.c
+++ b/servershr/ServerSendMessage.c
@@ -51,36 +51,32 @@ int ServerSendMessage();
 	Description:
 
 ------------------------------------------------------------------------------*/
-#define LOAD_INITIALIZESOCKETS
-#include <pthread_port.h>
 #include <mdsplus/mdsconfig.h>
-#include <ipdesc.h>
+
+#include <errno.h>
+#include <signal.h>
 #include <stdlib.h>
 #include <stdio.h>
+#include <string.h>
 #ifdef HAVE_UNISTD_H
   #include <unistd.h>
 #endif
-#include <string.h>
+
+#include <socket_port.h>
+#include <condition.h>
+#include <ipdesc.h>
 #include <servershr.h>
 #include <mds_stdarg.h>
 #include <mdsshr.h>
 #include <libroutines.h>
 #define _NO_SERVER_SEND_MESSAGE_PROTO
 #include "servershrp.h"
-#include <stdio.h>
-#include <errno.h>
 #ifdef _WIN32
- typedef int socklen_t;
  #define random rand
- #define close closesocket
  #define SOCKERROR(...) do{errno = WSAGetLastError();fprintf (stderr, __VA_ARGS__);}while (0)
 #else
  #define SOCKERROR(...) fprintf (stderr, __VA_ARGS__)
- #include <netinet/in.h>
- #include <netdb.h>
- #include <arpa/inet.h>
 #endif
-#include <signal.h>
 
 //#define DEBUG
 #ifdef DEBUG
@@ -450,6 +446,7 @@ static int RegisterJob(int *msgid, int *retstatus, pthread_rwlock_t *lock, void 
   return j->jobid;
 }
 
+DEFINE_INITIALIZESOCKETS;
 static SOCKET CreatePort(uint16_t *port_out) {
   static uint16_t start_port = 0, range_port;
   if (!start_port) {

--- a/servershr/servershrp.h
+++ b/servershr/servershrp.h
@@ -1,16 +1,15 @@
 #ifndef SERVERSHRP_H
- #define SERVERSHRP_H
- #include <mdsplus/mdsconfig.h>
- #include <mdsdescrip.h>
- #include <pthread_port.h>
- #ifdef _WIN32
-  #include <time.h>
- #else
-  #ifndef HAVE_PTHREAD_LOCK_GLOBAL_NP
-   extern void pthread_lock_global_np();
-   extern void pthread_unlock_global_np();
-  #endif
+#define SERVERSHRP_H
+#include <mdsplus/mdsconfig.h>
+#include <mdsdescrip.h>
+#ifdef _WIN32
+ #include <time.h>
+#else
+ #ifndef HAVE_PTHREAD_LOCK_GLOBAL_NP
+  extern void pthread_lock_global_np();
+  extern void pthread_unlock_global_np();
  #endif
+#endif
 
 #ifdef MDSOBJECTSCPPSHRVS_EXPORTS
 // visual studio uses int types for typedef

--- a/tdishr/TdiDoTask.c
+++ b/tdishr/TdiDoTask.c
@@ -37,16 +37,17 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 	Ken Klare, LANL P-4     (c)1992
 */
 #include <stdlib.h>
+#include <errno.h>
+#include <signal.h>
+
 #include <mdsdescrip.h>
-#include "tdirefstandard.h"
 #include <libroutines.h>
 #include <strroutines.h>
-#include <tdishr.h>
-#include <pthread_port.h>
-#include <errno.h>
+#include <condition.h>
 #include <mdsshr.h>
+#include <tdishr.h>
 #include <treeshr.h>
-#include <signal.h>
+#include "tdirefstandard.h"
 
 extern int TdiGetFloat();
 extern int TdiGetLong();


### PR DESCRIPTION
pthread_port.h has become pretty big and some of teh stuff is only remotelly pthread related. it stated out as a port for pthread to get windows on board but extended into a general header for all kinds of stuff. this just splits it into its topics, condition, socket stuff pthread-stuff. his requires a rebase if the nci lock is merged