### PR TITLE
Fix: clearer handling of access rights; honour denied (\!)

### DIFF
--- a/mdstcpip/CheckClient.c
+++ b/mdstcpip/CheckClient.c
@@ -69,19 +69,21 @@ static inline int filter_string(char **const str_ptr, const int upcase) {
   return c - str; // is strlen
 }
 
+#define ACCESS_NOMATCH	0
+#define ACCESS_GRANTED	1
+#define ACCESS_DENIED	2
 #ifdef _WIN32
 #define become_user(remote_user,local_user) 1
 #else
 static int become_user(const char *remote_user, const char *local_user)
 { // both args may be NULL
   if (!local_user || !*local_user)
-    return 0;// NULL or empty
+    return ACCESS_NOMATCH;// NULL or empty
   if (strcmp(local_user, "SELF") == 0)
-    return 1;// NOP
+    return ACCESS_GRANTED;// NOP
   const int map_to_local = strcmp(local_user, "MAP_TO_LOCAL") == 0;
   if (map_to_local && !(remote_user || *remote_user))
-    return 0;// cannot map to invalid remote user
-  int ok = 0;
+    return ACCESS_DENIED;// cannot map to invalid remote user
   const int is_root = remote_user && strcmp(remote_user, "root") == 0; // if map_to_local map root to nobody
   const char *user;
   if (map_to_local) {
@@ -99,33 +101,38 @@ static int become_user(const char *remote_user, const char *local_user)
     pwd = getpwnam(lowuser);
     free(lowuser);
   }
+  int access;
   if (pwd) {
     initgroups(pwd->pw_name, pwd->pw_gid);
     if (setgid(pwd->pw_gid) || setuid(pwd->pw_uid)) {
       fprintf(stderr,"Cannot set gid/uid - run server as root!\n");
-      exit(EX_NOPERM);
+      access = ACCESS_DENIED;
     } else {
-      ok = setenv("HOME",pwd->pw_dir,TRUE) ? 0 : 1;
-      if (!ok)
+      if (setenv("HOME",pwd->pw_dir,TRUE)) {
         fprintf(stderr,"Failed to set HOME for user \"%s\"\n", user);
+	access = ACCESS_DENIED;
+      } else
+	access = ACCESS_GRANTED;
     }
-  } else
+  } else {
     fprintf(stderr,"Invalid mapping, cannot find user \"%s\"\n", user);
-  return ok;
+    access = ACCESS_DENIED;
+  }
+  return access;
 }
 #endif
 
 int CheckClient(const char *const username, int num, char *const *const matchString)
 {
-  int ok = 0;
+  int access = ACCESS_NOMATCH;
   char *hostfile = GetHostfile();
   if (strncmp(hostfile, "TDI", 3)) {
     FILE *f = fopen(hostfile, "r");
     if (f) {
       char line_c[1024], *access_id, *local_user;
-      while (ok == 0 && fgets(line_c, 1023, f)) {
+      while (access == ACCESS_NOMATCH && fgets(line_c, 1023, f)) {
 	if (line_c[0] != '#') {
-	  int i;
+	  int i, deny;
           access_id = line_c;
 	  local_user = strchr(line_c,'|');
           if (local_user) {
@@ -133,23 +140,28 @@ int CheckClient(const char *const username, int num, char *const *const matchStr
 	    filter_string(&local_user, FALSE);
 	  }
 	  if (filter_string(&access_id,  TRUE )) { // not empty
-	    for (i = 0; i < num; i++) {
+	    if ((deny = access_id[0] == '!')) {
+	      access_id++; // drop '!'
+	      if (!filter_string(&access_id, FALSE)) {
+		if (username)
+                  access = ACCESS_DENIED; // deny
+		else
+		  continue; // looking for multi
+	      }
+	    }
+	    DESCRIPTOR_FROM_CSTRING(access_d,access_id);
+	    for (i = 0; i < num && access == ACCESS_NOMATCH; i++) {
 	      char *const buf = strdup(matchString[i]);
 	      mdsdsc_t match_d = { 0, DTYPE_T, CLASS_S, buf };
               match_d.length = (length_t)filter_string(&match_d.pointer,  TRUE );
-	      if (access_id[0] != '!') {
-		if (strcmp(match_d.pointer, "MULTI") == 0 && strcmp(access_id, "MULTI") == 0)
-		  ok = become_user(NULL, local_user);
-		else {
-		  DESCRIPTOR_FROM_CSTRING(access_d,access_id);
-		  if IS_OK(StrMatchWild(&match_d, &access_d))
-		    ok = GetMulti() ? 1 : become_user(username, local_user);
-		}
-	      } else {
-		access_id++; // drop '!'
-		DESCRIPTOR_FROM_CSTRING(access_d,access_id);
+	      if (deny) {
 		if IS_OK(StrMatchWild(&match_d, &access_d))
-		  ok = 2;
+		  access = ACCESS_DENIED;
+	      }	else {
+		if (strcmp(match_d.pointer, "MULTI") == 0 && strcmp(access_id, "MULTI") == 0)
+		  access = become_user(NULL, local_user);
+		else if IS_OK(StrMatchWild(&match_d, &access_d))
+		  access = GetMulti() ? ACCESS_GRANTED : become_user(username, local_user);
 	      }
 	      free(buf);
 	    }
@@ -177,14 +189,13 @@ int CheckClient(const char *const username, int num, char *const *const matchStr
 	 * or could lead to unsafe code execution
 	 */
         fprintf(stderr,"CheckClient: invalid username '%s'.",username);
-        return 0;
+        return ACCESS_DENIED;
       }
       cmdlen += strlen(username) + 1;
     }
     int i;
     for (i = 0; i < num; i++)
       cmdlen += strlen(matchString[i]) + 3;
-
     char *cmd_end, *const cmd = (char *)malloc(cmdlen);
     cmd_end = cmd + sprintf(cmd, "%s(", hostfile + 3);
     if (username)
@@ -199,19 +210,20 @@ int CheckClient(const char *const username, int num, char *const *const matchStr
     status = tdiExecute(&cmd_d, &ans_d MDS_END_ARG);
     free(cmd);
     if STATUS_OK {
-      ok = 1;
+      access = ACCESS_GRANTED;
       if (ans_d.pointer && ans_d.length > 0) {
-	if (GetMulti()) {
+	if (!GetMulti()) {
 	  ans_d.pointer = realloc(ans_d.pointer,ans_d.length+1);
 	  ans_d.pointer[ans_d.length] = '\0';
-	  ok = become_user(username, ans_d.pointer);
+	  access = become_user(username, ans_d.pointer);
         }
 	StrFree1Dx((mdsdsc_d_t *)&ans_d);
       }
     } else if (status == TdiUNKNOWN_VAR) {
       fprintf(stderr, "CheckClient: Failed to load tdi function \"%s\": terminate\n", hostfile + 3);
       exit(EXIT_FILE_OPEN_ERROR);
-    }
+    } else
+      access = ACCESS_DENIED;
   }
-  return ok;
+  return access;
 }

--- a/mdstcpip/ioroutinestcp.h
+++ b/mdstcpip/ioroutinestcp.h
@@ -273,7 +273,12 @@ static int io_listen(int argc, char **argv){
   // multiple connections with own context /////////////////////////////////
   char *matchString[] = { "multi" };
   if (CheckClient(0, 1, matchString) == ACCESS_DENIED)
-    exit(EX_NOPERM);
+#ifdef _WIN32
+  // cannot change user on Windows
+  fprintf(stderr,"WARNING: 'multi' user found hostfile but Windows cannot change user.\n");
+#else
+  exit(EX_NOPERM);
+#endif
   // SOCKET //
   /* Create the socket and set it up to accept connections. */
   SOCKET ssock = socket(AF_T, SOCK_STREAM, 0);

--- a/mdstcpip/ioroutinestcp.h
+++ b/mdstcpip/ioroutinestcp.h
@@ -272,7 +272,8 @@ static int io_listen(int argc, char **argv){
   // MULTIPLE CONNECTION MODE              /////////////////////////////////
   // multiple connections with own context /////////////////////////////////
   char *matchString[] = { "multi" };
-  CheckClient(0, 1, matchString);
+  if (CheckClient(0, 1, matchString) == ACCESS_DENIED)
+    exit(EX_NOPERM);
   // SOCKET //
   /* Create the socket and set it up to accept connections. */
   SOCKET ssock = socket(AF_T, SOCK_STREAM, 0);

--- a/mdstcpip/ioroutinesudt.h
+++ b/mdstcpip/ioroutinesudt.h
@@ -80,7 +80,13 @@ static int io_listen(int argc, char **argv){
       exit(EXIT_FAILURE);
     }
     char *matchString[] = { "multi" };
-    CheckClient(0, 1, matchString);
+    if (CheckClient(0, 1, matchString) == ACCESS_DENIED)
+#ifdef _WIN32
+  // cannot change user on Windows
+  fprintf(stderr,"WARNING: 'multi' user found hostfile but Windows cannot change user.\n");
+#else
+  exit(EX_NOPERM);
+#endif
     for (rp = result; rp != NULL; rp = rp->ai_next) {
       ssock = udt_socket(rp->ai_family, rp->ai_socktype, rp->ai_protocol);
       if (ssock == INVALID_SOCKET)

--- a/mdstcpip/ioroutinesx.h
+++ b/mdstcpip/ioroutinesx.h
@@ -284,7 +284,7 @@ static int io_authorize(Connection* c, char *username){
   char *iphost = NULL,*hoststr = NULL;
   FREE_ON_EXIT(iphost);
   FREE_ON_EXIT(hoststr);
-  ans = C_OK;
+  ans = ACCESS_NOMATCH;
   SOCKET sock = getSocket(c);
   char now[32];Now32(now);
   if ((iphost = getHostInfo(sock, &hoststr))) {

--- a/mdstcpip/mdsip_connections.h
+++ b/mdstcpip/mdsip_connections.h
@@ -3,6 +3,9 @@
 #define MdsLib_H
 #define _GNU_SOURCE /* glibc2 needs this */
 
+#ifndef _WIN32
+ #include <sysexits.h>
+#endif
 #include <mdsdescrip.h>
 #include <status.h>
 #include <ipdesc.h>
@@ -155,6 +158,9 @@ typedef struct _io_routines {
   ssize_t (*recv_to)(Connection* c, void *buffer, size_t len, int to_msec);
   int     (*check)(Connection* c);
 } IoRoutines;
+#define ACCESS_NOMATCH 0
+#define ACCESS_GRANTED 1
+#define ACCESS_DENIED  2
 
 #define EVENTASTREQUEST "---EVENTAST---REQUEST---"
 #define EVENTCANREQUEST "---EVENTCAN---REQUEST---"


### PR DESCRIPTION
```
!             : deny prefix or general DENY if no match string
                may be surrounded by space
multi         : match for multi mode - server will become this user on startup
user@1.2.3.*  : user from ip mask
user@hostname : user from host
user@*        : user from anywhere
*@1.2.3.4     : anyone from ip
*@hostname    : anyone from host
*             : anyone from anywhere
```