### PR TITLE
Feature: support ssh_config User, HostName, Port, and ProxyJump

### DIFF
--- a/java/mdsplus-api/src/main/java/mds/mdsip/Message.java
+++ b/java/mdsplus-api/src/main/java/mds/mdsip/Message.java
@@ -95,13 +95,14 @@ public final class Message extends Object{
 	private static final ByteBuffer readBuf(int bytes_to_read, final ReadableByteChannel dis, final Set<TransferEventListener> mdslisteners, long abstimeout) throws IOException {
 		final ByteBuffer buf = ByteBuffer.allocateDirect(bytes_to_read);
 		final boolean event = (bytes_to_read > 2000);
+		if (abstimeout == 0)
+			abstimeout = System.currentTimeMillis() + 3_000;
 		try{
 			while(buf.hasRemaining()){
 				final int read = dis.read(buf);
 				if(read == -1) throw new SocketException("connection lost");
 				else if (read == 0) {
-					if (abstimeout == 0
-					|| (abstimeout > 0 && System.currentTimeMillis() > abstimeout))
+					if (abstimeout > 0 && System.currentTimeMillis() > abstimeout)
 						throw new SocketException("connection timeout");
 					continue;
 				}


### PR DESCRIPTION
Added support for some essential ssh_config entries, namely StrictHostKeyChecking, User, HostName, Port, and ProxyJump.
Automatically resolve ProxyJump path and connect thru proxies.

TODO: Support for ProxyCommand. This will be much more difficult as using the command required prompts for passphrase, password, hostkey confirmations. Using internals would required proper parsing and would limit support for a selected number of tools. e.g. nc/netcat -> Socket, ssh -> JSch.Session.ExecChannel. And will not be part of this PR.