### PR TITLE
Fix: fix sign compare warning on lex generated c c

### DIFF
--- a/deploy/yylex.gen
+++ b/deploy/yylex.gen
@@ -27,5 +27,5 @@ fi
 OUTFILES="$(echo $(cat $1/yylex/outfiles))"
 ycmd="for y in $1/yylex/*.y; do echo \$y;$YACC $YFLAGS \$y; done"
 lcmd="for l in $1/yylex/*.l; do echo \$l;$LEX  $LFLAGS \$l; done"
-scmd="sed -i 's/int num_to_read/size_t num_to_read/g' $OUTFILES"
-eval "$ycmd ; $lcmd && $scmd"
+# scmd="sed -i 's/int num_to_read/size_t num_to_read/g' $OUTFILES"
+eval "$ycmd ; $lcmd " # && $scmd"

--- a/mdsdcl/Makefile.in
+++ b/mdsdcl/Makefile.in
@@ -63,6 +63,9 @@ cmdParseLex.o: cmdParseLex.c
 @MAKEBINDIR@mdsdcl$(EXE): mdsdcl.c @MAKESHLIBDIR@@LIBPRE@Mdsdcl@SHARETYPE@ $(IMPLIB) 
 	$(LINK.c) $(OUTPUT_OPTION) $<  -L@MAKESHLIBDIR@ -lMdsdcl -lMdsShr -lTreeShr $(LIBS) @LIBREADLINE@
 
+mdsdclDeltatimeToSeconds.o :
+	$(COMPILE.c) $(OUTPUT_OPTION) $(srcdir)/mdsdclDeltatimeToSeconds.c -Wno-sign-compare
+
 #cmdParse.c: cmdParse.y
 #        bison cmdParse.y
 

--- a/tdishr/Makefile.in
+++ b/tdishr/Makefile.in
@@ -128,3 +128,7 @@ TdiSql.o : TdiSql.c
 
 TdiYacc.o :
 	$(COMPILE.c) $(OUTPUT_OPTION) $(srcdir)/TdiYacc.c -Wno-array-bounds
+
+TdiLex.o :
+	$(COMPILE.c) $(OUTPUT_OPTION) $(srcdir)/TdiLex.c -Wno-sign-compare
+


### PR DESCRIPTION
Using the new bootstrap and attempting to then build MDSplus on
Ubuntu-10 with deploy/build.sh  the build fails because the code
generated by lex in mdsdcl and tdishr generates a warning.

I am not sure why our builds are succeeding, my guess is the
bison/flex on UB18 is newer or older than what was used for the
kits.