### PR TITLE
Fix: added EINVAL to the list of expected errnos

### DIFF
--- a/mdstcpip/GetMdsMsg.c
+++ b/mdstcpip/GetMdsMsg.c
@@ -50,6 +50,7 @@ static int GetBytesTO(Connection* c, void *buffer, size_t bytes_to_recv, int to_
       if (errno==ETIMEDOUT)		return TdiTIMEOUT;
       if (bytes_recv==0 && to_msec>=0)	return TdiTIMEOUT;
       if (errno == EINTR)		return MDSplusERROR;
+      if (errno == EINVAL)		return SsINTERNAL;
       if (errno) {fprintf(stderr, "Connection %d ", id);perror("possibly lost");}
       return SsINTERNAL;
     }


### PR DESCRIPTION
Error occurs if client or server (in an other thread) decides to drop connection after an exception, etc.
Kind of a race condition but has not impact as recv catches it (this way).