### PR TITLE
Feature: add LIB->ROUTINE:C that frees the returned pointer to TdiCall

### DIFF
--- a/include/dtypedef.h
+++ b/include/dtypedef.h
@@ -46,6 +46,8 @@ DEFINE(FS		,52)	/* IEEE float basic single S */
 DEFINE(FT		,53)	/* IEEE float basic double T */
 DEFINE(FSC		,54)	/* IEEE float basic single S complex */
 DEFINE(FTC		,55)	/* IEEE float basic double T complex */
+DEFINE(C		,56)	/* used for TdiCall returned char* that must be freed */
+
 DEFINE(IDENT		,191)
 DEFINE(NID		,192)
 DEFINE(PATH		,193)

--- a/tdishr/TdiCall.c
+++ b/tdishr/TdiCall.c
@@ -75,6 +75,7 @@ static inline int interlude(dtype_t rtype, mdsdsc_t **newdsc,
       LibCallg(newdsc, routine);
       break;
     }
+  case DTYPE_C:
   case DTYPE_T:
   case DTYPE_POINTER:
   case DTYPE_DSC:
@@ -120,7 +121,7 @@ int TdiCall(dtype_t rtype, int narg, mdsdsc_t *list[], mdsdsc_xd_t *out_ptr)
   char result[8] = { 0 };// we need up to 8 bytes
   unsigned short code;
   mdsdsc_t *newdsc[256] = {0};
-  mdsdsc_t dx = { 0, rtype, CLASS_S, result };
+  mdsdsc_t dx = { 0, rtype == DTYPE_C ? DTYPE_T : rtype, CLASS_S, result };
   unsigned char origin[255];
   if (narg > 255 + 2)
     status = TdiNDIM_OVER;
@@ -222,6 +223,7 @@ int TdiCall(dtype_t rtype, int narg, mdsdsc_t *list[], mdsdsc_xd_t *out_ptr)
 	  break;
 	}
       break;
+    case DTYPE_C: /* like T but with free */
     case DTYPE_T:
     case DTYPE_PATH:
     case DTYPE_EVENT:
@@ -244,6 +246,8 @@ int TdiCall(dtype_t rtype, int narg, mdsdsc_t *list[], mdsdsc_xd_t *out_ptr)
   }
   if STATUS_OK
     status = MdsCopyDxXd(&dx, out_ptr);
+  if (rtype == DTYPE_C)
+    free(*(char **)result); // free result
  skip:
   for (j = 0; j < ntmp; ++j) {
     for (pfun = (mds_function_t *)list[origin[j]]; pfun && pfun->dtype == DTYPE_DSC;)

--- a/tdishr/TdiDefCat.c
+++ b/tdishr/TdiDefCat.c
@@ -103,7 +103,8 @@ const struct TdiCatStruct_table TdiREF_CAT[] = {
   {"FS", 0x8703, 4, 16, FS_SYM},	/*52 ieee single floating */
   {"FT", 0x8707, 8, 32, FT_SYM},	/*53 ieee double floating */
   {"FSC", 0x9703, 8, 24, FS_SYM},	/*54 ieee single floating complex */
-  {"FTC", 0x9707, 16, 48, FT_SYM}	/*55 ieee double floating complex */
+  {"FTC", 0x9707, 16, 48, FT_SYM},	/*55 ieee double floating complex */
+  {"C", 0x8000, 0, 0, 0},	/*56 like 14 but used with TdiCall result will be freed */
 };
 
 const tdicat_t TdiCAT_MAX = sizeof(TdiREF_CAT) / sizeof(struct TdiCatStruct_table);

--- a/tditest/testing/test-tdishr.ans
+++ b/tditest/testing/test-tdishr.ans
@@ -6297,3 +6297,5 @@ x_to_i(["def4","abc"],["d"]) /** bsearch returns -1 mapping to nearest, i.e. 0-t
 [1]
 build_signal([1,2,3],*,["a","b","c"])["d"] /** empty signal **/
 Build_Signal([], *, [])
+TreeShr->MaskReplace:T(ref("/trees/~j~i/~h~g/~f~e/~d~c/~t"), ref("test"), val(123456789))
+"/trees/01/23/45/67/test"

--- a/tditest/testing/test-tdishr.ans
+++ b/tditest/testing/test-tdishr.ans
@@ -6297,5 +6297,5 @@ x_to_i(["def4","abc"],["d"]) /** bsearch returns -1 mapping to nearest, i.e. 0-t
 [1]
 build_signal([1,2,3],*,["a","b","c"])["d"] /** empty signal **/
 Build_Signal([], *, [])
-TreeShr->MaskReplace:T(ref("/trees/~j~i/~h~g/~f~e/~d~c/~t"), ref("test"), val(123456789))
+TreeShr->MaskReplace:C(ref("/trees/~j~i/~h~g/~f~e/~d~c/~t"), ref("test"), val(123456789))
 "/trees/01/23/45/67/test"

--- a/tditest/testing/test-tdishr.tdi
+++ b/tditest/testing/test-tdishr.tdi
@@ -3149,4 +3149,4 @@ x_to_i(["def4","abc"],["abc"]) /** [1] ; trailing " " ignored **/
 bsearch("d",["def4","abc"]) /** no match : index = -1 **/
 x_to_i(["def4","abc"],["d"]) /** bsearch returns -1 mapping to nearest, i.e. 0-th element (storted) **/
 build_signal([1,2,3],*,["a","b","c"])["d"] /** empty signal **/
-TreeShr->MaskReplace:T(ref("/trees/~j~i/~h~g/~f~e/~d~c/~t"), ref("test"), val(123456789))
+TreeShr->MaskReplace:C(ref("/trees/~j~i/~h~g/~f~e/~d~c/~t"), ref("test"), val(123456789))

--- a/tditest/testing/test-tdishr.tdi
+++ b/tditest/testing/test-tdishr.tdi
@@ -3149,3 +3149,4 @@ x_to_i(["def4","abc"],["abc"]) /** [1] ; trailing " " ignored **/
 bsearch("d",["def4","abc"]) /** no match : index = -1 **/
 x_to_i(["def4","abc"],["d"]) /** bsearch returns -1 mapping to nearest, i.e. 0-th element (storted) **/
 build_signal([1,2,3],*,["a","b","c"])["d"] /** empty signal **/
+TreeShr->MaskReplace:T(ref("/trees/~j~i/~h~g/~f~e/~d~c/~t"), ref("test"), val(123456789))


### PR DESCRIPTION
* first commit adds test that should fail with memchecks.
* second commit adds feature and alters test to use :C instead of :T
fixes issue #1865 