### PR TITLE
Fix: Add influxhistorian.py to htsdevices packaging

### DIFF
--- a/deploy/packaging/debian/htsdevices.noarch
+++ b/deploy/packaging/debian/htsdevices.noarch
@@ -10,3 +10,4 @@
 ./usr/local/mdsplus/pydevices/HtsDevices/acq435st.py
 ./usr/local/mdsplus/pydevices/HtsDevices/cryocon18i.py
 ./usr/local/mdsplus/pydevices/HtsDevices/cryocon24c.py
+./usr/local/mdsplus/pydevices/HtsDevices/influxhistorian.py

--- a/deploy/packaging/redhat/htsdevices.noarch
+++ b/deploy/packaging/redhat/htsdevices.noarch
@@ -12,3 +12,4 @@
 ./usr/local/mdsplus/pydevices/HtsDevices/acq435st.py
 ./usr/local/mdsplus/pydevices/HtsDevices/cryocon18i.py
 ./usr/local/mdsplus/pydevices/HtsDevices/cryocon24c.py
+./usr/local/mdsplus/pydevices/HtsDevices/influxhistorian.py


### PR DESCRIPTION
Recent update added new file to a package but did not
updated expected package content file