### PR TITLE
Fix: TreeShr.TreeDoMethodA expects a nid descriptor; must not be int32

### DIFF
--- a/python/MDSplus/tree.py
+++ b/python/MDSplus/tree.py
@@ -1646,7 +1646,7 @@ class TreeNode(_dat.TreeRef,_dat.Data): # HINT: TreeNode begin  (maybe subclass 
         """
         arglist=[self.ctx]
         xd=_dsc.Descriptor_xd()
-        argsobj = [_scr.Int32(self.nid),_scr.String(method)]
+        argsobj = [self,_scr.String(method)]
         arglist+=list(map(_dat.Data.byref,argsobj))
         arglist.append(len(args))
         if len(args)>0:


### PR DESCRIPTION
should fix #2050 