### PR TITLE
Build: dropped javabootclass

### DIFF
--- a/java/Makefile.inc.am
+++ b/java/Makefile.inc.am
@@ -1,7 +1,5 @@
 # common makefile for java packages
 
-RT6JAR = $(top_srcdir)/java/rt6.jar
-
 JSCH = $(top_srcdir)/java/jsch-0.1.54.jar
 $(JSCH):
         wget -O $@ http://sourceforge.net/projects/jsch/files/jsch.jar/0.1.54/jsch-0.1.54.jar/download

--- a/java/devicebeans/Makefile.am
+++ b/java/devicebeans/Makefile.am
@@ -1,5 +1,4 @@
 JAVASOURCE = 6
-JAVABOOTCLASSPATH = -bootclasspath $(RT6JAR)
 include ../Makefile.inc.am
 
 java_srcdir = $(srcdir)/src/main/java

--- a/java/jdevices/Makefile.am
+++ b/java/jdevices/Makefile.am
@@ -1,5 +1,4 @@
 JAVASOURCE = 6
-JAVABOOTCLASSPATH = -bootclasspath $(RT6JAR)
 include ../Makefile.inc.am
 
 EXTRA_DIST = *.form

--- a/java/jtraverser/Makefile.am
+++ b/java/jtraverser/Makefile.am
@@ -1,5 +1,4 @@
 JAVASOURCE = 6
-JAVABOOTCLASSPATH = -bootclasspath $(RT6JAR)
 include ../Makefile.inc.am
 
 EXTRA_DIST = servlet-2_3-fcs-classfiles.zip

--- a/java/mdsobjects/Makefile.am
+++ b/java/mdsobjects/Makefile.am
@@ -1,5 +1,4 @@
 JAVASOURCE = 6
-JAVABOOTCLASSPATH = -bootclasspath $(RT6JAR)
 include ../Makefile.inc.am
 
 java_srcdir = $(srcdir)/src/main/java

--- a/java/mdsplus/Makefile.am
+++ b/java/mdsplus/Makefile.am
@@ -1,5 +1,4 @@
 JAVASOURCE = 6
-JAVABOOTCLASSPATH = -bootclasspath $(RT6JAR)
 include ../Makefile.inc.am
 
 java_srcdir = $(srcdir)/src/main/java


### PR DESCRIPTION
rt6 might not be required. Does anyone recall the necessity of this classes. Were they only required when we were building on each platform (due to different jdk versions)?

Is java 8 ok for device beans?
The maven artifacts are built in java 8 and can be found here
http://jenkins2.mdsplus.org/job/maven/984/artifact/maven/
they work with 7.107.x alpha binaries.

If OK i would like to switch to java 8 for all but maybe mdsobjects (to support older matlab)