### PR TITLE
Fix:update .h include for TreeNode

### DIFF
--- a/java/devicebeans/src/main/java/mds/devices/Interface.java
+++ b/java/devicebeans/src/main/java/mds/devices/Interface.java
@@ -17,7 +17,7 @@ public interface Interface {
 	public float[] getFloatArray(String expr) throws Exception;
 	public double getDouble(String expr) throws Exception;
 	public String getString(String expr) throws Exception;
-	public String []getStringArray(String expr) throws Exception;
+	public String[] getStringArray(String expr) throws Exception;
 	public String getNodeName(int nid) throws Exception;
 	public String execute(String expr) throws Exception;
 	public void putDataExpr(int nid, String expr) throws Exception;

--- a/java/jtraverser/src/main/java/Database.java
+++ b/java/jtraverser/src/main/java/Database.java
@@ -239,16 +239,16 @@ public class Database implements Interface{
 		node.clearNciFlag(flagMask);
 
 	}
-	public void setNciFlag(int nid, int flagMask) throws Exception
+	public void setNciFlag(int nid, int flagId) throws Exception
 	{
 		MDSplus.TreeNode node = new MDSplus.TreeNode(nid, mdstree);
-		node.setNciFlag(flagMask);
+		node.setNciFlag(flagId);
 
 	}
-	public boolean getNciFlag(int nid, int flagMask) throws Exception
+	public boolean getNciFlag(int nid, int flagId) throws Exception
 	{
 		MDSplus.TreeNode node = new MDSplus.TreeNode(nid, mdstree);
-		return node.getNciFlag(flagMask);
+		return node.getNciFlag(flagId);
 	}
 	public int getNciFlags(int nid) throws Exception
 	{

--- a/java/mdsobjects/src/main/java/MDSplus/TreeNode.java
+++ b/java/mdsobjects/src/main/java/MDSplus/TreeNode.java
@@ -135,9 +135,9 @@ public class TreeNode extends Data
 	private static native long getNciLong(int nid, long ctx, int nciType) throws MdsException;
 	private static native java.lang.String getNciString(int nid, long ctx, int nciType) throws MdsException;
 	private static native void setNciFlag(int nid, long ctx, int flagType, boolean flag) throws MdsException;
-	//private static native void setNciFlags(int nid, long ctx, int flags) throws MdsException;
+	private static native void setNciFlags(int nid, long ctx, int flags) throws MdsException;
 	private static native boolean getNciFlag(int nid, long ctx, int flagType) throws MdsException;
-	//private static native int getNciFlags(int nid, long ctx) throws MdsException;
+	private static native int getNciFlags(int nid, long ctx) throws MdsException;
 	private static native int[]getNciNids(int nid, long ctx, int nciNumType, int nciType) throws MdsException;
 	private static native void turnOn(int nid, long ctx, boolean on) throws MdsException;
 	private static native boolean isOn(int nid, long ctx) throws MdsException;
@@ -593,36 +593,28 @@ public class TreeNode extends Data
 	public int getNciFlags() throws MdsException
 	{
 		resolveNid();
-		int flags = 0;
-		for (int i = 0, flag = 1 ; i < 31 ; flag = 1 << ++i)
-			if (getNciFlag(nid, ctxTree.getCtx(), flag))
-				flags += flag;
-		return flags;
+		return this.getNciFlags(nid, ctxTree.getCtx());
 	}
-
 	public void setNciFlags(int flags) throws MdsException
 	{
 		resolveNid();
-		for (int i = 0, flag = 1 ; i < 31 ; flag = 1 << ++i)
-			setNciFlag(nid, ctxTree.getCtx(), 1<<i, (flags & flag) > 0);
+		this.setNciFlags(nid, ctxTree.getCtx(),flags);
 	}
-
 	public boolean getNciFlag(int flagId) throws MdsException
 	{
 		resolveNid();
-		return getNciFlag(nid, ctxTree.getCtx(), 1 << flagId);
+		return this.getNciFlag(nid, ctxTree.getCtx(), 1<<flagId);
 	}
-
 	public void setNciFlag(int flagId) throws MdsException
 	{
 		resolveNid();
-		setNciFlag(nid, ctxTree.getCtx(), 1 << flagId, true);
+		this.setNciFlag(nid, ctxTree.getCtx(), 1 << flagId, true);
 	}
 
 	public void clearNciFlag(int flagId) throws MdsException
 	{
 		resolveNid();
-		setNciFlag(nid, ctxTree.getCtx(), 1 << flagId, false);
+		this.setNciFlag(nid, ctxTree.getCtx(), 1 << flagId, false);
 	}
 
 

--- a/javamds/MDSplus_TreeNode.h
+++ b/javamds/MDSplus_TreeNode.h
@@ -139,6 +139,8 @@ extern "C" {
 #define MDSplus_TreeNode_NciM_NID_REFERENCE 16384L
 #undef MDSplus_TreeNode_NciM_INCLUDE_IN_PULSE
 #define MDSplus_TreeNode_NciM_INCLUDE_IN_PULSE 32768L
+#undef MDSplus_TreeNode_NciM_COMPRESS_SEGMENTS
+#define MDSplus_TreeNode_NciM_COMPRESS_SEGMENTS 65536L
 #undef MDSplus_TreeNode_NciTIME_INSERTED
 #define MDSplus_TreeNode_NciTIME_INSERTED 4L
 #undef MDSplus_TreeNode_NciOWNER_ID
@@ -277,11 +279,27 @@ JNIEXPORT void JNICALL Java_MDSplus_TreeNode_setNciFlag
 
 /*
  * Class:     MDSplus_TreeNode
+ * Method:    setNciFlags
+ * Signature: (IJI)V
+ */
+JNIEXPORT void JNICALL Java_MDSplus_TreeNode_setNciFlags
+  (JNIEnv *, jclass, jint, jlong, jint);
+
+/*
+ * Class:     MDSplus_TreeNode
  * Method:    getNciFlag
  * Signature: (IJI)Z
  */
 JNIEXPORT jboolean JNICALL Java_MDSplus_TreeNode_getNciFlag
   (JNIEnv *, jclass, jint, jlong, jint);
+
+/*
+ * Class:     MDSplus_TreeNode
+ * Method:    getNciFlags
+ * Signature: (IJ)I
+ */
+JNIEXPORT jint JNICALL Java_MDSplus_TreeNode_getNciFlags
+  (JNIEnv *, jclass, jint, jlong);
 
 /*
  * Class:     MDSplus_TreeNode
@@ -305,6 +323,14 @@ JNIEXPORT void JNICALL Java_MDSplus_TreeNode_turnOn
  * Signature: (IJ)Z
  */
 JNIEXPORT jboolean JNICALL Java_MDSplus_TreeNode_isOn
+  (JNIEnv *, jclass, jint, jlong);
+
+/*
+ * Class:     MDSplus_TreeNode
+ * Method:    isParentOff
+ * Signature: (IJ)Z
+ */
+JNIEXPORT jboolean JNICALL Java_MDSplus_TreeNode_isParentOff
   (JNIEnv *, jclass, jint, jlong);
 
 /*


### PR DESCRIPTION
setNciFlags and getNciFlags were already implemented in mdsobjects.c, but I did not update (i.e. generate via javah) the include file. Now the new one has been generated