### PR TITLE
Fix: MdsException should not take char* as arg; possible leak

### DIFF
--- a/include/mdsobjects.h
+++ b/include/mdsobjects.h
@@ -123,8 +123,7 @@ class EXPORT MdsException : public std::exception {
 public:
 
     MdsException(const char *msg): msg(msg) { }
-    //MdsException(int status): msg(MdsGetMsg(status)) { }
-
+    MdsException(std::string msg): msg(msg) { }
     MdsException(int status);
 
     virtual ~MdsException() NOEXCEPT { }
@@ -134,12 +133,12 @@ public:
     /// \return error message
     virtual const char* what() const NOEXCEPT
     {
-	return msg;
+	return msg.c_str();
     }
 
 protected:
 
-    const char *msg;
+    const std::string msg;
 };
 
 

--- a/mdsobjects/cpp/mdsipobjects.cpp
+++ b/mdsobjects/cpp/mdsipobjects.cpp
@@ -256,14 +256,14 @@ Connection::Connection(char *mdsipAddr, int clevel) //mdsipAddr of the form <IP 
 {
 	mdsipAddrStr.assign((const char *)mdsipAddr);
 	this->clevel = clevel;
-    lockGlobal();
-    SetCompressionLevel(clevel);
-    sockId = ConnectToMds(mdsipAddr);
-    unlockGlobal();
+	lockGlobal();
+	SetCompressionLevel(clevel);
+	sockId = ConnectToMds(mdsipAddr);
+	unlockGlobal();
 	if(sockId <= 0) {
 		std::string msg("Cannot connect to ");
 		msg += mdsipAddr;
-		throw MdsException(msg.c_str());
+		throw MdsException(msg);
 	}
 }
 


### PR DESCRIPTION
fixes issue reported in 
http://jenkins2.mdsplus.org/job/debian9-64/534/

c.f.
https://stackoverflow.com/questions/20575291/memory-leak-using-c-exceptions