### PR TITLE
Tests: enable debian9 memcheck

### DIFF
--- a/conf/valgrind-python.supp
+++ b/conf/valgrind-python.supp
@@ -649,3 +649,47 @@
    fun:_PyCFunction_FastCallKeywords
    obj:*/libpython3.7m.so*
 }
+
+{
+   debian9-64 python3.5
+   Memcheck:Addr1
+   obj:/usr/*/*python3.5*
+}
+{
+   debian9-64 python3.5
+   Memcheck:Addr4
+   obj:/usr/*/*python3.5*
+}
+{
+   debian9-64 python3.5
+   Memcheck:Addr8
+   obj:/usr/*/*python3.5*
+}
+{
+   debian9-64 python3.5
+   Memcheck:Value8
+   obj:/usr/*/*python3.5*
+}
+{
+   debian9-64 python3.5
+   Memcheck:Cond
+   obj:/usr/*/*python3.5*
+}
+{
+   debian9-64 python3.5
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:*alloc
+   obj:/usr/*/*python3.5*
+}
+{
+   debian9-64 python3.5
+   Memcheck:Leak
+   match-leak-kinds: definite
+   fun:malloc
+   obj:/usr/bin/x86_64-linux-gnu-gcc-6
+   obj:/usr/bin/x86_64-linux-gnu-gcc-6
+   obj:/usr/bin/x86_64-linux-gnu-gcc-6
+   obj:/usr/bin/x86_64-linux-gnu-gcc-6
+   obj:/usr/bin/x86_64-linux-gnu-gcc-6
+}

--- a/python/MDSplus/tests/_UnitTest.py
+++ b/python/MDSplus/tests/_UnitTest.py
@@ -42,6 +42,7 @@ class logger(object):
 
 class Tests(TestCase):
     debug = False
+    is_win = sys.platform.startswith('win')
     in_valgrind = 'VALGRIND' in os.environ
     inThread = False
     index = 0
@@ -274,7 +275,7 @@ class TreeTests(Tests):
                 shutil.rmtree(cls.tmpdir)
     def tearDown(self):
         gc.collect()
-        if self.inThread: return
+        if not self.is_win or self.inThread: return
         def isTree(o):
             try:    return isinstance(o,Tree)
             except Exception as e:

--- a/python/MDSplus/tree.py
+++ b/python/MDSplus/tree.py
@@ -471,9 +471,8 @@ class Tree(object):
         @param mode: Optional mode, one of 'Normal','Edit','New','Readonly'
         @type mode: str
         """
-        if tree is None:
-            self.public = True
-        else:
+        self.public = tree is None
+        if not self.public:
             if path is not None: self.path = path
             self._ctx = _C.c_void_p(0)
             self.tree = tree
@@ -489,7 +488,7 @@ class Tree(object):
     def __del__(self):
         if not self.public:
             self.__exit__()
-            _TreeShr.TreeFreeDbid(self.ctx)
+            _TreeShr.TreeFreeDbid(self._ctx)
 
     def __exit__(self, *args):
         """ Cleanup for with statement. If tree is open for edit close it. """


### PR DESCRIPTION
since fc26 builds for both 64 and 32 bit memcheck takes quite long with little benefit. Detected extra issues are expected due to different python/java/libc versions and should be suppressed anyway.
Debian9 is a modern os that can test on 64 bit with a recent valgrind version. 
Its much faster, i.e.  <20 min compared to >50 min on fc26.