### PR TITLE
Fix: old Matlab api; no javalibpath on modern matlab and python3 bridge

### DIFF
--- a/matlab/MDSarg.m
+++ b/matlab/MDSarg.m
@@ -1,10 +1,8 @@
 function obj = MDSarg( value )
-%MDSarg deprecated function. New function is mdsFromMatlab.
+% MDSARG  deprecated in favour of mdsFromMatlab.
 %   This function is deprecated. please use mdsFromMatlab instead
-  info=mdsInfo();
-  if ~info.useLegacy
-    display('The MDSarg function is deprecated. Please use mdsFromMatlab instead')
-  end
-  obj = mdsFromMatlab(value);
+    warning('MDSplus:Legacy',...
+        'The MDSarg function is deprecated. Please use mdsFromMatlab instead')
+    obj = mdsFromMatlab(value);
 end
 

--- a/matlab/NATIVEvalue.m
+++ b/matlab/NATIVEvalue.m
@@ -1,9 +1,7 @@
-function [ obj ] = NATIVEvalue( value )
-%NATIVEvalue deprecated function. New function is mdsToMatlab.
+function obj = NATIVEvalue( value )
+% NATIVEVALUE  deprecated in favour of mdsToMatlab
 %   This function is deprecated. please use mdsToMatlab instead
-  info=mdsInfo();
-  if ~info.useLegacy
-    display('The NATIVEvalue function is deprecated. Please use mdsToMatlab instead')
-  end
-  obj = mdsToMatlab(value);
+    warning('MDSplus:Legacy',...
+        'The NATIVEvalue function is deprecated. Please use mdsToMatlab instead')
+    obj = mdsToMatlab(value);
 end

--- a/matlab/mdsFromMatlab.m
+++ b/matlab/mdsFromMatlab.m
@@ -1,102 +1,88 @@
-function  result = mdsFromMatlab( thing )
-%mdsFromMatlab - returns an MDSplus object created from a Matlab object
+function  result = mdsFromMatlab( value )
+% MDSFROMMATLAB  returns an MDSplus object created from a Matlab object
+%	This function returns an MDSplus object representation of its input
+%   argument.
 %
-% This function returns an MDSplus object representation of its input
-% argument.
+%   syntax:
+%       mdsresult=mdsFromMatlab(matlab-native-object)
 %
-% syntax:
-%   mdsresult=mdsFromMatlab(matlab-native-object)
-%
-  info=mdsInfo();
-  if info.usePython
-    dtype=class(thing);
-    switch dtype
-      case 'char'
-        result=thing;
-      otherwise
-        switch dtype
-          case 'single'
-            dtype='float32';
-          case 'double'
-            dtype='float64';
-          case 'cell'
-            dtype='string';
-        end
-        if isscalar(thing)
-          f=str2func(strcat('py.numpy.',dtype));
-          result=f(thing);
-	else
-	  py_numpy_array=str2func('py.numpy.array');  
-          sz=size(thing);
-          result=py_numpy_array(reshape(thing,int32(1),prod(int32(size(thing)))),dtype);
-          if not(numel(sz) == 2 && sz(2) == 1)
-	    py_numpy_resize=str2func('py.numpy.resize');
-            py_numpy_ascontiguousarray=str2func('py.numpy.ascontiguousarray');
-            presult=py_numpy_resize(result,int32(sz));
-            result=py_numpy_resize(result,presult.transpose().shape);
-            result=py_numpy_ascontiguousarray(result);
-          end
-        end
-    end
-  else
-    sz = size(thing);
-    if isequal(sz, [1,1])
-      switch class(thing)
-        case 'double'
-            result = javaObject('MDSplus.Float64',thing);
-        case 'single'
-            result = javaObject('MDSplus.Float32',thing);
-        case 'int64'
-            result = javaObject('MDSplus.Int64',thing);
-        case 'uint64'
-            result = javaObject('MDSplus.Uint64',thing);
-        case 'int32'
-            result = javaObject('MDSplus.Int32',thing);
-        case 'uint32'
-            result = javaObject('MDSplus.Uint32',thing);
-        case 'int16'
-            result = javaObject('MDSplus.Int16',thing);
-        case 'uint16'
-            result = javaObject('MDSplus.Uint16',thing);
-        case 'int8'
-            result = javaObject('MDSplus.Int8',thing);
-        case 'uint8'
-	          result = javaObject('MDSplus.Uint8',thing);
-        case 'char'
-            result = javaObject('MDSplus.String',thing);
-        otherwise
-            result = thing;
-      end
+    info = mdsInfo();
+    if info.usePython
+        result = matlab2python(value, info);
     else
-      switch class(thing)
-        case 'double'
-            result = javaObject('MDSplus.Float64Array',reshape(thing,[],1),sz);
-        case 'single'
-            result = javaObject('MDSplus.Float32Array',reshape(thing,[],1),sz);
-        case 'int64'
-            result = javaObject('MDSplus.Int64Array',reshape(thing,[],1),sz);
-        case 'uint64'
-            result = javaObject('MDSplus.Uint64Array',reshape(thing,[],1),sz);
-        case 'int32'
-             result = javaObject('MDSplus.Int32Array',reshape(thing,[],1),sz);
-        case 'uint32'
-             result = javaObject('MDSplus.Uint32Array',reshape(thing,[],1),sz);
-        case 'int16'
-            result = javaObject('MDSplus.Int16Array',reshape(thing,[],1),sz);
-        case 'uint16'
-            result = javaObject('MDSplus.Uint16Array',reshape(thing,[],1),sz);
-        case 'int8'
-            result = javaObject('MDSplus.Int8Array',reshape(thing,[],1),sz);
-        case 'uint8'
-            result = javaObject('MDSplus.Uint8Array',reshape(thing,[],1),sz);
-        case 'char'
-            result = javaObject('MDSplus.String',thing);
-        case 'cell'
-              result = javaObject('MDSplus.StringArray',reshape(thing,[],1),sz);
-        otherwise
-            result = thing;
-      end
+        result = matlab2java(value, info);
     end
-  end
 end
 
+function result = matlab2python(value, info)
+    dtype=class(value);
+    switch dtype
+        case 'char'
+            result = value;
+        otherwise
+            switch dtype
+                case 'single'
+                    dtype='float32';
+                case 'double'
+                    dtype='float64';
+                case 'cell'
+                    dtype='str';
+            end
+            if info.ispy2 && contains(dtype,'int64')
+                warning('MDSplus:python2_int64','%s\n',...
+                    'Loss of precision: python2 does not support int64 properly. Try python3 instead.',...
+                    'You can disable this warning with "warning(''off'', ''MDSplus:python2_int64'')"')
+                value = double(value);
+            end
+            if isscalar(value)
+                f=str2func(strcat('py.numpy.',dtype));
+                result=f(value);
+            else
+                sz = size(value);
+                result = py.numpy.array(reshape(value,int32(1),prod(int32(sz))),dtype);
+                if not(numel(sz) == 2 && sz(2) == 1)
+                    result = py.numpy.resize(result, flip(int32(sz)));
+                    result = py.numpy.ascontiguousarray(result);
+                end
+            end
+    end
+end
+
+function result = matlab2java(value, ~)
+    switch class(value)
+        case 'double'
+            javaclass = 'MDSplus.Float64';
+        case 'single'
+            javaclass = 'MDSplus.Float32';
+        case 'int64'
+            javaclass = 'MDSplus.Int64';
+        case 'uint64'
+            javaclass = 'MDSplus.Uint64';
+        case 'int32'
+            javaclass = 'MDSplus.Int32';
+        case 'uint32'
+            javaclass = 'MDSplus.Uint32';
+        case 'int16'
+            javaclass = 'MDSplus.Int16';
+        case 'uint16'
+            javaclass = 'MDSplus.Uint16';
+        case 'int8'
+            javaclass = 'MDSplus.Int8';
+        case 'uint8'
+            javaclass = 'MDSplus.Uint8';
+        case 'cell'
+            javaclass = 'MDSplus.String';
+        case 'char'
+            result = javaObject('MDSplus.String',value);
+            return
+        otherwise
+            result = value;
+            return
+    end
+    sz = size(value);
+    if isequal(sz, [1,1])
+        result = javaObject(javaclass,value);
+    else
+        result = javaObject(strcat(javaclass,'Array'),reshape(value,[],1),sz);
+    end
+end

--- a/matlab/mdsInfo.m
+++ b/matlab/mdsInfo.m
@@ -1,68 +1,109 @@
-function info = mdsInfo()
-%mdsInfo - used internally by other functions to retrieve configuration info
-%   
-%
- global MDSINFO
-  global MDSplus_legacy_behavior
-  if isempty(MDSINFO)
-    isOctave = (exist ('OCTAVE_VERSION', 'builtin') > 0);
-    usePython=false;
-    try
-      MDSPLUS_DIR=getenv('MDSPLUS_DIR');
-      if ismac
-        lib=strcat(MDSPLUS_DIR,'/lib/libJavaMds.dylib');
-      elseif isunix
-        lib=strcat(MDSPLUS_DIR,'/lib/libJavaMds.so');
-      elseif ispc
-        lib='C:\WINDOWS\SYSTEM32\JavaMds.dll';
-      end
-      if not(isOctave)
-        java.lang.System.setProperty('JavaMdsLib',lib);
-      end
-      p=javaclasspath('-all');
-      matches = strfind(p,'mdsobjects.jar');
-      if not(any(vertcat(matches{:})))
-        javaaddpath(strcat(MDSPLUS_DIR,'/java/classes/mdsobjects.jar'))
-      end
-      if isOctave
-        x=javaObject('MDSplus.Int32',1);
-      else
-        x=MDSplus.Data.execute('1',javaArray('MDSplus.Data',1));
-      end
-    catch javaerror
-      if isOctave
-        disp('Unable to connect to MDSplus using the java bridge')
-	return
-      end
-      usePython=true;
+function info = mdsInfo(varargin)
+% MDSINFO  used internally by other functions to retrieve configuration info
+    global MDSINFO
+    if ~isempty(MDSINFO)
+        info = MDSINFO;
+    else
+        l = getenv('MDSplus_legacy_behavior');
+        if strcmp(l,'yes')
+            MDSplus_legacy_behavior = true;
+        else
+            MDSplus_legacy_behavior = false;
+        end
+        info.isConnected = false;
+        info.connection = [];
+        info.connectedHost = '';
+        info.usePython = false;
+        info.isPythonConnection = false;
+        info.useLegacy = MDSplus_legacy_behavior;
+        MDSINFO = info;
     end
-    if ~islogical(MDSplus_legacy_behavior)
-      l = getenv('MDSplus_legacy_behavior');
-      if strcmp(l,'yes')
-        MDSplus_legacy_behavior = true;
-      else
-	MDSplus_legacy_behavior = false;
-      end
+    if nargin > 0
+        MDSINFO.usePython = varargin{1};
     end
-    if usePython
-      try
-        py_MDSplus_Int32=str2func('py.MDSplus.Int32');
-        x=py_MDSplus_Int32(int32(1));
-      catch pythonerror
-        disp('Unable to connect to MDSplus using either a java bridge or a python bridge')
-        disp(strcat(' Java error: ',javaerror.message))
-        disp(strcat(' Python error: ',pythonerror.message))
-        return
-      end
+    err = [true,true];
+    if MDSINFO.usePython
+        err(1) = setPython;
+        if ~islogical(err(1))
+            MDSINFO.usePython = false;
+            err(2) = setJavaMds;
+        end
+    else
+        err(2) = setJavaMds;
+        if ~islogical(err(2))
+            MDSINFO.usePython = true;
+            err(1) = setPython;
+        end
     end
-    info.isConnected=false;
-    info.connection=[];
-    info.connectedHost='';
-    info.usePython=usePython;
-    info.isPythonConnection=false;
-    info.useLegacy=MDSplus_legacy_behavior;
-    MDSINFO=info;
-  end
-  info=MDSINFO;
+    if any(~islogical(err))
+        if all(~islogical(err))
+            disp('Unable to connect to MDSplus using either a java bridge or a python bridge')
+            disp(strcat(' Java error: ',err(2).message))
+            disp(strcat(' Python error: ',err(1).message))
+            info = [];
+            MDSINFO = info;
+        elseif ~islogical(err(2))
+            disp('Unable to connect to MDSplus using java bridge, using python bridge instead')
+            disp(strcat(' Java error: ',err(2).message))
+        else % ~islogical(err(1))
+            disp('Unable to connect to MDSplus using python bridge, using python bridge instead')
+            disp(strcat(' Python error: ',err(1).message))
+        end
+    end
 end
-  
+
+function err = setPython()
+    persistent cache
+    if ~isempty(cache)
+        err = cache;
+    else
+        try
+            py.MDSplus.Int32(1);
+            err = false;
+            cache = err;
+        catch err
+        end
+    end
+end
+
+function err = setJavaMds()
+    persistent cache
+    if ~isempty(cache)
+        err = cache;
+    else
+        isOctave = (exist ('OCTAVE_VERSION', 'builtin') > 0);
+        try
+            MDSPLUS_DIR = getenv('MDSPLUS_DIR');
+            if ismac
+                lib = strcat(MDSPLUS_DIR,'/lib/libJavaMds.dylib');
+            elseif isunix
+                lib = strcat(MDSPLUS_DIR,'/lib/libJavaMds.so');
+            elseif ispc
+                lib = 'C:\WINDOWS\SYSTEM32\JavaMds.dll';
+                if ~isfile(lib)
+                    if strcmp(computer('arch'),'win64')
+                        lib = fullfile(MDSPLUS_DIR,'bin64','JavaMds.dll');
+                    else
+                        lib = fullfile(MDSPLUS_DIR,'bin32','JavaMds.dll');
+                    end
+                end
+            end
+            if not(isOctave)
+                java.lang.System.setProperty('JavaMdsLib',lib);
+            end
+            p=javaclasspath('-all');
+            matches = strfind(p,'mdsobjects.jar');
+            if not(any(vertcat(matches{:})))
+               javaaddpath(fullfile(MDSPLUS_DIR,'java','classes','mdsobjects.jar'))
+            end
+            if isOctave
+                javaObject('MDSplus.Int32',1);
+            else
+                MDSplus.Data.execute('1',javaArray('MDSplus.Data',1));
+            end
+            err = false;
+            cache = err;
+        catch err
+        end
+    end
+end

--- a/matlab/mdsToMatlab.m
+++ b/matlab/mdsToMatlab.m
@@ -1,136 +1,145 @@
 function  result = mdsToMatlab( mdsthing )
-%mdsToMatlab - returns a Native Matlab object from an MDSplus object
-%   
+% MDSTOMATLAB  returns a Native Matlab object from an MDSplus object
 % This Function takes an argument that is one of native scalar, native
-% array, mdsplus scalar, or mdsplus array.  It returns a Native matlab 
+% array, mdsplus scalar, or mdsplus array.  It returns a Native matlab
 % object of the corresponding type and shape.
 %
 % syntax:
 %    answer = mdsToMatlab(mdsnode.getData)
-%
-  info=mdsInfo();
-  if info.usePython
-    if strncmp(class(mdsthing),'py.MDSplus',10)
-      value=mdsthing.data();
+    info = mdsInfo();
+    if info.usePython
+        result = python2matlab(mdsthing, info);
     else
-      value=mdsthing;
+        result = java2matlab(mdsthing, info);
     end
-    if strncmp(class(value),'py.numpy',8) == 0 
-      result = value;
+end
+
+function result = python2matlab(value, info)
+    if startsWith(class(value),'py.MDSplus')
+        value = value.data();
+    end
+    if ~startsWith(class(value),'py.numpy')
+        result = value;
     else
-      dtype=char(value.dtype.name);
-      if strfind(dtype,'str') == 1
-        if value.ndim == 0
-          result=char(value);
+        dtype = char(value.dtype.name);
+        if contains(dtype,'str') || contains(dtype,'bytes')
+            if value.ndim == 0
+                result = char(value);
+            else
+                strs = value.flatten.tolist();
+                result{length(strs)} = '';
+                for idx = 1 : length(strs)
+                    result{idx} = char(py.MDSplus.version.tostr(strs{idx}));
+                end
+                shape = flip(int64(py.array.array('i', value.shape)));
+                if numel(shape) == 1
+                    shape = [shape, int64(1)];
+                end
+                result = reshape(result, shape);
+            end
         else
-          strs=value.flatten.tolist();
-          result{length(strs)}='';
-          for idx=1:length(strs)
-             result{idx}=char(strs{idx});
-          end
-          shape=int32(py.array.array('i',value.shape));
-          if numel(shape) == 1
-            shape = [shape, int32(1)];
-          else
-            shape=int32(py.array.array('i',value.transpose().shape));
-          end
-          result = reshape(result,shape);
+            switch dtype
+                case 'float32'
+                    dtype='single';
+                case 'float64'
+                    dtype='double';
+            end
+            f=str2func(dtype);
+            dtype = value.dtype.char;
+            if info.ispy2 && contains("Qq",char(dtype))
+                warning('MDSplus:python2_int64','%s\n',...
+                    'Loss of precision: python2 does not support int64 properly. Try python3 instead.',...
+                    'You can disable this warning with "warning(''off'', ''MDSplus:python2_int64'')"')
+                dtype='d';
+            end
+            if value.ndim > 1
+                shape = int64(py.array.array('i',value.shape));
+                if ~py.numpy.isfortran(value)
+                    shape = flip(shape);
+                end
+                value = py.numpy.asfortranarray(value);
+                value = py.array.array(dtype,value.flat);
+                result = reshape(f(value),shape);
+            else
+                if value.ndim > 0
+                    result=reshape(f(py.array.array(dtype,value)),[int64(value.shape{1}),1]);
+                else
+                    result=f(py.array.array(dtype,{value}));
+                end
+            end
         end
-      else
-        switch dtype
-          case 'float32'
-            dtype='single';
-          case 'float64'
-            dtype='double';
-        end
-        f=str2func(dtype);
-        if value.ndim > 1
-	  py_numpy_transpose=str2func('py.numpy.transpose');
-          py_numpy_asfortranarray=str2func('py.numpy.asfortranarray');
-          shape=int32(py.array.array('i',py_numpy_transpose(value).shape));
-          val=py_numpy_asfortranarray(value);
-          pyarray=py.array.array(value.dtype.char,val.flat);
-          result=reshape(f(py.array.array(value.dtype.char,pyarray)),shape);
-        else
-          if value.ndim > 0
-            result=reshape(f(py.array.array(value.dtype.char,value)),[value.shape{1},1]);
-          else
-            result=f(py.array.array(value.dtype.char,{value}));
-          end
-        end
-      end
     end
-  else
-    if strncmp(class(mdsthing),'MDSplus',7) == 0 
-      result = mdsthing;
+end
+
+function result = java2matlab(mdsthing, info)
+    if ~startsWith(class(mdsthing),'MDSplus')
+        result = mdsthing;
     else
-      if numel(mdsthing.getShape()) > 0
-        shape = mdsthing.getShape;
-        if numel(shape) == 1
-            shape = [shape, 1];
+        if numel(mdsthing.getShape()) > 0
+            shape = mdsthing.getShape;
+            if numel(shape) == 1
+                shape = [shape, 1];
+            else
+                shape = shape';
+            end
+            switch class(mdsthing)
+                case 'MDSplus.Int64Array'
+                    result = reshape(mdsthing.getLongArray, shape);
+                case 'MDSplus.Uint64Array'
+                    result = reshape(typecast(mdsthing.getLongArray, 'uint64'), shape);
+                case 'MDSplus.Int32Array'
+                    result = reshape(mdsthing.getIntArray, shape);
+                case 'MDSplus.Uint32Array'
+                    result = reshape(typecast(mdsthing.getIntArray, 'uint32'), shape);
+                case 'MDSplus.Int16Array'
+                    result = reshape(mdsthing.getShortArray, shape);
+                case 'MDSplus.Uint16Array'
+                    result = reshape(typecast(mdsthing.getShortArray, 'uint16'), shape);
+                case 'MDSplus.Int8Array'
+                    result = reshape(mdsthing.getByteArray, shape);
+                case 'MDSplus.Uint8Array'
+                    result = reshape(typecast(mdsthing.getByteArray, 'uint8'), shape);
+                case 'MDSplus.Float64Array'
+                    result = double(reshape(mdsthing.getDoubleArray, shape));
+                case 'MDSplus.Float32Array'
+                    result = reshape(mdsthing.getFloatArray,  shape);
+                case 'MDSplus.StringArray'
+                    result = reshape(cellstr(char(mdsthing.getStringArray)),shape);
+                otherwise
+                    throw(MException('MDSplus:mdsToMatlab', 'class %s not supported by mdsToMatlab function\n', class(mdsthing)));
+            end
         else
-            shape = shape';
+            switch class(mdsthing)
+                case 'MDSplus.Int64'
+                    result = mdsthing.getLongArray();
+                case 'MDSplus.Uint64'
+                    result = typecast(mdsthing.getLongArray(), 'uint64');
+                case 'MDSplus.Int32'
+                    result = int32(mdsthing.getIntArray());
+                case 'MDSplus.Uint32'
+                    result = typecast(mdsthing.getIntArray(), 'uint32');
+                case 'MDSplus.Int16'
+                    result = mdsthing.getShortArray();
+                case 'MDSplus.Uint16'
+                    result = typecast(mdsthing.getShortArray(), 'uint16');
+                case 'MDSplus.Int8'
+                    result = mdsthing.getByteArray();
+                case 'MDSplus.Uint8'
+                    result = typecast(mdsthing.getByteArray(), 'uint8');
+                case 'MDSplus.Float64'
+                    result = mdsthing.getDoubleArray();
+                case 'MDSplus.Float32'
+                    result = mdsthing.getFloatArray();
+                case 'MDSplus.String'
+                    result = char(mdsthing.getString());
+                otherwise
+                    throw(MException('MDSplus:mdsToMatlab', 'class %s not supported by mdsToMatlab function\n', class(mdsthing)));
+            end
         end
-            
-        switch class(mdsthing)
-          case 'MDSplus.Int64Array'
-            result = reshape(mdsthing.getLongArray, shape);
-          case 'MDSplus.Uint64Array'
-            result = reshape(typecast(mdsthing.getLongArray, 'uint64'), shape);
-          case 'MDSplus.Int32Array'
-            result = reshape(mdsthing.getIntArray, shape);
-          case 'MDSplus.Uint32Array'
-            result = reshape(typecast(mdsthing.getIntArray, 'uint32'), shape);
-          case 'MDSplus.Int16Array'
-            result = reshape(mdsthing.getShortArray, shape);
-          case 'MDSplus.Uint16Array'
-            result = reshape(typecast(mdsthing.getShortArray, 'uint16'), shape);
-          case 'MDSplus.Int8Array'
-            result = reshape(mdsthing.getByteArray, shape);
-          case 'MDSplus.Uint8Array'
-            result = reshape(typecast(mdsthing.getByteArray, 'uint8'), shape);
-          case 'MDSplus.Float64Array'
-            result = double(reshape(mdsthing.getDoubleArray, shape));
-          case 'MDSplus.Float32Array'
-            result = reshape(mdsthing.getFloatArray,  shape);
-          case 'MDSplus.StringArray'
-	        result = reshape(cellstr(char(mdsthing.getStringArray)),shape);
-          otherwise
-            throw(MException('MDSplus:mdsToMatlab', 'class %s not supported by mdsToMatlab function\n', class(mdsthing)));
+        if info.useLegacy
+            if ~ischar(result)
+                result = double(result);
+            end
         end
-      else
-        switch class(mdsthing)
-          case 'MDSplus.Int64'
-            result = mdsthing.getLongArray();
-          case 'MDSplus.Uint64'
-            result = typecast(mdsthing.getLongArray(), 'uint64');
-          case 'MDSplus.Int32'
-            result = int32(mdsthing.getIntArray());
-          case 'MDSplus.Uint32'
-            result = typecast(mdsthing.getIntArray(), 'uint32');
-          case 'MDSplus.Int16'
-            result = mdsthing.getShortArray();
-          case 'MDSplus.Uint16'
-            result = typecast(mdsthing.getShortArray(), 'uint16');
-          case 'MDSplus.Int8'
-            result = mdsthing.getByteArray();
-          case 'MDSplus.Uint8'
-            result = typecast(mdsthing.getByteArray(), 'uint8');
-          case 'MDSplus.Float64'
-            result = mdsthing.getDoubleArray();
-          case 'MDSplus.Float32'
-            result = mdsthing.getFloatArray();
-          case 'MDSplus.String'
-            result = char(mdsthing.getString());
-          otherwise
-            throw(MException('MDSplus:mdsToMatlab', 'class %s not supported by mdsToMatlab function\n', class(mdsthing)));
-        end
-      end
-      if info.useLegacy
-        if ~ischar(result)
-          result = double(result);
-        end
-      end 
     end
-  end
 end

--- a/matlab/mdsToMatlab.m
+++ b/matlab/mdsToMatlab.m
@@ -137,7 +137,7 @@ function result = java2matlab(mdsthing, info)
             end
         end
         if info.useLegacy
-            if ~ischar(result)
+            if ~ischar(result) && ~iscell(result)
                 result = double(result);
             end
         end

--- a/matlab/mdsUseLegacy.m
+++ b/matlab/mdsUseLegacy.m
@@ -1,5 +1,5 @@
 function mdsUseLegacy( varargin )
-%mdsUseLegacy - enable (or disable) the use of the legacy mode.
+% MDSUSELEGACY  enable (or disable) the use of the legacy mode.
 %   This function is can be used to enable legacy mode.
 %   In legacy mode floating point values will always be returned as doubles.
 %   Also the warnings about the deprecated functions will be disabled.
@@ -7,15 +7,23 @@ function mdsUseLegacy( varargin )
 %   If you want to turn off legacy mode use mdsUseLegacy(false).
 %   This is not a permanent setting and only applies to the current
 %   invocation of matlab.
-   mdsInfo();
-   global MDSINFO
-   if nargin == 0
-     MDSINFO.useLegacy=true;
-   else
-     MDSINFO.useLegacy=varargin{1};
-   end
-   if MDSINFO.useLegacy
-     display('Legacy mode enabled. Floating point values will be returned as doubles and MDSarg and NATIVEvalue will not display deprecation warnings. It is recommended that you modify your code to not depend on this legacy mode as it will eventually be deprecated.')
-   end
+    mdsInfo();
+    global MDSINFO
+    if nargin == 0
+        MDSINFO.useLegacy = true;
+    else
+        MDSINFO.useLegacy = varargin{1};
+    end
+    if MDSINFO.useLegacy
+        fprintf('%s\n',...
+            'Legacy mode enabled. Floating point values will be returned',...
+            'as doubles and MDSarg and NATIVEvalue will not display',...
+            'deprecation warnings. It is recommended that you modify',...
+            'your code to not depend on this legacy mode as it will',...
+            'eventually be deprecated.')
+        warning('off', 'MDSplus:Legacy')
+    else
+        warning('on', 'MDSplus:Legacy')
+    end
 end
 

--- a/matlab/mdsUsePython.m
+++ b/matlab/mdsUsePython.m
@@ -1,25 +1,14 @@
 function mdsUsePython( varargin )
-%mdsUsePython - enable (or disable) the use of the python MDSplus bridge.
+% MDSUSEPYTHON  enable (or disable) the use of the python MDSplus bridge.
 %   This function is can be used to select the python bridge instead of the
 %   default java bridge. It will enable the use of python if called with
 %   no arguments or use mdsUsePython(false) to revert back to the java
 %   bridge. This is not a permanent setting and only applies to the current
 %   invocation of matlab.
-   mdsInfo();
-   global MDSINFO
    if nargin == 0
-     MDSINFO.usePython=true;
+       mdsInfo(true);
    else
-     MDSINFO.usePython=varargin{1};
+       mdsInfo(varargin{1});
    end
-   if MDSINFO.usePython
-     try
-       py_MDSplus_Int32=str2func('py.MDSplus.Int32');
-       x=py_MDSplus_Int32(int32(1));
-     catch
-         display('The python bridge to MDSplus is not available. Reverting to java brdige.')
-         MDSINFO.usePython=false;
-     end
-  end
 end
 

--- a/matlab/mdsclose.m
+++ b/matlab/mdsclose.m
@@ -1,22 +1,22 @@
 function [ status ] = mdsclose()
-%mdsconnect - connect to a remote mdsplus data server. 
+% MDSCLOSE - closes currently active tree 
 %   
 %     This routine will close the tree at the top of the open tree stack.
 % 
 %      Previous incarnations also disconnected thin-client (mdsconnect) connections.
 %      THAT IS NO LONGER DONE
 %
-   info=mdsInfo();
-   status = 1;
-   if info.isConnected
-     try
-       info.connection.get('TreeClose()');
-     catch err
-         status=0;
-         err.message
-     end
-   else
-     status = mdsvalue('TreeClose()');   
-   end
+    info = mdsInfo();
+    status = 1;
+    if info.isConnected
+        try
+            info.connection.get('TreeClose()');
+        catch err
+            status=0;
+            err.message
+        end
+    else
+        status = mdsvalue('TreeClose()');
+    end
 end
 

--- a/matlab/mdsconnect.m
+++ b/matlab/mdsconnect.m
@@ -1,40 +1,39 @@
 function [ status ] = mdsconnect( host )
-%mdsconnect - connect to a remote mdsplus data server. 
-%   
+% MDSCONNECT  connect to a remote mdsplus data server.
 %      This routine will make a thin client connection to the specified
-%      mdsplus data server.  It will cause subsequent invocations of 
+%      mdsplus data server.  It will cause subsequent invocations of
 %      mdsopen, mdsvalue, mdsput, and mdsclose to be executed remotely
 %      on the specified host.
 %
 %      mdsdisconnect will destroy this connection, reverting the above
 %      described routines to their local behaviors
 %
-  mdsInfo();
-  global MDSINFO   
-  if MDSINFO.isConnected && strcmp(MDSINFO.connectedHost, host) && MDSINFO.usePython == MDSINFO.isPythonConnection
-    status = 1;
-  else
-    if strcmpi(host,'LOCAL') == 1
-      MDSINFO.isConnected = false;
-      MDSINFO.connection = [];
-      MDSINFO.connectedHost = host;
-      status = 1;
-    else
-      try
-        if MDSINFO.usePython
-	  py_MDSplus_Connection=str2func('py.MDSplus.Connection');
-          MDSINFO.connection=py_MDSplus_Connection(host);
-        else
-          MDSINFO.connection=javaObject('MDSplus.Connection',host);
-        end
-        MDSINFO.isPythonConnection=MDSINFO.usePython;
-        MDSINFO.connectedHost=host;
-        MDSINFO.isConnected=true;
+    global MDSINFO
+    mdsInfo();
+    if MDSINFO.isConnected && strcmp(MDSINFO.connectedHost, host) && MDSINFO.usePython == MDSINFO.isPythonConnection
         status = 1;
-      catch
-	      status = -1;
-      end
+    else
+        if strcmpi(host,'LOCAL') == 1
+            MDSINFO.isConnected = false;
+            MDSINFO.connection = [];
+            MDSINFO.connectedHost = host;
+            status = 1;
+        else
+            try
+                if MDSINFO.usePython
+                    py_MDSplus_Connection=str2func('py.MDSplus.Connection');
+                    MDSINFO.connection=py_MDSplus_Connection(host);
+                else
+                    MDSINFO.connection=javaObject('MDSplus.Connection',host);
+                end
+                MDSINFO.isPythonConnection=MDSINFO.usePython;
+                MDSINFO.connectedHost=host;
+                MDSINFO.isConnected=true;
+                status = 1;
+            catch
+                status = -1;
+            end
+        end
     end
-  end
 end
 

--- a/matlab/mdsdisconnect.m
+++ b/matlab/mdsdisconnect.m
@@ -1,9 +1,7 @@
 function [ status ] = mdsdisconnect( )
-%mdsdisconnect - disconnect from  a remote mdsplus data server. 
-%   
+% MDSDISCONNECT  disconnect from  a remote mdsplus data server.   
 %      mdsdisconnect will destroy this connection, reverting the above
 %      described routines to their local behaviors
-%
-  status = mdsconnect('local');
+    status = mdsconnect('local');
 end
 

--- a/matlab/mdsgetmsg.m
+++ b/matlab/mdsgetmsg.m
@@ -1,32 +1,34 @@
-%% msg = mdsgetmsg(id, [throwerror, except])
-% id         : message id
-% throwerror : throw an error by default flag      : false
-% except     : exception list of ids               : []
-%
-% translates the tdi message ID into the tdi message MSG
-% - If THROWERROR is true, an error with the tdi message is thrown,
-%   unless the ID is a member of the EXCEPT list.
-% - If THROWERROR is false, no error will be thrown,
-%   unless the ID is a member of the EXCEPT list.
-
 function msg = mdsgetmsg(id,throwerror,except)
-narginchk(1,3)
-if nargin<3
-  except     = [];
-  if nargin<2
-    throwerror = false;
-  end
-end
+% MDSGETMSG  used to message for status code
+%   msg = mdsgetmsg(id, [throwerror, except])
+%   id         : message id
+%   throwerror : throw an error by default flag      : false
+%   except     : exception list of ids               : []
+%
+%   translates the tdi message ID into the tdi message MSG
+%   - If THROWERROR is true, an error with the tdi message is thrown,
+%     unless the ID is a member of the EXCEPT list.
+%   - If THROWERROR is false, no error will be thrown,
+%     unless the ID is a member of the EXCEPT list.
 
-if ischar(id)
-    error(id);
-else
-    try
-        msg = mdsvalue('_msg = REPEAT(0,255);MdsShr->MdsGetMsgDsc(val($),descr(_msg));TRIM(_msg)',id);
-    catch
-        msg = sprintf('message not found: 0x%08x',id);
+    narginchk(1,3)
+    if nargin<3
+        except     = [];
+        if nargin<2
+            throwerror = false;
+        end
     end
-    if xor(throwerror,ismember(id, except))
-        error(msg)
+
+    if ischar(id)
+        error(id);
+    else
+        try
+            msg = mdsvalue('_msg = REPEAT(0,255);MdsShr->MdsGetMsgDsc(val($),descr(_msg));TRIM(_msg)',id);
+        catch
+            msg = sprintf('message not found: 0x%08x',id);
+        end
+        if xor(throwerror,ismember(id, except))
+            error(msg)
+        end
     end
 end

--- a/matlab/mdsopen.m
+++ b/matlab/mdsopen.m
@@ -1,23 +1,17 @@
-function [ shoto,status ] = mdsopen( tree, shot )
-%mdsconnect - connect to a remote mdsplus data server. 
-%   
-%      This routine will make a thin client connection to the specified
-%      mdsplus data server.  It will cause subsequent invocations of 
-%      mdsopen, mdsvalue, mdsput, and mdsclose to be executed remotely
-%      on the specified host.
-%
-%      mdsdisconnect will destroy this connection, reverting the above
-%      described routines to their local behaviors
-%
+function [ shoto,status ] = mdsopen( expt, shot )
+% MDSOPEN  opend connect to a remote mdsplus data server. 
+%   This routine will invoke a treeopen(expt, shot)
+%   expt may contain information about a remote server "server::expt"
+
    status = 1;
    shoto = 'Failed';
-   idx=strfind(tree, '::');
+   idx=strfind(expt, '::');
    if ~isempty(idx)
-       host = tree(1:idx-1);
-       ltree = tree(idx+2:end);
+       host = expt(1:idx-1);
+       ltree = expt(idx+2:end);
        status = mdsconnect(host);
     else
-       ltree=tree;
+       ltree=expt;
    end
    if mod(status,2)
      info=mdsInfo();

--- a/matlab/mdsput.m
+++ b/matlab/mdsput.m
@@ -1,7 +1,7 @@
 function [ status ] = mdsput( node, expression, varargin)
-%mdsput put data into MDSplus tree node
-%   Detailed explanation goes here
-info=mdsInfo();
+% MDSPUT  put data into MDSplus tree node
+%   This routine invokes treeput(node, expression, ...)
+info = mdsInfo();
 if nargin == 2 && info.useLegacy
   status = mdsput(node,'$',expression);
 else

--- a/matlab/mdstcl.m
+++ b/matlab/mdstcl.m
@@ -1,34 +1,35 @@
 function mdstcl(command)
+% MDSTCL  used to run tcl command or open a tcl prompt
+%	This function provides Matlab with the same MDSTCL interface as IDL.
+%   Written by R. Granetz on 2014/12/23
+%
+%   If a TCL command is passed to this routine, then execute it, output the
+%   response, if any, to the terminal, and return to the Matlab prompt.  If
+%   this routine is called without a TCL command, then go into a loop,
+%   prompting for, and executing TCL commands, and outputting the responses,
+%   until 'exit' is entered.
 
-% This function provides Matlab with the same MDSTCL interface as IDL.
-% Written by R. Granetz on 2014/12/23
+    if (exist('command','var'))
+        mdsvalue('tcl($, _response)', command);
+        response = char(mdsvalue('_response'));
+        if (~isempty(response))
+            fprintf(1, '%s\n', response);
+        end
+        return;
+    end
 
-% If a TCL command is passed to this routine, then execute it, output the
-% response, if any, to the terminal, and return to the Matlab prompt.  If
-% this routine is called without a TCL command, then go into a loop,
-% prompting for, and executing TCL commands, and outputting the responses,
-% until 'exit' is entered.
-
-if (exist('command','var'));
-  mdsvalue('tcl($, _response)', command);
-  response = char(mdsvalue('_response'));
-  if (~isempty(response));
-    fprintf(1, '%s\n', response);
-  end;
-  return;
-end;
-
-while 1;
-  tclcmd = input('TCL> ','s');
-  if (isempty(tclcmd));
-    continue;
-  elseif (any(strcmpi(tclcmd,{'ex','exi','exit'})));
-    return;
-  else
-    mdsvalue('tcl($, _response)', tclcmd);
-    response = char(mdsvalue('_response'));
-    if (~isempty(response));
-      fprintf(1, '%s\n', response);
-    end;
-  end;
-end;
+    while 1
+        tclcmd = input('TCL> ','s');
+        if (isempty(tclcmd))
+            continue;
+        elseif (any(strcmpi(tclcmd,{'ex','exi','exit'})))
+            return;
+        else
+            mdsvalue('tcl($, _response)', tclcmd);
+            response = char(mdsvalue('_response'));
+            if (~isempty(response))
+                fprintf(1, '%s\n', response);
+            end
+        end
+    end
+end

--- a/matlab/mdstest.m
+++ b/matlab/mdstest.m
@@ -1,19 +1,17 @@
 function result = mdstest(varargin)
-% MDSTEST connect to a remote mdsplus data server.
+% MDSTEST  test the MDSplus - MATLAB API (types and shapes)
 %   This routine tests the various functions in the MDSplus
 %   Matlab/Octave interface.
+%   mdstest()   % tests current bridge
+%   mdstest(0)  % tests java bridge
+%   mdstest(1)  % tests python bridge
 
-    info=mdsInfo(varargin{:});
-    if info.useLegacy
-        single='double';
-    else
-        single='single';
-    end
+    mdsInfo(varargin{:}); % update MDSINFO
     result=mdscheck('1BU','uint8',[1,1]);
     result=result && mdscheck('1WU','uint16',[1,1]);
     result=result && mdscheck('1LU','uint32',[1,1]);
     result=result && mdscheck('100000000000QU','uint64',[1,1]);
-    result=result && mdscheck('1.',single,[1,1]);
+    result=result && mdscheck('1.','single',[1,1]);
     result=result && mdscheck('1D0','double',[1,1]);
     result=result && mdscheck('"string test"','char',[1,11]);
     result=result && mdscheck('BYTE_UNSIGNED(1 : 100)','uint8',[100,1]);
@@ -24,19 +22,21 @@ function result = mdstest(varargin)
     result=result && mdscheck('1 : 100','int32',[100,1]);
     result=result && mdscheck('QUADWORD(1 : 100)','int64',[100,1]);
     result=result && mdscheck('set_range(10,2,5,1 : 100)','int32',[10,2,5]);
-    result=result && mdscheck('FS_FLOAT(1 : 100)',single,[100,1]);
+    result=result && mdscheck('FS_FLOAT(1 : 100)','single',[100,1]);
     result=result && mdscheck('FT_FLOAT(1 : 100)','double',[100,1]);
     result=result && mdscheck('set_range(10,2,5,FT_FLOAT(1 : 100))','double',[10,2,5]);
     result=result && mdscheck('$ : $','int32',[100,1],int32(1),int32(100));
     result=result && mdscheck('$ == $','uint8',[1,1],1,2);
     result=result && mdscheck('QUADWORD_UNSIGNED(1 : 100)','uint64',[100,1]);
-    if ~info.useLegacy
-        result=result && mdscheck('["a","b","c","d"]','cell',[4,1]);
-        result=result && mdscheck('set_range(2,3,["a","b","c long string","d","e","f"])','cell',[2,3]);
-    end
+    result=result && mdscheck('["a","b","c","d"]','cell',[4,1]);
+    result=result && mdscheck('set_range(2,3,["a","b","c long string","d","e","f"])','cell',[2,3]);
 end
 
 function result = mdscheck(exp,result_class,result_size,varargin)
+    global MDSINFO
+    if MDSINFO.useLegacy && ~strcmp(result_class,'char') && ~strcmp(result_class,'cell')
+        result_class = 'double';
+    end
     x = mdsvalue(exp,varargin{:});
     if ~strcmp(class(x),result_class)
         fprintf('Error %s: expected class %s got %s\n',exp,result_class,class(x))

--- a/matlab/mdstest.m
+++ b/matlab/mdstest.m
@@ -1,97 +1,83 @@
+function result = mdstest(varargin)
+% MDSTEST connect to a remote mdsplus data server.
+%   This routine tests the various functions in the MDSplus
+%   Matlab/Octave interface.
 
-function  result = mdstest( )
-% mdstest - connect to a remote mdsplus data server. 
-%   
-%      This routine is to test the various functions in the MDSplus
-%      Matlab/Octave interface.
-%
-  function result = mdscheck(exp,result_class,result_size,varargin)
+    info=mdsInfo(varargin{:});
+    if info.useLegacy
+        single='double';
+    else
+        single='single';
+    end
+    result=mdscheck('1BU','uint8',[1,1]);
+    result=result && mdscheck('1WU','uint16',[1,1]);
+    result=result && mdscheck('1LU','uint32',[1,1]);
+    result=result && mdscheck('100000000000QU','uint64',[1,1]);
+    result=result && mdscheck('1.',single,[1,1]);
+    result=result && mdscheck('1D0','double',[1,1]);
+    result=result && mdscheck('"string test"','char',[1,11]);
+    result=result && mdscheck('BYTE_UNSIGNED(1 : 100)','uint8',[100,1]);
+    result=result && mdscheck('WORD_UNSIGNED(1 : 100)','uint16',[100,1]);
+    result=result && mdscheck('LONG_UNSIGNED(1 : 100)','uint32',[100,1]);
+    result=result && mdscheck('BYTE(1 : 100)','int8',[100,1]);
+    result=result && mdscheck('WORD(1 : 100)','int16',[100,1]);
+    result=result && mdscheck('1 : 100','int32',[100,1]);
+    result=result && mdscheck('QUADWORD(1 : 100)','int64',[100,1]);
+    result=result && mdscheck('set_range(10,2,5,1 : 100)','int32',[10,2,5]);
+    result=result && mdscheck('FS_FLOAT(1 : 100)',single,[100,1]);
+    result=result && mdscheck('FT_FLOAT(1 : 100)','double',[100,1]);
+    result=result && mdscheck('set_range(10,2,5,FT_FLOAT(1 : 100))','double',[10,2,5]);
+    result=result && mdscheck('$ : $','int32',[100,1],int32(1),int32(100));
+    result=result && mdscheck('$ == $','uint8',[1,1],1,2);
+    result=result && mdscheck('QUADWORD_UNSIGNED(1 : 100)','uint64',[100,1]);
+    if ~info.useLegacy
+        result=result && mdscheck('["a","b","c","d"]','cell',[4,1]);
+        result=result && mdscheck('set_range(2,3,["a","b","c long string","d","e","f"])','cell',[2,3]);
+    end
+end
 
-    x=mdsvalue(exp,varargin{:});
+function result = mdscheck(exp,result_class,result_size,varargin)
+    x = mdsvalue(exp,varargin{:});
     if ~strcmp(class(x),result_class)
-        display(sprintf('Error %s: expected class %s got %s',exp,result_class,class(x)))
+        fprintf('Error %s: expected class %s got %s\n',exp,result_class,class(x))
         result = 0;
         return
     end
     try
         if ~all(size(x)==result_size)
-            display(sprintf('Error %s: expected size %s got %s',exp,mat2str(result_size),mat2str(size(x))))
+            fprintf('Error %s: expected size %s got %s\n',exp,mat2str(result_size),mat2str(size(x)))
             result = 0;
             return
         end
     catch
-        display(sprintf('Error %s: expected size %s got %s',exp,mat2str(result_size),mat2str(size(x))))
+        fprintf('Error %s: expected size %s got %s\n',exp,mat2str(result_size),mat2str(size(x)))
         result = 0;
         return
     end
     y=mdsvalue('$',x);
     if isa(x,'cell')
-      try
-        result = strcmp(x,y);
-        result = all(result(:));
-        if ~result
-          display(strcat('Error testing ',exp,' : string array does not match'))
+        try
+            result = strcmp(x,y);
+            result = all(result(:));
+            if ~result
+                display(strcat('Error testing ',exp,' : string array does not match'))
+            end
+        catch err
+            display(strcat('Error testing ',exp,' : ',err.message))
+            rethrow(err)
         end
-      catch err
-        display(strcat('Error testing ',exp,' : ',err.message))
-        result=0;
-      end
     else
-      try
-        result = x==y;
-        result = all(result(:));
-        if ~result
-          display(sprintf('Error %s: input != output',exp))
-          display(x);
-          display(y);
+        try
+            result = x==y;
+            result = all(result(:));
+            if ~result
+                fprintf('Error %s: input != output\n',exp)
+                display(x);
+                display(y);
+            end
+        catch err
+            display(strcat('Error testing ',exp,' : ',err.message))
+            rethrow(err)
         end
-      catch err
-        display(strcat('Error testing ',exp,' : ',err.message))
-        result = 0;
-      end
     end
-  end
-  try
-    info=mdsInfo();
-    usePython=info.usePython;
-    legacy=info.useLegacy;
-  catch
-    usePython=false;
-    legacy=true;
-  end
-  if legacy
-    single='double';
-  else
-    single='single';
-  end
-  result=mdscheck('1BU','uint8',[1,1]);
-  result=result && mdscheck('1WU','uint16',[1,1]);
-  result=result && mdscheck('1LU','uint32',[1,1]);
-  result=result && mdscheck('1QU','uint64',[1,1]);
-  result=result && mdscheck('1.',single,[1,1]);
-  result=result && mdscheck('1D0','double',[1,1]);
-  result=result && mdscheck('"string test"','char',[1,11]);
-  result=result && mdscheck('BYTE_UNSIGNED(1 : 100)','uint8',[100,1]);
-  result=result && mdscheck('WORD_UNSIGNED(1 : 100)','uint16',[100,1]);
-  result=result && mdscheck('LONG_UNSIGNED(1 : 100)','uint32',[100,1]);
-  if ~usePython
-    result=result && mdscheck('QUADWORD_UNSIGNED(1 : 100)','uint64',[100,1]);
-  end
-  result=result && mdscheck('BYTE(1 : 100)','int8',[100,1]);
-  result=result && mdscheck('WORD(1 : 100)','int16',[100,1]);
-  result=result && mdscheck('1 : 100','int32',[100,1]);
-  if ~usePython
-    result=result && mdscheck('QUADWORD(1 : 100)','int64',[100,1]);
-  end
-  result=result && mdscheck('set_range(10,2,5,1 : 100)','int32',[10,2,5]);
-  result=result && mdscheck('FS_FLOAT(1 : 100)',single,[100,1]);
-  result=result && mdscheck('FT_FLOAT(1 : 100)','double',[100,1]);
-  result=result && mdscheck('set_range(10,2,5,FT_FLOAT(1 : 100))','double',[10,2,5]);
-  if ~legacy
-    result=result && mdscheck('["a","b","c","d"]','cell',[4,1]);
-    result=result && mdscheck('set_range(2,3,["a","b","c long string","d","e","f"])','cell',[2,3]);
-  end
-  result=result && mdscheck('$ : $','int32',[100,1],int32(1),int32(100));
-  result=result && mdscheck('$ == $','uint8',[1,1],1,2);
-  
 end

--- a/matlab/mdsvalue.m
+++ b/matlab/mdsvalue.m
@@ -1,58 +1,56 @@
-
 function [ result, status ] = mdsvalue( expression, varargin)
-%mdsvalue - evaluate an expression
-%   
-%
-  info=mdsInfo();
-  if info.usePython
+% MDSVALUE evaluate an expression
+%   [ result, status ] = mdsvalue( expression, varargin)
+    info = mdsInfo();
     n = nargin-1;
-    args=cell(n,1);
-    for idx = 1:n
-      args{idx}=mdsFromMatlab(varargin{idx});
-    end
-  else
-    if info.isConnected
-      extra=0;
+    if info.usePython
+        args=cell(n,1);
     else
-      extra=1;
-    end
-    n = size(varargin,2);
-    args = javaArray('MDSplus.Data',max(1,n+extra));
-    for k = 1: n
-      argin=varargin(k);
-      try
-        arg = mdsFromMatlab(cell2mat(argin));
-      catch
-        arg = mdsFromMatlab(argin{1});
-      end
-      args(k) = arg;
-    end
-  end
-
-  try
-    if info.isConnected
-      if n > 0
-        if info.usePython
-          result = info.connection.get(expression,args{:});
+        if info.isConnected
+            extra=0;
         else
-          result = info.connection.get(expression,args);
+            extra=1;
         end
-      else
-        result = info.connection.get(expression);
-      end
-    else
-      if info.usePython
-        py_MDSplus_EXECUTE=str2func('py.MDSplus.EXECUTE');
-        result = py_MDSplus_EXECUTE(expression,args{:}).evaluate();
-      else
-        dobj=javaObject('MDSplus.Data');
-        result = dobj.execute(expression, args);
-      end
+        args = javaArray('MDSplus.Data',max(1,n+extra));
     end
-    status=1;
-  catch err
-    status=0;
-    result=err.message;
-  end
-  result=mdsToMatlab(result);
+    for k = 1: n
+        argin=varargin(k);
+        if iscell(argin{1})
+            argout = mdsFromMatlab(argin{1});
+        else
+            argout = mdsFromMatlab(cell2mat(argin));
+        end
+        if info.usePython
+            args{k} = argout;
+        else
+            args(k) = argout;
+        end
+    end
+
+    try
+        if info.isConnected
+            if n > 0
+                if info.usePython
+                    result = info.connection.get(expression,args{:});
+                else
+                    result = info.connection.get(expression,args);
+                end
+            else
+                result = info.connection.get(expression);
+            end
+        else
+            if info.usePython
+                result = py.MDSplus.EXECUTE(expression,args{:});
+                result.evaluate();
+            else
+                dobj=javaObject('MDSplus.Data');
+                result = dobj.execute(expression, args);
+            end
+        end
+        status=1;
+    catch err
+        status=0;
+        result=err.message;
+    end
+    result=mdsToMatlab(result);
 end


### PR DESCRIPTION
- java bridge now works out of the box without adding paths to anything but matlab path
```matlab
addpath(fullfile(getenv("MDSPLUS_DIR"),"matlab"));
savepath();
```
- python bridge provides workaround for int64 on python2
- python bridge now works with python3 as well

briges are only tested when activated

mdstest(true)  % tests explicitly the python bridge
mdstest(false)  % tests explicitly the java bridge