### PR TITLE
Fix: updated constants

### DIFF
--- a/java/mdsplus-api/src/main/java/mds/data/descriptor_r/function/CONST.java
+++ b/java/mdsplus-api/src/main/java/mds/data/descriptor_r/function/CONST.java
@@ -9,176 +9,239 @@ import mds.data.descriptor_r.With_Error;
 import mds.data.descriptor_r.With_Units;
 import mds.data.descriptor_s.Complex32;
 import mds.data.descriptor_s.Float32;
+import mds.data.descriptor_s.Float64;
 import mds.data.descriptor_s.Int32;
 import mds.data.descriptor_s.Missing;
 import mds.data.descriptor_s.StringDsc;
 import mds.data.descriptor_s.Uint8;
 
-public abstract class CONST extends Function{
-	public static final class d2Pi extends CONST{
-		public d2Pi(){
+public abstract class CONST extends Function {
+	static final With_Units CONST_EU32(double data, float error, String unit) {
+		return new With_Units(new With_Error(new Float32((float) data), new Float32(error)), new StringDsc(unit));
+	}
+
+	static final With_Error CONST_E32(double data, float error) {
+		return new With_Error(new Float32((float) data), new Float32(error));
+	}
+
+	static final With_Units CONST_U32(double data, String unit) {
+		return new With_Units(new Float32((float) data), new StringDsc(unit));
+	}
+
+	static final With_Units CONST_U64(double data, String unit) {
+		return new With_Units(new Float64((float) data), new StringDsc(unit));
+	}
+
+	static final float ERROR(double ddata) {
+		final float fdata = (float) ddata;
+		final float ferror = (float) (ddata - (double) fdata);
+		return ferror < 0 ? -ferror : ferror;
+	}
+
+	static final double PI_DATA = Math.PI;
+	static final double MU0_DATA = 4e-7 * Math.PI;
+	static final double C_DATA = 299792458.;
+	static final double E_DATA = 1.602176634e-19;
+	static final double GAS_DATA = 8.31446261815324;
+	static final double GN_DATA = 9.80665;
+	static final double H_DATA = 6.62607015e-34;
+	static final double K_DATA = 1.3806505e-23;
+	static final double NA_DATA = 6.02214076e23;
+	static final double P0_DATA = 101325;
+	static final double T0_DATA = 273.15;
+	static final double ALPHA_DATA = (MU0_DATA * C_DATA * E_DATA * E_DATA) / (2 * H_DATA);
+	static final double EPS0_DATA = 1. / (MU0_DATA * C_DATA * C_DATA);
+	static final double HBAR_DATA = H_DATA / (2 * PI_DATA);
+	static final double FARADAY_DATA = E_DATA * NA_DATA;
+	static final double N0_DATA = P0_DATA / (K_DATA * T0_DATA);
+	static final double TORR_DATA = P0_DATA / 760.;
+
+	static final double CAL_DATA = 4.1868f;
+	static final double G_DATA = 6.67430e-11;
+	static final float G_ERROR = 15e-16f;
+	static final double MU_DATA = 1.66053906660e-27;
+	static final double ME_DATA = 9.1093837015e-31;
+	static final double MP_DATA = 1.67262192369e-27;
+	static final double A0_DATA = (EPS0_DATA * H_DATA * H_DATA) / (PI_DATA * E_DATA * E_DATA * ME_DATA);
+	static final double RE_DATA = (MU0_DATA * C_DATA * C_DATA * E_DATA * E_DATA)
+			/ (4 * PI_DATA * ME_DATA * C_DATA * C_DATA);
+	static final double RYDBERG_DATA = (ALPHA_DATA * ALPHA_DATA * ME_DATA * C_DATA) / (2 * H_DATA);
+
+	public static final class d2Pi extends CONST {
+		public d2Pi() {
 			super(OPC.Opc2Pi);
 		}
 
-		public d2Pi(final ByteBuffer b){
+		public d2Pi(final ByteBuffer b) {
 			super(b);
 		}
 
 		@Override
-		public final Float32 evaluate() {
-			return new Float32(6.2831853072f);
+		public final Float64 evaluate() {
+			return new Float64(2 * PI_DATA);
 		}
 	}
-	public static final class dA0 extends CONST{
-		public dA0(){
+
+	public static final class dA0 extends CONST {
+		public dA0() {
 			super(OPC.OpcA0);
 		}
 
-		public dA0(final ByteBuffer b){
+		public dA0(final ByteBuffer b) {
 			super(b);
 		}
 
 		@Override
 		public final With_Units evaluate() {
-			return new With_Units(new With_Error(new Float32(5.29177249e-11f), new Float32(0.00000024e-11f)), new StringDsc("m"));
+			return CONST_EU32(A0_DATA, ERROR(A0_DATA), "m");
 		}
 	}
-	public static final class dAlpha extends CONST{
-		public dAlpha(){
+
+	public static final class dAlpha extends CONST {
+		public dAlpha() {
 			super(OPC.OpcAlpha);
 		}
 
-		public dAlpha(final ByteBuffer b){
+		public dAlpha(final ByteBuffer b) {
 			super(b);
 		}
 
 		@Override
 		public final With_Error evaluate() {
-			return new With_Error(new Float32(.00729735f), new Float32(330e-12f));
+			return CONST_E32(ALPHA_DATA, ERROR(ALPHA_DATA));
 		}
 	}
-	public static final class dAmu extends CONST{
-		public dAmu(){
+
+	public static final class dAmu extends CONST {
+		public dAmu() {
 			super(OPC.OpcAmu);
 		}
 
-		public dAmu(final ByteBuffer b){
+		public dAmu(final ByteBuffer b) {
 			super(b);
 		}
 
 		@Override
 		public final With_Units evaluate() {
-			return new With_Units(new With_Error(new Float32(1.6605402e-27f), new Float32(0.0000010e-27f)), new StringDsc("kg"));
+			return CONST_EU32(MU_DATA, ERROR(MU_DATA), "kg");
 		}
 	}
-	public static final class dAtm extends CONST{
-		public dAtm(){
+
+	public static final class dAtm extends CONST {
+		public dAtm() {
 			super(OPC.OpcAtm);
 		}
 
-		public dAtm(final ByteBuffer b){
+		public dAtm(final ByteBuffer b) {
 			super(b);
 		}
 
 		@Override
 		public final With_Units evaluate() {
-			return new With_Units(new Float32(101325.f), new StringDsc("Pa"));
+			return CONST_U32(P0_DATA, "Pa");
 		}
 	}
-	public static final class dC extends CONST{
-		public dC(){
+
+	public static final class dC extends CONST {
+		public dC() {
 			super(OPC.OpcC);
 		}
 
-		public dC(final ByteBuffer b){
+		public dC(final ByteBuffer b) {
 			super(b);
 		}
 
 		@Override
 		public final With_Units evaluate() {
-			return new With_Units(new Float32(299792458.f), new StringDsc("m/s"));
+			return CONST_U64(C_DATA, "m/s");
 		}
 	}
-	public static final class dCal extends CONST{
-		public dCal(){
+
+	public static final class dCal extends CONST {
+		public dCal() {
 			super(OPC.OpcCal);
 		}
 
-		public dCal(final ByteBuffer b){
+		public dCal(final ByteBuffer b) {
 			super(b);
 		}
 
 		@Override
 		public final With_Units evaluate() {
-			return new With_Units(new Float32(4.1868f), new StringDsc("J"));
+			return CONST_U32(CAL_DATA, "J");
 		}
 	}
-	public static final class dDefault extends CONST{
-		public dDefault(){
+
+	public static final class dDefault extends CONST {
+		public dDefault() {
 			super(OPC.OpcMdsDefault);
 		}
 
-		public dDefault(final ByteBuffer b){
+		public dDefault(final ByteBuffer b) {
 			super(b);
 		}
 
 		@Override
 		public final StringDsc evaluate() {
-			try{
+			try {
 				return this.mds.getDescriptor(this.tree, "$DEFAULT", StringDsc.class);
-			}catch(final MdsException e){
+			} catch (final MdsException e) {
 				return new StringDsc(this.tree.getDefaultC().decompile());
 			}
 		}
 	}
-	public static final class dDegree extends CONST{
-		public dDegree(){
+
+	public static final class dDegree extends CONST {
+		public dDegree() {
 			super(OPC.OpcDegree);
 		}
 
-		public dDegree(final ByteBuffer b){
+		public dDegree(final ByteBuffer b) {
 			super(b);
 		}
 
 		@Override
-		public final Float32 evaluate() {
-			return new Float32(.01745329252f);
+		public final Float64 evaluate() {
+			return new Float64(PI_DATA / 180.);
 		}
 	}
-	public static final class dEpsilon0 extends CONST{
-		public dEpsilon0(){
+
+	public static final class dEpsilon0 extends CONST {
+		public dEpsilon0() {
 			super(OPC.OpcEpsilon0);
 		}
 
-		public dEpsilon0(final ByteBuffer b){
+		public dEpsilon0(final ByteBuffer b) {
 			super(b);
 		}
 
 		@Override
 		public final With_Units evaluate() {
-			return new With_Units(new Float32(8.854187817e-12f), new StringDsc("F/m"));
+			return CONST_U64(EPS0_DATA, "F/m");
 		}
 	}
-	public static final class dEv extends CONST{
-		public dEv(){
+
+	public static final class dEv extends CONST {
+		public dEv() {
 			super(OPC.OpcEv);
 		}
 
-		public dEv(final ByteBuffer b){
+		public dEv(final ByteBuffer b) {
 			super(b);
 		}
 
 		@Override
 		public final With_Units evaluate() {
-			return new With_Units(new With_Error(new Float32(1.60217733e-19f), new Float32(0.00000049e-19f)), new StringDsc("J/eV"));
+			return CONST_EU32(E_DATA, ERROR(E_DATA), "J/eV");
 		}
 	}
-	public static final class dExpt extends CONST{
-		public dExpt(){
+
+	public static final class dExpt extends CONST {
+		public dExpt() {
 			super(OPC.OpcExpt);
 		}
 
-		public dExpt(final ByteBuffer b){
+		public dExpt(final ByteBuffer b) {
 			super(b);
 		}
 
@@ -187,12 +250,13 @@ public abstract class CONST extends Function{
 			return new StringDsc(this.tree.expt);
 		}
 	}
-	public static final class dFalse extends CONST{
-		public dFalse(){
+
+	public static final class dFalse extends CONST {
+		public dFalse() {
 			super(OPC.OpcFalse);
 		}
 
-		public dFalse(final ByteBuffer b){
+		public dFalse(final ByteBuffer b) {
 			super(b);
 		}
 
@@ -201,96 +265,103 @@ public abstract class CONST extends Function{
 			return new Uint8(0);
 		}
 	}
-	public static final class dFaraday extends CONST{
-		public dFaraday(){
+
+	public static final class dFaraday extends CONST {
+		public dFaraday() {
 			super(OPC.OpcFaraday);
 		}
 
-		public dFaraday(final ByteBuffer b){
+		public dFaraday(final ByteBuffer b) {
 			super(b);
 		}
 
 		@Override
 		public final With_Units evaluate() {
-			return new With_Units(new With_Error(new Float32(9.6485309e4f), new Float32(0.0000029e4f)), new StringDsc("C/mol"));
+			return CONST_EU32(FARADAY_DATA, ERROR(FARADAY_DATA), "C/mol");
 		}
 	}
-	public static final class dG extends CONST{
-		public dG(){
+
+	public static final class dG extends CONST {
+		public dG() {
 			super(OPC.OpcG);
 		}
 
-		public dG(final ByteBuffer b){
+		public dG(final ByteBuffer b) {
 			super(b);
 		}
 
 		@Override
 		public final With_Units evaluate() {
-			return new With_Units(new With_Error(new Float32(6.67259e-11f), new Float32(0.00085f)), new StringDsc("m^3/s^2/kg"));
+			return CONST_EU32(G_DATA, G_ERROR, "m^3/s^2/kg");
 		}
 	}
-	public static final class dGas extends CONST{
-		public dGas(){
+
+	public static final class dGas extends CONST {
+		public dGas() {
 			super(OPC.OpcGas);
 		}
 
-		public dGas(final ByteBuffer b){
+		public dGas(final ByteBuffer b) {
 			super(b);
 		}
 
 		@Override
 		public final With_Units evaluate() {
-			return new With_Units(new With_Error(new Float32(8.314510f), new Float32(0.000070f)), new StringDsc("J/K/mol"));
+			return CONST_EU32(GAS_DATA, ERROR(GAS_DATA), "J/K/mol");
 		}
 	}
-	public static final class dGn extends CONST{
-		public dGn(){
+
+	public static final class dGn extends CONST {
+		public dGn() {
 			super(OPC.OpcGn);
 		}
 
-		public dGn(final ByteBuffer b){
+		public dGn(final ByteBuffer b) {
 			super(b);
 		}
 
 		@Override
 		public final With_Units evaluate() {
-			return new With_Units(new Float32(9.80665f), new StringDsc("m/s^2"));
+			return CONST_U32(GN_DATA, "m/s^2");
 		}
 	}
-	public static final class dH extends CONST{
-		public dH(){
+
+	public static final class dH extends CONST {
+		public dH() {
 			super(OPC.OpcH);
 		}
 
-		public dH(final ByteBuffer b){
+		public dH(final ByteBuffer b) {
 			super(b);
 		}
 
 		@Override
 		public final With_Units evaluate() {
-			return new With_Units(new With_Error(new Float32(6.6260755e-34f), new Float32(0.0000040f)), new StringDsc("J*s"));
+			return CONST_EU32(H_DATA, ERROR(H_DATA), "J*s");
 		}
 	}
-	public static final class dHbar extends CONST{
-		public dHbar(){
+
+	public static final class dHbar extends CONST {
+		public dHbar() {
 			super(OPC.OpcHbar);
 		}
 
-		public dHbar(final ByteBuffer b){
+		public dHbar(final ByteBuffer b) {
 			super(b);
 		}
 
 		@Override
 		public final With_Units evaluate() {
-			return new With_Units(new With_Error(new Float32(1.05457266e-34f), new Float32(0.00000063f)), new StringDsc("J*s"));
+			return CONST_EU32(HBAR_DATA, ERROR(HBAR_DATA), "J*s");
 		}
 	}
-	public static final class dI extends CONST{
-		public dI(){
+
+	public static final class dI extends CONST {
+		public dI() {
 			super(OPC.OpcI);
 		}
 
-		public dI(final ByteBuffer b){
+		public dI(final ByteBuffer b) {
 			super(b);
 		}
 
@@ -299,40 +370,43 @@ public abstract class CONST extends Function{
 			return new Complex32(0.f, 1.f);
 		}
 	}
-	public static final class dK extends CONST{
-		public dK(){
+
+	public static final class dK extends CONST {
+		public dK() {
 			super(OPC.OpcK);
 		}
 
-		public dK(final ByteBuffer b){
+		public dK(final ByteBuffer b) {
 			super(b);
 		}
 
 		@Override
 		public final With_Units evaluate() {
-			return new With_Units(new With_Error(new Float32(1.380658e-23f), new Float32(0.000012e-23f)), new StringDsc("J/K"));
+			return CONST_EU32(K_DATA, ERROR(K_DATA), "J/K");
 		}
 	}
-	public static final class dMe extends CONST{
-		public dMe(){
+
+	public static final class dMe extends CONST {
+		public dMe() {
 			super(OPC.OpcMe);
 		}
 
-		public dMe(final ByteBuffer b){
+		public dMe(final ByteBuffer b) {
 			super(b);
 		}
 
 		@Override
 		public final With_Units evaluate() {
-			return new With_Units(new With_Error(new Float32(9.1093897e-31f), new Float32(0.0000054e-31f)), new StringDsc("kg"));
+			return CONST_EU32(ME_DATA, ERROR(ME_DATA), "kg");
 		}
 	}
-	public static final class dMissing extends CONST{
-		public dMissing(){
+
+	public static final class dMissing extends CONST {
+		public dMissing() {
 			super(OPC.OpcMissing);
 		}
 
-		public dMissing(final ByteBuffer b){
+		public dMissing(final ByteBuffer b) {
 			super(b);
 		}
 
@@ -341,142 +415,152 @@ public abstract class CONST extends Function{
 			return Missing.NEW;
 		}
 	}
-	public static final class dMp extends CONST{
-		public dMp(){
+
+	public static final class dMp extends CONST {
+		public dMp() {
 			super(OPC.OpcMp);
 		}
 
-		public dMp(final ByteBuffer b){
+		public dMp(final ByteBuffer b) {
 			super(b);
 		}
 
 		@Override
 		public final With_Units evaluate() {
-			return new With_Units(new With_Error(new Float32(1.6726231e-27f), new Float32(0.0000010e-27f)), new StringDsc("kg"));
+			return CONST_EU32(MP_DATA, ERROR(MP_DATA), "kg");
 		}
 	}
-	public static final class dMu0 extends CONST{
-		public dMu0(){
+
+	public static final class dMu0 extends CONST {
+		public dMu0() {
 			super(OPC.OpcMu0);
 		}
 
-		public dMu0(final ByteBuffer b){
+		public dMu0(final ByteBuffer b) {
 			super(b);
 		}
 
 		@Override
 		public final With_Units evaluate() {
-			return new With_Units(new Float32(12.566370614e-7f), new StringDsc("N/A^2"));
+			return CONST_U64(MU0_DATA, "N/A^2");
 		}
 	}
-	public static final class dN0 extends CONST{
-		public dN0(){
+
+	public static final class dN0 extends CONST {
+		public dN0() {
 			super(OPC.OpcN0);
 		}
 
-		public dN0(final ByteBuffer b){
+		public dN0(final ByteBuffer b) {
 			super(b);
 		}
 
 		@Override
 		public final With_Units evaluate() {
-			return new With_Units(new With_Error(new Float32(2.686763e25f), new Float32(0.000023e25f)), new StringDsc("/m^3"));
+			return CONST_EU32(N0_DATA, ERROR(N0_DATA), "/m^3");
 		}
 	}
-	public static final class dNa extends CONST{
-		public dNa(){
+
+	public static final class dNa extends CONST {
+		public dNa() {
 			super(OPC.OpcNa);
 		}
 
-		public dNa(final ByteBuffer b){
+		public dNa(final ByteBuffer b) {
 			super(b);
 		}
 
 		@Override
 		public final With_Units evaluate() {
-			return new With_Units(new With_Error(new Float32(6.0221367e23f), new Float32(0.0000036e23f)), new StringDsc("/mol"));
+			return CONST_EU32(NA_DATA, ERROR(NA_DATA), "/mol");
 		}
 	}
-	public static final class dNarg extends CONST{
-		public dNarg(){
+
+	public static final class dNarg extends CONST {
+		public dNarg() {
 			super(OPC.OpcNarg);
 		}
 
-		public dNarg(final ByteBuffer b){
+		public dNarg(final ByteBuffer b) {
 			super(b);
 		}
 
 		@Override
 		public final Descriptor<?> evaluate() {
-			try{
+			try {
 				return this.mds.getDescriptor("$NARGS");
-			}catch(final MdsException e){
+			} catch (final MdsException e) {
 				return Missing.NEW;
 			}
 		}
 	}
-	public static final class dP0 extends CONST{
-		public dP0(){
+
+	public static final class dP0 extends CONST {
+		public dP0() {
 			super(OPC.OpcP0);
 		}
 
-		public dP0(final ByteBuffer b){
+		public dP0(final ByteBuffer b) {
 			super(b);
 		}
 
 		@Override
 		public final With_Units evaluate() {
-			return new With_Units(new Float32(1.01325e5f), new StringDsc("Pa"));
+			return CONST_U32(P0_DATA, "Pa");
 		}
 	}
-	public static final class dPi extends CONST{
-		public dPi(){
+
+	public static final class dPi extends CONST {
+		public dPi() {
 			super(OPC.OpcPi);
 		}
 
-		public dPi(final ByteBuffer b){
+		public dPi(final ByteBuffer b) {
 			super(b);
 		}
 
 		@Override
-		public final Float32 evaluate() {
-			return new Float32(3.1415926536f);
+		public final Float64 evaluate() {
+			return new Float64(PI_DATA);
 		}
 	}
-	public static final class dQe extends CONST{
-		public dQe(){
+
+	public static final class dQe extends CONST {
+		public dQe() {
 			super(OPC.OpcQe);
 		}
 
-		public dQe(final ByteBuffer b){
+		public dQe(final ByteBuffer b) {
 			super(b);
 		}
 
 		@Override
 		public final With_Units evaluate() {
-			return new With_Units(new With_Error(new Float32(1.60217733e-19f), new Float32(0.000000493e-19f)), new StringDsc("C"));
+			return CONST_EU32(E_DATA, ERROR(E_DATA), "C");
 		}
 	}
-	public static final class dRe extends CONST{
-		public dRe(){
+
+	public static final class dRe extends CONST {
+		public dRe() {
 			super(OPC.OpcRe);
 		}
 
-		public dRe(final ByteBuffer b){
+		public dRe(final ByteBuffer b) {
 			super(b);
 		}
 
 		@Override
 		public final With_Units evaluate() {
-			return new With_Units(new With_Error(new Float32(2.81794092e-15f), new Float32(0.00000038e-15f)), new StringDsc("m"));
+			return CONST_EU32(RE_DATA, ERROR(RE_DATA), "m");
 		}
 	}
-	public static final class dRoprand extends CONST{
-		public dRoprand(){
+
+	public static final class dRoprand extends CONST {
+		public dRoprand() {
 			super(OPC.OpcRoprand);
 		}
 
-		public dRoprand(final ByteBuffer b){
+		public dRoprand(final ByteBuffer b) {
 			super(b);
 		}
 
@@ -485,26 +569,28 @@ public abstract class CONST extends Function{
 			return CONST.ROPRAND;
 		}
 	}
-	public static final class dRydberg extends CONST{
-		public dRydberg(){
+
+	public static final class dRydberg extends CONST {
+		public dRydberg() {
 			super(OPC.OpcRydberg);
 		}
 
-		public dRydberg(final ByteBuffer b){
+		public dRydberg(final ByteBuffer b) {
 			super(b);
 		}
 
 		@Override
 		public final With_Units evaluate() {
-			return new With_Units(new With_Error(new Float32(1.0973731534e7f), new Float32(0.0000000013e7f)), new StringDsc("/m"));
+			return CONST_EU32(RYDBERG_DATA, ERROR(RYDBERG_DATA), "/m");
 		}
 	}
-	public static final class dShot extends CONST{
-		public dShot(){
+
+	public static final class dShot extends CONST {
+		public dShot() {
 			super(OPC.OpcShot);
 		}
 
-		public dShot(final ByteBuffer b){
+		public dShot(final ByteBuffer b) {
 			super(b);
 		}
 
@@ -513,64 +599,70 @@ public abstract class CONST extends Function{
 			return new Int32(this.tree.shot);
 		}
 	}
-	public static final class dShotname extends CONST{
-		public dShotname(){
+
+	public static final class dShotname extends CONST {
+		public dShotname() {
 			super(OPC.OpcShotname);
 		}
 
-		public dShotname(final ByteBuffer b){
+		public dShotname(final ByteBuffer b) {
 			super(b);
 		}
 
 		@Override
 		public final StringDsc evaluate() {
-			if(this.tree.shot == -1) return new StringDsc("MODEL");
+			if (this.tree.shot == -1)
+				return new StringDsc("MODEL");
 			return new StringDsc(String.valueOf(this.tree.shot));
 		}
 	}
-	public static final class dT0 extends CONST{
-		public dT0(){
+
+	public static final class dT0 extends CONST {
+		public dT0() {
 			super(OPC.OpcT0);
 		}
 
-		public dT0(final ByteBuffer b){
+		public dT0(final ByteBuffer b) {
 			super(b);
 		}
 
 		@Override
 		public final With_Units evaluate() {
-			return new With_Units(new Float32(273.16f), new StringDsc("K"));
+			return CONST_U32(T0_DATA, "K");
 		}
 	}
-	public static final class dThis extends CONST{
-		public dThis(){
+
+	public static final class dThis extends CONST {
+		public dThis() {
 			super(OPC.OpcThis);
 		}
 
-		public dThis(final ByteBuffer b){
+		public dThis(final ByteBuffer b) {
 			super(b);
 		}
 	}
-	public static final class dTorr extends CONST{
-		public dTorr(){
+
+	public static final class dTorr extends CONST {
+		public dTorr() {
 			super(OPC.OpcTorr);
 		}
 
-		public dTorr(final ByteBuffer b){
+		public dTorr(final ByteBuffer b) {
 			super(b);
 		}
 
 		@Override
 		public final With_Units evaluate() {
-			return new With_Units(new Float32(1.3332e2f), new StringDsc("Pa"));
+			return CONST_U64(TORR_DATA, "Pa");
 		}
 	}
-	public static final class dTrue extends CONST{
-		public dTrue(){
+
+	public static final class dTrue extends CONST {
+		public dTrue() {
 			super(OPC.OpcTrue);
 		}
 
-		public dTrue(final ByteBuffer b){
+		public dTrue(final ByteBuffer b) {
 			super(b);
 		}
 
@@ -579,12 +671,13 @@ public abstract class CONST extends Function{
 			return new Uint8(1);
 		}
 	}
-	public static final class dValue extends CONST{
-		public dValue(){
+
+	public static final class dValue extends CONST {
+		public dValue() {
 			super(OPC.OpcValue);
 		}
 
-		public dValue(final ByteBuffer b){
+		public dValue(final ByteBuffer b) {
 			super(b);
 		}
 
@@ -593,180 +686,181 @@ public abstract class CONST extends Function{
 			return this.VALUE.VALUE();
 		}
 	}
-	public static final Float32		ROPRAND		= Float32.F(ByteBuffer.wrap(new byte[]{0, 0, -128, 0}).getFloat());
-	public final static Function	$VALUE		= new dValue();
-	public static final dRoprand	$ROPRAND	= new dRoprand();
-	public static final dRydberg	$RYDBERG	= new dRydberg();
-	public static final dTorr		$TORR		= new dTorr();
-	public static final dTrue		$TRUE		= new dTrue();
-	public static final d2Pi		$2PI		= new d2Pi();
-	public static final dA0			$A0			= new dA0();
-	public static final dAlpha		$ALPHA		= new dAlpha();
-	public static final dAmu		$AMU		= new dAmu();
-	public static final dC			$C			= new dC();
-	public static final dCal		$CAL		= new dCal();
-	public static final dDegree		$DEGREE		= new dDegree();
-	public static final dFalse		$FALSE		= new dFalse();
-	public static final dFaraday	$FARADAY	= new dFaraday();
-	public static final dG			$G			= new dG();
-	public static final dGas		$GAS		= new dGas();
-	public static final dH			$H			= new dH();
-	public static final dHbar		$HBAR		= new dHbar();
-	public static final dI			$I			= new dI();
-	public static final dK			$K			= new dK();
-	public static final dMissing	$MISSING	= new dMissing();
-	public static final dMp			$MP			= new dMp();
-	public static final dN0			$N0			= new dN0();
-	public static final dNa			$NA			= new dNa();
-	public static final dP0			$P0			= new dP0();
-	public static final dPi			$PI			= new dPi();
-	public static final dQe			$QE			= new dQe();
-	public static final dRe			$RE			= new dRe();
+
+	public static final Float32 ROPRAND = Float32.F(ByteBuffer.wrap(new byte[] { 0, 0, -128, 0 }).getFloat());
+	public final static Function $VALUE = new dValue();
+	public static final dRoprand $ROPRAND = new dRoprand();
+	public static final dRydberg $RYDBERG = new dRydberg();
+	public static final dTorr $TORR = new dTorr();
+	public static final dTrue $TRUE = new dTrue();
+	public static final d2Pi $2PI = new d2Pi();
+	public static final dA0 $A0 = new dA0();
+	public static final dAlpha $ALPHA = new dAlpha();
+	public static final dAmu $AMU = new dAmu();
+	public static final dC $C = new dC();
+	public static final dCal $CAL = new dCal();
+	public static final dDegree $DEGREE = new dDegree();
+	public static final dFalse $FALSE = new dFalse();
+	public static final dFaraday $FARADAY = new dFaraday();
+	public static final dG $G = new dG();
+	public static final dGas $GAS = new dGas();
+	public static final dH $H = new dH();
+	public static final dHbar $HBAR = new dHbar();
+	public static final dI $I = new dI();
+	public static final dK $K = new dK();
+	public static final dMissing $MISSING = new dMissing();
+	public static final dMp $MP = new dMp();
+	public static final dN0 $N0 = new dN0();
+	public static final dNa $NA = new dNa();
+	public static final dP0 $P0 = new dP0();
+	public static final dPi $PI = new dPi();
+	public static final dQe $QE = new dQe();
+	public static final dRe $RE = new dRe();
 
 	public static final boolean coversOpCode(final OPC opcode) {
-		switch(opcode){
-			default:
-				return false;
-			case OpcA0:
-			case OpcAlpha:
-			case OpcAmu:
-			case OpcC:
-			case OpcCal:
-			case OpcDegree:
-			case OpcEv:
-			case OpcFalse:
-			case OpcFaraday:
-			case OpcG:
-			case OpcGas:
-			case OpcH:
-			case OpcHbar:
-			case OpcI:
-			case OpcK:
-			case OpcMe:
-			case OpcMissing:
-			case OpcMp:
-			case OpcN0:
-			case OpcNa:
-			case OpcP0:
-			case OpcPi:
-			case OpcQe:
-			case OpcRe:
-			case OpcRoprand:
-			case OpcRydberg:
-			case OpcT0:
-			case OpcTorr:
-			case OpcTrue:
-			case OpcValue:
-			case Opc2Pi:
-			case OpcNarg:
-			case OpcMdsDefault:
-			case OpcExpt:
-			case OpcShot:
-			case OpcThis:
-			case OpcAtm:
-			case OpcEpsilon0:
-			case OpcGn:
-			case OpcMu0:
-			case OpcShotname:
-				return true;
+		switch (opcode) {
+		default:
+			return false;
+		case OpcA0:
+		case OpcAlpha:
+		case OpcAmu:
+		case OpcC:
+		case OpcCal:
+		case OpcDegree:
+		case OpcEv:
+		case OpcFalse:
+		case OpcFaraday:
+		case OpcG:
+		case OpcGas:
+		case OpcH:
+		case OpcHbar:
+		case OpcI:
+		case OpcK:
+		case OpcMe:
+		case OpcMissing:
+		case OpcMp:
+		case OpcN0:
+		case OpcNa:
+		case OpcP0:
+		case OpcPi:
+		case OpcQe:
+		case OpcRe:
+		case OpcRoprand:
+		case OpcRydberg:
+		case OpcT0:
+		case OpcTorr:
+		case OpcTrue:
+		case OpcValue:
+		case Opc2Pi:
+		case OpcNarg:
+		case OpcMdsDefault:
+		case OpcExpt:
+		case OpcShot:
+		case OpcThis:
+		case OpcAtm:
+		case OpcEpsilon0:
+		case OpcGn:
+		case OpcMu0:
+		case OpcShotname:
+			return true;
 		}
 	}
 
 	public static CONST deserialize(final ByteBuffer b) throws MdsException {
 		final OPC opcode = OPC.get(b.getShort(b.getInt(Descriptor._ptrI)));
-		switch(opcode){
-			case OpcA0:
-				return new dA0(b);
-			case OpcAlpha:
-				return new dAlpha(b);
-			case OpcAmu:
-				return new dAmu(b);
-			case OpcC:
-				return new dC(b);
-			case OpcCal:
-				return new dCal(b);
-			case OpcDegree:
-				return new dDegree(b);
-			case OpcEv:
-				return new dEv(b);
-			case OpcFalse:
-				return new dFalse(b);
-			case OpcFaraday:
-				return new dFaraday(b);
-			case OpcG:
-				return new dG(b);
-			case OpcGas:
-				return new dGas(b);
-			case OpcH:
-				return new dH(b);
-			case OpcHbar:
-				return new dHbar(b);
-			case OpcI:
-				return new dI(b);
-			case OpcK:
-				return new dK(b);
-			case OpcMe:
-				return new dMe(b);
-			case OpcMissing:
-				return new dMissing(b);
-			case OpcMp:
-				return new dMp(b);
-			case OpcN0:
-				return new dN0(b);
-			case OpcNa:
-				return new dNa(b);
-			case OpcP0:
-				return new dP0(b);
-			case OpcPi:
-				return new dPi(b);
-			case OpcQe:
-				return new dQe(b);
-			case OpcRe:
-				return new dRe(b);
-			case OpcRoprand:
-				return new dRoprand(b);
-			case OpcRydberg:
-				return new dRydberg(b);
-			case OpcT0:
-				return new dT0(b);
-			case OpcTorr:
-				return new dTorr(b);
-			case OpcTrue:
-				return new dTrue(b);
-			case OpcValue:
-				return new dValue(b);
-			case Opc2Pi:
-				return new d2Pi(b);
-			case OpcNarg:
-				return new dNarg(b);
-			case OpcMdsDefault:
-				return new dDefault(b);
-			case OpcExpt:
-				return new dExpt(b);
-			case OpcShot:
-				return new dShot(b);
-			case OpcThis:
-				return new dThis(b);
-			case OpcAtm:
-				return new dAtm(b);
-			case OpcEpsilon0:
-				return new dEpsilon0(b);
-			case OpcGn:
-				return new dGn(b);
-			case OpcMu0:
-				return new dMu0(b);
-			case OpcShotname:
-				return new dShotname(b);
-			default:
-				throw new MdsException(MdsException.TdiINV_OPC);
+		switch (opcode) {
+		case OpcA0:
+			return new dA0(b);
+		case OpcAlpha:
+			return new dAlpha(b);
+		case OpcAmu:
+			return new dAmu(b);
+		case OpcC:
+			return new dC(b);
+		case OpcCal:
+			return new dCal(b);
+		case OpcDegree:
+			return new dDegree(b);
+		case OpcEv:
+			return new dEv(b);
+		case OpcFalse:
+			return new dFalse(b);
+		case OpcFaraday:
+			return new dFaraday(b);
+		case OpcG:
+			return new dG(b);
+		case OpcGas:
+			return new dGas(b);
+		case OpcH:
+			return new dH(b);
+		case OpcHbar:
+			return new dHbar(b);
+		case OpcI:
+			return new dI(b);
+		case OpcK:
+			return new dK(b);
+		case OpcMe:
+			return new dMe(b);
+		case OpcMissing:
+			return new dMissing(b);
+		case OpcMp:
+			return new dMp(b);
+		case OpcN0:
+			return new dN0(b);
+		case OpcNa:
+			return new dNa(b);
+		case OpcP0:
+			return new dP0(b);
+		case OpcPi:
+			return new dPi(b);
+		case OpcQe:
+			return new dQe(b);
+		case OpcRe:
+			return new dRe(b);
+		case OpcRoprand:
+			return new dRoprand(b);
+		case OpcRydberg:
+			return new dRydberg(b);
+		case OpcT0:
+			return new dT0(b);
+		case OpcTorr:
+			return new dTorr(b);
+		case OpcTrue:
+			return new dTrue(b);
+		case OpcValue:
+			return new dValue(b);
+		case Opc2Pi:
+			return new d2Pi(b);
+		case OpcNarg:
+			return new dNarg(b);
+		case OpcMdsDefault:
+			return new dDefault(b);
+		case OpcExpt:
+			return new dExpt(b);
+		case OpcShot:
+			return new dShot(b);
+		case OpcThis:
+			return new dThis(b);
+		case OpcAtm:
+			return new dAtm(b);
+		case OpcEpsilon0:
+			return new dEpsilon0(b);
+		case OpcGn:
+			return new dGn(b);
+		case OpcMu0:
+			return new dMu0(b);
+		case OpcShotname:
+			return new dShotname(b);
+		default:
+			throw new MdsException(MdsException.TdiINV_OPC);
 		}
 	}
 
-	public CONST(final ByteBuffer b){
+	public CONST(final ByteBuffer b) {
 		super(b);
 	}
 
-	private CONST(final OPC opcode){
+	private CONST(final OPC opcode) {
 		super(opcode);
 	}
 

--- a/java/mdsplus-api/src/test/java/mds/data/CONST_Test.java
+++ b/java/mdsplus-api/src/test/java/mds/data/CONST_Test.java
@@ -10,7 +10,10 @@ import org.junit.Test;
 import org.junit.runners.MethodSorters;
 import mds.AllTests;
 import mds.Mds;
+import mds.MdsException;
 import mds.data.descriptor.Descriptor;
+import mds.data.descriptor_r.With_Error;
+import mds.data.descriptor_r.With_Units;
 import mds.data.descriptor_r.function.CONST.dA0;
 import mds.data.descriptor_r.function.CONST.dAlpha;
 import mds.data.descriptor_r.function.CONST.dAmu;
@@ -41,7 +44,7 @@ import mds.data.descriptor_r.function.CONST.dTorr;
 import mds.data.descriptor_r.function.CONST.dTrue;
 
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
-public class CONST_Test{
+public class CONST_Test {
 	private static Mds mds;
 
 	@BeforeClass
@@ -54,41 +57,63 @@ public class CONST_Test{
 		AllTests.tearDownAfterClass(CONST_Test.mds);
 	}
 
+	private static void check(Descriptor<?> java, Descriptor<?> mdsip, float reldelta) throws MdsException {
+		Assert.assertEquals(java.getUnits(), mdsip.getUnits());
+		if (mdsip instanceof With_Units) {
+			Assert.assertTrue(java instanceof With_Units);
+			java = ((With_Units)java).getValue();
+			mdsip = ((With_Units)mdsip).getValue();
+		}
+		if (mdsip instanceof With_Error) {
+			Assert.assertTrue(java instanceof With_Error);
+			Assert.assertSame(((With_Error)java).getError().getClass(), ((With_Error)mdsip).getError().getClass());
+			java = ((With_Error)java).getValue();
+			mdsip = ((With_Error)mdsip).getValue();
+			Assert.assertEquals(java.getClass(), mdsip.getClass());
+		}		
+		final float data = mdsip.toFloat();
+		Assert.assertEquals(java.toFloat(), data, data * reldelta);
+	}
+
 	@Test
 	public void compare() throws Exception {
-		Assert.assertEquals(new dA0().evaluate(), CONST_Test.mds.getDescriptor("$A0", Descriptor.class));
-		Assert.assertEquals(new dAlpha().evaluate(), CONST_Test.mds.getDescriptor("$Alpha", Descriptor.class));
-		Assert.assertEquals(new dAmu().evaluate(), CONST_Test.mds.getDescriptor("$Amu", Descriptor.class));
-		Assert.assertEquals(new dC().evaluate(), CONST_Test.mds.getDescriptor("$C", Descriptor.class));
-		Assert.assertEquals(new dCal().evaluate(), CONST_Test.mds.getDescriptor("$Cal", Descriptor.class));
-		Assert.assertEquals(new dDegree().evaluate(), CONST_Test.mds.getDescriptor("$Degree", Descriptor.class));
-		Assert.assertEquals(new dFalse().evaluate(), CONST_Test.mds.getDescriptor("$False", Descriptor.class));
-		Assert.assertEquals(new dFaraday().evaluate(), CONST_Test.mds.getDescriptor("$Faraday", Descriptor.class));
-		Assert.assertEquals(new dG().evaluate(), CONST_Test.mds.getDescriptor("$G", Descriptor.class));
-		Assert.assertEquals(new dGas().evaluate(), CONST_Test.mds.getDescriptor("$Gas", Descriptor.class));
-		Assert.assertEquals(new dH().evaluate(), CONST_Test.mds.getDescriptor("$H", Descriptor.class));
-		Assert.assertEquals(new dHbar().evaluate(), CONST_Test.mds.getDescriptor("$Hbar", Descriptor.class));
-		Assert.assertEquals(new dI().evaluate(), CONST_Test.mds.getDescriptor("$I", Descriptor.class));
-		Assert.assertEquals(new dK().evaluate(), CONST_Test.mds.getDescriptor("$K", Descriptor.class));
-		Assert.assertEquals(new dMe().evaluate(), CONST_Test.mds.getDescriptor("$Me", Descriptor.class));
+		// exact
 		Assert.assertEquals(new dMissing().evaluate(), CONST_Test.mds.getDescriptor("$Missing", Descriptor.class));
-		Assert.assertEquals(new dMp().evaluate(), CONST_Test.mds.getDescriptor("$Mp", Descriptor.class));
-		Assert.assertEquals(new dN0().evaluate(), CONST_Test.mds.getDescriptor("$N0", Descriptor.class));
-		Assert.assertEquals(new dNa().evaluate(), CONST_Test.mds.getDescriptor("$Na", Descriptor.class));
-		Assert.assertEquals(new dP0().evaluate(), CONST_Test.mds.getDescriptor("$P0", Descriptor.class));
-		Assert.assertEquals(new dPi().evaluate(), CONST_Test.mds.getDescriptor("$Pi", Descriptor.class));
-		Assert.assertEquals(new dQe().evaluate(), CONST_Test.mds.getDescriptor("$Qe", Descriptor.class));
-		Assert.assertEquals(new dRe().evaluate(), CONST_Test.mds.getDescriptor("$Re", Descriptor.class));
 		Assert.assertEquals(new dRoprand().evaluate(), CONST_Test.mds.getDescriptor("$Roprand", Descriptor.class));
-		Assert.assertEquals(new dRydberg().evaluate(), CONST_Test.mds.getDescriptor("$Rydberg", Descriptor.class));
-		Assert.assertEquals(new dT0().evaluate(), CONST_Test.mds.getDescriptor("$T0", Descriptor.class));
-		Assert.assertEquals(new dTorr().evaluate(), CONST_Test.mds.getDescriptor("$Torr", Descriptor.class));
+		Assert.assertEquals(new dI().evaluate(), CONST_Test.mds.getDescriptor("$I", Descriptor.class));
 		Assert.assertEquals(new dTrue().evaluate(), CONST_Test.mds.getDescriptor("$True", Descriptor.class));
+		Assert.assertEquals(new dFalse().evaluate(), CONST_Test.mds.getDescriptor("$False", Descriptor.class));
+		// approximately
+		check(new dA0().evaluate(), CONST_Test.mds.getDescriptor("$A0", Descriptor.class), 1e-5f);
+		check(new dAlpha().evaluate(), CONST_Test.mds.getDescriptor("$Alpha", Descriptor.class), 1e-5f);
+		check(new dAmu().evaluate(), CONST_Test.mds.getDescriptor("$Amu", Descriptor.class), 1e-5f);
+		check(new dC().evaluate(), CONST_Test.mds.getDescriptor("$C", Descriptor.class), 1e-5f);
+		check(new dCal().evaluate(), CONST_Test.mds.getDescriptor("$Cal", Descriptor.class), 1e-5f);
+		check(new dDegree().evaluate(), CONST_Test.mds.getDescriptor("$Degree", Descriptor.class), 1e-5f);
+		check(new dFaraday().evaluate(), CONST_Test.mds.getDescriptor("$Faraday", Descriptor.class), 1e-5f);
+		check(new dG().evaluate(), CONST_Test.mds.getDescriptor("$G", Descriptor.class), 1e-3f);
+		check(new dGas().evaluate(), CONST_Test.mds.getDescriptor("$Gas", Descriptor.class), 1e-5f);
+		check(new dH().evaluate(), CONST_Test.mds.getDescriptor("$H", Descriptor.class), 1e-5f);
+		check(new dHbar().evaluate(), CONST_Test.mds.getDescriptor("$Hbar", Descriptor.class), 1e-5f);
+		check(new dK().evaluate(), CONST_Test.mds.getDescriptor("$K", Descriptor.class), 1e-5f);
+		check(new dMe().evaluate(), CONST_Test.mds.getDescriptor("$Me", Descriptor.class), 1e-5f);
+		check(new dMp().evaluate(), CONST_Test.mds.getDescriptor("$Mp", Descriptor.class), 1e-5f);
+		check(new dN0().evaluate(), CONST_Test.mds.getDescriptor("$N0", Descriptor.class), 1e-5f);
+		check(new dNa().evaluate(), CONST_Test.mds.getDescriptor("$Na", Descriptor.class), 1e-5f);
+		check(new dP0().evaluate(), CONST_Test.mds.getDescriptor("$P0", Descriptor.class), 1e-5f);
+		check(new dPi().evaluate(), CONST_Test.mds.getDescriptor("$Pi", Descriptor.class), 1e-5f);
+		check(new dQe().evaluate(), CONST_Test.mds.getDescriptor("$Qe", Descriptor.class), 1e-5f);
+		check(new dRe().evaluate(), CONST_Test.mds.getDescriptor("$Re", Descriptor.class), 1e-5f);
+		check(new dRydberg().evaluate(), CONST_Test.mds.getDescriptor("$Rydberg", Descriptor.class), 1e-5f);
+		check(new dT0().evaluate(), CONST_Test.mds.getDescriptor("$T0", Descriptor.class), 1e-4f);
+		check(new dTorr().evaluate(), CONST_Test.mds.getDescriptor("$Torr", Descriptor.class), 1e-4f);
 	}
 
 	@Before
-	public void setUp() throws Exception {/*stub*/}
+	public void setUp() throws Exception {
+		/* stub */}
 
 	@After
-	public void tearDown() throws Exception {/*stub*/}
+	public void tearDown() throws Exception {
+		/* stub */}
 }

--- a/tdishr/TdiConstant.c
+++ b/tdishr/TdiConstant.c
@@ -33,8 +33,13 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "tdireffunction.h"
 #include "tdirefstandard.h"
 #include <mdsshr.h>
+#include <math.h>
 #if defined __GNUC__ && 800 <= __GNUC__ * 100 + __GNUC_MINOR__
     _Pragma ("GCC diagnostic ignored \"-Wcast-function-type\"")
+#endif
+
+#ifndef M_PI
+#define M_PI 3.14159265358979323846
 #endif
 
 int Tdi1Constant(opcode_t opcode, int narg __attribute__ ((unused)),
@@ -80,12 +85,13 @@ Major sources:
 "1980 Revised NRL Plasma Formulary" by Book.
 	NEED to remove / ** / when ANSI C permits sharp-sharp
 */
-typedef void (*MISSING) ();
-typedef unsigned char BU;
-typedef float FLOAT;
+typedef void* MISSING;
+typedef uint8_t BU;
+typedef float FS;
+typedef double FT;
 typedef struct {
   float x, y;
-} FLOAT_COMPLEX;
+} FSC;
 typedef unsigned int FROP;
 
 #define DTYPE_FROP      DTYPE_F
@@ -120,39 +126,37 @@ typedef unsigned int FROP;
 	static const DESCRIPTOR_WITH_UNITS(Tdi##x##Constant,&dwe##x,&du##x);\
 	mdsdsc_t *Tdi3##x(){return (mdsdsc_t *)&Tdi##x##Constant;}
 
-#define II {(float)0., (float)1.}
-#define RR 0x8000
-
-DATUM(FLOAT, 2Pi, (float)6.2831853072)	/* circumference/radius    */
-UERR(FLOAT, A0, (float)5.29177249e-11, (float)0.00000024e-11, "m")	/*a0       Bohr radius             */
-DERR(FLOAT, Alpha, (float)7.29735308e-3, (float)0.00000033e-3)	/* fine-structure constant */
-UERR(FLOAT, Amu, (float)1.6605402e-27, (float)0.0000010e-27, "kg")	/* u atomic mass unit, unified */
-UNITS(FLOAT, C, (float)299792458., "m/s")	/* c speed of light(exact) */
-UNITS(FLOAT, Cal, (float)4.1868, "J")	/* calorie                 */
-DATUM(FLOAT, Degree, (float).01745329252)	/* pi/180                  */
-UNITS(FLOAT, Epsilon0, (float)8.854187817e-12, "F/m")	/* permitivity of vacuum(exact) */
-UERR(FLOAT, Ev, (float)1.60217733e-19, (float)0.00000049e-19, "J/eV")	/* eV electron volt        */
-DATUM(BU, False, 0)		/* logically false         */
-UERR(FLOAT, Faraday, (float)9.6485309e4, (float)0.0000029e4, "C/mol")	/*F        Faraday constant        */
-UERR(FLOAT, G, (float)6.67259e-11, (float)0.00085, "m^3/s^2/kg")	/*G gravitational constant */
-UERR(FLOAT, Gas, (float)8.314510, (float)0.000070, "J/K/mol")	/*R       gas constant            */
-UNITS(FLOAT, Gn, (float)9.80665, "m/s^2")	/*gn       acceleration of gravity(exact) */
-UERR(FLOAT, H, (float)6.6260755e-34, (float)0.0000040, "J*s")	/*h        Planck constant         */
-UERR(FLOAT, Hbar, (float)1.05457266e-34, (float)0.00000063, "J*s")	/*hbar h/(2pi)             */
-DATUM(FLOAT_COMPLEX, I, II)	/*i        imaginary               */
-UERR(FLOAT, K, (float)1.380658e-23, (float)0.000012e-23, "J/K")	/*k        Boltzmann constant      */
-UERR(FLOAT, Me, (float)9.1093897e-31, (float)0.0000054e-31, "kg")	/*me       mass of electron        */
-DATUM(MISSING, Missing, 0)	/* missing argument        */
-UERR(FLOAT, Mp, (float)1.6726231e-27, (float)0.0000010e-27, "kg")	/*mp       mass of proton          */
-UNITS(FLOAT, Mu0, (float)12.566370614e-7, "N/A^2")	/* permeability of vacuum(exact) */
-UERR(FLOAT, N0, (float)2.686763e25, (float)0.000023e25, "/m^3")	/*n0       Loschmidt's number (STP) */
-UERR(FLOAT, Na, (float)6.0221367e23, (float)0.0000036e23, "/mol")	/*NA or L Avogadro number  */
-UNITS(FLOAT, P0, (float)1.01325e5, "Pa")	/*atm      atmospheric pressure(exact) */
-DATUM(FLOAT, Pi, (float)3.1415926536)	/* circumference/diameter  */
-UERR(FLOAT, Qe, (float)1.60217733e-19, (float)0.000000493e-19, "C")	/*e        charge on electron      */
-UERR(FLOAT, Re, (float)2.81794092e-15, (float)0.00000038e-15, "m")	/*re       classical electron radius */
-DATUM(FROP, Roprand, RR)	/* reserved operand        */
-UERR(FLOAT, Rydberg, (float)1.0973731534e7, (float)0.0000000013e7, "/m")	/*Rinf Rydberg constant    */
-UNITS(FLOAT, T0, (float)273.16, "K")	/*?        standard temperature    */
-UNITS(FLOAT, Torr, (float)1.3332e2, "Pa")	/*?torr 1mm Hg pressure    */
-DATUM(BU, True, 1)
+#define I_DATA {0., 1.}
+DATUM(FT,	2Pi,		2*M_PI					)/*	circumference/radius	*/
+UERR (FS,	A0,		5.29177249e-11,	0.00000024e-11,	"m"	)/*a0	Bohr radius		*/
+DERR (FS,	Alpha,		7.29735308e-3,	0.00000033e-3		)/*	fine-structure constant	*/
+UERR (FS,	Amu,		1.6605402e-27,	0.0000010e-27,	"kg"	)/*u	unified atomic mass unit*/
+UNITS(FS,	C,		299792458.,			"m/s"	)/*c	speed of light		*/
+UNITS(FS,	Cal,		4.1868,				"J"	)/*	calorie			*/
+DATUM(FS,	Degree,		M_PI/180				)/*	pi/180			*/
+UNITS(FS,	Epsilon0,	8.854187817e-12,		"F/m"	)/*eps0 permitivity of vacuum	*/
+UERR (FS,	Ev,	 	1.60217733e-19,	0.00000049e-19,	"J/eV"	)/*eV	electron volt		*/
+DATUM(BU,	False,		0					)/*	logically false		*/
+UERR (FS,	Faraday,	9.6485309e4,	0.0000029e4,	"C/mol"	)/*F	Faraday constant	*/
+UERR (FS,	G,		6.67259e-11,	0.00085,    "m^3/s^2/kg")/*G gravitational constant	*/
+UERR (FS,	Gas,		8.314510,	0.000070,      "J/K/mol")/*R	gas constant		*/
+UNITS(FS,	Gn,		9.80665,			"m/s^2"	)/*gn	acceleration of gravity	*/
+UERR (FS,	H,		6.6260755e-34,	0.0000040,	"J*s"	)/*h	Planck constant		*/
+UERR (FS,	Hbar,		1.05457266e-34,	0.00000063,	"J*s"	)/*hbar h/(2pi)			*/
+DATUM(FSC,	I,		I_DATA					)/*i	imaginary		*/
+UERR (FS,	K,		1.380658e-23,	0.000012e-23,	"J/K"	)/*k	Boltzmann constant	*/
+UERR (FS,	Me,		9.1093897e-31,	0.0000054e-31,	"kg"	)/*me	mass of electron	*/
+DATUM(MISSING,	Missing,	0					)/*	missing argument	*/
+UERR (FS,	Mp,		1.6726231e-27,	0.0000010e-27,	"kg"	)/*mp	mass of proton		*/
+UNITS(FS,	Mu0,		12.566370614e-7,		"N/A^2"	)/*mu0	permeability of vacuum	*/
+UERR (FS,	N0,		2.686763e25,	0.000023e25, "/m^3"	)/*n0	Loschmidt's number (STP)*/
+UERR (FS,	Na,		6.0221367e23,	0.0000036e23, "/mol"	)/*NA	Avogadro number		*/
+UNITS(FS,	P0,		1.01325e5,			"Pa"	)/*atm	atmospheric pressure	*/
+DATUM(FT,	Pi,		M_PI					)/*pi	circumference/diameter  */
+UERR (FS,	Qe, 		1.60217733e-19, 0.000000493e-19,"C"	)/*e	charge on electron      */
+UERR (FS,	Re, 		2.81794092e-15,	0.00000038e-15,	"m"	)/*re	class. electron radius	*/
+DATUM(FROP, 	Roprand,	0x8000					)/*	reserved operand        */
+UERR (FS,	Rydberg,	1.0973731534e7, 0.0000000013e7,	"/m"	)/*Rinf	Rydberg constant	*/
+UNITS(FS,	T0,		273.16,				"K"	)/*	0 degC in Kelvin	*/
+UNITS(FS,	Torr,		1.3332e2,			"Pa"	)/*	torr 1mm Hg pressure    */
+DATUM(BU,	True,		1					)/*	logically true		*/

--- a/tdishr/TdiMath2.c
+++ b/tdishr/TdiMath2.c
@@ -64,13 +64,15 @@ int Tdi3Mod(struct descriptor *in1, struct descriptor *in2, struct descriptor *o
 #include <mdsdescrip.h>
 #include <tdishr_messages.h>
 
-
+#ifndef M_PI
+#define M_PI 3.14159265358979323846
+#endif
 
 extern int CvtConvertFloat();
 extern double WideIntToDouble();
 extern void DoubleToWideInt();
 
-#define radians_to_degrees 57.295778
+const double radians_to_degrees = 180./M_PI;
 
 #define SetupArgs \
   struct descriptor_a *ina1 = (struct descriptor_a *)in1;\
@@ -148,9 +150,9 @@ static inline double mod_float(double x, double m)
 
 static void mod_bin(int size, int is_signed, char *in1, char *in2, char *out)
 {
-  double in1_d = WideIntToDouble(in1, size/sizeof(int), is_signed);
   double in2_d = WideIntToDouble(in2, size/sizeof(int), is_signed);
-  double ans = fmod(in1_d, in2_d);
+  double in1_d = WideIntToDouble(in1, size/sizeof(int), is_signed);
+  double ans = mod_float(in1_d, in2_d);
   DoubleToWideInt(&ans, size/sizeof(int), out);
 }
 
@@ -181,11 +183,11 @@ int Tdi3Mod(struct descriptor *in1, struct descriptor *in2, struct descriptor *o
 	case DTYPE_QU:	Operate(uint64_t, %)
 	case DTYPE_O:	OperateBin(in1->length, 1, mod_bin)
 	case DTYPE_OU:	OperateBin(in1->length, 0, mod_bin)
-	case DTYPE_F:	OperateFloat(float,  DTYPE_F,  fmod);
-	case DTYPE_FS:	OperateFloat(float,  DTYPE_FS, fmod);
-	case DTYPE_D:	OperateFloat(double, DTYPE_D,  fmod);
-	case DTYPE_G:	OperateFloat(double, DTYPE_G,  fmod);
-	case DTYPE_FT:	OperateFloat(double, DTYPE_FT, fmod);
+	case DTYPE_F:	OperateFloat(float,  DTYPE_F,  mod_float);
+	case DTYPE_FS:	OperateFloat(float,  DTYPE_FS, mod_float);
+	case DTYPE_D:	OperateFloat(double, DTYPE_D,  mod_float);
+	case DTYPE_G:	OperateFloat(double, DTYPE_G,  mod_float);
+	case DTYPE_FT:	OperateFloat(double, DTYPE_FT, mod_float);
     default:
       return TdiINVDTYDSC;
   }

--- a/tdishr/TdiMath2.c
+++ b/tdishr/TdiMath2.c
@@ -116,11 +116,13 @@ extern void DoubleToWideInt();
 
 static const int roprand = 0x8000;
 
-static double mod_d(double in1, double in2)
+static inline double mod_float(double x, double m)
 {
+  if (m == 0.0)
+    return x;
   double intpart;
-  modf((in2 != 0.0) ? in1 / in2 : 0., &intpart);
-  return in1 - intpart * in2;
+  modf(x / m, &intpart);
+  return x - intpart * m;
 }
 
 #define OperateFloatOne(dtype,routine,p1,p2) \
@@ -148,7 +150,7 @@ static void mod_bin(int size, int is_signed, char *in1, char *in2, char *out)
 {
   double in1_d = WideIntToDouble(in1, size/sizeof(int), is_signed);
   double in2_d = WideIntToDouble(in2, size/sizeof(int), is_signed);
-  double ans = mod_d(in1_d, in2_d);
+  double ans = fmod(in1_d, in2_d);
   DoubleToWideInt(&ans, size/sizeof(int), out);
 }
 
@@ -169,28 +171,23 @@ static void mod_bin(int size, int is_signed, char *in1, char *in2, char *out)
 int Tdi3Mod(struct descriptor *in1, struct descriptor *in2, struct descriptor *out)
 {
   SetupArgs switch (in1->dtype) {
-  case DTYPE_B:
-    Operate(char, %)
-    case DTYPE_BU:Operate(unsigned char, %)
-    case DTYPE_W:Operate(short, %)
-    case DTYPE_WU:Operate(unsigned short, %)
-    case DTYPE_L:Operate(int, %)
-    case DTYPE_LU:Operate(unsigned int, %)
-    case DTYPE_Q:OperateBin(in1->length, 1, mod_bin)
-    case DTYPE_QU:OperateBin(in1->length, 0, mod_bin)
-    case DTYPE_O:OperateBin(in1->length, 1, mod_bin)
-    case DTYPE_OU:OperateBin(in1->length, 0, mod_bin)
-    case DTYPE_F:OperateFloat(float, DTYPE_F, mod_d);
-  case DTYPE_FS:
-    OperateFloat(float, DTYPE_FS, mod_d);
-  case DTYPE_D:
-    OperateFloat(double, DTYPE_D, mod_d);
-  case DTYPE_G:
-    OperateFloat(double, DTYPE_G, mod_d);
-  case DTYPE_FT:
-    OperateFloat(double, DTYPE_FT, mod_d);
-  default:
-    return TdiINVDTYDSC;
+	case DTYPE_B:	Operate( int8_t,  %)
+	case DTYPE_BU:	Operate(uint8_t,  %)
+	case DTYPE_W:	Operate( int16_t, %)
+	case DTYPE_WU:	Operate(uint16_t, %)
+	case DTYPE_L:	Operate( int32_t, %)
+	case DTYPE_LU:	Operate(uint32_t, %)
+	case DTYPE_Q:	Operate( int64_t, %)
+	case DTYPE_QU:	Operate(uint64_t, %)
+	case DTYPE_O:	OperateBin(in1->length, 1, mod_bin)
+	case DTYPE_OU:	OperateBin(in1->length, 0, mod_bin)
+	case DTYPE_F:	OperateFloat(float,  DTYPE_F,  fmod);
+	case DTYPE_FS:	OperateFloat(float,  DTYPE_FS, fmod);
+	case DTYPE_D:	OperateFloat(double, DTYPE_D,  fmod);
+	case DTYPE_G:	OperateFloat(double, DTYPE_G,  fmod);
+	case DTYPE_FT:	OperateFloat(double, DTYPE_FT, fmod);
+    default:
+      return TdiINVDTYDSC;
   }
   return 1;
 }
@@ -198,16 +195,11 @@ int Tdi3Mod(struct descriptor *in1, struct descriptor *in2, struct descriptor *o
 int Tdi3Atan2(struct descriptor *in1, struct descriptor *in2, struct descriptor *out)
 {
   SetupArgs switch (in1->dtype) {
-  case DTYPE_F:
-    OperateFloat(float, DTYPE_F, atan2);
-  case DTYPE_FS:
-    OperateFloat(float, DTYPE_FS, atan2);
-  case DTYPE_D:
-    OperateFloat(double, DTYPE_D, atan2);
-  case DTYPE_G:
-    OperateFloat(double, DTYPE_G, atan2);
-  case DTYPE_FT:
-    OperateFloat(double, DTYPE_FT, atan2);
+	case DTYPE_F:	OperateFloat(float,  DTYPE_F,  atan2);
+	case DTYPE_FS:	OperateFloat(float,  DTYPE_FS, atan2);
+	case DTYPE_D:	OperateFloat(double, DTYPE_D,  atan2);
+	case DTYPE_G:	OperateFloat(double, DTYPE_G,  atan2);
+	case DTYPE_FT:	OperateFloat(double, DTYPE_FT, atan2);
   default:
     return TdiINVDTYDSC;
   }
@@ -217,16 +209,11 @@ int Tdi3Atan2(struct descriptor *in1, struct descriptor *in2, struct descriptor 
 int Tdi3Atan2d(struct descriptor *in1, struct descriptor *in2, struct descriptor *out)
 {
   SetupArgs switch (in1->dtype) {
-  case DTYPE_F:
-    OperateFloat(float, DTYPE_F, radians_to_degrees * atan2);
-  case DTYPE_FS:
-    OperateFloat(float, DTYPE_FS, radians_to_degrees * atan2);
-  case DTYPE_D:
-    OperateFloat(double, DTYPE_D, radians_to_degrees * atan2);
-  case DTYPE_G:
-    OperateFloat(double, DTYPE_G, radians_to_degrees * atan2);
-  case DTYPE_FT:
-    OperateFloat(double, DTYPE_FT, radians_to_degrees * atan2);
+	case DTYPE_F:	OperateFloat(float,  DTYPE_F,  radians_to_degrees * atan2);
+	case DTYPE_FS:	OperateFloat(float,  DTYPE_FS, radians_to_degrees * atan2);
+	case DTYPE_D:	OperateFloat(double, DTYPE_D,  radians_to_degrees * atan2);
+	case DTYPE_G:	OperateFloat(double, DTYPE_G,  radians_to_degrees * atan2);
+	case DTYPE_FT:	OperateFloat(double, DTYPE_FT, radians_to_degrees * atan2);
   default:
     return TdiINVDTYDSC;
   }

--- a/tditest/testing/test-tdishr.ans
+++ b/tditest/testing/test-tdishr.ans
@@ -2468,71 +2468,71 @@ VERIFY("ABBA","A")
 VERIFY("ABBA","A",$TRUE)
 2
 $2PI
-6.28319
+6.283185307179586D0
 $A0
-Build_With_Units(Build_With_Error(52.9177E-12, 2400E-21), "m")
+Build_With_Units(Build_With_Error(52.9177E-12, 1168.02E-21), "m")
 $Alpha
-Build_With_Error(.00729735, 330E-12)
+Build_With_Error(.00729735, 143.276E-12)
 $Amu
-Build_With_Units(Build_With_Error(1660.54E-30, 1000E-36), "kg")
+Build_With_Units(Build_With_Error(1660.54E-30, 43.0666E-36), "kg")
 $Atm
 Build_With_Units(101325., "Pa")
 $C
-Build_With_Units(299.792E6, "m/s")
+Build_With_Units(299792458D0, "m/s")
 $Cal
 Build_With_Units(4.1868, "J")
 $Degree
-.0174533
+.0174532925199433D0
 $Epsilon0
-Build_With_Units(8854.19E-15, "F/m")
+Build_With_Units(8854.187817620389D-15, "F/m")
 $Ev
-Build_With_Units(Build_With_Error(160.218E-21, 49E-27), "J/eV")
+Build_With_Units(Build_With_Error(160.218E-21, 3654.14E-30), "J/eV")
 $False
 0BU
 $Faraday
-Build_With_Units(Build_With_Error(96485.3, .029), "C/mol")
+Build_With_Units(Build_With_Error(96485.3, .00381419), "C/mol")
 $G
-Build_With_Units(Build_With_Error(66.7259E-12, .00085), "m^3/s^2/kg")
+Build_With_Units(Build_With_Error(66.743E-12, 1500.02E-18), "m^3/s^2/kg")
 $Gas
-Build_With_Units(Build_With_Error(8.31451, 70E-6), "J/K/mol")
+Build_With_Units(Build_With_Error(8.31446, 43.5899E-9), "J/K/mol")
 $Gn
 Build_With_Units(9.80665, "m/s^2")
 $H
-Build_With_Units(Build_With_Error(662.608E-36, 4000E-9), "J*s")
+Build_With_Units(Build_With_Error(662.607E-36, 2857.25E-45), "J*s")
 $Hbar
-Build_With_Units(Build_With_Error(105.457E-36, 630E-9), "J*s")
+Build_With_Units(Build_With_Error(105.457E-36, 1967.42E-45), "J*s")
 $I
 Cmplx(0.,1.)
 $K
-Build_With_Units(Build_With_Error(13.8066E-24, 120E-30), "J/K")
+Build_With_Units(Build_With_Error(13.8065E-24, 276.341E-33), "J/K")
 $Me
-Build_With_Units(Build_With_Error(910.939E-33, 540E-39), "kg")
+Build_With_Units(Build_With_Error(910.938E-33, 25.8874E-39), "kg")
 $Missing
 $Missing
 $Mp
-Build_With_Units(Build_With_Error(1672.62E-30, 1000E-36), "kg")
+Build_With_Units(Build_With_Error(1672.62E-30, 85.2717E-36), "kg")
 $Mu0
-Build_With_Units(1256.64E-9, "N/A^2")
+Build_With_Units(1256.637061435917D-9, "N/A^2")
 $N0
-Build_With_Units(Build_With_Error(26.8676E24, 230E18), "/m^3")
+Build_With_Units(Build_With_Error(26.8678E24, 743.623E15), "/m^3")
 $Na
-Build_With_Units(Build_With_Error(602.214E21, 360E15), "/mol")
+Build_With_Units(Build_With_Error(602.214E21, 11.645E15), "/mol")
 $P0
 Build_With_Units(101325., "Pa")
 $Pi
-3.14159
+3.141592653589793D0
 $Qe
-Build_With_Units(Build_With_Error(160.218E-21, 49.3E-27), "C")
+Build_With_Units(Build_With_Error(160.218E-21, 3654.14E-30), "C")
 $Re
-Build_With_Units(Build_With_Error(2817.94E-18, 380E-24), "m")
+Build_With_Units(Build_With_Error(2817.94E-18, 12.7156E-24), "m")
 $Roprand
 $ROPRAND
 $Rydberg
-Build_With_Units(Build_With_Error(10.9737E6, .013), "/m")
+Build_With_Units(Build_With_Error(10.9737E6, .443876), "/m")
 $T0
-Build_With_Units(273.16, "K")
+Build_With_Units(273.15, "K")
 $Torr
-Build_With_Units(133.32, "Pa")
+Build_With_Units(133.3223684210526D0, "Pa")
 $True
 1BU
 byte_unsigned(42ub)


### PR DESCRIPTION
* use M_PI as PI
* updated precision on constants
* replaced measured value by definition if available
* use double precision for data w/o error
* correct error by error due to cast (loss of precision)
* fixes two error entries that had wrong order of magnitude (missing exp)