### PR TITLE
Feature: Add ACQ WRPG device class

### DIFF
--- a/deploy/packaging/debian/htsdevices.noarch
+++ b/deploy/packaging/debian/htsdevices.noarch
@@ -1,5 +1,6 @@
 ./usr/local/mdsplus/pydevices/HtsDevices/_version.py
 ./usr/local/mdsplus/pydevices/HtsDevices/acq2106_423st.py
+./usr/local/mdsplus/pydevices/HtsDevices/acq2106_WRPG.py
 ./usr/local/mdsplus/pydevices/HtsDevices/acq435st.py
 ./usr/local/mdsplus/pydevices/HtsDevices/cryocon18i.py
 ./usr/local/mdsplus/pydevices/HtsDevices/cryocon24c.py

--- a/deploy/packaging/redhat/htsdevices.noarch
+++ b/deploy/packaging/redhat/htsdevices.noarch
@@ -1,6 +1,7 @@
 ./usr/local/mdsplus/pydevices/HtsDevices
 ./usr/local/mdsplus/pydevices/HtsDevices/_version.py
 ./usr/local/mdsplus/pydevices/HtsDevices/acq2106_423st.py
+./usr/local/mdsplus/pydevices/HtsDevices/acq2106_WRPG.py
 ./usr/local/mdsplus/pydevices/HtsDevices/acq435st.py
 ./usr/local/mdsplus/pydevices/HtsDevices/cryocon18i.py
 ./usr/local/mdsplus/pydevices/HtsDevices/cryocon24c.py

--- a/pydevices/HtsDevices/acq2106_WRPG.py
+++ b/pydevices/HtsDevices/acq2106_WRPG.py
@@ -129,7 +129,8 @@ class ACQ2106_WRPG(MDSplus.Device):
         rows, cols = (len(t_times), nchan)
         state = [[0 for i in range(cols)] for j in range(rows)]
 
-        # Building the state matrix. For each channel, we traverse all the transition times to find those who are in the particular channel. 
+        # Building the state matrix. For each channel, we traverse all the transition times to find those who are 
+        # in the particular channel. 
         # If the transition time is in the channel, we copied its state into the state[i][j] element. 
         # If a transition time does not appear in that channel, we keep the previous state for, i.e. the state doesn't change.
         for j in range(nchan):
@@ -143,8 +144,10 @@ class ACQ2106_WRPG(MDSplus.Device):
                     state[i][j] = state[i-1][j]
                     
                     # chan_t_states its elements are pairs of [ttimes, state]. e.g [[0.0, 0],[1.0, 1],...]
-                    # chan_t_states[0] are all the first elements of those pairs, i.e the trans. times: e.g [[1D0], [2D0], [3D0], [4D0] ... ]
-                    # chan_t_states[1] are all the second elements of those pairs, the states: .e.g [[0],[1],...]
+                    # chan_t_states[0] are all the first elements of those pairs, i.e the trans. times: 
+                    # e.g [[1D0], [2D0], [3D0], [4D0] ... ]
+                    # chan_t_states[1] are all the second elements of those pairs, i.e. the states: 
+                    # e.g [[0],[1],...]
                     for t in range(len(chan_t_states[0])):
                         #Check if the transition time is one of the times that belongs to this channel:
                         if t_times[i] == chan_t_states[0][t][0]:

--- a/pydevices/HtsDevices/acq2106_WRPG.py
+++ b/pydevices/HtsDevices/acq2106_WRPG.py
@@ -68,7 +68,7 @@ class ACQ2106_WRPG(MDSplus.Device):
         # the digitazer, like d1.
         uut.s0.GPG_ENABLE    ='enable'
         uut.s0.GPG_TRG       ='1'    #external=1, internal=0
-        uut.s0.GPG_TRG_DX    ='d1'   #d1 when testing two WRTTs, WRTT0 or WRTT1. d0 when testing using only one WRTT.
+        uut.s0.GPG_TRG_DX    ='d1'   #d1 for WRTT1. d0 for WRTT0 or EXT.
         uut.s0.GPG_TRG_SENSE ='rising'
         uut.s0.GPG_MODE      ='ONCE'
 

--- a/pydevices/HtsDevices/acq2106_WRPG.py
+++ b/pydevices/HtsDevices/acq2106_WRPG.py
@@ -29,8 +29,6 @@ import time
 import socket
 import math
 import numpy as np
-import csv
-import copy
 
 try:
     acq400_hapi = __import__('acq400_hapi', globals(), level=1)
@@ -41,18 +39,7 @@ class ACQ2106_WRPG(MDSplus.Device):
     """
     D-Tacq ACQ2106 with ACQ423 Digitizers (up to 6)  real time streaming support.
 
-    32 Channels * number of slots
-    Minimum 2Khz Operation
-    24 bits == +-10V
-
-    3 trigger modes:
-      Automatic - starts recording on arm
-      Soft - starts recording on trigger method (reboot / configuration required to switch )
-      Hard - starts recording on hardware trigger input
-
-    Software sample decimation
-
-    Settable segment length in number of samples
+    DIO with 32 channels
 
     debugging() - is debugging enabled.  Controlled by environment variable DEBUG_DEVICES
 
@@ -74,6 +61,9 @@ class ACQ2106_WRPG(MDSplus.Device):
 
     def init(self):
         uut = acq400_hapi.Acq400(self.node.data(), monitor=False)
+        
+        #Number of channels of the DIO482
+        nchans = 32
 
         # #Setting the trigger in the GPG module
         uut.s0.GPG_ENABLE    ='enable'
@@ -83,9 +73,10 @@ class ACQ2106_WRPG(MDSplus.Device):
         uut.s0.GPG_MODE      ='ONCE'
 
         #Create the STL table from a series of transition times and states given in OUTPUT.
+        start_time = time.time()
         print("Building STL: start")
-        self.set_stl()
-        print("Building STL: end")
+        self.set_stl(nchans)
+        print("Building STL: end --- %s seconds ---" % (time.time() - start_time))
 
         #Load the STL into the WRPG hardware: GPG
         traces = False  # True: shows debugging information during loading
@@ -96,21 +87,19 @@ class ACQ2106_WRPG(MDSplus.Device):
 
 
     def load_stl_file(self,traces):
-        example_stl=self.stl_file.data()    
+        stl_table = self.stl_file.data()    
 
-        print('Path to State Table: ', example_stl)
+        print('Path to State Table: {}'.format(stl_table))
         uut = acq400_hapi.Acq400(self.node.data(), monitor=False)
         uut.s0.trace = traces
         
         print('Loading STL table into WRPG')
-        with open(example_stl, 'r') as fp:
+        with open(stl_table, 'r') as fp:
             uut.load_wrpg(fp.read(), uut.s0.trace)
 
-    def set_stl(self):
-        nchan = 32
 
-        states_hex    = []
-        states_bits   = []
+    def set_stl(self, nchan):
+
         all_t_times   = []
         all_t_times_states = []
 
@@ -120,7 +109,7 @@ class ACQ2106_WRPG(MDSplus.Device):
             # Pair of (transition time, state) for each channel:
             chan_t_states = chan_t_times.data()
 
-            # Creation of an array that contains as EVERY OTHER element all the transition times in it, adding them
+            # Creation of an array that contains, as EVERY OTHER element, all the transition times in it, appending them
             # for each channel:
             for x in np.nditer(chan_t_states):
                 all_t_times_states.append(x) #Appends arrays made of one element,
@@ -136,49 +125,51 @@ class ACQ2106_WRPG(MDSplus.Device):
 
         # t_times contains the unique set of transitions times used in the experiment:
         t_times = sorted(np.float64(t_times))
-        print(t_times)
 
         # initialize the state matrix
-        cols = nchan
-        state = [[0]*cols]
+        rows, cols = (len(t_times), nchan)
+        state = [[0 for i in range(cols)] for j in range(rows)]
 
-        # Building the state matrix. For each transition times given by t_times, we look for those times that
-        # appear in the channel. If a transition time does not appear in that channel, then the state
-        # doesn't change.
+        # Building the state matrix. For each channel, we traverse all the transition times to find those who are in the particular channel. 
+        # If the transition time is in the channel, we copied its state into the state[i][j] element. 
+        # If a transition time does not appear in that channel, we keep the previous state for, i.e. the state doesn't change.
+        for j in range(nchan):
+            chan_t_states = self.__getattr__('OUTPUT_%3.3d' % (j+1))
 
-        for i in range(len(t_times)):
-            for j in range(nchan):
-                chan_t_states = self.__getattr__('OUTPUT_%3.3d' % (j+1))
-                
-                # chan_t_states its elements are pairs of [ttimes, state]. e.g [[0.0, 0],[1.0, 1],...]
-                # chan_t_states[0] are all the first elements of those pairs, i.e the trans. times: e.g [[1D0], [2D0], [3D0], [4D0] ... ]
-                # chan_t_states[1] are all the second elements of those pairs, the states: .e.g [[0],[1],...]
-                for s in range(len(chan_t_states[0])):
+            for i in range(len(t_times)):
+
+                if i == 0:
+                    state[i][j] = 0
+                else:
+                    state[i][j] = state[i-1][j]
                     
-                    #Check if the transition time is one of the times that belongs to this channel:
-                    if t_times[i] == chan_t_states[0][s][0]:
-                        print("inside ", int(chan_t_states[1][s][0]))
-                        state[i][j] = int(chan_t_states[1][s][0]) 
+                    # chan_t_states its elements are pairs of [ttimes, state]. e.g [[0.0, 0],[1.0, 1],...]
+                    # chan_t_states[0] are all the first elements of those pairs, i.e the trans. times: e.g [[1D0], [2D0], [3D0], [4D0] ... ]
+                    # chan_t_states[1] are all the second elements of those pairs, the states: .e.g [[0],[1],...]
+                    for t in range(len(chan_t_states[0])):
+                        #Check if the transition time is one of the times that belongs to this channel:
+                        if t_times[i] == chan_t_states[0][t][0]:
+                            state[i][j] = int(chan_t_states[1][t][0])
 
-            # Building the string of 1s and 0s for each transition time:
-            binstr = ''
-            for element in np.flip(state[i]):
-                binstr += str(element)
-            states_bits.append(binstr)
-            
-            # If the transition time is not in that channel, then keep a copy of the state of the previous channel
-            state.append(copy.deepcopy(state[i]))
+
+        # Building the string of 1s and 0s for each transition time:
+        binrows = []
+        for row in state:
+            rowstr = [str(i) for i in np.flip(row)]  # flipping the bits so that chan 1 is in the far right position
+            binrows.append(''.join(rowstr))
 
         # Converting the original units of the transtion times in seconds, to micro-seconts:
         times_usecs = []
         for elements in t_times:
             times_usecs.append(int(elements * 1E6)) #in micro-seconds
         # Building a pair between the t_times and hex states:
-        state_list = zip(times_usecs, states_bits)
+        state_list = zip(times_usecs, binrows)
 
+        # Creating the STL file with the path and file name given in self.stl_file.data()
         f=open(self.stl_file.data(), 'w')
 
         for s in state_list:
             f.write('%d,%08X\n' % (s[0], int(s[1], 2)))
 
         f.close()
+

--- a/pydevices/HtsDevices/acq2106_WRPG.py
+++ b/pydevices/HtsDevices/acq2106_WRPG.py
@@ -75,7 +75,8 @@ class ACQ2106_WRPG(MDSplus.Device):
         #Create the STL table from a series of transition times and states given in OUTPUT.
         self.set_stl(nchans)
         
-        self.dprint(2, "Building STL: end --- %s seconds ---", (time.time() - start_time))
+        if self.debug >= 2:
+            self.dprint(2, "Building STL: end --- %s seconds ---", (time.time() - start_time))
 
         #Load the STL into the WRPG hardware: GPG
         traces = False  # True: shows debug information during loading

--- a/pydevices/HtsDevices/acq2106_WRPG.py
+++ b/pydevices/HtsDevices/acq2106_WRPG.py
@@ -62,10 +62,12 @@ class ACQ2106_WRPG(MDSplus.Device):
         #Number of channels of the DIO482
         nchans = 32
 
+        # uut.s0.SIG_SRC_TRG_0 ='WRTT0'
         # Setting the trigger in the GPG module. These settings depends very much on what is the
         # configuration of the experiment. For example, when using one WRTT timing highway, the we can use d0, which will be
         # the same used by the digitazer module. Otherwise, we can choose a different one, to be a independent highway from
         # the digitazer, like d1.
+        uut.s0.SIG_EVENT_SRC_0 = 'GPG'
         uut.s0.GPG_ENABLE    ='enable'
         uut.s0.GPG_TRG       ='1'    #external=1, internal=0
         uut.s0.GPG_TRG_DX    ='d1'   #d1 for WRTT1. d0 for WRTT0 or EXT.

--- a/pydevices/HtsDevices/acq2106_WRPG.py
+++ b/pydevices/HtsDevices/acq2106_WRPG.py
@@ -35,7 +35,7 @@ class ACQ2106_WRPG(MDSplus.Device):
     DIO with 32 channels
 
     MDSplus.Device.debug - Controlled by environment variable DEBUG_DEVICES
-		MDSplus.Device.dprint(debuglevel, fmt, args)
+        MDSplus.Device.dprint(debuglevel, fmt, args)
          - print if debuglevel >= MDSplus.Device.debug
 
     """
@@ -48,6 +48,7 @@ class ACQ2106_WRPG(MDSplus.Device):
         {'path':':LOG_OUTPUT',  'type':'text',   'options':('no_write_model', 'write_once', 'write_shot',)},
         {'path':':INIT_ACTION', 'type':'action', 'valueExpr':"Action(Dispatch('CAMAC_SERVER','INIT',50,None),Method(None,'INIT',head))",'options':('no_write_shot',)},
         {'path':':STOP_ACTION', 'type':'action', 'valueExpr':"Action(Dispatch('CAMAC_SERVER','STORE',50,None),Method(None,'STOP',head))",      'options':('no_write_shot',)},
+        {'path':':STL_LISTS',   'type':'text',                  'options':('write_shot',)},
         {'path':':GPG_TRG_DX',  'type':'text', 'value': 'dx', 'options':('write_shot',)},
     ]
 
@@ -70,7 +71,7 @@ class ACQ2106_WRPG(MDSplus.Device):
         uut.s0.SIG_EVENT_SRC_0 = 'GPG'
         uut.s0.GPG_ENABLE    ='enable'
         uut.s0.GPG_TRG       ='1'    #external=1, internal=0
-        uut.s0.GPG_TRG_DX    =str(self.gpg_trg_dx.data())   #d1 for WRTT1. d0 for WRTT0 or EXT.
+        uut.s0.GPG_TRG_DX    = str(self.gpg_trg_dx.data())   #d1 for WRTT1. d0 for WRTT0 or EXT.
         uut.s0.GPG_TRG_SENSE ='rising'
         uut.s0.GPG_MODE      ='ONCE'
 
@@ -179,10 +180,9 @@ class ACQ2106_WRPG(MDSplus.Device):
         #Record the list of lists into a tree node:
         stl_list  = []
         
-        # Write to file with states in HEX form.
+        # Write to a list with states in HEX form.
         for s in stl_tuple:
             stl_list.append('%d,%08X\n' % (s[0], int(s[1], 2)))
-        print(stl_list)
 
         # MDSplus wants a numpy array
         self.stl_lists.putData(numpy.array(stl_list))

--- a/pydevices/HtsDevices/acq2106_WRPG.py
+++ b/pydevices/HtsDevices/acq2106_WRPG.py
@@ -162,13 +162,14 @@ class ACQ2106_WRPG(MDSplus.Device):
         times_usecs = []
         for elements in t_times:
             times_usecs.append(int(elements * 1E6)) #in micro-seconds
-        # Building a pair between the t_times and hex states:
-        state_list = zip(times_usecs, binrows)
+        # Building a pair between the t_times and bin states:
+        stl_list = zip(times_usecs, binrows)
 
         # Creating the STL file with the path and file name given in self.stl_file.data()
         f=open(self.stl_file.data(), 'w')
 
-        for s in state_list:
+        # Write to file with states in HEX form.
+        for s in stl_list:
             f.write('%d,%08X\n' % (s[0], int(s[1], 2)))
 
         f.close()

--- a/pydevices/HtsDevices/acq2106_WRPG.py
+++ b/pydevices/HtsDevices/acq2106_WRPG.py
@@ -62,7 +62,10 @@ class ACQ2106_WRPG(MDSplus.Device):
         #Number of channels of the DIO482
         nchans = 32
 
-        # #Setting the trigger in the GPG module
+        # Setting the trigger in the GPG module. These settings depends very much on what is the
+        # configuration of the experiment. For example, when using one WRTT timing highway, the we can use d0, which will be
+        # the same used by the digitazer module. Otherwise, we can choose a different one, to be a independent highway from
+        # the digitazer, like d1.
         uut.s0.GPG_ENABLE    ='enable'
         uut.s0.GPG_TRG       ='1'    #external=1, internal=0
         uut.s0.GPG_TRG_DX    ='d1'   #d1 when testing two WRTTs, WRTT0 or WRTT1. d0 when testing using only one WRTT.

--- a/pydevices/HtsDevices/acq2106_WRPG.py
+++ b/pydevices/HtsDevices/acq2106_WRPG.py
@@ -48,7 +48,7 @@ class ACQ2106_WRPG(MDSplus.Device):
         {'path':':LOG_OUTPUT',  'type':'text',   'options':('no_write_model', 'write_once', 'write_shot',)},
         {'path':':INIT_ACTION', 'type':'action', 'valueExpr':"Action(Dispatch('CAMAC_SERVER','INIT',50,None),Method(None,'INIT',head))",'options':('no_write_shot',)},
         {'path':':STOP_ACTION', 'type':'action', 'valueExpr':"Action(Dispatch('CAMAC_SERVER','STORE',50,None),Method(None,'STOP',head))",      'options':('no_write_shot',)},
-        # {'path':':STL_FILE',    'type':'TEXT'},
+        {'path':':GPG_TRG_DX',  'type':'text', 'value': 'dx', 'options':('write_shot',)},
     ]
 
 
@@ -59,18 +59,18 @@ class ACQ2106_WRPG(MDSplus.Device):
         import acq400_hapi
         uut = acq400_hapi.Acq400(self.node.data(), monitor=False)
         
-        #Number of channels of the DIO482
-        nchans = 32
+        #Number of channels of the DIO482, e.g nchans = 32
+        nchans = int(uut.s6.NCHAN)
 
         # uut.s0.SIG_SRC_TRG_0 ='WRTT0'
         # Setting the trigger in the GPG module. These settings depends very much on what is the
-        # configuration of the experiment. For example, when using one WRTT timing highway, the we can use d0, which will be
-        # the same used by the digitazer module. Otherwise, we can choose a different one, to be a independent highway from
+        # configuration of the experiment. For example, when using one WRTT timing highway, then we can use d0, which will be
+        # the same used by the digitazer module. Otherwise, we can choose a different one, to be in an independent highway from
         # the digitazer, like d1.
         uut.s0.SIG_EVENT_SRC_0 = 'GPG'
         uut.s0.GPG_ENABLE    ='enable'
         uut.s0.GPG_TRG       ='1'    #external=1, internal=0
-        uut.s0.GPG_TRG_DX    ='d1'   #d1 for WRTT1. d0 for WRTT0 or EXT.
+        uut.s0.GPG_TRG_DX    =str(self.gpg_trg_dx.data())   #d1 for WRTT1. d0 for WRTT0 or EXT.
         uut.s0.GPG_TRG_SENSE ='rising'
         uut.s0.GPG_MODE      ='ONCE'
 

--- a/pydevices/HtsDevices/acq2106_WRPG.py
+++ b/pydevices/HtsDevices/acq2106_WRPG.py
@@ -99,7 +99,7 @@ class ACQ2106_WRPG(MDSplus.Device):
         # Pair of (transition time, 32 bit channel states):
         stl_pairs = self.stl_lists.data()
         # Change from Numpy array to List with toList()
-        pairs = b"\n".join([ item for item in stl_pairs.tolist() ])        
+        pairs = "\n".join([ str(item) for item in stl_pairs.tolist() ])        
 
         uut = acq400_hapi.Acq400(self.node.data(), monitor=False)
         uut.s0.trace = traces

--- a/pydevices/HtsDevices/acq2106_WRPG.py
+++ b/pydevices/HtsDevices/acq2106_WRPG.py
@@ -99,7 +99,7 @@ class ACQ2106_WRPG(MDSplus.Device):
         # Pair of (transition time, 32 bit channel states):
         stl_pairs = self.stl_lists.data()
         # Change from Numpy array to List with toList()
-        pairs = "\n".join([ item for item in stl_pairs.tolist() ])        
+        pairs = b"\n".join([ item for item in stl_pairs.tolist() ])        
 
         uut = acq400_hapi.Acq400(self.node.data(), monitor=False)
         uut.s0.trace = traces

--- a/pydevices/HtsDevices/acq2106_WRPG.py
+++ b/pydevices/HtsDevices/acq2106_WRPG.py
@@ -1,0 +1,184 @@
+#
+# Copyright (c) 2017, Massachusetts Institute of Technology All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# Redistributions of source code must retain the above copyright notice, this
+# list of conditions and the following disclaimer.
+#
+# Redistributions in binary form must reproduce the above copyright notice, this
+# list of conditions and the following disclaimer in the documentation and/or
+# other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+import MDSplus
+import threading
+from queue import Queue, Empty
+import time
+import socket
+import math
+import numpy as np
+import csv
+import copy
+
+try:
+    acq400_hapi = __import__('acq400_hapi', globals(), level=1)
+except:
+    acq400_hapi = __import__('acq400_hapi', globals())
+
+class ACQ2106_WRPG(MDSplus.Device):
+    """
+    D-Tacq ACQ2106 with ACQ423 Digitizers (up to 6)  real time streaming support.
+
+    32 Channels * number of slots
+    Minimum 2Khz Operation
+    24 bits == +-10V
+
+    3 trigger modes:
+      Automatic - starts recording on arm
+      Soft - starts recording on trigger method (reboot / configuration required to switch )
+      Hard - starts recording on hardware trigger input
+
+    Software sample decimation
+
+    Settable segment length in number of samples
+
+    debugging() - is debugging enabled.  Controlled by environment variable DEBUG_DEVICES
+
+    """
+
+    parts=[
+        {'path':':NODE',        'type':'text',                     'options':('no_write_shot',)},
+        {'path':':COMMENT',     'type':'text',                     'options':('no_write_shot',)},
+        {'path':':TRIG_TIME',   'type':'numeric',                  'options':('write_shot',)},
+        {'path':':RUNNING',     'type':'numeric',                  'options':('no_write_model',)},
+        {'path':':LOG_OUTPUT',  'type':'text',   'options':('no_write_model', 'write_once', 'write_shot',)},
+        {'path':':INIT_ACTION', 'type':'action', 'valueExpr':"Action(Dispatch('CAMAC_SERVER','INIT',50,None),Method(None,'INIT',head))",'options':('no_write_shot',)},
+        {'path':':STOP_ACTION', 'type':'action', 'valueExpr':"Action(Dispatch('CAMAC_SERVER','STORE',50,None),Method(None,'STOP',head))",      'options':('no_write_shot',)},
+        {'path':':STL_FILE',    'type':'TEXT'},
+    ]
+
+    for j in range(32):
+        parts.append({'path':':OUTPUT_%3.3d' % (j+1,), 'type':'NUMERIC', 'options':('no_write_shot',)})
+
+    def init(self):
+        uut = acq400_hapi.Acq400(self.node.data(), monitor=False)
+
+        # #Setting the trigger in the GPG module
+        uut.s0.GPG_ENABLE    ='enable'
+        uut.s0.GPG_TRG       ='1'    #external=1, internal=0
+        uut.s0.GPG_TRG_DX    ='d0'
+        uut.s0.GPG_TRG_SENSE ='rising'
+        uut.s0.GPG_MODE      ='ONCE'
+
+        #Create the STL table from a series of transition times and states given in OUTPUT.
+        print("Building STL: start")
+        self.set_stl()
+        print("Building STL: end")
+
+        #Load the STL into the WRPG hardware: GPG
+        traces = False  # True: shows debugging information during loading
+        self.load_stl_file(traces)
+        print('WRPG has loaded the STL')
+      
+    INIT=init
+
+
+    def load_stl_file(self,traces):
+        example_stl=self.stl_file.data()    
+
+        print('Path to State Table: ', example_stl)
+        uut = acq400_hapi.Acq400(self.node.data(), monitor=False)
+        uut.s0.trace = traces
+        
+        print('Loading STL table into WRPG')
+        with open(example_stl, 'r') as fp:
+            uut.load_wrpg(fp.read(), uut.s0.trace)
+
+    def set_stl(self):
+        nchan = 32
+
+        states_hex    = []
+        states_bits   = []
+        all_t_times   = []
+        all_t_times_states = []
+
+        for i in range(nchan):
+            chan_t_times = self.__getattr__('OUTPUT_%3.3d' % (i+1))
+
+            # Pair of (transition time, state) for each channel:
+            chan_t_states = chan_t_times.data()
+
+            # Creation of an array that contains as EVERY OTHER element all the transition times in it, adding them
+            # for each channel:
+            for x in np.nditer(chan_t_states):
+                all_t_times_states.append(x) #Appends arrays made of one element,
+
+        # Choosing only the transition times:
+        all_t_times = all_t_times_states[0::2]
+
+        # Removing duplicates and then sorting in ascending manner:
+        t_times = []
+        for i in all_t_times:
+            if i not in t_times:
+                t_times.append(i)
+
+        # t_times contains the unique set of transitions times used in the experiment:
+        t_times = sorted(np.float64(t_times))
+        print(t_times)
+
+        # initialize the state matrix
+        cols = nchan
+        state = [[0]*cols]
+
+        # Building the state matrix. For each transition times given by t_times, we look for those times that
+        # appear in the channel. If a transition time does not appear in that channel, then the state
+        # doesn't change.
+
+        for i in range(len(t_times)):
+            for j in range(nchan):
+                chan_t_states = self.__getattr__('OUTPUT_%3.3d' % (j+1))
+                
+                # chan_t_states its elements are pairs of [ttimes, state]. e.g [[0.0, 0],[1.0, 1],...]
+                # chan_t_states[0] are all the first elements of those pairs, i.e the trans. times: e.g [[1D0], [2D0], [3D0], [4D0] ... ]
+                # chan_t_states[1] are all the second elements of those pairs, the states: .e.g [[0],[1],...]
+                for s in range(len(chan_t_states[0])):
+                    
+                    #Check if the transition time is one of the times that belongs to this channel:
+                    if t_times[i] == chan_t_states[0][s][0]:
+                        print("inside ", int(chan_t_states[1][s][0]))
+                        state[i][j] = int(chan_t_states[1][s][0]) 
+
+            # Building the string of 1s and 0s for each transition time:
+            binstr = ''
+            for element in np.flip(state[i]):
+                binstr += str(element)
+            states_bits.append(binstr)
+            
+            # If the transition time is not in that channel, then keep a copy of the state of the previous channel
+            state.append(copy.deepcopy(state[i]))
+
+        # Converting the original units of the transtion times in seconds, to micro-seconts:
+        times_usecs = []
+        for elements in t_times:
+            times_usecs.append(int(elements * 1E6)) #in micro-seconds
+        # Building a pair between the t_times and hex states:
+        state_list = zip(times_usecs, states_bits)
+
+        f=open(self.stl_file.data(), 'w')
+
+        for s in state_list:
+            f.write('%d,%08X\n' % (s[0], int(s[1], 2)))
+
+        f.close()

--- a/pydevices/acq400Devices/acq2106_st.py
+++ b/pydevices/acq400Devices/acq2106_st.py
@@ -24,23 +24,21 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
-try:
-    acq400_base = __import__('acq400_base', globals(), level=1)
-except:
-    acq400_base = __import__('acq400_base', globals())
+import importlib
 
+acq400_base = importlib.import_module('acq400_base')
 
 class _ACQ2106_ST(acq400_base._ACQ400_ST_BASE):
     """
     D-Tacq ACQ2106 stream support.
-    """
-
+    """     
 
 class_ch_dict = acq400_base.create_classes(
     _ACQ2106_ST, "ACQ2106_ST",
     list(_ACQ2106_ST.base_parts) + list(_ACQ2106_ST.st_base_parts),
     acq400_base.ACQ2106_CHANNEL_CHOICES
 )
+
 globals().update(class_ch_dict)
 
 if __name__ == '__main__':

--- a/pydevices/acq400Devices/acq2106_tr.py
+++ b/pydevices/acq400Devices/acq2106_tr.py
@@ -23,12 +23,9 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+import importlib
 
-try:
-    acq400_base = __import__('acq400_base', globals(), level=1)
-except:
-    acq400_base = __import__('acq400_base', globals())
-
+acq400_base = importlib.import_module('acq400_base')
 
 class _ACQ2106_TR(acq400_base._ACQ400_TR_BASE):
     """

--- a/pydevices/acq400Devices/acq2106_tr.py
+++ b/pydevices/acq400Devices/acq2106_tr.py
@@ -38,7 +38,7 @@ class _ACQ2106_TR(acq400_base._ACQ400_TR_BASE):
 
 class_ch_dict = acq400_base.create_classes(
     _ACQ2106_TR, "ACQ2106_TR",
-    list(_ACQ2106_TR.base_parts),
+    list(_ACQ2106_TR.base_parts) + list(_ACQ2106_TR.tr_base_parts),
     acq400_base.ACQ2106_CHANNEL_CHOICES
 )
 globals().update(class_ch_dict)

--- a/pydevices/acq400Devices/acq400_base.py
+++ b/pydevices/acq400Devices/acq400_base.py
@@ -94,6 +94,32 @@ class _ACQ400_BASE(MDSplus.Device):
 
         uut.s0.transient = "POST={}".format(self.samples.data())
 
+        #Set the Sampling rate in the ACQ:
+        # MB Clock (WR Clock): 20MHz
+        # mb_freq = uut.s0.SIG_CLK_MB_FREQ
+        mb_freq = 20000000.00 #MHz
+
+        print("Setting sample rate to {} Hz".format(self.freq.data()))
+        clockdiv      = mb_freq/self.freq.data()
+
+        uut.s1.CLKDIV = "{}".format(clockdiv)
+
+        acq_sample_freq = uut.s0.SIG_CLK_S1_FREQ
+        print("After setting the sample rate the value in the ACQ is {} Hz".format(acq_sample_freq))
+
+        #The following is what the ACQ script called "/mnt/local/set_clk_WR" does to set the WR clock to 20MHz
+        uut.s0.SYS_CLK_FPMUX     = 'ZCLK'
+        uut.s0.SIG_ZCLK_SRC      = 'WR31M25'
+        uut.s0.set_si5326_bypass = 'si5326_31M25-20M.txt'
+
+        #Setting SYNC Main Timing Highway Source Routing --> White Rabbit Time Trigger
+        uut.s0.SIG_SRC_TRG_0 ='WRTT'
+
+        #Setting the trigger in ACQ2106 stream control
+        uut.s1.TRG       ='enable'
+        uut.s1.TRG_DX    ='d0'
+        uut.s1.TRG_SENSE ='rising'
+
     INIT = init
 
 
@@ -118,6 +144,14 @@ class _ACQ400_ST_BASE(_ACQ400_BASE):
         thread = self.MDSWorker(self)
         thread.start()
     ARM=arm
+
+    def trig(self, msg=''):
+        message = str(msg)
+        uut = acq400_hapi.Acq400(self.node.data(), monitor=False)
+        print("The message is: %s" %message)
+        wrtdtx = '1 --tx_id=' + message
+        uut.s0.wrtd_tx_immediate = wrtdtx
+    TRIG=trig
 
     def stop(self):
         self.running.on = False

--- a/pydevices/acq400Devices/acq400_base.py
+++ b/pydevices/acq400Devices/acq400_base.py
@@ -41,6 +41,10 @@ class _ACQ400_BASE(MDSplus.Device):
     D-Tacq ACQ400 Base parts and methods.
 
     All other carrier/function combinations use this class as a parent class.
+
+    MDSplus.Device.debug - Controlled by environment variable DEBUG_DEVICES
+	MDSplus.Device.dprint(debuglevel, fmt, args)
+         - print if debuglevel >= MDSplus.Device.debug
     """
 
     base_parts=[

--- a/pydevices/acq400Devices/acq400_base.py
+++ b/pydevices/acq400Devices/acq400_base.py
@@ -250,6 +250,7 @@ class _ACQ400_ST_BASE(_ACQ400_BASE):
 
             def __init__(self,mds):
                 threading.Thread.__init__(self)
+                self.dprint = mds.dev.dprint
                 self.node_addr = mds.dev.node.data()
                 self.seg_length = mds.dev.seg_length.data()
                 self.segment_bytes = mds.segment_bytes
@@ -265,7 +266,7 @@ class _ACQ400_ST_BASE(_ACQ400_BASE):
 
             def run(self):
 
-                self.dev.dprint(1, "DeviceWorker running")
+                self.dprint(1, "DeviceWorker running")
 
                 self.running = True
 
@@ -303,16 +304,16 @@ class _ACQ400_ST_BASE(_ACQ400_BASE):
                             # print (' recv timed out, retry later')
                             continue
                         else:
-                            self.dev.dprint(0, "error: %s", e)
+                            self.dprint(0, "error: %s", e)
                             break
                     except socket.error as e:
                         # Something else happened, handle error, exit, etc.
-                        self.dev.dprint(0, "socket error: %s", e)
+                        self.dprint(0, "socket error: %s", e)
                         self.full_buffers.put(buf[:self.segment_bytes-toread])
                         break
                     else:
                         if toread != 0:
-                            self.dev.dprint(1, 'orderly shutdown on server end')
+                            self.dprint(1, 'orderly shutdown on server end')
 
                             break
                         else:

--- a/pydevices/acq400Devices/acq400_base.py
+++ b/pydevices/acq400Devices/acq400_base.py
@@ -78,10 +78,10 @@ class _ACQ400_BASE(MDSplus.Device):
 
         # The default case is to use the trigger set by sync_role.
         if self.trig_mode.data() == 'role_default':
-            uut.s0.sync_role = "{} {}".format(self.role.data(), self.freq.data())
+            uut.s0.sync_role = "%s %d" % (self.role.data(), self.freq.data())
         else:
             # If the user has specified a trigger.
-            uut.s0.sync_role = '{} {} TRG:DX={}'.format(self.role.data(), self.freq.data(), trg_dx)
+            uut.s0.sync_role = "%s %d TRG:DX=%s" % (self.role.data(), self.freq.data(), trg_dx)
 
         # Now we set the trigger to be soft when desired.
         if trg == 'soft':
@@ -103,7 +103,7 @@ class _ACQ400_BASE(MDSplus.Device):
         self.dprint(1, "Setting sample rate to %r Hz", self.freq.data())
         clockdiv      = mb_freq/self.freq.data()
 
-        uut.s1.CLKDIV = "{}".format(clockdiv)
+        uut.s1.CLKDIV = "%d" % clockdiv
 
         acq_sample_freq = uut.s0.SIG_CLK_S1_FREQ
         
@@ -162,7 +162,7 @@ class _ACQ400_ST_BASE(_ACQ400_BASE):
         message = str(msg)
         import acq400_hapi
         uut = acq400_hapi.Acq400(self.node.data())
-        self.dprint(1, "The trigger message for streamming is: %s", message)
+        self.dprint(1, "The trigger message for streamming is: %s" % message)
 
         wrtdtx = '1 --tx_id=' + message + '\n'
         uut.s0.wrtd_tx_immediate = wrtdtx
@@ -206,7 +206,7 @@ class _ACQ400_ST_BASE(_ACQ400_BASE):
                 if ch.on:
                     ch.EOFF.putData(float(eoff[ic]))
                     ch.ESLO.putData(float(eslo[ic]))
-                    expr = "{} * {} + {}".format(ch, ch.ESLO, ch.EOFF)
+                    expr = "%d*%d + %d" % (ch, ch.ESLO, ch.EOFF)
 
                     ch.CAL_INPUT.putData(MDSplus.Data.compile(expr))
 
@@ -377,14 +377,14 @@ class _ACQ400_TR_BASE(_ACQ400_BASE):
 
         trstate = acq400_hapi.acq400.STATE.str(_status[0])
         
-        print("TR state: {}".format(trstate))
-        print("TR status: {}".format(_status))
+        print("TR state: %d" % (trstate))
+        print("TR status: %d" % (_status))
     STATE=state
     
     def stop(self):
         import acq400_hapi
         uut = acq400_hapi.Acq400(self.node.data())
-        print("PRE {}, POST {} and ELAPSED {}".format(uut.pre_samples(), uut.post_samples(), uut.elapsed_samples()))
+        print("PRE %d, POST %d and ELAPSED %d" % (uut.pre_samples(), uut.post_samples(), uut.elapsed_samples()))
         uut.s0.set_abort=1
     STOP = stop
 
@@ -430,7 +430,7 @@ class _ACQ400_TR_BASE(_ACQ400_BASE):
                 ch.ESLO.putData(float(eslo[ic]))
 
                 #Expression to calculate the calibrarted inputs:
-                expr = "{} * {} + {}".format(ch, ch.ESLO, ch.EOFF)
+                expr = "%d*%d + %d" % (ch, ch.ESLO, ch.EOFF)
 
                 ch.CAL_INPUT.putData(MDSplus.Data.compile(expr))
 
@@ -490,7 +490,7 @@ class _ACQ400_MR_BASE(_ACQ400_TR_BASE):
                 ch.putData(channel_data[ic])
                 ch.EOFF.putData(float(eoff[ic]))
                 ch.ESLO.putData(float(eslo[ic]))
-                expr = "{} * {} + {}".format(ch, ch.ESLO, ch.EOFF)
+                expr = "%d*%d + %d" % (ch, ch.ESLO, ch.EOFF)
                 ch.CAL_INPUT.putData(MDSplus.Data.compile(expr))
 
 	    self.create_time_base(uut)
@@ -538,7 +538,7 @@ class _ACQ400_MR_BASE(_ACQ400_TR_BASE):
                 delayk = int(delay * 40000000 / 1000000)
                 delaym = delayk - delayk % self.MR10DEC.data()
                 state = state << self.evsel0.data()
-                elem = "{}{:d},{:02x}".format(delayp, delaym, state)
+                elem = "%s%d,%x" % (delayp, delaym, state)
                 stl_literal_lines.append(elem)
                 # if args.verbose:
                 #     print(line)
@@ -566,8 +566,8 @@ class _ACQ400_MR_BASE(_ACQ400_TR_BASE):
         uut.s0.GPG_ENABLE = '0'
         uut.load_gpg(lit_stl, 2) # TODO: Change to MDSplus debug.
         uut.set_MR(True, evsel0=self.evsel0.data(), evsel1=self.evsel0.data()+1, MR10DEC=self.MR10DEC.data())
-        uut.s0.set_knob('SIG_EVENT_SRC_{}'.format(self.evsel0.data()), 'GPG')
-        uut.s0.set_knob('SIG_EVENT_SRC_{}'.format(self.evsel0.data()+1), 'GPG')
+        uut.s0.set_knob('SIG_EVENT_SRC_%s' % (self.evsel0.data()), 'GPG')
+        uut.s0.set_knob('SIG_EVENT_SRC_%s' % (self.evsel0.data()+1), 'GPG')
         uut.s0.GPG_ENABLE = '1'
     INIT = init
 
@@ -581,10 +581,10 @@ def print_generated_classes(class_dict):
     for key in sorted(class_dict.keys(), key=int_key_chan):
         if key1 is None:
             key1 = key
-        print("# {}".format(key))
-    print("{}".format(key1))
+        print("# %s" % (key))
+    print("%s" % (key1))
     for p in class_dict[key1].parts:
-        print("{}".format(p))
+        print("%s" % (p))
 
 
 INPFMT3 = ':INPUT_%3.3d'
@@ -611,7 +611,7 @@ def assemble(cls):
 def create_classes(base_class, root_name, parts, channel_choices):
     my_classes = {}
     for nchan in channel_choices:
-        class_name = "{}_{}".format(root_name, str(nchan))
+        class_name = "%s_%s".format(root_name, str(nchan))
         my_parts = list(parts)
         my_classes[class_name] = assemble(
             type(class_name, (base_class,), {"nchan": nchan, "parts": my_parts}))

--- a/pydevices/acq400Devices/acq400_base.py
+++ b/pydevices/acq400Devices/acq400_base.py
@@ -146,6 +146,7 @@ class _ACQ400_ST_BASE(_ACQ400_BASE):
     ARM=arm
 
     def trig(self, msg=''):
+        import acq400_hapi
         message = str(msg)
         uut = acq400_hapi.Acq400(self.node.data(), monitor=False)
         print("The message is: %s" %message)

--- a/pydevices/acq400Devices/acq400_base.py
+++ b/pydevices/acq400Devices/acq400_base.py
@@ -23,13 +23,11 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
-import sys
 import threading
 import socket
 import time
-import inspect
 
-import numpy as np
+import numpy
 import MDSplus
 
 if MDSplus.version.ispy3:
@@ -102,13 +100,14 @@ class _ACQ400_BASE(MDSplus.Device):
         # mb_freq = uut.s0.SIG_CLK_MB_FREQ
         mb_freq = 20000000.00 #MHz
 
-        print("Setting sample rate to {} Hz".format(self.freq.data()))
+        self.dprint(1, "Setting sample rate to %r Hz", self.freq.data())
         clockdiv      = mb_freq/self.freq.data()
 
         uut.s1.CLKDIV = "{}".format(clockdiv)
 
         acq_sample_freq = uut.s0.SIG_CLK_S1_FREQ
-        print("After setting the sample rate the value in the ACQ is {} Hz".format(acq_sample_freq))
+        
+        self.dprint(1, "After setting the sample rate the value in the ACQ is%r Hz", acq_sample_freq)
 
         #The following is what the ACQ script called "/mnt/local/set_clk_WR" does to set the WR clock to 20MHz
         uut.s0.SYS_CLK_FPMUX     = 'ZCLK'
@@ -152,7 +151,7 @@ class _ACQ400_ST_BASE(_ACQ400_BASE):
         import acq400_hapi
         message = str(msg)
         uut = acq400_hapi.Acq400(self.node.data(), monitor=False)
-        print("The message is: %s" %message)
+        self.dprint(1, "The message is: %s", message)
         wrtdtx = '1 --tx_id=' + message
         uut.s0.wrtd_tx_immediate = wrtdtx
     TRIG=trig
@@ -180,7 +179,7 @@ class _ACQ400_ST_BASE(_ACQ400_BASE):
                 self.chans.append(getattr(self.dev, 'INPUT_%3.3d'%(i+1)))
                 self.decim.append(getattr(self.dev, 'INPUT_%3.3d:DECIMATE' %(i+1)).data())
             self.seg_length = self.dev.seg_length.data()
-            self.segment_bytes = self.seg_length*self.nchans*np.int16(0).nbytes
+            self.segment_bytes = self.seg_length*self.nchans*numpy.int16(0).nbytes
 
             self.empty_buffers = Queue()
             self.full_buffers  = Queue()
@@ -200,8 +199,7 @@ class _ACQ400_ST_BASE(_ACQ400_BASE):
                     ans = lcm(ans, e)
                 return int(ans)
 
-            if self.dev.debug:
-                print("MDSWorker running")
+            self.dev.dprint(1, "DeviceWorker running")
 
             event_name = self.dev.seg_event.data()
 
@@ -223,7 +221,7 @@ class _ACQ400_ST_BASE(_ACQ400_BASE):
                 except Empty:
                     continue
 
-                buffer = np.frombuffer(buf, dtype='int16')
+                buffer = numpy.frombuffer(buf, dtype='int16')
                 i = 0
                 for c in self.chans:
                     slength = self.seg_length/self.decim[i]
@@ -240,7 +238,7 @@ class _ACQ400_ST_BASE(_ACQ400_BASE):
 
                 self.empty_buffers.put(buf)
 
-            self.dev.trig_time.record = self.device_thread.trig_time - ((self.device_thread.io_buffer_size / np.int16(0).nbytes) * dt)
+            self.dev.trig_time.record = self.device_thread.trig_time - ((self.device_thread.io_buffer_size / numpy.int16(0).nbytes) * dt)
             self.device_thread.stop()
 
         class DeviceWorker(threading.Thread):
@@ -248,7 +246,6 @@ class _ACQ400_ST_BASE(_ACQ400_BASE):
 
             def __init__(self,mds):
                 threading.Thread.__init__(self)
-                self.debug = mds.dev.debug
                 self.node_addr = mds.dev.node.data()
                 self.seg_length = mds.dev.seg_length.data()
                 self.segment_bytes = mds.segment_bytes
@@ -263,8 +260,8 @@ class _ACQ400_ST_BASE(_ACQ400_BASE):
                 self.running = False
 
             def run(self):
-                if self.debug:
-                    print("DeviceWorker running")
+
+                self.dev.dprint(1, "DeviceWorker running")
 
                 self.running = True
 
@@ -302,16 +299,17 @@ class _ACQ400_ST_BASE(_ACQ400_BASE):
                             # print (' recv timed out, retry later')
                             continue
                         else:
-                            print (e)
+                            self.dev.dprint(0, "error: %s", e)
                             break
                     except socket.error as e:
                         # Something else happened, handle error, exit, etc.
-                        print("socket error", e)
+                        self.dev.dprint(0, "socket error: %s", e)
                         self.full_buffers.put(buf[:self.segment_bytes-toread])
                         break
                     else:
                         if toread != 0:
-                            print ('orderly shutdown on server end')
+                            self.dev.dprint(1, 'orderly shutdown on server end')
+
                             break
                         else:
                             self.full_buffers.put(buf)

--- a/pydevices/acq400Devices/acq400_base.py
+++ b/pydevices/acq400Devices/acq400_base.py
@@ -118,8 +118,12 @@ class _ACQ400_BASE(MDSplus.Device):
         uut.s0.SIG_ZCLK_SRC      = 'WR31M25'
         uut.s0.set_si5326_bypass = 'si5326_31M25-20M.txt'
 
-        #Setting SYNC Main Timing Highway Source Routing --> White Rabbit Time Trigger
-        uut.s0.SIG_SRC_TRG_0 ='WRTT'
+        # Setting SYNC Main Timing Highway Source Routing --> White Rabbit Time Trigger
+        # uut.s0.SIG_SRC_TRG_0 ='WRTT'
+        # When using two WRTT triggers:
+        uut.s0.SIG_SRC_TRG_0 ='WRTT0'
+        uut.s0.SIG_SRC_TRG_1 ='WRTT1'
+
 
         #Setting the trigger in ACQ2106 stream control
         uut.s1.TRG       ='enable'

--- a/pydevices/acq400Devices/acq400_base.py
+++ b/pydevices/acq400Devices/acq400_base.py
@@ -345,12 +345,19 @@ class _ACQ400_TR_BASE(_ACQ400_BASE):
     A child class of _ACQ400_BASE that contains the specific methods for
     taking a transient capture.
     """
+    def stop(self):
+        import acq400_hapi
+        uut = acq400_hapi.Acq400(self.node.data())
+        uut.s0.set_abort = 1
+        self.running = False
+    STOP=stop
 
     def arm(self):
         import acq400_hapi
         uut = acq400_hapi.Acq400(self.node.data())
-        shot_controller = acq400_hapi.ShotController([uut])
-        shot_controller.run_shot()
+        # shot_controller = acq400_hapi.ShotController([uut])
+        # shot_controller.run_shot()
+        uut.s0.set_arm = 1
     ARM=arm
 
 

--- a/pydevices/acq400Devices/acq400_base.py
+++ b/pydevices/acq400Devices/acq400_base.py
@@ -94,6 +94,9 @@ class _ACQ400_BASE(MDSplus.Device):
 
         uut.s0.transient = "POST={}".format(self.samples.data())
 
+        #Setting WR Clock to 20MHz by first being sure that MBCLK FIN is in fact = 0
+        uut.s0.SIG_CLK_MB_FIN = '0'
+
         #Set the Sampling rate in the ACQ:
         # MB Clock (WR Clock): 20MHz
         # mb_freq = uut.s0.SIG_CLK_MB_FREQ
@@ -289,14 +292,14 @@ class _ACQ400_ST_BASE(_ACQ400_BASE):
                             toread -= nbytes
 
                     except socket.timeout as e:
-                        print("Got a timeout.")
+                        # print("Got a timeout.")
                         err = e.args[0]
                         # this next if/else is a bit redundant, but illustrates how the
                         # timeout exception is setup
 
                         if err == 'timed out':
                             time.sleep(1)
-                            print (' recv timed out, retry later')
+                            # print (' recv timed out, retry later')
                             continue
                         else:
                             print (e)

--- a/pydevices/acq400Devices/acq400_base.py
+++ b/pydevices/acq400Devices/acq400_base.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2017, Massachusetts Institute of Technology All rights reserved.
+# Copyright (c) 2020, Massachusetts Institute of Technology All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:

--- a/pydevices/acq400Devices/acq400_base.py
+++ b/pydevices/acq400Devices/acq400_base.py
@@ -63,11 +63,6 @@ class _ACQ400_BASE(MDSplus.Device):
     trig_types=[ 'hard', 'soft', 'automatic']
 
 
-    def setChanScale(self,num):
-        chan=self.__getattr__('INPUT_%3.3d' % num)
-        chan.setSegmentScale(MDSplus.ADD(MDSplus.MULTIPLY(chan.COEFFICIENT,MDSplus.dVALUE()),chan.OFFSET))
-
-
     def init(self):
         uut = acq400_hapi.Acq400(self.node.data(), monitor=False)
         trig_types=[ 'hard', 'soft', 'automatic']
@@ -121,22 +116,22 @@ class _ACQ400_BASE(MDSplus.Device):
         uut.s0.set_si5326_bypass = 'si5326_31M25-20M.txt'
 
         # Setting SYNC Main Timing Highway Source Routing --> EXT or White Rabbit Time Trigger
-        uut.s0.SIG_SRC_TRG_0 ='EXT'
-        uut.s0.SIG_SRC_TRG_1 ='STRIG'  #Soft TRIG
+        # uut.s0.SIG_SRC_TRG_0 ='EXT'
+        # uut.s0.SIG_SRC_TRG_1 ='STRIG'  #Soft TRIG
 
         # When using two WRTT triggers:
-        # uut.s0.SIG_SRC_TRG_0 ='WRTT0'
-        #uut.s0.SIG_SRC_TRG_1 ='WRTT1'
+        uut.s0.SIG_SRC_TRG_0 ='WRTT0'
+        uut.s0.SIG_SRC_TRG_1 ='WRTT1'
 
         #Setting the trigger in ACQ2106 stream control
         uut.s1.TRG       ='enable'
-        uut.s1.TRG_DX    ='d1'
+        uut.s1.TRG_DX    ='d0'
         uut.s1.TRG_SENSE ='rising'
 
         if presamples !=0:
             uut.s0.SIG_EVENT_SRC_0 = 'TRG' # The source needs to be TRG to be able to connect d0 with EXT
             uut.s1.EVENT0    ='enable'
-            uut.s1.EVENT0_DX ='d0'
+            uut.s1.EVENT0_DX ='d1'
             uut.s1.EVENT0_SENSE ='rising'
 
     INIT = init
@@ -595,8 +590,7 @@ def assemble(cls):
 # probably easier for analysis code if ALWAYS INPUT_001
 #    inpfmt = INPFMT2 if cls.nchan < 100 else INPFMT3
     for ch in range(1, cls.nchan+1):
-        cls.parts.append({'path':inpfmt%(ch,), 'type':'signal','options':('no_write_model','write_once',),
-                          'valueExpr':'head.setChanScale(%d)' %(ch,)})
+        cls.parts.append({'path':inpfmt%(ch,), 'type':'signal','options':('no_write_model','write_once',)})
         cls.parts.append({'path':inpfmt%(ch,)+':DECIMATE', 'type':'NUMERIC', 'value':1, 'options':('no_write_shot')})
         cls.parts.append({'path':inpfmt%(ch,)+':COEFFICIENT','type':'NUMERIC', 'value':1, 'options':('no_write_shot')})
         cls.parts.append({'path':inpfmt%(ch,)+':OFFSET', 'type':'NUMERIC', 'value':1, 'options':('no_write_shot')})

--- a/pydevices/acq400Devices/acq400_base.py
+++ b/pydevices/acq400Devices/acq400_base.py
@@ -69,9 +69,7 @@ class _ACQ400_BASE(MDSplus.Device):
 
 
     def init(self):
-        
         uut = acq400_hapi.Acq400(self.node.data(), monitor=False)
-
         trig_types=[ 'hard', 'soft', 'automatic']
         trg = self.trig_mode.data()
 
@@ -95,7 +93,10 @@ class _ACQ400_BASE(MDSplus.Device):
         if trg == 'automatic':
             uut.s0.transient = 'SOFT_TRIGGER=1'
 
-        uut.s0.transient = "POST={}".format(self.samples.data())
+        # If PRE samples different from zero
+        presamples = 100000
+        # presamples = 0
+        uut.s0.transient = "PRE={} POST={}".format(presamples, self.samples.data())
 
         #Setting WR Clock to 20MHz by first being sure that MBCLK FIN is in fact = 0
         uut.s0.SIG_CLK_MB_FIN = '0'
@@ -120,17 +121,23 @@ class _ACQ400_BASE(MDSplus.Device):
         uut.s0.set_si5326_bypass = 'si5326_31M25-20M.txt'
 
         # Setting SYNC Main Timing Highway Source Routing --> EXT or White Rabbit Time Trigger
-        # uut.s0.SIG_SRC_TRG_0 ='EXT'
+        uut.s0.SIG_SRC_TRG_0 ='EXT'
+        uut.s0.SIG_SRC_TRG_1 ='STRIG'  #Soft TRIG
 
         # When using two WRTT triggers:
-        uut.s0.SIG_SRC_TRG_0 ='WRTT0'
-        uut.s0.SIG_SRC_TRG_1 ='WRTT1'
-
+        # uut.s0.SIG_SRC_TRG_0 ='WRTT0'
+        #uut.s0.SIG_SRC_TRG_1 ='WRTT1'
 
         #Setting the trigger in ACQ2106 stream control
         uut.s1.TRG       ='enable'
-        uut.s1.TRG_DX    ='d0'
+        uut.s1.TRG_DX    ='d1'
         uut.s1.TRG_SENSE ='rising'
+
+        if presamples !=0:
+            uut.s0.SIG_EVENT_SRC_0 = 'TRG' # The source needs to be TRG to be able to connect d0 with EXT
+            uut.s1.EVENT0    ='enable'
+            uut.s1.EVENT0_DX ='d0'
+            uut.s1.EVENT0_SENSE ='rising'
 
     INIT = init
 
@@ -147,7 +154,7 @@ class _ACQ400_ST_BASE(_ACQ400_BASE):
         {'path':':SEG_LENGTH',  'type':'numeric', 'value': 8000,   'options':('no_write_shot',)},
         {'path':':MAX_SEGMENTS','type':'numeric', 'value': 1000,   'options':('no_write_shot',)},
         {'path':':SEG_EVENT',   'type':'text',   'value': 'STREAM','options':('no_write_shot',)},
-        {'path':':TRIG_TIME',   'type':'numeric',                  'options':('write_shot',)}
+        {'path':':TRIG_TIME',   'type':'numeric',                  'options':('write_shot',)},
         ]
 
 
@@ -158,12 +165,14 @@ class _ACQ400_ST_BASE(_ACQ400_BASE):
     ARM=arm
 
     def trig(self, msg=''):
-
         message = str(msg)
-        uut = acq400_hapi.Acq400(self.node.data(), monitor=False)
-        self.dprint(1, "The message is: %s", message)
+        uut = acq400_hapi.Acq400(self.node.data())
+        self.dprint(1, "The trigger message for streamming is: %s", message)
+
         wrtdtx = '1 --tx_id=' + message
         uut.s0.wrtd_tx_immediate = wrtdtx
+    
+        self.trig_time.putData(MDSplus.Int64(uut.s0.wr_tai_cur))
     TRIG=trig
 
     def stop(self):
@@ -345,6 +354,42 @@ class _ACQ400_TR_BASE(_ACQ400_BASE):
     A child class of _ACQ400_BASE that contains the specific methods for
     taking a transient capture.
     """
+    tr_base_parts = [
+        {'path':':RUNNING',     'type':'numeric',                  'options':('no_write_model',)},
+        {'path':':TRIG_TIME',   'type':'numeric',                  'options':('write_shot',)}
+        ]
+
+    def trig(self, msg=''):
+        message = str(msg)
+        uut = acq400_hapi.Acq400(self.node.data())
+        self.dprint(1, "The trigger message for transient recording is: %s", message)
+
+        wrtdtx = '1 --tx_id=' + message
+        uut.s0.wrtd_tx_immediate = wrtdtx
+    
+        #self.trig_time.putData(MDSplus.Int64(uut.s0.wr_tai_cur))
+    TRIG=trig
+
+    def state(self):
+        uut = acq400_hapi.Acq400(self.node.data())
+        _status = [int(x) for x in uut.s0.state.split(" ")]
+
+        #statemon = acq400_hapi.acq400.Statusmonitor(self.node.data(), _status)
+        #istate   = int(statemon.get_state())
+
+        trstate = acq400_hapi.acq400.STATE.str(_status[0])
+        
+        print("TR state: {}".format(trstate))
+        print("TR status: {}".format(_status))
+    STATE=state
+    
+    def stop(self):
+        uut = acq400_hapi.Acq400(self.node.data())
+        print("PRE {}, POST {} and ELAPSED {}".format(uut.pre_samples(), uut.post_samples(), uut.elapsed_samples()))
+        uut.s0.set_abort=1
+    STOP = stop
+
+
     def _arm(self):
         uut = acq400_hapi.Acq400(self.node.data())
         shot_controller = acq400_hapi.ShotController([uut])
@@ -363,7 +408,6 @@ class _ACQ400_TR_BASE(_ACQ400_BASE):
         thread.start()
         return None
     STORE=store
-
 
     def _store(self):
 
@@ -384,11 +428,145 @@ class _ACQ400_TR_BASE(_ACQ400_BASE):
                 ch.putData(channel_data[ic])
                 ch.EOFF.putData(float(eoff[ic]))
                 ch.ESLO.putData(float(eslo[ic]))
+
+                #Expression to calculate the calibrarted inputs:
                 expr = "{} * {} + {}".format(ch, ch.ESLO, ch.EOFF)
 
                 ch.CAL_INPUT.putData(MDSplus.Data.compile(expr))
 
     _STORE=_store
+
+class _ACQ400_MR_BASE(_ACQ400_TR_BASE):
+    """
+    A sub-class of _ACQ400_TR_BASE that includes functions for MR data
+    and the extra nodes for MR processing.
+    """
+
+    mr_base_parts = [
+        {'path':':DT',       'type':'numeric','options':('write_shot',)},
+        {'path':':TB_NS',    'type':'signal', 'options':('no_write_model','write_once',)},
+        {'path':':DECIMS',   'type':'signal','options':('no_write_model','write_once',)},
+        {'path':':Fclk',     'type':'numeric','value':40000000,'options':('write_shot',)},
+        {'path':':trg0_src', 'type':'text',   'value':'EXT','options':('write_model',)},
+        {'path':':evsel0',   'type':'numeric','value':4,'options':('write_model',)},
+        {'path':':MR10DEC',  'type':'numeric','value':8,'options':('write_model',)},
+        {'path':':STL',      'type':'text',   'options':('write_model',)}
+        ]
+
+
+    def _create_time_base(self, decims, dt):
+        tb = np.zeros(decims.shape[-1])
+        ttime = 0
+        for ix, dec in enumerate(decims):
+                tb[ix] = ttime
+                ttime += float(dec) * dt
+
+        return tb
+
+    def create_time_base(self, uut):
+        decims = uut.read_decims()
+        dt = 1 / ((round(float(uut.s0.SIG_CLK_MB_FREQ.split(" ")[1]), -4)) * 1e-9)
+        tb_ns = self._create_time_base(decims, dt)
+
+        self.DECIMS.putData(decims)
+        self.DT.putData(dt)
+        self.TB_NS.putData(tb_ns)
+
+    def store(self):
+        uut = acq400_hapi.Acq400(self.node.data())
+        self.chans = []
+        nchans = uut.nchan()
+        for ii in range(nchans):
+            self.chans.append(getattr(self, 'INPUT_%3.3d'%(ii+1)))
+
+        uut.fetch_all_calibration()
+        eslo = uut.cal_eslo[1:]
+        eoff = uut.cal_eoff[1:]
+        channel_data = uut.read_channels()
+
+        for ic, ch in enumerate(self.chans):
+            if ch.on:
+                ch.putData(channel_data[ic])
+                ch.EOFF.putData(float(eoff[ic]))
+                ch.ESLO.putData(float(eslo[ic]))
+                expr = "{} * {} + {}".format(ch, ch.ESLO, ch.EOFF)
+                ch.CAL_INPUT.putData(MDSplus.Data.compile(expr))
+
+	    self.create_time_base(uut)
+        # return None
+    STORE=store
+
+
+    def arm():
+        # A customised ARM function for the acq2106_MR setup.
+        uut = acq400_hapi.Acq400(self.node.data())
+        shot_controller = acq400_hapi.ShotController(uut)
+        shot_controller.run_shot(remote_trigger=self.selects_trg_src(uut, self.trg0_src.data()))
+        return None
+    ARM = arm
+
+
+    def selects_trg_src(self, uut, src):
+        def select_trg_src():
+            uut.s0.SIG_SRC_TRG_0 = src
+        return select_trg_src
+
+
+    def denormalise_stl(self, stl):
+
+        # lines = args.stl.splitlines()
+        lines = stl.splitlines()
+        stl_literal_lines = []
+        for line in lines:
+            if line.startswith('#') or len(line) < 2:
+                # if args.verbose:
+                #     print(line)
+                continue
+            else:
+                action = line.split('#')[0]
+
+                if action.startswith('+'): # support relative increments
+                    delayp = '+'
+                    action  = action[1:]
+                else:
+                    delayp = ''
+
+                delay, state = [int(x) for x in action.split(',')]
+                # delayk = int(delay * self.Fclk.data() / 1000000)
+                delayk = int(delay * 40000000 / 1000000)
+                delaym = delayk - delayk % self.MR10DEC.data()
+                state = state << self.evsel0.data()
+                elem = "{}{:d},{:02x}".format(delayp, delaym, state)
+                stl_literal_lines.append(elem)
+                # if args.verbose:
+                #     print(line)
+
+        return "\n".join(stl_literal_lines)
+
+
+    def init(self):
+        # args.uuts = [ acq400_hapi.Acq2106(u, has_comms=False) for u in args.uut ]
+        uut = acq400_hapi.Acq2106(self.node.data())
+        # master = args.uuts[0]
+        self.STL.putData("/home/dt100/PROJECTS/acq400_hapi/user_apps/STL/acq2106_test10.stl")
+        with open(self.STL.data(), 'r') as fp:
+            stl = fp.read()
+
+        lit_stl = self.denormalise_stl(stl)
+
+        uut.s0.SIG_SRC_TRG_0 = 'NONE'
+
+        # for u in args.uuts:
+        # acq400_hapi.Acq400UI.exec_args(uut, args)
+        uut.s0.gpg_trg = '1,0,1'
+        uut.s0.gpg_clk = '1,1,1'
+        uut.s0.GPG_ENABLE = '0'
+        uut.load_gpg(lit_stl, 2) # TODO: Change to MDSplus debug.
+        uut.set_MR(True, evsel0=self.evsel0.data(), evsel1=self.evsel0.data()+1, MR10DEC=self.MR10DEC.data())
+        uut.s0.set_knob('SIG_EVENT_SRC_{}'.format(self.evsel0.data()), 'GPG')
+        uut.s0.set_knob('SIG_EVENT_SRC_{}'.format(self.evsel0.data()+1), 'GPG')
+        uut.s0.GPG_ENABLE = '1'
+    INIT = init
 
 
 def int_key_chan(elem):


### PR DESCRIPTION
This PR contains basically one additions and 3 changes:
Addition:
- New MDSplus device class to create and load an STL table into the D-TACQ WRPG. These are in acq2106_WRPG.py.

Changes: 
- Changes to the D-TACQ's new streaming device class. The controls or knobs to the WR clocks were added, as well as the triggerig highway to use WR messaging as triggers.
- Changes to the deploy packaging, Debina and Redhat, adding the new device class.