### PR TITLE
Fix: show example overview for wgsi even without trailing /

### DIFF
--- a/python/MDSplus/wsgi/conf/25-mdsplus.conf
+++ b/python/MDSplus/wsgi/conf/25-mdsplus.conf
@@ -13,5 +13,5 @@ fastcgi.server += ("/mdsplus.wsgi" =>
 )
 
 url.rewrite-once += (
-	"^/mdsplus/(.*)$" => "/mdsplus.wsgi/$1"
+	"^/mdsplus(|/(.*))$" => "/mdsplus.wsgi/$2"
 )


### PR DESCRIPTION
before: http://server:80/mdsplus showed 404 error
now: http://server:80/mdsplus is the same as http://server:80/mdsplus/