### PR TITLE
Feature: mdsrecord and cached decorators to tree.py

### DIFF
--- a/python/MDSplus/tests/devices/TestDevice.py
+++ b/python/MDSplus/tests/devices/TestDevice.py
@@ -228,7 +228,7 @@ class TestDevice(Device):
     @mdsrecord(filter=int, default=0)
     def done(self): return self.manual_done
 
-    _reg = 0
+    _reg = 0  # used to simulate volatile readout
     @cached_property
     def cache(self):
         self._reg += 1

--- a/python/MDSplus/tests/devices/TestDevice.py
+++ b/python/MDSplus/tests/devices/TestDevice.py
@@ -25,70 +25,211 @@
 
 import time
 import threading
-from MDSplus import Device,DevUNKOWN_STATE,Int32Array
+from MDSplus import Device, DevUNKOWN_STATE, Int32Array
+from MDSplus import with_mdsrecords, mdsrecord, cached_property
 
+
+@with_mdsrecords
 class TestDevice(Device):
-    parts=[
-        {'path': ':ACTIONSERVER',               'type': 'TEXT',    'options':('no_write_shot','write_once')},
-        {'path': ':ACTIONSERVER:INIT1',         'type': 'ACTION',  'options':('no_write_shot','write_once'), 'valueExpr':'Action(Dispatch(head.ACTIONSERVER,"INIT",10),Method(None,"init1",head))'},
-        {'path': ':ACTIONSERVER:INIT2',         'type': 'ACTION',  'options':('no_write_shot','write_once'), 'valueExpr':'Action(Dispatch(head.ACTIONSERVER,"INIT",head.ACTIONSERVER.INIT1),Method(None,"init2",head))'},
-        {'path': ':ACTIONSERVER:PULSE',         'type': 'ACTION',  'options':('no_write_shot','write_once'), 'valueExpr':'Action(node.DISPATCH,node.TASK)'},
-        {'path': ':ACTIONSERVER:PULSE:DISPATCH','type': 'DISPATCH','options':('no_write_shot','write_once'), 'valueExpr':'Dispatch(head.ACTIONSERVER,"PULSE",10)'},
-        {'path': ':ACTIONSERVER:PULSE:TASK',    'type': 'TASK',    'options':('no_write_shot','write_once'), 'valueExpr':'Method(None,"pulse",head)'},
-        {'path': ':ACTIONSERVER:STORE',         'type': 'ACTION',  'options':('no_write_shot','write_once'), 'valueExpr':'Action(node.DISPATCH,node.TASK)'},
-        {'path': ':ACTIONSERVER:STORE:DISPATCH','type': 'DISPATCH','options':('no_write_shot','write_once'), 'valueExpr':'Dispatch(head.ACTIONSERVER,"STORE",10)'},
-        {'path': ':ACTIONSERVER:STORE:TASK',    'type': 'TASK',    'options':('no_write_shot','write_once'), 'valueExpr':'Method(None,"store",head)'},
-        {'path': ':ACTIONSERVER:MANUAL',        'type': 'ACTION',  'options':('no_write_shot','write_once'), 'valueExpr':'Action(node.DISPATCH,node.TASK)'},
-        {'path': ':ACTIONSERVER:MANUAL:DISPATCH','type':'DISPATCH','options':('no_write_shot','write_once'), 'valueExpr':'Dispatch(head.ACTIONSERVER,"MANUAL",10)'},
-        {'path': ':ACTIONSERVER:MANUAL:TASK',   'type': 'TASK',    'options':('no_write_shot','write_once'), 'valueExpr':'Method(None,"manual",head)'},
-        {'path': ':TASK_TEST',                  'type': 'TASK',    'options':('no_write_shot','write_once'), 'valueExpr':'Method(None,"test",head)'},
-        {'path': ':TASK_ERROR1',                'type': 'TASK',    'options':('no_write_shot','write_once'), 'valueExpr':'Method(None,"error",head)'},
-        {'path': ':TASK_TIMEOUT',               'type': 'TASK',    'options':('no_write_shot','write_once'), 'valueExpr':'Method(1.,"timeout",head)'},
-        {'path': ':TASK_ERROR2',                'type': 'TASK',    'options':('no_write_shot','write_once'), 'valueExpr':'Method(10.,"error",head)'},
-        {'path': ':INIT1_DONE',                 'type': 'NUMERIC', 'options':('no_write_model','write_once')},
-        {'path': ':INIT2_DONE',                 'type': 'NUMERIC', 'options':('no_write_model','write_once')},
-        {'path': ':PULSE_DONE',                 'type': 'NUMERIC', 'options':('no_write_model','write_once')},
-        {'path': ':STORE_DONE',                 'type': 'NUMERIC', 'options':('no_write_model','write_once')},
-        {'path': ':MANUAL_DONE',                'type': 'NUMERIC', 'options':('no_write_model','write_once')},
-        {'path': ':DATA',                       'type': 'SIGNAL',  'options':('no_write_model','write_once')},
+    parts = [
+        dict(
+            path=':ACTIONSERVER',
+            type='TEXT',
+            options=('no_write_shot', 'write_once'),
+        ),
+        dict(
+            path=':ACTIONSERVER:INIT1',
+            type='ACTION',
+            options=('no_write_shot', 'write_once'),
+            valueExpr=(
+             'Action('
+             'Dispatch(head.ACTIONSERVER, "INIT", 10),'
+             'Method(None, "init1", head))'),
+        ),
+        dict(
+            path=':ACTIONSERVER:INIT2',
+            type='ACTION',
+            options=('no_write_shot', 'write_once'),
+            valueExpr=(
+             'Action('
+             'Dispatch(head.ACTIONSERVER, "INIT", head.ACTIONSERVER.INIT1),'
+             'Method(None, "init2", head))'),
+        ),
+        dict(
+            path=':ACTIONSERVER:PULSE',
+            type='ACTION',
+            options=('no_write_shot', 'write_once'),
+            valueExpr='Action(node.DISPATCH, node.TASK)'
+        ),
+        dict(
+            path=':ACTIONSERVER:PULSE:DISPATCH',
+            type='DISPATCH',
+            options=('no_write_shot', 'write_once'),
+            valueExpr='Dispatch(head.ACTIONSERVER, "PULSE", 10)'
+        ),
+        dict(
+            path=':ACTIONSERVER:PULSE:TASK',
+            type='TASK',
+            options=('no_write_shot', 'write_once'),
+            valueExpr='Method(None, "pulse", head)'
+        ),
+        dict(
+            path=':ACTIONSERVER:STORE',
+            type='ACTION',
+            options=('no_write_shot', 'write_once'),
+            valueExpr='Action(node.DISPATCH, node.TASK)',
+        ),
+        dict(
+            path=':ACTIONSERVER:STORE:DISPATCH',
+            type='DISPATCH',
+            options=('no_write_shot', 'write_once'),
+            valueExpr='Dispatch(head.ACTIONSERVER, "STORE", 10)',
+        ),
+        dict(
+            path=':ACTIONSERVER:STORE:TASK',
+            type='TASK',
+            options=('no_write_shot', 'write_once'),
+            valueExpr='Method(None,"store",head)',
+        ),
+        dict(
+            path=':ACTIONSERVER:MANUAL',
+            type='ACTION',
+            options=('no_write_shot', 'write_once'),
+            valueExpr='Action(node.DISPATCH,node.TASK)',
+        ),
+        dict(
+            path=':ACTIONSERVER:MANUAL:DISPATCH',
+            type='DISPATCH',
+            options=('no_write_shot', 'write_once'),
+            valueExpr='Dispatch(head.ACTIONSERVER, "MANUAL", 10)',
+        ),
+        dict(
+            path=':ACTIONSERVER:MANUAL:TASK',
+            type='TASK',
+            options=('no_write_shot', 'write_once'),
+            valueExpr='Method(None,"manual",head)',
+        ),
+        dict(
+            path=':TASK_TEST',
+            type='TASK',
+            options=('no_write_shot', 'write_once'),
+            valueExpr='Method(None, "test", head)',
+        ),
+        dict(
+            path=':TASK_ERROR1',
+            type='TASK',
+            options=('no_write_shot', 'write_once'),
+            valueExpr='Method(None, "error", head)'
+        ),
+        dict(
+            path=':TASK_TIMEOUT',
+            type='TASK',
+            options=('no_write_shot', 'write_once'),
+            valueExpr='Method(1., "timeout", head)',
+        ),
+        dict(
+            path=':TASK_ERROR2',
+            type='TASK',
+            options=('no_write_shot', 'write_once'),
+            valueExpr='Method(10., "error", head)',
+        ),
+        dict(
+            path=':INIT1_DONE',
+            type='NUMERIC',
+            options=('no_write_model', 'write_once'),
+            filter=float,
+            cached=0,  # cache_on_set = False
+        ),
+        dict(
+            path=':INIT2_DONE',
+            type='NUMERIC',
+            options=('no_write_model', 'write_once'),
+            filter=float,
+            cached=1,  # cache_on_set = True
+        ),
+        dict(
+            path=':PULSE_DONE',
+            type='NUMERIC',
+            options=('no_write_model', 'write_once'),
+            filter=float,
+        ),
+        dict(
+            path=':STORE_DONE',
+            type='NUMERIC',
+            options=('no_write_model', 'write_once'),
+            filter=float,
+        ),
+        dict(
+            path=':MANUAL_DONE',
+            type='NUMERIC',
+            options=('no_write_model', 'write_once'),
+            filter=float,
+            default=-1,
+        ),
+        dict(
+            path=':DATA',
+            type='SIGNAL',
+            options=('no_write_model', 'write_once'),
+        ),
     ]
+
     class Worker(threading.Thread):
         """An async worker should be a proper class
            This ensures that the methods remian in memory
            It should at least take one argument: teh device node
         """
-        def __init__(self,dev):
-            super(TestDevice.Worker,self).__init__(name=dev.path)
-            # make a thread safe copy of the device node with a non-global context
+        def __init__(self, dev):
+            super(TestDevice.Worker, self).__init__(name=dev.path)
+            # make thread safe copy of device node with a non-global context
             self.dev = dev.copy()
+
         def run(self):
             self.dev.tree.normal()
-            self.dev.DATA.beginSegment(0,9,Int32Array(range(10)),Int32Array([0]*10))
+            self.dev.DATA.beginSegment(0, 9,
+                                       Int32Array(range(10)),
+                                       Int32Array([0]*10))
             for i in range(10):
                 time.sleep(.1)
-                self.dev.DATA.putSegment(Int32Array([i]),i)
+                self.dev.DATA.putSegment(Int32Array([i]), i)
+
     def init1(self):
-        self.init1_done.record = time.time()
+        self._init1_done = time.time()
+
     def init2(self):
         """start async worker"""
         thread = self.Worker(self)
         thread.start()
         # store thread reference in persistent field
-        self.persistent = {'thread':thread}
-        self.init2_done.record = time.time()
+        self.persistent = dict(thread=thread)
+        self._init2_done = time.time()
+
     def pulse(self):
-        self.pulse_done.record = time.time()
+        self._pulse_done = time.time()
+
     def store(self):
         """joins async worker"""
         self.persistent['thread'].join()
         # cleanup thread reference
         self.persistent = None
-        self.store_done.record = time.time()
+        self._store_done = time.time()
+
     def manual(self):
-        self.manual_done.record = time.time()
+        self._manual_done = time.time()
+
     def test(self):
         return 'TEST'
+
     def error(self):
         raise DevUNKOWN_STATE
+
     def timeout(self):
         time.sleep(10)
+
+    @mdsrecord(filter=int, default=0)
+    def done(self): return self.manual_done
+
+    _reg = 0
+    @cached_property
+    def cache(self):
+        self._reg += 1
+        return self._reg

--- a/python/MDSplus/tests/treeUnitTest.py
+++ b/python/MDSplus/tests/treeUnitTest.py
@@ -371,8 +371,28 @@ class Tests(_UnitTest.TreeTests):
             pytree.SIG_CMPRS.record=node.record
             self.assertTrue((pytree.SIG_CMPRS.record == node.record).all(),
                              msg="Error writing compressed signal%s"%node)
+    def mdsrecords(self):
+        with Tree('pytree',self.shot+11,'new') as pytree:
+            node = pytree.addDevice('DEV', 'TestDevice')
+            pytree.write()
+        pytree.normal()
+        cls = node.__class__
+        self.assertFalse(cls._init1_done.cache_on_set)
+        self.assertTrue(cls._init2_done.cache_on_set)
+        self.assertEqual(node._manual_done, -1)
+        self.assertEqual(node.done, 0)
+        node._manual_done = 123.456
+        self.assertEqual(node._manual_done, 123.456)
+        self.assertEqual(node.done, 123)
+        self.assertEqual(float(node.manual_done.getData()), 123.456)
+        self.assertEqual(node._manual_done.__class__, float)
+        self.assertEqual(node.cache, 1)
+        self.assertEqual(node.cache, 1)
+        del(node.cache)
+        self.assertEqual(node.cache, 2)
+
     @staticmethod
     def getTests():
-        return ['extAttr','openTrees','getNode','setDefault','nodeLinkage','nciInfo','getData','getXYSignal','getCompression']
+        return ['extAttr','openTrees','getNode','setDefault','nodeLinkage','nciInfo','getData','getXYSignal','getCompression','mdsrecords']
 
 Tests.main(__name__)

--- a/python/MDSplus/tree.py
+++ b/python/MDSplus/tree.py
@@ -2935,7 +2935,6 @@ class cached_property(object):
     del(self._trigger)  <=> clear cache
     """
     def __init__(self, target=None, is_property=False, **opt):
-        """ """
         mode = opt.get('mode', 0)
         self.lock = _threading.Lock()
         self.cache_on_set = (mode & 1) > 0
@@ -2984,7 +2983,7 @@ class mdsrecord(object):
     ...
     dev = tree.MYDEVICE
     dev._trigger = 5   <=>   dev.trigger.record = 5
-    a = dev._trigger   <=>   a = float(dev.trigger.record.data())
+    a = dev._trigger   <=>   a = float(dev.trigger.record)
     del(dev._trigger)  <=>   dev.trigger.record = None
     # if trigger contains no data _trigger defaults to 0
     """

--- a/python/MDSplus/tree.py
+++ b/python/MDSplus/tree.py
@@ -1868,7 +1868,7 @@ class TreeNode(_dat.TreeRef,_dat.Data): # HINT: TreeNode begin  (maybe subclass 
         """
         if isinstance(path,(int,_scr.Int32)):
             ans = TreeNode(path,self.tree)
-        else:       
+        else:
             nidout=_C.c_int32(0)
             _exc.checkStatus(
                         _TreeShr._TreeFindNodeRelative(self.ctx,
@@ -2924,6 +2924,123 @@ class TreeNodeArray(_dat.TreeRef,_arr.Int32Array): # HINT: TreeNodeArray begin
             ans.append(val)
         try:    return _arr.Array(ans)
         except: return _apd.List(*ans)
+
+
+class cached_property(object):
+    """ converts to property with cache
+    cache_on_set: controls if setter will set or clear cache
+    class MYDEVICE(Device):
+        @cached_property
+        def _trigger(self): return self.trigger
+    del(self._trigger)  <=> clear cache
+    """
+    def __init__(self, target=None, is_property=False, **opt):
+        """ """
+        mode = opt.get('mode', 0)
+        self.cache_on_set = (mode & 1) > 0
+        if target:
+            if is_property:
+                self.target = target
+            else:
+                self.target = property(target)
+
+    def __call__(self, method):
+        if hasattr(self, 'target'):
+            raise Exception("cached_property.target already set")
+        self.target = property(method)
+        return self
+
+    def __get__(self, inst, cls):
+        if inst is None: return self
+        if self.target in inst.__dict__:
+            return inst.__dict__[self.target]
+        else:
+            data = self.target.__get__(inst, cls)
+            inst.__dict__[self.target] = data
+            return data
+
+    def __set__(self, inst, value):
+        self.target.__set__(inst, value)
+        if (self.cache_on_set):
+            inst.__dict__[self.target] = value
+        else:
+            del(inst.__dict__[self.target])
+
+    def __delete__(self, inst):
+        if self.target in inst.__dict__:
+            del(inst.__dict__[self.target])
+
+
+class mdsrecord(object):
+    """ turns method into property
+    expects method that return MDSplus node
+    class MYDEVICE(Device):
+        @mdsrecord(filter=float, default=0)
+        def _trigger(self): return self.trigger
+    ...
+    dev = tree.MYDEVICE
+    dev._trigger = 5   <=>   dev.trigger.record = 5
+    a = dev._trigger   <=>   a = float(dev.trigger.record.data())
+    del(dev._trigger)  <=>   dev.trigger.record = None
+    # if trigger contains no data _trigger defaults to 0
+    """
+    def __new__(cls, *target, **opt):
+        """ use new so in can return cached_property """
+        self = object.__new__(cls)
+        self.filter = opt.get("filter", None)
+        if 'default' in opt:
+            self.default = [opt['default']]
+        else:
+            self.default = []
+        self.cached = opt.get("cached", None)
+        if target:
+            return self(target[0])
+        return self
+
+    def __call__(self, target):
+        if hasattr(self, 'target'):
+            raise Exception("mdsrecord.target already set")
+        self.target = target
+        if self.cached is None:
+            return self
+        return cached_property(self, True, mode=self.cached)
+
+    def __get__(self, inst, cls):
+        if inst is None: return self
+        node = self.target.__get__(inst, cls)()
+        try:
+            data = node.getRecord()
+        except _exc.TreeNODATA:
+            if self.default:
+                return self.default[0]
+            raise
+        if self.filter is None:
+            return data
+        return self.filter(data)
+
+    def __set__(self, inst, value):
+        node = self.target.__get__(inst)()
+        node.putData(value)
+
+    def __delete__(self, inst):
+        node = self.target.__get__(inst)()
+        node.deleteData()
+
+
+def with_mdsrecords(cls):
+    """ decorator for device class
+    adds mdsrecord for each part in parts field
+    """
+    def genfun(field, part):
+        @mdsrecord(**part)
+        def _(self): return getattr(self, field)
+        return _
+    for part in cls.parts:
+        field = part['path'].lower().replace('.', '_').replace(':', '_')
+        fun = genfun(field[1:], part)
+        setattr(cls, field, fun)
+    return cls
+
 
 class Device(TreeNode): # HINT: Device begin
     """Used for device support classes. Provides ORIGINAL_PART_NAME, PART_NAME and Add methods and allows referencing of subnodes as conglomerate node attributes.


### PR DESCRIPTION
This adds two useful decorators I use in all of my devices; I figured they might be useful to others as well.
updated TestDevice:
- show usage of mdsrecord, cached_property, and with_mdsrecords
- changed coding style to comply with PEP8 for best practice

added tests