### PR TITLE
Fix: MdsEvent locks - recursivity is not required

### DIFF
--- a/include/socket_port.h
+++ b/include/socket_port.h
@@ -19,11 +19,13 @@
  #define getpid _getpid
  #define SHUT_RDWR 2
 #else
+ typedef int SOCKET;
  #define INVALID_SOCKET -1
  #define FIONREAD_TYPE int
  #include <sys/socket.h>
  #include <netdb.h>
  #include <netinet/in.h>
+ #include <netinet/tcp.h>
  #include <arpa/inet.h>
  #include <sys/ioctl.h>
  #include <sys/wait.h>

--- a/mdsshr/UdpEventSettings.c
+++ b/mdsshr/UdpEventSettings.c
@@ -29,7 +29,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <libxml/xpathInternals.h>
 #include <strings.h>
 #include <socket_port.h>
-#include "mdsshrthreadsafe.h"
 #include <stdlib.h>
 #include <string.h>
 #include <sys/types.h>

--- a/mdsshr/UdpEvents.c
+++ b/mdsshr/UdpEvents.c
@@ -23,18 +23,6 @@ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 #include <mdsplus/mdsconfig.h>
-#ifdef _WIN32
-#include <ws2tcpip.h>
-#define SHUT_RDWR SD_BOTH
-#else
-#define SOCKET int
-#define INVALID_SOCKET -1
-#include <sys/socket.h>
-#include <netinet/in.h>
-#include <netdb.h>
-#include <arpa/inet.h>
-#include <netinet/tcp.h>
-#endif
 
 #include <stdlib.h>
 #include <stdio.h>
@@ -43,9 +31,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <errno.h>
 #include <unistd.h>
 
+#include <socket_port.h>
 #include <mdsshr.h>
 #include <libroutines.h>
-#include "mdsshrthreadsafe.h"
 
 extern int UdpEventGetPort(unsigned short *port);
 extern int UdpEventGetAddress(char **addr_format, unsigned char *arange);


### PR DESCRIPTION
MdsEvents and UdpEvents used recursive locks but there is no need for it.
* replaced locks with faster regular mutexes and some clean up