### PR TITLE
Fix: fix python cast with units and help and error

### DIFF
--- a/python/MDSplus/compound.py
+++ b/python/MDSplus/compound.py
@@ -510,21 +510,25 @@ class Opaque(_dat.TreeRefX,Compound):
         return opq
 _dsc.addDtypeToClass(Opaque)
 
-class WithUnits(_dat.TreeRefX,Compound):
+class WithCompound(Compound):
+    def __str__(self): return str(self.__getattr__('data'))
+    def __bytes__(self): return bytes(self.__getattr__('data'))
+
+class WithUnits(_dat.TreeRefX,WithCompound):
     """Specifies a units for any kind of data.
     """
     fields=('data','units')
     dtype_id=211
 _dsc.addDtypeToClass(WithUnits)
 
-class WithError(_dat.TreeRefX,Compound):
+class WithError(_dat.TreeRefX,WithCompound):
     """Specifies error information for any kind of data.
     """
     fields=('data','error')
     dtype_id=213
 _dsc.addDtypeToClass(WithError)
 
-class Parameter(_dat.TreeRefX,Compound):
+class Parameter(_dat.TreeRefX,WithCompound):
     """Specifies a help text and validation information for any kind of data.
     """
     fields=('data','help','validation')

--- a/python/MDSplus/mdsdata.py
+++ b/python/MDSplus/mdsdata.py
@@ -421,7 +421,7 @@ class Data(NoTreeRef):
     def __int__(self):
         """Integer: x.__int__() <==> int(x)
         @rtype: int"""
-        return int(self.getLong()._value)
+        return int(_cmp.DATA(_cmp.QUADWORD(self)).evaluate()._value)
     __index__ = __int__
 
     def __len__(self):
@@ -433,12 +433,12 @@ class Data(NoTreeRef):
     def __long__(self):
         """Convert this object to python long
         @rtype: long"""
-        return _ver.long(self.getLong()._value)
+        return _ver.long(_cmp.DATA(_cmp.QUADWORD(self)).evaluate()._value)
 
     def __float__(self):
         """Float: x.__float__() <==> float(x)
         @rtype: float"""
-        return float(self.getDouble()._value)
+        return float(_cmp.DATA(_cmp.FT_FLOAT(self)).evaluate()._value)
 
     def __round__(self,*arg):
         """Round value to next integer: x.__round__() <==> round(x)
@@ -512,19 +512,28 @@ class Data(NoTreeRef):
         except _exc.MDSplusException:
             return None
 
+    def _str_bad_ref(self):
+        return super(Data,self).__str__()
+
     def __str__(self):
         try:
             return _ver.tostr(self.decompile())
         except _exc.MDSplusException:
             return self._str_bad_ref()
 
-    def _str_bad_ref(self):
-        return super(Data,self).__str__()
+    def __bytes__(self):
+        try:
+            return _ver.tobytes(self.decompile())
+        except _exc.MDSplusException:
+            return self._str_bad_ref()
 
     def __repr__(self):
         """Representation
         @rtype: String"""
-        return str(self)
+        try:
+            return _ver.tostr(self.decompile())
+        except _exc.MDSplusException:
+            return self._str_bad_ref()
 
     def data(self,*altvalue):
         """Return primitimive value of the data.

--- a/python/MDSplus/tests/dataUnitTest.py
+++ b/python/MDSplus/tests/dataUnitTest.py
@@ -354,18 +354,6 @@ class Tests(_UnitTest.Tests):
         self._doTdiTest('_d=dict(*,1,"1",2,"2")', m.Dictionary([1,'1',2,'2']))
         self._doTdiTest('_d=dict(_d,3,"3")', m.Dictionary([1,'1',2,'2',3,"3"]))
 
-    def tdiPythonInterface(self):
-        self._doTdiTest("Py('a=None')",1)
-        self._doTdiTest("Py('a=None','a')",None)
-        self._doTdiTest("Py('a=123','a')",123)
-        self._doTdiTest("Py('import MDSplus;a=MDSplus.Uint8(-1)','a')",m.Uint8(255))
-        self._doTdiTest('addfun("test","import __main__\n_file_=__main__.__file__\nstatic=[0]\ndef test():\n static[0]+=1\n return [1 if __main__.__file__==_file_ else 0]+static")',"TEST")
-        if not self.inThread: self._doTdiTest("TEST()",m.Array([1, 1]))
-        self._doTdiTest("pyfun('Uint8','MDSplus',-1)",m.Uint8(255))
-        self._doTdiTest("pyfun('Uint8',*,-1)",m.Uint8(255))
-        self._doTdiTest("pyfun('str',*,123)",m.String("123"))
-        if not self.inThread: self._doTdiTest("TEST()",m.Array([1, 2]))
-
     def decompile(self):
         self.assertEqual(str(m.Uint8(123)),'123BU')
         self.assertEqual(str(m.Uint16(123)),'123WU')
@@ -379,8 +367,30 @@ class Tests(_UnitTest.Tests):
         self.assertEqual(str(m.Float64(1.2E-3)),'.0012D0')
         self.assertEqual(str(m.Signal(m.ZERO(100000,0.).evaluate(),None,0.)),"Build_Signal(Set_Range(100000,0D0 /*** etc. ***/), *, 0D0)")
 
+    def python_casts(self):
+        for WITH in (m.WithError, m.Parameter, m.WithUnits):
+            data = WITH(1,"with")
+            self.assertEqual(int(data), 1, WITH)
+            if m.version.ispy2:
+                self.assertEqual(long(data), 1, WITH)
+            self.assertEqual(float(data), 1., WITH)
+            self.assertEqual(str(data), "1", WITH)
+            self.assertEqual(bytes(data), b"1", WITH)
+
+    def tdiPythonInterface(self):
+        self._doTdiTest("Py('a=None')",1)
+        self._doTdiTest("Py('a=None','a')",None)
+        self._doTdiTest("Py('a=123','a')",123)
+        self._doTdiTest("Py('import MDSplus;a=MDSplus.Uint8(-1)','a')",m.Uint8(255))
+        self._doTdiTest('addfun("test","import __main__\n_file_=__main__.__file__\nstatic=[0]\ndef test():\n static[0]+=1\n return [1 if __main__.__file__==_file_ else 0]+static")',"TEST")
+        if not self.inThread: self._doTdiTest("TEST()",m.Array([1, 1]))
+        self._doTdiTest("pyfun('Uint8','MDSplus',-1)",m.Uint8(255))
+        self._doTdiTest("pyfun('Uint8',*,-1)",m.Uint8(255))
+        self._doTdiTest("pyfun('str',*,123)",m.String("123"))
+        if not self.inThread: self._doTdiTest("TEST()",m.Array([1, 2]))
+
     @staticmethod
     def getTests():
-        return ['data','scalars','arrays','vmsSupport','tdiFunctions','decompile','tdiPythonInterface']
+        return ['data','scalars','arrays','vmsSupport','tdiFunctions','decompile','python_casts','tdiPythonInterface']
 
 Tests.main(__name__)


### PR DESCRIPTION
The core issue its that descriptors dont unpack WithError Properties and WithUnits for performance reasons. I think this is a good thing but int() str() long() and float() dont support it
this PR changes it. also it restores the str behavior for WithError WithUnits and Parameter 