### PR TITLE
Fix: mdsplus-api comma(...) as arg support

### DIFF
--- a/java/mdsplus-api/src/main/java/mds/Mds.java
+++ b/java/mdsplus-api/src/main/java/mds/Mds.java
@@ -6,6 +6,7 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.Hashtable;
 import java.util.Vector;
+import java.util.regex.Pattern;
 import mds.Mdsdcl.DclStatus;
 import mds.data.CTX;
 import mds.data.TREE;
@@ -49,11 +50,11 @@ public abstract class Mds{
 			this.cls = cls;
 			this.props = props;
 			this.args = args;
-			if(args.length > 0 && expr.indexOf("$") == -1){
+			if(args.length > 0 && !Mds.dollar.matcher(expr).find()){
 				/** If no $ args specified, build argument list cmd($,$,...) **/
 				final StringBuilder newexpr = new StringBuilder(expr.length() + args.length * 2 + 1).append(expr);
 				for(int i = 0; i < args.length; i++)
-					newexpr.append(i == 0 ? '(' : ',').append('$');
+					newexpr.append(i == 0 ? '(' : ',').append("($;)");
 				this.expr = newexpr.append(')').toString();
 			}else this.expr = expr;
 		}
@@ -73,6 +74,7 @@ public abstract class Mds{
 			return sb.toString();
 		}
 	}
+	public static final Pattern	dollar = Pattern.compile("\\$[0-9]*(?=[^a-zA-Z]|$)");
 	protected static final int	MAX_NUM_EVENTS	= 256;
 	private static Mds			active;
 	private static MdsIp shared_tunnel = null;

--- a/java/mdsplus-api/src/main/java/mds/Shr.java
+++ b/java/mdsplus-api/src/main/java/mds/Shr.java
@@ -43,13 +43,13 @@ public abstract class Shr{
 		}
 
 		public final LibCall<T> ctx(final Pointer ctx) {
-			this.descr.insert(0, "__c=$;");
+			this.descr.insert(0, "__c=($;);");
 			this.args.add(0, ctx);
 			return this.arg("val(__c)");
 		}
 
 		public final LibCall<T> ctxp(final Pointer ctxp) {
-			this.descr.insert(0, "__c=$;");
+			this.descr.insert(0, "__c=($;);");
 			this.args.add(0, ctxp);
 			return this.arg("ref(__c)");
 		}
@@ -57,7 +57,7 @@ public abstract class Shr{
 		public final LibCall<T> descr(final Descriptor<?> d) {
 			if(Descriptor.isMissing(d)) return this.miss();
 			this.args.add(d);
-			return this.arg("descr($)");
+			return this.arg("descr(($;))");
 		}
 
 		public final LibCall<T> descr(final int val) {
@@ -135,7 +135,7 @@ public abstract class Shr{
 		public final LibCall<T> ref(final Descriptor<?> d) {
 			if(Descriptor.isMissing(d)) return this.miss();
 			this.args.add(d);
-			return this.arg("ref($)");
+			return this.arg("ref(($;))");
 		}
 
 		public final LibCall<T> ref(final long val) {
@@ -163,7 +163,7 @@ public abstract class Shr{
 		public final LibCall<T> val(final Descriptor<?> d) {
 			if(Descriptor.isMissing(d)) return this.miss();
 			this.args.add(d);
-			return this.arg("val($)");
+			return this.arg("val(($;))");
 		}
 
 		public final LibCall<T> val(final int val) {
@@ -185,7 +185,7 @@ public abstract class Shr{
 		public final LibCall<T> xd(final Descriptor<?> d) {
 			if(Descriptor.isMissing(d)) return this.miss();
 			this.args.add(d);
-			return this.arg("xd(as_is($))");
+			return this.arg("xd(as_is(($;)))");
 		}
 
 		public final LibCall<T> xd(final String var) {
@@ -195,7 +195,7 @@ public abstract class Shr{
 
 		final LibCall<T> obj(final String mod, final String... ex) {
 			this.sep().append(mod).append('(');
-			if(ex.length == 0) this.sb.append('$');
+			if(ex.length == 0) this.sb.append("($;)");
 			else for(final String e : ex)
 				this.sb.append(e);
 			this.sb.append(')');

--- a/java/mdsplus-api/src/main/java/mds/TdiShr.java
+++ b/java/mdsplus-api/src/main/java/mds/TdiShr.java
@@ -49,7 +49,7 @@ public class TdiShr extends TreeShr{
 
 	public final DescriptorStatus _tdiIntrinsic(final CTX ctx, final OPC opcode, final Descriptor<?>... args) throws MdsException {
 		final Request<List> request = new TdiCall<List>(List.class, "_TdiIntrinsic").ctxp(ctx.getDbid()).val(opcode.ordinal())//
-		        .val(args.length).ref(new List(args)).xd("a").finL("a", "s", "c");
+				.val(args.length).ref(new List(args)).xd("a").finL("a", "s", "c");
 		return new DescriptorStatus(this.mds.getDescriptor(null, request));
 	}
 
@@ -67,19 +67,19 @@ public class TdiShr extends TreeShr{
 
 	public final int[] getShotDB(final StringDsc expt, final Descriptor_S<?> path, final Int32 lower, final Int32 upper) throws MdsException {
 		final ArrayList<Descriptor<?>> args = new ArrayList<Descriptor<?>>(4);
-		final StringBuilder expr = new StringBuilder(32).append("getShotDB($");
+		final StringBuilder expr = new StringBuilder(63).append("getShotDB(($;)");
 		args.add(expt);
 		if(path != null){
 			args.add(path);
-			expr.append(",$");
+			expr.append(",($;)");
 		}else expr.append(",*");
 		if(lower != null){
 			args.add(lower);
-			expr.append(",$");
+			expr.append(",($;)");
 		}else expr.append(",*");
 		if(upper != null){
 			args.add(upper);
-			expr.append(",$");
+			expr.append(",($;)");
 		}else expr.append(",*");
 		return this.mds.getIntegerArray(expr.append(')').toString(), args.toArray(new Descriptor[args.size()]));
 	}
@@ -114,7 +114,7 @@ public class TdiShr extends TreeShr{
 	public final DescriptorStatus tdiIntrinsic(final CTX ctx, final OPC opcode, final Descriptor<?>... args) throws MdsException {
 		if(ctx != null && this.mds.MdsEND_ARG() > 0) return this._tdiIntrinsic(ctx, opcode, args);
 		final Request<List> request = new TdiCall<List>(List.class, "TdiIntrinsic").val(opcode.ordinal())//
-		        .val(args.length).ref(new List(args)).xd("a").finL("a", "s");
+				.val(args.length).ref(new List(args)).xd("a").finL("a", "s");
 		return new DescriptorStatus(this.mds.getDescriptor(ctx, request));
 	}
 

--- a/java/mdsplus-api/src/main/java/mds/data/descriptor/Descriptor.java
+++ b/java/mdsplus-api/src/main/java/mds/data/descriptor/Descriptor.java
@@ -386,7 +386,7 @@ public abstract class Descriptor<T>{
 	public Descriptor<?> getData(final DTYPE... omits) {
 		try{
 			if(this instanceof DATA) return this;
-			if(this.use_mds_local()) return Descriptor.mds_local.getDescriptor(this.tree, "DATA($)", this.getLocal());
+			if(this.use_mds_local()) return Descriptor.mds_local.getDescriptor(this.tree, "DATA(($;))", this.getLocal());
 			return this.getData_(omits);
 		}catch(final MdsException e){
 			return Missing.NEW;

--- a/java/mdsplus-api/src/main/java/mds/mdsip/MdsIp.java
+++ b/java/mdsplus-api/src/main/java/mds/mdsip/MdsIp.java
@@ -14,7 +14,6 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.Vector;
 import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 import debug.DEBUG;
 import mds.ContextEventListener;
 import mds.Mds;
@@ -250,7 +249,6 @@ public class MdsIp extends Mds{
 			this.use_ssh = usessh;
 		}
 	}
-	private static final Pattern	dollar				= Pattern.compile("\\$");
 	public static final int			LOGIN_OK			= 1, LOGIN_ERROR = 2, LOGIN_CANCEL = 3;
 	private static final byte		MAX_MSGS			= 8;
 	private static final String		NOT_CONNECTED		= "Not Connected.";
@@ -281,10 +279,10 @@ public class MdsIp extends Mds{
 					if(notatomic[i]) args[i] = req.args[i].serializeDsc();
 					else args[i] = req.args[i];
 				}
-			final Matcher m = MdsIp.dollar.matcher(req.expr);
+			final Matcher m = Mds.dollar.matcher(req.expr);
 			int pos = 0;
 			for(int i = 0; i < args.length && m.find(); i++){
-				cmd.append(req.expr.substring(pos, m.start())).append(notatomic[i] ? "`__$si($)" : "$");
+				cmd.append(req.expr.substring(pos, m.start())).append(notatomic[i] ? "`__$si(($;))" : "($;)");
 				pos = m.end();
 			}
 			cmd.append(req.expr.substring(pos));
@@ -370,10 +368,10 @@ public class MdsIp extends Mds{
 			}
 			return (T)new Int32(msg.asIntArray()[0]);
 		}
-		final StringBuilder sb = new StringBuilder().append("List(*,EXECUTE($");
+		final StringBuilder sb = new StringBuilder().append("List(*,EXECUTE(($;)");
 		for(int i = 0; i < req.args.length; i++)
-			sb.append(",$");
-		sb.append("),__$sw(`_$c_=__$sw($)))");
+			sb.append(",($;)");
+		sb.append("),__$sw(`_$c_=__$sw(($;))))");
 		final Vector<Descriptor<?>> vec = new Vector<Descriptor<?>>();
 		vec.add(Descriptor.valueOf(req.expr));
 		vec.addAll(Arrays.asList(req.args));

--- a/java/mdsplus-api/src/test/java/mds/AllTests.java
+++ b/java/mdsplus-api/src/test/java/mds/AllTests.java
@@ -16,7 +16,7 @@ import mds.mdsip.MdsIp.Provider;
 @RunWith(Suite.class)
 @SuiteClasses({TREE_Test.class, CONST_Test.class, Mds_Test.class, TreeShr_Test.class, MdsShr_Test.class, Function_Test.class, Descriptor_S_Test.class, Descriptor_A_Test.class, Descriptor_CA_Test.class}) // , Editors_Test.class})
 public class AllTests{
-	private static boolean			local		= false;
+	private static boolean			local		= true;
 	private static boolean			mdsip		= true;
 	private static boolean			use_local	= false;
 	private static final int		port		= 8000;

--- a/java/mdsplus-api/src/test/java/mds/TreeShr_Test.java
+++ b/java/mdsplus-api/src/test/java/mds/TreeShr_Test.java
@@ -24,7 +24,7 @@ import mds.data.descriptor_s.Int32;
 import mds.data.descriptor_s.Missing;
 import mds.data.descriptor_s.NODE;
 import mds.data.descriptor_s.NODE.Flags;
-import mds.data.descriptor_s.Nid;
+import mds.data.descriptor_s.Path;
 import mds.data.descriptor_s.Pointer;
 
 public class TreeShr_Test{
@@ -131,7 +131,7 @@ public class TreeShr_Test{
 	@Test
 	@SuppressWarnings({"unchecked", "rawtypes"})
 	public final void testTreeCall() {
-		Assert.assertEquals("__a=*;__b=0Q;__s=TreeShr->TreeMethod(ref($),ref(0Q),ref(__b),val(1),xd(as_is($)),xd(__a),descr($));execute(\"deallocate('__*');as_is(`(__a;))\")", new TreeShr.TreeCall(null, "TreeMethod").ref(new Int32(1)).ref(0l).ref("b", "0Q").val(1).xd(new Int32(1)).xd("a").descr(new Int32(1)).expr("__a"));
+		Assert.assertEquals("__a=*;__b=0Q;__s=TreeShr->TreeMethod(ref(($;)),ref(0Q),ref(__b),val(1),xd(as_is(($;))),xd(__a),descr(($;)));execute(\"deallocate('__*');as_is(`(__a;))\")", new TreeShr.TreeCall(null, "TreeMethod").ref(new Int32(1)).ref(0l).ref("b", "0Q").val(1).xd(new Int32(1)).xd("a").descr(new Int32(1)).expr("__a"));
 	}
 
 	@Test
@@ -280,10 +280,12 @@ public class TreeShr_Test{
 	public final void testTreePutRecord() throws MdsException {
 		TreeShr_Test.treeshr.treeOpenNew(ctx, TreeShr_Test.expt, TreeShr_Test.model);
 		try{
-			Assert.assertEquals(1, TreeShr_Test.treeshr.treeAddNode(ctx, "A", NODE.USAGE_ANY).getData());
-			Assert.assertEquals(2, TreeShr_Test.treeshr.treeAddNode(ctx, "D", NODE.USAGE_DISPATCH).getData());
-			Assert.assertEquals(3, TreeShr_Test.treeshr.treeAddNode(ctx, "T", NODE.USAGE_TASK).getData());
-			Assert.assertEquals(MdsException.TreeSUCCESS, TreeShr_Test.treeshr.treePutRecord(ctx, 1, new Action(new Nid(2), new Nid(3), null, null, null)));
+			Assert.assertEquals(1, TreeShr_Test.treeshr.treeAddNode(ctx, "ACT", NODE.USAGE_ACTION).getData());
+			Assert.assertEquals(2, TreeShr_Test.treeshr.treeAddNode(ctx, "TSK", NODE.USAGE_TASK).getData());
+			Assert.assertEquals(3, TreeShr_Test.treeshr.treeAddNode(ctx, "ANY", NODE.USAGE_ANY).getData());
+			Assert.assertEquals(MdsException.TreeSUCCESS, TreeShr_Test.treeshr.treePutRecord(ctx, 1, new Action(new Path("TSK"), new Path("ANY"), null, null, null)));
+			Assert.assertEquals(MdsException.TreeSUCCESS, TreeShr_Test.treeshr.treePutRecord(ctx, 3, TreeShr_Test.mds.getAPI().tdiCompile(ctx, "_=1,_").getData()));
+			Assert.assertEquals("_ = 1, _", TreeShr_Test.treeshr.treeGetRecord(ctx, 3).decompile());
 		}finally{
 		}
 	}


### PR DESCRIPTION
 execute('fun($)',comma(1,2)) expands to fun(1,2), protect with ($;)

addresses  #1904