### PR TITLE
Feature: adds tests for CheckClient and fixes issues on the way

### DIFF
--- a/include/mdsdescrip.h
+++ b/include/mdsdescrip.h
@@ -142,6 +142,8 @@ arsize	total size of array in bytes,
   dimct_t  dimct;	\
   arsize_t arsize;
 
+#define IS_ARRAY_DSC(p) ((p)->class == CLASS_A || (p)->class == CLASS_CA || (p)->class == CLASS_APD)
+
 typedef struct descriptor_a {
   ARRAY_HEAD(char)
   /*

--- a/tdishr/TdiBound.c
+++ b/tdishr/TdiBound.c
@@ -65,14 +65,16 @@ static const length_t size_l = (length_t)sizeof(int);
 int Tdi1Bound(opcode_t opcode, int narg, struct descriptor *list[], struct descriptor_xd *out_ptr)
 {
   INIT_STATUS;
-  array_bounds *pa = 0;
+  array_bounds *pa;
   struct descriptor_xd sig[1] = {EMPTY_XD}, uni[1] = {EMPTY_XD}, dat[1] = {EMPTY_XD};
   struct TdiCatStruct cats[2];
   int dim, rank = 0;
 
   status = TdiGetArgs(opcode, 1, list, sig, uni, dat, cats);
+  pa = (array_bounds *) dat[0].pointer;
+  if (pa && pa->class == CLASS_APD) // size lists
+    status = SsINTERNAL;
   if STATUS_OK {
-    pa = (array_bounds *) dat[0].pointer;
     if (pa)
       switch (pa->class) {
       case CLASS_D:
@@ -83,6 +85,8 @@ int Tdi1Bound(opcode_t opcode, int narg, struct descriptor *list[], struct descr
 	  rank = 1;
 	break;
       case CLASS_A:
+      case CLASS_CA:
+      case CLASS_APD:
 	rank = pa->aflags.coeff ? pa->dimct : 1;
 	break;
       default:
@@ -111,8 +115,11 @@ int Tdi1Bound(opcode_t opcode, int narg, struct descriptor *list[], struct descr
     if STATUS_OK
       status = MdsGet1DxA((struct descriptor_a *)&adsc, &size_l, &dtype_l, out_ptr);
   }
-  if (STATUS_OK && rank > 0)
-    (*TdiRefFunction[opcode].f3) (pa, dim, out_ptr->pointer->pointer);
+  if (STATUS_OK && rank > 0) {
+    TdiRefFunction[opcode].f3(pa, dim, out_ptr->pointer->pointer);
+    if (STATUS_OK && pa->dtype == DTYPE_DICTIONARY)
+        *(int*)out_ptr->pointer->pointer /= 2; // count pairs
+  }
   MdsFree1Dx(&dat[0], NULL);
   MdsFree1Dx(&uni[0], NULL);
   MdsFree1Dx(&sig[0], NULL);
@@ -126,7 +133,7 @@ void Tdi3Lbound(array_bounds * pa, int dim, int *pbound)
 {
   int dimct, j;
 
-  if (pa->class != CLASS_A)
+  if (!IS_ARRAY_DSC(pa))
     *pbound = 0;
   else if (pa->aflags.coeff) {
     dimct = pa->dimct;
@@ -153,7 +160,7 @@ void Tdi3Shape(array_bounds * pa, int dim, int *pbound)
 {
   int dimct, j;
 
-  if (pa->class != CLASS_A)
+  if (!IS_ARRAY_DSC(pa))
     *pbound = -1;
   else if (pa->aflags.coeff) {
     dimct = pa->dimct;
@@ -181,8 +188,7 @@ void Tdi3Shape(array_bounds * pa, int dim, int *pbound)
 int Tdi3Size(array_bounds * pa, int dim, int *pbound)
 {
   int dimct, j;
-
-  if (pa->class != CLASS_A)
+  if (!IS_ARRAY_DSC(pa))
     *pbound = pa->dtype == DTYPE_MISSING ? 0 : 1;
   else if (pa->aflags.coeff) {
     *pbound = 1;
@@ -213,8 +219,7 @@ int Tdi3Size(array_bounds * pa, int dim, int *pbound)
 void Tdi3Ubound(array_bounds * pa, int dim, int *pbound)
 {
   int dimct, j;
-
-  if (pa->class != CLASS_A)
+  if (!IS_ARRAY_DSC(pa))
     *pbound = pa->dtype == DTYPE_MISSING ? -1 : 0;
   else if (pa->aflags.coeff) {
     dimct = pa->dimct;

--- a/tdishr/TdiSubscript.c
+++ b/tdishr/TdiSubscript.c
@@ -122,17 +122,18 @@ int Tdi1Subscript(opcode_t opcode, int narg, struct descriptor *list[], struct d
       DESCRIPTOR_LONG(ans, &check);
       ARRAY(struct descriptor *) * apd = (void *)dat[0].pointer;
       for (idx = 0; idx < ((apd->arsize / apd->length) - 1); idx += 2) {
-	if ((TdiEq(apd->pointer[idx], list[1], &ans MDS_END_ARG) & 1) == 1 && check == 1) {
+	if (IS_OK(TdiEq(apd->pointer[idx], list[1], &ans MDS_END_ARG)) && check == 1) {
 	  status = MdsCopyDxXd(apd->pointer[idx + 1], out_ptr);
-	  break;
+	  goto baddat;
 	}
       }
+      status = MdsCopyDxXd(NULL, out_ptr);
     } else if (dat[0].pointer && dat[0].pointer->dtype == DTYPE_LIST) {
       unsigned int idx;
-      int stat;
       ARRAY(struct descriptor *) * apd = (void *)dat[0].pointer;
-      stat = TdiGetLong(list[1], &idx);
-      if (stat & 1 && idx < apd->arsize / apd->length) {
+      status = TdiGetLong(list[1], &idx);
+      if STATUS_NOT_OK goto baddat;
+      if (idx < apd->arsize / apd->length) {
 	status = MdsCopyDxXd(apd->pointer[idx], out_ptr);
       }
     }

--- a/tditest/tditest.c
+++ b/tditest/tditest.c
@@ -223,7 +223,7 @@ int main(int argc, char **argv)
   rl_completer_word_break_characters = " ,;[{(+-*\\/^<>=:&|!?~";
   mdsdsc_t expr_dsc = { 0, DTYPE_T, CLASS_S, 0};
   EMPTYXD(ans);
-  char *command=NULL;
+  char * buf, *command;
   char error_out_c[64], clear_errors_c[64];
   DESCRIPTOR(mdsconnect, "MDSCONNECT($)");
   DESCRIPTOR(mdsvalue,   "MDSVALUE('DECOMPILE(`EXECUTE($))',$)");
@@ -307,17 +307,19 @@ int main(int argc, char **argv)
   sigaction(SIGINT, &act, NULL);
 #endif
   set_readline_handlers();
-  while ((command=getExpression(f_in))
+  while ((buf=command=getExpression(f_in))
       && strcasecmp(command,"exit") != 0
       && strcasecmp(command,"quit") != 0   ) {
     int comment = command[0] == '#';
     if (!comment) {
       if (f_in) {
-	fprintf(f_out,"%s\n",command);
-	fflush(f_out);
+	if (command[0] == '@') {
+	  command++;
+	} else {
+	  fprintf(f_out,"%s\n",command);
+	  fflush(f_out);
+	}
       }
-    }
-    if (!comment) {
       expr_dsc.length = strlen(command);
       expr_dsc.pointer = command;
       set_execute_handlers();
@@ -335,7 +337,7 @@ int main(int argc, char **argv)
       set_readline_handlers();
       add_history(command);
     }
-    free(command);
+    free(buf);
   }
   MdsFree1Dx(&ans,NULL);
   if (history_file) {

--- a/tditest/testing/test-mdsip.ans
+++ b/tditest/testing/test-mdsip.ans
@@ -10,3 +10,27 @@ mdsvalue("$",[[[[[[[[1]]]]]]]])
 [[[[[[[[1]]]]]]]]
 mdsvalue("$",[[[[[[[[1,2]]]]]]],[[[[[[[3,4]]]]]]]])
 [[[[[[[[1,2]]]]]]], [[[[[[[3,4]]]]]]]]
+cat - > /tmp/test-mdsip.hosts << EOF
+unknown@* | MAP_TO_LOCAL
+known@1.* | SELF
+EOF
+          0          1          1          0
+          1          1          1          0
+cat - > /tmp/test-mdsip.hosts << EOF
+!known@2.*.*.7
+unknown@* | MAP_TO_LOCAL
+unknown@* | SELF
+known@*
+!*@*
+*
+EOF
+          1          2          2          0
+          1          1          1          1
+cat - > /tmp/test-mdsip.hosts << EOF
+!known@*.*.*.7
+*
+multi | SELF
+EOF
+          0          0          2          1
+          1          1          2          1
+"/tmp/test-mdsip.hosts"

--- a/tditest/testing/test-mdsip.tdi
+++ b/tditest/testing/test-mdsip.tdi
@@ -11,3 +11,45 @@ mdsvalue("$",[[[[[[[1]]]]]]])
 mdsvalue("$",[[[[[[[[1]]]]]]]])
 # 8 dims dim[i] != 1 for first and last
 mdsvalue("$",[[[[[[[[1,2]]]]]]],[[[[[[[3,4]]]]]]]])
+# test CheckClient
+@public _hostfile = "/tmp/test-mdsip.hosts";\
+fun set_hostfile(in _lines) {\
+	WRITE(,"cat - > "//_hostfile//" << EOF");\
+	_f = FOPEN(_hostfile,"w+");\
+	_s = SIZE(_lines);\
+	for(_i=0;_i<_s;_i++) {\
+		WRITE(_f,_lines[_i]);\
+		WRITE(,_lines[_i]);\
+	}\
+	FCLOSE(_f);\
+	WRITE(,"EOF");\
+};\
+/*workaround to get persistent pointer to string*/\
+public fun strdup(in _str) {setenv("_="//_str);MdsShr->TranslateLogical:P(ref("_"));};\
+public fun free(in _ptr) MdsShr->MdsFree:MISSING(val(_ptr));\
+fun check_user(in _user, in _host, in _ip) {\
+	_match = [strdup(_user//"@"//_host),strdup(_user//"@"//_ip)];\
+	_res = MdsIpShr->CheckClient(ref(_user),val(2),ref(_match));\
+	free(_match[0]);free(_match[1]);return(_res);\
+};\
+MdsIpShr->SetHostfile(val(strdup(_hostfile)));\
+_hostfiles = LIST(\
+,LIST(,"unknown@* | MAP_TO_LOCAL","known@1.* | SELF")\
+,LIST(,"!known@2.*.*.7","unknown@* | MAP_TO_LOCAL","unknown@* | SELF","known@*","!*@*","*")\
+,LIST(,"!known@*.*.*.7","*","multi | SELF")\
+);\
+_multi = [strdup("multi")];\
+_hs = SIZE(_hostfiles);\
+for(_h=0;_h<_hs;_h++) {\
+set_hostfile(execute("(`_hostfiles)[_h]"));\
+for(_m=0;_m<=1;_m++) {\
+MdsIpShr->SetMulti(val(_m));WRITE(,[\
+check_user("unknown","anywhere","1.2.3.4"),\
+check_user("known","anywhere","1.2.3.4"),\
+check_user("known","badserver","1.2.3.7"),\
+MdsIpShr->CheckClient(ref(0),val(1),ref(_multi)),\
+*]);};\
+};\
+_hostfile = MdsIpShr->GetHostfile:T();\
+free(MdsIpShr->SetHostfile:P(val(0)));\
+free(_multi);_hostfile


### PR DESCRIPTION
* Added support for SIZE SHAPE ... on APD
* Added special character "@" to tditest that can be used to suppress 
* CheckClient shall not exit the process on issues but deny access instead
* rtype MISSING should not try to read return value as it might be undefined behavior
  use lib->fun:MISSING() if fun is "void fun()"
* APD array should return MISSING just like arrays if index out of bounds

Concludes fix of issue #1926 for patch in stable.