### PR TITLE
Build: add debug information for alpha builds

### DIFF
--- a/camshr/QueryHighwayType.c
+++ b/camshr/QueryHighwayType.c
@@ -105,6 +105,7 @@ int QueryHighwayType(char *serial_hwy_driver)
       printf(" new, unknown highway type\n");
 
     foundHost = FALSE;
+    foundVendor = FALSE;
     while (!foundHost && (fgets(line, sizeof(line), fp)) != NULL) {
       if (strstr(line, "Host:")) {
 	sscanf(line, "Host: scsi%1d Channel: %*2d Id: %2d", &tmpHost, &tmpId);
@@ -113,7 +114,6 @@ int QueryHighwayType(char *serial_hwy_driver)
 	  foundHost = TRUE;
 	  if (MSGLVL(DETAILS))
 	    printf("%s", line);
-	  foundVendor = FALSE;
 	  while (!foundVendor && fgets(line, sizeof(line), fp) != NULL) {
 	    if (strstr(line, "Vendor:")) {
 	      sscanf(line, "  Vendor: %8s Model: %16s Rev: %5s", tmpVendor, tmpModel, tmpRev);

--- a/configure
+++ b/configure
@@ -4953,38 +4953,38 @@ fi
 
 	{ $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
 $as_echo "yes" >&6; }
-	CFLAGS="${CFLAGS} -g -O0"
-	CXXFLAGS="${CXXFLAGS} -g -O0"
-	FCFLAGS="${FCFLAGS} -g -O0"
-	OBJCFLAGS="${OBJCFLAGS} -g -O0"
+	CFLAGS="${CFLAGS} -g -Og"
+	CXXFLAGS="${CXXFLAGS} -g -Og"
+	FCFLAGS="${FCFLAGS} -g -Og"
+	OBJCFLAGS="${OBJCFLAGS} -g -Og"
        ;; #(
   define) :
 
 	{ $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
 $as_echo "yes" >&6; }
-	CFLAGS="${CFLAGS} -g -O0 -DDEBUG"
-	CXXFLAGS="${CXXFLAGS} -g -O0 -DDEBUG"
-	FCFLAGS="${FCFLAGS} -g -O0"
-	OBJCFLAGS="${OBJCFLAGS} -g -O0"
+	CFLAGS="${CFLAGS} -g -Og -DDEBUG"
+	CXXFLAGS="${CXXFLAGS} -g -Og -DDEBUG"
+	FCFLAGS="${FCFLAGS} -g -Og"
+	OBJCFLAGS="${OBJCFLAGS} -g -Og"
        ;; #(
   info) :
 
 	{ $as_echo "$as_me:${as_lineno-$LINENO}: result: info" >&5
 $as_echo "info" >&6; }
-	CFLAGS="${CFLAGS} -g"
-	CXXFLAGS="${CXXFLAGS} -g"
-	FCFLAGS="${FCFLAGS} -g"
-	OBJCFLAGS="${OBJCFLAGS} -g"
+	CFLAGS="${CFLAGS} -g -O3"
+	CXXFLAGS="${CXXFLAGS} -g -O3"
+	FCFLAGS="${FCFLAGS} -g -O3"
+	OBJCFLAGS="${OBJCFLAGS} -g -O3"
        ;; #(
   profile) :
 
 	{ $as_echo "$as_me:${as_lineno-$LINENO}: result: profile" >&5
 $as_echo "profile" >&6; }
-	CFLAGS="${CFLAGS} -g -pg"
-	CXXFLAGS="${CXXFLAGS} -g -pg"
-	FCFLAGS="${FCFLAGS} -g -pg"
-	OBJCFLAGS="${OBJCFLAGS} -g -pg"
-	LDFLAGS="${LDFLAGS} -pg"
+	CFLAGS="${CFLAGS} -g -pg -O3"
+	CXXFLAGS="${CXXFLAGS} -g -pg -O3"
+	FCFLAGS="${FCFLAGS} -g -pg -O3"
+	OBJCFLAGS="${OBJCFLAGS} -g -pg -O3"
+	LDFLAGS="${LDFLAGS} -pg -O3"
        ;; #(
   *) :
 

--- a/configure
+++ b/configure
@@ -4953,19 +4953,19 @@ fi
 
 	{ $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
 $as_echo "yes" >&6; }
-	CFLAGS="${CFLAGS} -g -Og"
-	CXXFLAGS="${CXXFLAGS} -g -Og"
-	FCFLAGS="${FCFLAGS} -g -Og"
-	OBJCFLAGS="${OBJCFLAGS} -g -Og"
+	CFLAGS="${CFLAGS} -g -O0"
+	CXXFLAGS="${CXXFLAGS} -g -O0"
+	FCFLAGS="${FCFLAGS} -g -O0"
+	OBJCFLAGS="${OBJCFLAGS} -g -O0"
        ;; #(
   define) :
 
 	{ $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
 $as_echo "yes" >&6; }
-	CFLAGS="${CFLAGS} -g -Og -DDEBUG"
-	CXXFLAGS="${CXXFLAGS} -g -Og -DDEBUG"
-	FCFLAGS="${FCFLAGS} -g -Og"
-	OBJCFLAGS="${OBJCFLAGS} -g -Og"
+	CFLAGS="${CFLAGS} -g -O0 -DDEBUG"
+	CXXFLAGS="${CXXFLAGS} -g -O0 -DDEBUG"
+	FCFLAGS="${FCFLAGS} -g -O0"
+	OBJCFLAGS="${OBJCFLAGS} -g -O0"
        ;; #(
   info) :
 

--- a/deploy/platform/alpine/alpine_docker_build.sh
+++ b/deploy/platform/alpine/alpine_docker_build.sh
@@ -43,7 +43,7 @@ buildrelease() {
     mkdir -p /workspace/releasebld/${ARCH}
     rm -Rf /workspace/releasebld/${ARCH}/*
     pushd /workspace/releasebld/${ARCH}
-    config ${ARCH} ${host} bin lib
+    config ${ARCH} ${host} bin lib ${ALPHA_DEBUG_INFO}
     if [ -z "$NOMAKE" ]; then
       $MAKE
       $MAKE install

--- a/deploy/platform/debian/debian_docker_build.sh
+++ b/deploy/platform/debian/debian_docker_build.sh
@@ -73,7 +73,7 @@ buildrelease() {
     mkdir -p ${MDSPLUS_DIR};
     mkdir -p /workspace/releasebld/${bits};
     pushd /workspace/releasebld/${bits};
-    config ${config_param}
+    config ${config_param} ${ALPHA_DEBUG_INFO}
     if [ -z "$NOMAKE" ]; then
       $MAKE
       $MAKE install

--- a/deploy/platform/macosx/macosx_build.sh
+++ b/deploy/platform/macosx/macosx_build.sh
@@ -85,7 +85,7 @@ then
     ${SRCDIR}/configure \
 	    --prefix=${MDSPLUS_DIR} \
 	    --exec_prefix=${MDSPLUS_DIR} \
-	    ${JAVA_OPTS}
+	    ${JAVA_OPTS} ${ALPHA_DEBUG_INFO}
     $MAKE
     $MAKE install
     popd

--- a/deploy/platform/platform_build.sh
+++ b/deploy/platform/platform_build.sh
@@ -111,6 +111,7 @@ rundocker(){
 		   -e "HOME=/workspace" \
 		   -e "JARS_DIR=$jars_dir" \
 		   -e "TEST_TIMEUNIT" \
+		   -e "ALPHA_DEBUG_INFO" \
 		   -v ${SRCDIR}:${DOCKER_SRCDIR} \
 		   -v ${WORKSPACE}:/workspace \
 		   $port_forwarding \
@@ -157,6 +158,11 @@ default_build(){
         mkdir -p ${PUBLISHDIR}/${BRANCH}
     fi
 }
+
+if [ "$BRANCH" = "alpha" ]
+then ALPHA_DEBUG_INFO=--enable-debug=info
+else ALPHA_DEBUG_INFO=
+fi
 set +e
 platform_build="${SRCDIR}/deploy/platform/${PLATFORM}/${PLATFORM}_build.sh"
 if [ -f "${platform_build}" ]

--- a/deploy/platform/redhat/redhat_docker_build.sh
+++ b/deploy/platform/redhat/redhat_docker_build.sh
@@ -54,7 +54,7 @@ buildrelease(){
     mkdir -p ${MDSPLUS_DIR};
     mkdir -p /workspace/releasebld/64;
     pushd /workspace/releasebld/64;
-    config ${test64}
+    config ${test64} ${ALPHA_DEBUG_INFO}
     if [ -z "$NOMAKE" ]; then
       $MAKE
       $MAKE install
@@ -62,7 +62,7 @@ buildrelease(){
     popd;
     mkdir -p /workspace/releasebld/32;
     pushd /workspace/releasebld/32;
-    config ${test32}
+    config ${test32} ${ALPHA_DEBUG_INFO}
     if [ -z "$NOMAKE" ]; then
       $MAKE
       $MAKE install

--- a/deploy/platform/windows/windows_docker_build.sh
+++ b/deploy/platform/windows/windows_docker_build.sh
@@ -28,7 +28,7 @@ buildrelease() {
     mkdir -p ${MDSPLUS_DIR};
     mkdir -p /workspace/releasebld/64;
     pushd /workspace/releasebld/64;
-    config ${test64}
+    config ${test64} ${ALPHA_DEBUG_INFO}
     if [ -z "$NOMAKE" ]; then
       $MAKE
       $MAKE install
@@ -36,7 +36,7 @@ buildrelease() {
     popd;
     mkdir -p /workspace/releasebld/32;
     pushd /workspace/releasebld/32;
-    config ${test32}
+    config ${test32} ${ALPHA_DEBUG_INFO}
     if [ -z "$NOMAKE" ]; then
       $MAKE
       $MAKE install

--- a/m4/m4_ax_check_enable_debug.m4
+++ b/m4/m4_ax_check_enable_debug.m4
@@ -76,32 +76,32 @@ AC_DEFUN([AX_CHECK_ENABLE_DEBUG],[
     AS_CASE([$enable_debug],
       [yes],[
 	AC_MSG_RESULT(yes)
-	CFLAGS="${CFLAGS} -g -O0"
-	CXXFLAGS="${CXXFLAGS} -g -O0"
-	FCFLAGS="${FCFLAGS} -g -O0"
-	OBJCFLAGS="${OBJCFLAGS} -g -O0"
+	CFLAGS="${CFLAGS} -g -Og"
+	CXXFLAGS="${CXXFLAGS} -g -Og"
+	FCFLAGS="${FCFLAGS} -g -Og"
+	OBJCFLAGS="${OBJCFLAGS} -g -Og"
       ],
       [define],[
 	AC_MSG_RESULT(yes)
-	CFLAGS="${CFLAGS} -g -O0 -DDEBUG"
-	CXXFLAGS="${CXXFLAGS} -g -O0 -DDEBUG"
-	FCFLAGS="${FCFLAGS} -g -O0"
-	OBJCFLAGS="${OBJCFLAGS} -g -O0"
+	CFLAGS="${CFLAGS} -g -Og -DDEBUG"
+	CXXFLAGS="${CXXFLAGS} -g -Og -DDEBUG"
+	FCFLAGS="${FCFLAGS} -g -Og"
+	OBJCFLAGS="${OBJCFLAGS} -g -Og"
       ],
       [info],[
 	AC_MSG_RESULT(info)
-	CFLAGS="${CFLAGS} -g"
-	CXXFLAGS="${CXXFLAGS} -g"
-	FCFLAGS="${FCFLAGS} -g"
-	OBJCFLAGS="${OBJCFLAGS} -g"
+	CFLAGS="${CFLAGS} -g $5"
+	CXXFLAGS="${CXXFLAGS} -g $5"
+	FCFLAGS="${FCFLAGS} -g $5"
+	OBJCFLAGS="${OBJCFLAGS} -g $5"
       ],
       [profile],[
 	AC_MSG_RESULT(profile)
-	CFLAGS="${CFLAGS} -g -pg"
-	CXXFLAGS="${CXXFLAGS} -g -pg"
-	FCFLAGS="${FCFLAGS} -g -pg"
-	OBJCFLAGS="${OBJCFLAGS} -g -pg"
-	LDFLAGS="${LDFLAGS} -pg"
+	CFLAGS="${CFLAGS} -g -pg $5"
+	CXXFLAGS="${CXXFLAGS} -g -pg $5"
+	FCFLAGS="${FCFLAGS} -g -pg $5"
+	OBJCFLAGS="${OBJCFLAGS} -g -pg $5"
+	LDFLAGS="${LDFLAGS} -pg $5"
       ],
       [
 	AC_MSG_RESULT(no)

--- a/m4/m4_ax_check_enable_debug.m4
+++ b/m4/m4_ax_check_enable_debug.m4
@@ -76,17 +76,17 @@ AC_DEFUN([AX_CHECK_ENABLE_DEBUG],[
     AS_CASE([$enable_debug],
       [yes],[
 	AC_MSG_RESULT(yes)
-	CFLAGS="${CFLAGS} -g -Og"
-	CXXFLAGS="${CXXFLAGS} -g -Og"
-	FCFLAGS="${FCFLAGS} -g -Og"
-	OBJCFLAGS="${OBJCFLAGS} -g -Og"
+	CFLAGS="${CFLAGS} -g -O0"
+	CXXFLAGS="${CXXFLAGS} -g -O0"
+	FCFLAGS="${FCFLAGS} -g -O0"
+	OBJCFLAGS="${OBJCFLAGS} -g -O0"
       ],
       [define],[
 	AC_MSG_RESULT(yes)
-	CFLAGS="${CFLAGS} -g -Og -DDEBUG"
-	CXXFLAGS="${CXXFLAGS} -g -Og -DDEBUG"
-	FCFLAGS="${FCFLAGS} -g -Og"
-	OBJCFLAGS="${OBJCFLAGS} -g -Og"
+	CFLAGS="${CFLAGS} -g -O0 -DDEBUG"
+	CXXFLAGS="${CXXFLAGS} -g -O0 -DDEBUG"
+	FCFLAGS="${FCFLAGS} -g -O0"
+	OBJCFLAGS="${OBJCFLAGS} -g -O0"
       ],
       [info],[
 	AC_MSG_RESULT(info)

--- a/mdsdcl/cmdHelp.c
+++ b/mdsdcl/cmdHelp.c
@@ -113,7 +113,7 @@ static void findEntity(xmlNodePtr node, const char *category, const char *name, 
 static char *formatHelp(char *content)
 {
   int indentation = -1;
-  int offset;
+  int offset = 0;
   char *ans = strdup("");
   char *help = strdup(content);
   char *hlp = help;

--- a/mdsdcl/mdsdcl_commands.c
+++ b/mdsdcl/mdsdcl_commands.c
@@ -526,7 +526,7 @@ static void mdsdclSubstitute(char **cmd, char *p1, char *p2, char *p3, char *p4,
   char *ps[7] = { p1, p2, p3, p4, p5, p6, p7 };
   int p;
   for (p = 0; p < 7; p++) {
-    char param[10];
+    char param[15];
     size_t i;
     sprintf(param, "'p%d'", p + 1);
     for (i = 0; (i + 3) < strlen(*cmd); i++) {

--- a/mdslib/MdsLib.c
+++ b/mdslib/MdsLib.c
@@ -453,7 +453,7 @@ static inline int MdsValueVargs(va_list incrmtr, int connection, char *expressio
        **/
 
       if (status & 1) {
-	int ansdescr;
+	int ansdescr = 0;
 	int dims[MAX_DIMS];
 	int null = 0;
 	int dtype = arg->dtype;
@@ -679,7 +679,7 @@ static inline int MdsValue2Vargs(va_list incrmtr, int connection, char *expressi
        **/
 
       if (status & 1) {
-	int ansdescr;
+	int ansdescr = 0;
 	int dims[MAX_DIMS];
 	int null = 0;
 	int dtype = arg->dtype;

--- a/mdsmisc/ScopeUtilities.c
+++ b/mdsmisc/ScopeUtilities.c
@@ -709,7 +709,7 @@ EXPORT int GetXYSignalXd(mdsdsc_t *const inY, mdsdsc_t *const inX, mdsdsc_t *con
   if STATUS_OK status = TdiData((mdsdsc_t *)&xXd, &xXd MDS_END_ARG);
   if STATUS_OK status = TdiData((mdsdsc_t *)&yXd, &yXd MDS_END_ARG);
 
-  int nSamples;
+  int nSamples = 0;
   if STATUS_OK status = getNSamples(&yXd,&xXd,&nSamples);
   if STATUS_NOT_OK goto return_err;
   mdsdsc_a_t *xArrD = (mdsdsc_a_t *)xXd.pointer;

--- a/mitdevices/b5910a.c
+++ b/mitdevices/b5910a.c
@@ -235,8 +235,8 @@ static void ResetWave(Widget w)
 	float *x;
 	Boolean *selected;
 	Boolean *pendown;
-	float *knot_x;
-	float *knot_y;
+	float *knot_x = NULL;
+	float *knot_y = NULL;
 	int num_knots = 0;
 	int j;
 	//int knot = 0;
@@ -277,7 +277,8 @@ static void ResetWave(Widget w)
 	y = (float *)XtCalloc(num_knots + count, sizeof(float));
 	selected = XtCalloc(num_knots + count, sizeof(Boolean));
 	pendown = XtCalloc(num_knots + count, sizeof(Boolean));
-	for (j = 0; j < num_knots; j++) {
+        if (knot_x && knot_y)
+	 for (j = 0; j < num_knots; j++) {
 	  x[j] = knot_x[j];
 	  y[j] = knot_y[j];
 	  selected[j] = 1;

--- a/treeshr/TreeOpen.c
+++ b/treeshr/TreeOpen.c
@@ -596,7 +596,7 @@ static int CreateDbSlot(PINO_DATABASE ** dblist, char *tree, int shot, int editt
   int status;
   PINO_DATABASE *db;
   PINO_DATABASE *prev_db;
-  PINO_DATABASE *saved_prev_db;
+  PINO_DATABASE *saved_prev_db = NULL;
   PINO_DATABASE *useable_db = 0;
   int count;
   int stack_size = DEFAULT_STACK_LIMIT;
@@ -651,7 +651,6 @@ static int CreateDbSlot(PINO_DATABASE ** dblist, char *tree, int shot, int editt
     treeshr_errno = TreeWRITEFIRST;
     break;
   default:
-
     for (count = 0, prev_db = 0, db = *dblist; db; count++, prev_db = db, db = db->next) {
       if (!db->open) {
 	move_to_top(prev_db, db);

--- a/xmdsshr/XmdsWaveform.c
+++ b/xmdsshr/XmdsWaveform.c
@@ -2395,9 +2395,9 @@ static void DrawLines(Display * display, Window win, GC gc, XPoint * point, int 
     int num_to_right = 0;
     int num_in_middle = 0;
     short lastx = 0;
-    short enter_y;
-    short max_y;
-    short min_y;
+    short enter_y = 0;
+    short max_y = 0;
+    short min_y = 0;
     short leave_y;
     for (i = 0; i < kp; i++) {
       if (point[i].x < 0) {

--- a/xtreeshr/XTreeDefaultSquish.c
+++ b/xtreeshr/XTreeDefaultSquish.c
@@ -257,7 +257,7 @@ EXPORT int XTreeDefaultSquish(struct descriptor_a *signalsApd,
   int status = checkShapes(signalsApd,&totShapes,outShape);
   if STATUS_NOT_OK return status;
   //Check that the number of dimensions in signals is the same
-  int numDimensions;
+  int numDimensions = 0;
   status = checkNumDimensions(signalsApd,&numDimensions);
   if STATUS_NOT_OK return status;
   DESCRIPTOR_SIGNAL(outSignalD, MAX_DIMS, 0, 0);


### PR DESCRIPTION
added -g to the compiler without breaking the logic of configure simply by using the 
'--enable-debug=info' parameter if branch is alpha. worked locally but the jenkins test are not on branch alpha so.. its hard to test.
nonetheless changing the -O to -Og revealed more uninitialized compiler warnings

But then i had to drop -Og because some OS g++ did not support it.