### PR TITLE
Fix: consider all entries in CASE() and fixes switch and case when used in function form

### DIFF
--- a/tdishr/TdiStatement.c
+++ b/tdishr/TdiStatement.c
@@ -353,9 +353,9 @@ static int switch_case(
 	mdsdsc_xd_t *out_ptr)
 {
   int status = MDSplusSUCCESS;
-  if (arg && arg->dtype == DTYPE_FUNCTION && *(opcode_t*)arg->pointer == OPC_COMMA ) {
+  mds_function_t *const fun = (mds_function_t *)arg;
+  if (fun && fun->dtype == DTYPE_FUNCTION && *fun->pointer == OPC_COMMA ) {
     int i;
-    const mds_function_t *fun = (mds_function_t *)arg;
     for (i = 0 ; STATUS_OK && IS_NOT_OK(*test_ptr) && i < fun->ndesc ; i++) {
       status = switch_case(ptest, fun->arguments[i], test_ptr, out_ptr);
     }
@@ -397,7 +397,7 @@ static int switch1(
 
   for (j = 0; STATUS_OK && j < narg; ++j)
     if (list[j] && list[j]->dtype == DTYPE_FUNCTION) {
-      opcode_t opcode = *(opcode_t *)list[j]->pointer;
+      opcode_t opcode = *list[j]->pointer;
 
       off = -1;
       if (opcode == OPC_STATEMENT)
@@ -447,10 +447,11 @@ int Tdi1Switch(opcode_t opcode __attribute__ ((unused)), int narg, mdsdsc_t *lis
   int jdefault = 0;
   mds_function_t **pdefault = NULL;
   mdsdsc_xd_t tmp = EMPTY_XD;
-  if (list[0] && list[0]->dtype == DTYPE_FUNCTION && *(opcode_t*)list[0]->pointer == OPC_COMMA && narg == 2 && !list[1]) {
+  mds_function_t *const fun = (mds_function_t *)list[0];
+  if (fun && fun->dtype == DTYPE_FUNCTION && *fun->pointer == OPC_COMMA && narg == 2 && !list[1]) {
     // switch used in function form
-    narg = ((mds_function_t *)list[0])->ndesc;
-    list = ((mds_function_t *)list[0])->arguments;
+    list = fun->arguments;
+    narg = fun->ndesc;
   }
   status = TdiEvaluate(list[0], &tmp MDS_END_ARG);
   if STATUS_OK

--- a/tdishr/TdiStatement.c
+++ b/tdishr/TdiStatement.c
@@ -45,7 +45,7 @@ extern int TdiGe();
 extern int TdiLe();
 extern int TdiEq();
 
-static int goto1(int, struct descriptor *[], struct descriptor_xd *);
+static int goto1(int, mdsdsc_t *[], mdsdsc_xd_t *);
 
 /*-----------------------------------------------------------------
 	ABORT processing.
@@ -68,7 +68,7 @@ int Tdi1Break()
 /*-----------------------------------------------------------------
 	CASE within SWITCH.
 */
-int Tdi1Case(opcode_t opcode __attribute__ ((unused)), int narg, struct descriptor *list[], struct descriptor_xd *out_ptr)
+int Tdi1Case(opcode_t opcode __attribute__ ((unused)), int narg, mdsdsc_t *list[], mdsdsc_xd_t *out_ptr)
 {
   return TdiIntrinsic(OPC_STATEMENT, narg - 1, &list[1], out_ptr);
 }
@@ -77,7 +77,7 @@ int Tdi1Case(opcode_t opcode __attribute__ ((unused)), int narg, struct descript
 	Evaluates all arguments but returns last only.
 	        result = evaluation,...evaluation
 */
-int Tdi1Comma(opcode_t opcode __attribute__ ((unused)), int narg, struct descriptor *list[], struct descriptor_xd *out_ptr)
+int Tdi1Comma(opcode_t opcode __attribute__ ((unused)), int narg, mdsdsc_t *list[], mdsdsc_xd_t *out_ptr)
 {
   INIT_STATUS;
   int j;
@@ -100,7 +100,7 @@ int Tdi1Continue()
 /*-----------------------------------------------------------------
 	CASE DEFAULT within SWITCH.
 */
-int Tdi1Default(opcode_t opcode __attribute__ ((unused)), int narg, struct descriptor *list[], struct descriptor_xd *out_ptr)
+int Tdi1Default(opcode_t opcode __attribute__ ((unused)), int narg, mdsdsc_t *list[], mdsdsc_xd_t *out_ptr)
 {
   return TdiIntrinsic(OPC_STATEMENT, narg, &list[0], out_ptr);
 }
@@ -109,7 +109,7 @@ int Tdi1Default(opcode_t opcode __attribute__ ((unused)), int narg, struct descr
 	Loops until expression is false, doing a statement.
 	        DO {statement} WHILE (expression);
 */
-int Tdi1Do(opcode_t opcode __attribute__ ((unused)), int narg, struct descriptor *list[], struct descriptor_xd *out_ptr)
+int Tdi1Do(opcode_t opcode __attribute__ ((unused)), int narg, mdsdsc_t *list[], mdsdsc_xd_t *out_ptr)
 {
   INIT_STATUS;
   int test;
@@ -128,7 +128,7 @@ int Tdi1Do(opcode_t opcode __attribute__ ((unused)), int narg, struct descriptor
 	Loops FOR expression true and doing a statement.
 	        FOR ([init]; [test]; [update]) statement
 */
-int Tdi1For(opcode_t opcode __attribute__ ((unused)), int narg, struct descriptor *list[], struct descriptor_xd *out_ptr)
+int Tdi1For(opcode_t opcode __attribute__ ((unused)), int narg, mdsdsc_t *list[], mdsdsc_xd_t *out_ptr)
 {
   INIT_STATUS;
   int test;
@@ -154,7 +154,7 @@ int Tdi1For(opcode_t opcode __attribute__ ((unused)), int narg, struct descripto
 	GOTO a label in active area of code.
 	        GOTO label;
 */
-int Tdi1Goto(opcode_t opcode __attribute__ ((unused)), int narg __attribute__ ((unused)), struct descriptor *list[], struct descriptor_xd *out_ptr)
+int Tdi1Goto(opcode_t opcode __attribute__ ((unused)), int narg __attribute__ ((unused)), mdsdsc_t *list[], mdsdsc_xd_t *out_ptr)
 {
   INIT_STATUS;
   status = TdiEvaluate(list[0], out_ptr MDS_END_ARG);
@@ -173,7 +173,7 @@ int Tdi1Goto(opcode_t opcode __attribute__ ((unused)), int narg __attribute__ ((
 	Tests IF expression and does a statement if true or possibly another if false.
 	        IF (expression) statement ELSE statement
 */
-int Tdi1If(opcode_t opcode __attribute__ ((unused)), int narg, struct descriptor *list[], struct descriptor_xd *out_ptr)
+int Tdi1If(opcode_t opcode __attribute__ ((unused)), int narg, mdsdsc_t *list[], mdsdsc_xd_t *out_ptr)
 {
   INIT_STATUS;
   int test = 0;
@@ -200,7 +200,7 @@ int Tdi1If(opcode_t opcode __attribute__ ((unused)), int narg, struct descriptor
 	If last fails, return EMPTY descriptor and success.
 	        first_good = IF_ERROR(a,...)
 */
-int Tdi1IfError(opcode_t opcode __attribute__ ((unused)), int narg, struct descriptor *list[], struct descriptor_xd *out_ptr)
+int Tdi1IfError(opcode_t opcode __attribute__ ((unused)), int narg, mdsdsc_t *list[], mdsdsc_xd_t *out_ptr)
 {
   INIT_STATUS;
   int j;
@@ -218,7 +218,7 @@ int Tdi1IfError(opcode_t opcode __attribute__ ((unused)), int narg, struct descr
 	Hold LABEL for GOTO.
 	        label : stmt
 */
-int Tdi1Label(opcode_t opcode __attribute__ ((unused)), int narg, struct descriptor *list[], struct descriptor_xd *out_ptr)
+int Tdi1Label(opcode_t opcode __attribute__ ((unused)), int narg, mdsdsc_t *list[], mdsdsc_xd_t *out_ptr)
 {
   return TdiIntrinsic(OPC_STATEMENT, narg - 1, &list[1], out_ptr);
 }
@@ -239,7 +239,7 @@ int Tdi1Rem()
 	        ...
 	}
 */
-int Tdi1Return(opcode_t opcode __attribute__ ((unused)), int narg, struct descriptor *list[], struct descriptor_xd *out_ptr)
+int Tdi1Return(opcode_t opcode __attribute__ ((unused)), int narg, mdsdsc_t *list[], mdsdsc_xd_t *out_ptr)
 {
   INIT_STATUS;
   if (narg > 0 && list[0])
@@ -278,23 +278,23 @@ int Tdi1Return(opcode_t opcode __attribute__ ((unused)), int narg, struct descri
 	WHERE (exp) stmt ELSEWHERE stmt
 	{stmt ...}
 */
-static int goto1(int narg, struct descriptor *list[], struct descriptor_xd *out_ptr)
+static int goto1(int narg, mdsdsc_t *list[], mdsdsc_xd_t *out_ptr)
 {
   int status = SsINTERNAL;
   int j = 0, off, opcode;
-  struct descriptor *pstr = (struct descriptor *)out_ptr;
+  mdsdsc_t *pstr = (mdsdsc_t *)out_ptr;
 
 	/***************************
 	Watch for D converted to XD.
 	***************************/
   while (pstr && pstr->dtype == DTYPE_DSC)
-    pstr = (struct descriptor *)pstr->pointer;
+    pstr = (mdsdsc_t *)pstr->pointer;
   if (pstr && pstr->dtype == DTYPE_T)
     for (j = 0; status == 0 && j < narg; ++j) {
-      struct descriptor_function *pfun = (struct descriptor_function *)list[j];
+      mds_function_t *pfun = (mds_function_t *)list[j];
 
       if (pfun && pfun->dtype == DTYPE_DSC)
-	pfun = (struct descriptor_function *)pfun->pointer;
+	pfun = (mds_function_t *)pfun->pointer;
       if (pfun && pfun->dtype == DTYPE_FUNCTION) {
 	off = -1;
 	opcode = *(unsigned short *)pfun->pointer;
@@ -320,7 +320,7 @@ static int goto1(int narg, struct descriptor *list[], struct descriptor_xd *out_
 	Note statements end with a semicolon or right brace.
 	        {statement ... statement}
 */
-int Tdi1Statement(opcode_t opcode __attribute__ ((unused)), int narg, struct descriptor *list[], struct descriptor_xd *out_ptr)
+int Tdi1Statement(opcode_t opcode __attribute__ ((unused)), int narg, mdsdsc_t *list[], mdsdsc_xd_t *out_ptr)
 {
   INIT_STATUS;
   int j;
@@ -346,51 +346,68 @@ int Tdi1Statement(opcode_t opcode __attribute__ ((unused)), int narg, struct des
 	        FOR IF ELSE SWITCH WHERE ELSEWHERE or WHILE.
 	NEED to handle vector cases and stepped ranges, NEED IS_IN.
 */
-static int switch1(struct descriptor *ptest,
-			   int *jdefault,
-			   struct descriptor_function ***pdefault,
-			   int narg,
-			   struct descriptor_function *list[], struct descriptor_xd *out_ptr)
+static int switch_case(
+	const mdsdsc_t *ptest,
+	const mdsdsc_t *arg,
+	int *test_ptr,
+	mdsdsc_xd_t *out_ptr)
+{
+  int status = MDSplusSUCCESS;
+  if (arg && arg->dtype == DTYPE_FUNCTION && *(opcode_t*)arg->pointer == OPC_COMMA ) {
+    int i;
+    const mds_function_t *fun = (mds_function_t *)arg;
+    for (i = 0 ; STATUS_OK && IS_NOT_OK(*test_ptr) && i < fun->ndesc ; i++) {
+      status = switch_case(ptest, fun->arguments[i], test_ptr, out_ptr);
+    }
+  } else {
+    mdsdsc_xd_t xd = EMPTY_XD;
+    status = TdiEvaluate(arg, &xd MDS_END_ARG);
+    if STATUS_OK {
+      mds_range_t *pr = (mds_range_t *)xd.pointer;
+      if (pr && pr->dtype == DTYPE_RANGE) {
+	if (pr->begin) {
+	  status = TdiGe(ptest, pr->begin, out_ptr MDS_END_ARG);
+	  if STATUS_OK
+	    status = TdiGetLong(out_ptr, test_ptr);
+	} else
+	  *test_ptr = 1;
+	if (STATUS_OK && IS_OK(*test_ptr) && pr->ending)
+	  status = TdiLe(ptest, pr->ending, out_ptr MDS_END_ARG);
+      } else
+	status = TdiEq(ptest, pr, out_ptr MDS_END_ARG);
+      MdsFree1Dx(&xd, NULL);
+      if STATUS_OK
+	status = TdiGetLong(out_ptr, test_ptr);
+    }
+  }
+  return status;
+}
+
+static int switch1(
+	const mdsdsc_t *ptest,
+	int *jdefault,
+	mds_function_t ***pdefault,
+	const int narg,
+	mds_function_t *list[],
+	mdsdsc_xd_t *out_ptr)
 {
   INIT_STATUS;
-  int j, ndesc, off, test;
-  struct descriptor_range *pr;
-  struct descriptor_xd tmp = EMPTY_XD;
+  int j, off, test = FALSE;
+  mdsdsc_xd_t tmp = EMPTY_XD;
 
   for (j = 0; STATUS_OK && j < narg; ++j)
     if (list[j] && list[j]->dtype == DTYPE_FUNCTION) {
-      unsigned short opcode = *(unsigned short *)list[j]->pointer;
+      opcode_t opcode = *(opcode_t *)list[j]->pointer;
 
       off = -1;
       if (opcode == OPC_STATEMENT)
 	off = 0;
       else if (opcode == OPC_CASE) {
-	ndesc = list[j]->ndesc;
-	if (ndesc == 0) {
+	if (list[j]->ndesc == 0) {
 	  status = TdiMISS_ARG;
 	  break;
 	}
-	status = TdiEvaluate(list[j]->arguments[0], out_ptr MDS_END_ARG);
-	if STATUS_OK {
-	  pr = (struct descriptor_range *)out_ptr->pointer;
-	  if (pr && pr->dtype == DTYPE_RANGE) {
-	    if (pr->begin) {
-	      status = TdiGe(ptest, pr->begin, &tmp MDS_END_ARG);
-	      if STATUS_OK
-		status = TdiGetLong(&tmp, &test);
-	    } else
-	      test = 1;
-	    if (STATUS_OK && IS_OK(test) && pr->ending) {
-	      status = TdiLe(ptest, pr->ending, &tmp MDS_END_ARG);
-	      if STATUS_OK
-		status = TdiGetLong(&tmp, &test);
-	    }
-	  } else {
-	    status = TdiEq(ptest, pr, &tmp MDS_END_ARG);
-	    if STATUS_OK
-	      status = TdiGetLong(&tmp, &test);
-	  }
-	}
+	status = switch_case(ptest, list[j]->arguments[0], &test, out_ptr);
 	if (STATUS_OK && IS_OK(test)) {
 	  *jdefault = 0;
 	  break;
@@ -404,7 +421,7 @@ static int switch1(struct descriptor *ptest,
       if (off >= 0 && STATUS_OK) {
 	status =
 	    switch1(ptest, jdefault, pdefault, list[j]->ndesc - off,
-		    (struct descriptor_function **)&list[j]->arguments[off], out_ptr);
+		    (mds_function_t **)&list[j]->arguments[off], out_ptr);
 	if STATUS_OK {
 	  ++j;
 	  break;
@@ -424,22 +441,22 @@ static int switch1(struct descriptor *ptest,
   return status;
 }
 
-int Tdi1Switch(opcode_t opcode __attribute__ ((unused)), int narg, struct descriptor *list[], struct descriptor_xd *out_ptr)
+int Tdi1Switch(opcode_t opcode __attribute__ ((unused)), int narg, mdsdsc_t *list[], mdsdsc_xd_t *out_ptr)
 {
   INIT_STATUS;
   int jdefault = 0;
-  struct descriptor_function **pdefault = NULL;
-  struct descriptor_xd tmp = EMPTY_XD;
+  mds_function_t **pdefault = NULL;
+  mdsdsc_xd_t tmp = EMPTY_XD;
 
   status = TdiEvaluate(list[0], &tmp MDS_END_ARG);
   if STATUS_OK
     status = switch1(tmp.pointer, &jdefault, &pdefault, narg - 1,
-		     (struct descriptor_function **)&list[1], out_ptr);
+		     (mds_function_t **)&list[1], out_ptr);
   MdsFree1Dx(&tmp, NULL);
   if (status == TdiCASE) {
     status = MDSplusSUCCESS;
     for (; jdefault > 0 && STATUS_OK; --jdefault, ++pdefault) {
-      status = TdiEvaluate(*(struct descriptor **)pdefault, out_ptr MDS_END_ARG);
+      status = TdiEvaluate(*(mdsdsc_t **)pdefault, out_ptr MDS_END_ARG);
     }
   }
   if (status == TdiBREAK)
@@ -457,7 +474,7 @@ int Tdi1Switch(opcode_t opcode __attribute__ ((unused)), int narg, struct descri
 	Loops while expression is true and does a statement.
 	        WHILE (expression) statement
 */
-int Tdi1While(opcode_t opcode __attribute__ ((unused)), int narg, struct descriptor *list[], struct descriptor_xd *out_ptr)
+int Tdi1While(opcode_t opcode __attribute__ ((unused)), int narg, mdsdsc_t *list[], mdsdsc_xd_t *out_ptr)
 {
   INIT_STATUS;
   int test;

--- a/tdishr/TdiStatement.c
+++ b/tdishr/TdiStatement.c
@@ -447,7 +447,11 @@ int Tdi1Switch(opcode_t opcode __attribute__ ((unused)), int narg, mdsdsc_t *lis
   int jdefault = 0;
   mds_function_t **pdefault = NULL;
   mdsdsc_xd_t tmp = EMPTY_XD;
-
+  if (list[0] && list[0]->dtype == DTYPE_FUNCTION && *(opcode_t*)list[0]->pointer == OPC_COMMA && narg == 2 && !list[1]) {
+    // switch used in function form
+    narg = ((mds_function_t *)list[0])->ndesc;
+    list = ((mds_function_t *)list[0])->arguments;
+  }
   status = TdiEvaluate(list[0], &tmp MDS_END_ARG);
   if STATUS_OK
     status = switch1(tmp.pointer, &jdefault, &pdefault, narg - 1,

--- a/tditest/testing/test-tdishr.ans
+++ b/tditest/testing/test-tdishr.ans
@@ -6299,3 +6299,5 @@ build_signal([1,2,3],*,["a","b","c"])["d"] /** empty signal **/
 Build_Signal([], *, [])
 TreeShr->MaskReplace:C(ref("/trees/~j~i/~h~g/~f~e/~d~c/~t"), ref("test"), val(123456789))
 "/trees/01/23/45/67/test"
+switch(5){case(0:2,4:6,8:10)_=$TRUE;break;case default _=$FALSE;break;};_
+1BU

--- a/tditest/testing/test-tdishr.ans
+++ b/tditest/testing/test-tdishr.ans
@@ -6299,5 +6299,11 @@ build_signal([1,2,3],*,["a","b","c"])["d"] /** empty signal **/
 Build_Signal([], *, [])
 TreeShr->MaskReplace:C(ref("/trees/~j~i/~h~g/~f~e/~d~c/~t"), ref("test"), val(123456789))
 "/trees/01/23/45/67/test"
-switch(5){case(0:2,4:6,8:10)_=$TRUE;break;case default _=$FALSE;break;};_
+_=*;switch(3){case(0:2,4:6,8:10)_=$TRUE;break;case default _=$FALSE;break;};_
+0BU
+_=*;switch(5){case(0:2,4:6,8:10)_=$TRUE;break;case default _=$FALSE;break;};_
+1BU
+_=*;switch(3,statement(default(statement(_=$FALSE,break())),case((0:2,4:6,8:10),statement(_=$TRUE,break()))));_
+0BU
+_=*;switch(5,statement(default(statement(_=$FALSE,break())),case((0:2,4:6,8:10),statement(_=$TRUE,break()))));_
 1BU

--- a/tditest/testing/test-tdishr.tdi
+++ b/tditest/testing/test-tdishr.tdi
@@ -3150,3 +3150,4 @@ bsearch("d",["def4","abc"]) /** no match : index = -1 **/
 x_to_i(["def4","abc"],["d"]) /** bsearch returns -1 mapping to nearest, i.e. 0-th element (storted) **/
 build_signal([1,2,3],*,["a","b","c"])["d"] /** empty signal **/
 TreeShr->MaskReplace:C(ref("/trees/~j~i/~h~g/~f~e/~d~c/~t"), ref("test"), val(123456789))
+switch(5){case(0:2,4:6,8:10)_=$TRUE;break;case default _=$FALSE;break;};_

--- a/tditest/testing/test-tdishr.tdi
+++ b/tditest/testing/test-tdishr.tdi
@@ -3150,4 +3150,7 @@ bsearch("d",["def4","abc"]) /** no match : index = -1 **/
 x_to_i(["def4","abc"],["d"]) /** bsearch returns -1 mapping to nearest, i.e. 0-th element (storted) **/
 build_signal([1,2,3],*,["a","b","c"])["d"] /** empty signal **/
 TreeShr->MaskReplace:C(ref("/trees/~j~i/~h~g/~f~e/~d~c/~t"), ref("test"), val(123456789))
-switch(5){case(0:2,4:6,8:10)_=$TRUE;break;case default _=$FALSE;break;};_
+_=*;switch(3){case(0:2,4:6,8:10)_=$TRUE;break;case default _=$FALSE;break;};_
+_=*;switch(5){case(0:2,4:6,8:10)_=$TRUE;break;case default _=$FALSE;break;};_
+_=*;switch(3,statement(default(statement(_=$FALSE,break())),case((0:2,4:6,8:10),statement(_=$TRUE,break()))));_
+_=*;switch(5,statement(default(statement(_=$FALSE,break())),case((0:2,4:6,8:10),statement(_=$TRUE,break()))));_


### PR DESCRIPTION
Allows multiple ranges in case
```tdi
switch(5) {
  case default {
    _ = $FALSE;
    break;
  }
  case(0:2, 4:6, 8:10) {
    _ = $TRUE;
    break;
  }
};_
1BU
```
as well as its function form
```tdi
switch(5, statement(\
 default(statement(_ = $FALSE, break())),\
 case((0:2, 4:6, 8:10), statement(_ = $TRUE, break())),\
));_
1BU
```
before multiple ranges in case were allowed but only the last one was tests against because they are combined in a OPC_COMMA which was evaluated first. Similar COMMA combination prevented evaluation of function form switch. This may apply to FOR UNTIL etc. as well. but will be considered in a separate PR