### PR TITLE
Fix:Missing tree context in fixup nid in copydx

### DIFF
--- a/include/mdsshr.h
+++ b/include/mdsshr.h
@@ -72,7 +72,7 @@ extern int MdsCompareXd(const mdsdsc_t *const dsc1_ptr, const mdsdsc_t *const ds
 extern int MdsDecompress(const mdsdsc_r_t *const rec_ptr, mdsdsc_xd_t *const out_ptr);
 extern int MdsCopyDxXd(const mdsdsc_t *const in, mdsdsc_xd_t *const out);
 extern int MdsCopyDxXdZ(const mdsdsc_t *const in, mdsdsc_xd_t *const out, void **const zone,
-	int (*const fixup_nid)(), void *const fixup_nid_arg,
+	int (*const fixup_nid)(), void *const fixup_nid_arg1,void *const fixup_nid_arg2,
 	int (*const fixup_path)(),void *const fixup_path_arg);
 extern char *MdsDescrToCstring(const mdsdsc_t *const string_dsc);
 extern void MdsEnableSandbox();
@@ -91,10 +91,11 @@ extern int MDSGetEventQueue(const int eventid, const int timeout, int *const dat
 extern int MdsSandboxEnabled();
 extern int MdsSerializeDscIn(const char *const in, mdsdsc_xd_t *const out);
 extern int MdsSerializeDscOutZ(const mdsdsc_t *const in, mdsdsc_xd_t *const out,
-	int (*const fixupNid) (),void *const fixupNidArg,
+	int (*const fixupNid) (),void *const fixupNidArg1,void *const fixupNidArg2,
 	int (*const fixupPath)(),void *const fixupPathArg,
 	const int compress, int *const compressible, l_length_t *const length, l_length_t *const reclen,
-	dtype_t *const dtype, class_t *const classType, const int altbuflen, void *const altbuf, int *const data_in_altbuf);
+	dtype_t *const dtype, class_t *const classType, const int altbuflen, void *const altbuf, 
+	int *const data_in_altbuf);
 extern int MdsSerializeDscOut(const mdsdsc_t *const in, mdsdsc_xd_t *const out);
 extern int MDSSetEventTimeout(const int seconds);
 extern int MDSEvent(const char *eventName, int num_bytes, char *data);

--- a/mdsshr/MdsSerialize.c
+++ b/mdsshr/MdsSerialize.c
@@ -904,7 +904,8 @@ STATIC_CONSTANT int PointerToOffset(mdsdsc_t *dsc_ptr, l_length_t *length){
 EXPORT int MdsSerializeDscOutZ(mdsdsc_t const *in,
 			mdsdsc_xd_t *out,
 			int (*fixupNid) (),
-			void *fixupNidArg,
+			void *fixupNidArg1,
+			void *fixupNidArg2,
 			int (*fixupPath) (),
 			void *fixupPathArg,
 			int compress,
@@ -924,7 +925,7 @@ EXPORT int MdsSerializeDscOutZ(mdsdsc_t const *in,
   dtype_t dtype = 0;
   class_t class = 0;
   int data_in_altbuf = 0;
-  status = MdsCopyDxXdZ(in, out, 0, fixupNid, fixupNidArg, fixupPath, fixupPathArg);
+  status = MdsCopyDxXdZ(in, out, 0, fixupNid, fixupNidArg1, fixupNidArg2, fixupPath, fixupPathArg);
   if (status == MdsCOMPRESSIBLE) {
     if (compress) {
       tempxd = *out;
@@ -1003,5 +1004,5 @@ EXPORT int MdsSerializeDscOutZ(mdsdsc_t const *in,
 
 EXPORT int MdsSerializeDscOut(mdsdsc_t const *in, mdsdsc_xd_t *out)
 {
-  return MdsSerializeDscOutZ(in, out, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
+  return MdsSerializeDscOutZ(in, out, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
 }

--- a/servershr/ServerBuildDispatchTable.c
+++ b/servershr/ServerBuildDispatchTable.c
@@ -139,6 +139,10 @@ static int fixup_nid(int *nid, int idx, struct descriptor_d *path_out)
   }
   return B_FALSE;
 }
+static int fixup_nid_patch(int *nid, int *idx, void *dbid, struct descriptor_d *path_out)
+{
+  return fixup_nid(nid, *idx, path_out);
+}
 
 static int fixup_path(struct descriptor *path_in, int idx, struct descriptor_d *path_out)
 {
@@ -165,8 +169,8 @@ static void LinkConditions()
   for (i = 0; i < num_actions; i++) {
     if (actions[i].condition) {
       EMPTYXD(xd);
-      MdsCopyDxXdZ(actions[i].condition, &xd, 0, fixup_nid, i + (char *)0, fixup_path, i + (char *)0);
-      MdsCopyDxXdZ((struct descriptor *)&xd, (struct descriptor_xd *)actions[i].condition, 0, 0, 0, make_idents, i + (char *)0);
+      MdsCopyDxXdZ(actions[i].condition, &xd, 0, fixup_nid_patch, &i, NULL, fixup_path, i + (char *)0);
+      MdsCopyDxXdZ((struct descriptor *)&xd, (struct descriptor_xd *)actions[i].condition, 0, 0, 0, 0, make_idents, i + (char *)0);
       MdsFree1Dx(&xd, 0);
     }
   }

--- a/servershr/ServerBuildDispatchTable.c
+++ b/servershr/ServerBuildDispatchTable.c
@@ -139,7 +139,7 @@ static int fixup_nid(int *nid, int idx, struct descriptor_d *path_out)
   }
   return B_FALSE;
 }
-static int fixup_nid_patch(int *nid, int *idx, void *dbid, struct descriptor_d *path_out)
+static int fixup_nid_patch(int *nid, int *idx, void* dbid __attribute__ ((unused)), struct descriptor_d *path_out)
 {
   return fixup_nid(nid, *idx, path_out);
 }

--- a/tdishr/TdiGetDbi.c
+++ b/tdishr/TdiGetDbi.c
@@ -302,7 +302,7 @@ int Tdi1Using(opcode_t opcode __attribute__ ((unused)),
     status = _TdiEvaluate(ctx, list[0], &tmp MDS_END_ARG);
     if STATUS_OK
       status = MdsCopyDxXdZ((struct descriptor *)&tmp, out_ptr, NULL,
-			    fixup_nid, NULL, fixup_path, NULL);
+			    fixup_nid, NULL, NULL, fixup_path, NULL);
     MdsFree1Dx(&tmp, NULL);
   }
   if (dbid)

--- a/tdishr/TdiGetDbi.c
+++ b/tdishr/TdiGetDbi.c
@@ -165,7 +165,8 @@ int Tdi1GetDbi(opcode_t opcode __attribute__ ((unused)),
 	Note that DEFAULT may be NID/PATH and will not be data at same.
 */
 static int fixup_nid(int *pin, /* NID pointer */
-			     int arg __attribute__ ((unused)),
+			     void* arg1 __attribute__ ((unused)),
+			     void* arg2 __attribute__ ((unused)),
 			     struct descriptor_d *pout)
 {
   char *path = TreeGetPath(*pin);

--- a/tdishr/TdiVar.c
+++ b/tdishr/TdiVar.c
@@ -383,7 +383,7 @@ static inline int put_ident_inner(const mdsdsc_r_t *const ident_ptr, mdsdsc_xd_t
     if (data_ptr)
       status =
 	  MdsCopyDxXdZ(data_ptr->pointer, &node_ptr->xd,
-		       &block_ptr->data_zone, NULL, NULL, NULL, NULL);
+		       &block_ptr->data_zone, NULL, NULL, NULL, NULL, NULL);
     else {
       MdsFree1Dx(&node_ptr->xd, &block_ptr->data_zone);
       node_ptr->xd = NULL_XD;

--- a/tdishr/TdiYaccSubs.c
+++ b/tdishr/TdiYaccSubs.c
@@ -84,7 +84,7 @@ int tdi_yacc_ARG(struct marker *mark_ptr, TDITHREADSTATIC_ARG) {
 	/*******************************
 	Size it and copy it to our zone.
 	*******************************/
-  status = MdsCopyDxXdZ(ptr, &junk, &TDI_REFZONE.l_zone, NULL, NULL, NULL, NULL);
+  status = MdsCopyDxXdZ(ptr, &junk, &TDI_REFZONE.l_zone, NULL, NULL, NULL, NULL, NULL);
   if STATUS_OK
     mark_ptr->rptr = (mdsdsc_r_t *)junk.pointer;
   return status;
@@ -180,7 +180,7 @@ int tdi_yacc_IMMEDIATE(mdsdsc_xd_t **dsc_ptr_ptr, TDITHREADSTATIC_ARG) {
 	Copy it to our zone.
 	*******************/
   if STATUS_OK
-    status = MdsCopyDxXdZ(xd.pointer, &junk, &TDI_REFZONE.l_zone, NULL, NULL, NULL, NULL);
+    status = MdsCopyDxXdZ(xd.pointer, &junk, &TDI_REFZONE.l_zone, NULL, NULL, NULL, NULL, NULL);
   if STATUS_OK
     *dsc_ptr_ptr = (mdsdsc_xd_t *)junk.pointer;
   MdsFree1Dx(&xd, NULL);

--- a/treeshr/TreeSegments.c
+++ b/treeshr/TreeSegments.c
@@ -1871,7 +1871,7 @@ int TreePutDsc(TREE_INFO *tinfo, int nid_in, mdsdsc_t *dsc, int64_t *offset,
   int data_in_altbuf;
   NID *nid = (NID *)&nid_in;
   unsigned char tree = nid->tree;
-  int status = MdsSerializeDscOutZ(dsc, &xd, TreeFixupNid, &tree, 0, 0,
+  int status = MdsSerializeDscOutZ(dsc, &xd, TreeFixupNid, &tree, 0, 0, 0,
                                    compress, &compressible, &ddlen, &reclen,
                                    &dtype, &class, 0, 0, &data_in_altbuf);
   if (STATUS_OK && xd.pointer && xd.pointer->class == CLASS_A &&


### PR DESCRIPTION
TreePutRecord TreeFixupNid needs also tree context otherwise TreeGetPath() fails whan getting the path of a node in a different subtree. (see issue 2043).  MdsCopyDxXdOutZ has been changed to account for an additional parameter to FixupNid. Subsequent changes around derive from this