### PR TITLE
Fix: prevent LOCK_FAILURE on windows

### DIFF
--- a/java/mdsobjects/src/test/java/MDSplus/MdsTreeNodeTest.java
+++ b/java/mdsobjects/src/test/java/MDSplus/MdsTreeNodeTest.java
@@ -102,15 +102,7 @@ public class MdsTreeNodeTest {
 		Assert.assertEquals(true, node.isOn());
 
 		// setOn()
-		try
-		{
-			node.setOn(false);
-		}
-		catch (MdsException exc)
-		{
-			if (!exc.getMessage().contains("LOCK_FAILURE"))
-				throw exc;
-		}
+		node.setOn(false);
 		Assert.assertEquals(false, node.isOn());
 		node.setOn(true);
 		Assert.assertEquals(true, node.isOn());

--- a/java/mdsplus-api/src/main/java/mds/data/TREE.java
+++ b/java/mdsplus-api/src/main/java/mds/data/TREE.java
@@ -1126,19 +1126,13 @@ public final class TREE implements ContextEventListener, CTX, AutoCloseable
 
 	public final TREE turnOff(final int nid) throws MdsException
 	{
-		final int status = this.setActive().api.treeTurnOff(this.ctx, nid);
-		if (status == MdsException.TreeLOCK_FAILURE)
-			return this;// ignore: it changes the state
-		MdsException.handleStatus(status);
+		MdsException.handleStatus(this.setActive().api.treeTurnOff(this.ctx, nid));
 		return this;
 	}
 
 	public final TREE turnOn(final int nid) throws MdsException
 	{
-		final int status = this.setActive().api.treeTurnOn(this.ctx, nid);
-		if (status == MdsException.TreeLOCK_FAILURE)
-			return this;// ignore: it changes the state
-		MdsException.handleStatus(status);
+		MdsException.handleStatus(this.setActive().api.treeTurnOn(this.ctx, nid));
 		return this;
 	}
 

--- a/java/mdsplus-api/src/test/java/mds/TreeShr_Test.java
+++ b/java/mdsplus-api/src/test/java/mds/TreeShr_Test.java
@@ -372,11 +372,9 @@ public class TreeShr_Test{
 		AllTests.testStatus(MdsException.TreeSUCCESS, TreeShr_Test.treeshr.treeOpenNew(ctx, AllTests.tree, TreeShr_Test.shot));
 		try{
 			Assert.assertEquals(1, TreeShr_Test.treeshr.treeAddNode(ctx, "A", NODE.USAGE_ANY).getData());
-			int status = TreeShr_Test.treeshr.treeTurnOff(ctx, 1);
-			Assert.assertTrue(status == MdsException.TreeSUCCESS || status == MdsException.TreeLOCK_FAILURE);
+			AllTests.testStatus(MdsException.TreeSUCCESS, TreeShr_Test.treeshr.treeTurnOff(ctx, 1));
 			AllTests.testStatus(MdsException.TreeOFF, TreeShr_Test.treeshr.treeIsOn(ctx, 1));
-			status = TreeShr_Test.treeshr.treeTurnOn(ctx, 1);
-			Assert.assertTrue(status == MdsException.TreeSUCCESS || status == MdsException.TreeLOCK_FAILURE);
+			AllTests.testStatus(MdsException.TreeSUCCESS, TreeShr_Test.treeshr.treeTurnOn(ctx, 1));
 		}finally{
 		}
 	}

--- a/python/MDSplus/tree.py
+++ b/python/MDSplus/tree.py
@@ -2578,12 +2578,7 @@ class TreeNode(_dat.TreeRef,_dat.Data): # HINT: TreeNode begin  (maybe subclass 
         @rtype: None
         """
         method = _TreeShr._TreeTurnOn if flag else _TreeShr._TreeTurnOff
-        try:
-            _exc.checkStatus(
-                method(self.ctx,
-                       self._nid))
-        except _exc.TreeLOCK_FAILURE:
-            if not _ver.iswin: raise
+        _exc.checkStatus(method(self.ctx, self._nid))
         return self
 
     def setSegmentScale(self,scale):
@@ -2623,10 +2618,7 @@ class TreeNode(_dat.TreeRef,_dat.Data): # HINT: TreeNode begin  (maybe subclass 
         @rtype: original type
         """
         method = _TreeShr._TreeSetSubtree if flag else _TreeShr._TreeSetNoSubtree
-        _exc.checkStatus(
-                method(self.ctx,
-                       self._nid),
-                ignore=(_exc.TreeLOCK_FAILURE,))
+        _exc.checkStatus(method(self.ctx, self._nid))
         return self
 
     def setUsage(self,usage):

--- a/treeshr/TreeAddNode.c
+++ b/treeshr/TreeAddNode.c
@@ -187,18 +187,18 @@ int _TreeAddNode(void *dbid, char const *name, int *nid_out, char usage)
 	  NCI scratch_nci;
 	  NID nid;
 	  int parent_nid;
+          int ncilocked = 0;
 	  memset(&new_nci, 0, sizeof(NCI));
 	  parent_nid = node_to_nid(dblist, parent, 0);
 	  node_to_nid(dblist, new_ptr, &nid);
-	  status = TreeGetNciLw(dblist->tree_info, nid.node, &scratch_nci);
+	  status = tree_get_nci(dblist->tree_info, nid.node, &scratch_nci, &ncilocked);
 	  if STATUS_OK {
 	    if (_TreeIsOn(dblist, *(int *)&parent_nid) & 1)
 	      new_nci.flags &= (unsigned)~NciM_PARENT_STATE;
 	    else
 	      new_nci.flags |= NciM_PARENT_STATE;
 	    new_nci.flags |= NciM_COMPRESS_ON_PUT;
-	    status = TreePutNci(dblist->tree_info, nid.node, &new_nci, 1);
-	    TreeUnLockNci(dblist->tree_info, 0, nid.node);
+	    status = tree_put_nci(dblist->tree_info, nid.node, &new_nci, &ncilocked);
 	  }
 	}
       } else

--- a/treeshr/TreeAddNode.c
+++ b/treeshr/TreeAddNode.c
@@ -191,7 +191,7 @@ int _TreeAddNode(void *dbid, char const *name, int *nid_out, char usage)
 	  memset(&new_nci, 0, sizeof(NCI));
 	  parent_nid = node_to_nid(dblist, parent, 0);
 	  node_to_nid(dblist, new_ptr, &nid);
-	  status = tree_get_nci(dblist->tree_info, nid.node, &scratch_nci, &ncilocked);
+	  status = tree_get_and_lock_nci(dblist->tree_info, nid.node, &scratch_nci, &ncilocked);
 	  if STATUS_OK {
 	    if (_TreeIsOn(dblist, *(int *)&parent_nid) & 1)
 	      new_nci.flags &= (unsigned)~NciM_PARENT_STATE;

--- a/treeshr/TreeCleanDatafile.c
+++ b/treeshr/TreeCleanDatafile.c
@@ -87,7 +87,7 @@ STATIC_ROUTINE int RewriteDatafile(char *tree, int shot, int compress)
 		  NCI nci;
 		  struct nci_list *next;
 		} *list = memset(malloc(sizeof(struct nci_list)), 0, sizeof(struct nci_list));
-		TreeGetNciW(info1, i, &list->nci, 0);
+		{int locked = 0;tree_get_nci(info1, i, &list->nci, 0, &locked);}
 		while (list->nci.flags & NciM_VERSIONS) {
 		  struct nci_list *old_list = list;
 		  list = malloc(sizeof(struct nci_list));
@@ -102,7 +102,7 @@ STATIC_ROUTINE int RewriteDatafile(char *tree, int shot, int compress)
 		  if (first) {
 		    oldlength = list->nci.length;
 		    list->nci.length = 0;
-		    tree_put_nci(info2, i, &list->nci, NULL);
+		    {int locked = 0;tree_put_nci(info2, i, &list->nci, &locked);}
 		    list->nci.length = oldlength;
 		    first = 0;
 		  }

--- a/treeshr/TreeCleanDatafile.c
+++ b/treeshr/TreeCleanDatafile.c
@@ -102,7 +102,7 @@ STATIC_ROUTINE int RewriteDatafile(char *tree, int shot, int compress)
 		  if (first) {
 		    oldlength = list->nci.length;
 		    list->nci.length = 0;
-		    TreePutNci(info2, i, &list->nci, 1);
+		    tree_put_nci(info2, i, &list->nci, NULL);
 		    list->nci.length = oldlength;
 		    first = 0;
 		  }

--- a/treeshr/TreeDeleteNode.c
+++ b/treeshr/TreeDeleteNode.c
@@ -300,10 +300,12 @@ void _TreeDeleteNodesWrite(void *dbid) {
     } else
       node->parent = 0;
     nidx = nid.node;
-    TreeGetNciLw(dblist->tree_info, nidx, &old_nci);
-    NCI empty_nci = {0};
-    TreePutNci(dblist->tree_info, nidx, &empty_nci, 1);
-    TreeUnLockNci(dblist->tree_info, 0, nidx);
+    int ncilocked = 0;
+    if IS_OK(tree_get_nci(dblist->tree_info, nidx, &old_nci, &ncilocked))
+    {
+      NCI empty_nci = {0};
+      tree_put_nci(dblist->tree_info, nidx, &empty_nci, &ncilocked);
+    }
   }
 }
 

--- a/treeshr/TreeDeleteNode.c
+++ b/treeshr/TreeDeleteNode.c
@@ -301,7 +301,7 @@ void _TreeDeleteNodesWrite(void *dbid) {
       node->parent = 0;
     nidx = nid.node;
     int ncilocked = 0;
-    if IS_OK(tree_get_nci(dblist->tree_info, nidx, &old_nci, &ncilocked))
+    if IS_OK(tree_get_and_lock_nci(dblist->tree_info, nidx, &old_nci, &ncilocked))
     {
       NCI empty_nci = {0};
       tree_put_nci(dblist->tree_info, nidx, &empty_nci, &ncilocked);

--- a/treeshr/TreeGetRecord.c
+++ b/treeshr/TreeGetRecord.c
@@ -79,7 +79,8 @@ int TreeGetRecord(int nid_in, struct descriptor_xd *dsc){
       return 0;
     status = TreeOpenDatafileR(info);
     if STATUS_OK {
-      status = TreeGetNciW(info, nidx, &nci, 0);
+      int locked = 0;
+      status = tree_get_nci(info, nidx, &nci, 0, &locked);
       if STATUS_OK {
 	if (nci.length) {
 	  TreeCallHookFun("TreeNidHook","GetData", info->treenam, info->shot, nid, NULL);

--- a/treeshr/TreePutRecord.c
+++ b/treeshr/TreePutRecord.c
@@ -146,7 +146,7 @@ int _TreePutRecord(void *dbid, int nid, struct descriptor *descriptor_ptr, int u
     if (status && !(status & 1))
       return status;
     TreeGetViewDate(&saved_viewdate);
-    RETURN_IF_NOT_OK(tree_get_nci(info_ptr, nidx, &local_nci, &locked_nci));
+    RETURN_IF_NOT_OK(tree_get_and_lock_nci(info_ptr, nidx, &local_nci, &locked_nci));
     TreeSetViewDate(&saved_viewdate);
     memcpy(&old_nci, &local_nci, sizeof(local_nci));
     if (info_ptr->data_file ? (!info_ptr->data_file->open_for_write) : 1)

--- a/treeshr/TreeRenameNode.c
+++ b/treeshr/TreeRenameNode.c
@@ -65,6 +65,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 static int FixParentState(PINO_DATABASE * dblist, NODE * parent_ptr, NODE * child_ptr);
 
+extern int tree_set_parent_state(PINO_DATABASE * db, NODE * node, unsigned int state);
 extern void **TreeCtx();
 
 int TreeRenameNode(int nid, char const *newname)
@@ -231,7 +232,7 @@ static int FixParentState(PINO_DATABASE * dblist, NODE * parent_ptr, NODE * chil
   if (status & 1) {
     child_parent_state = ((child_flags & NciM_PARENT_STATE) == 0);
     if (child_parent_state != parent_state)
-      status = SetParentState(dblist, child_ptr, !parent_state);
+      status = tree_set_parent_state(dblist, child_ptr, !parent_state);
   }
 
   return status;

--- a/treeshr/TreeSegments.c
+++ b/treeshr/TreeSegments.c
@@ -183,6 +183,7 @@ typedef struct vars {
   _vars.nid_ptr = (NID *)&nid;              \
   _vars.xnci = xnci;                        \
   _vars.xnci_len = xnci ? strlen(xnci) : 0; \
+  _vars.nci_locked = 0;                     \
   if (_vars.xnci && (_vars.xnci_len < 1 || _vars.xnci_len > NAMED_ATTRIBUTE_NAME_SIZE)) \
     return TreeFAILURE;                     \
   int status;
@@ -311,7 +312,7 @@ inline static int open_datafile_read(vars_t *vars) {
   RETURN_IF_NOT_OK(check_segment_remote(vars));
   RETURN_IF_NOT_OK(load_info_ptr(vars));
   TreeGetViewDate(&vars->saved_viewdate);
-  RETURN_IF_NOT_OK(TreeGetNciW(vars->tinfo, vars->nidx, &vars->local_nci, 0));
+  RETURN_IF_NOT_OK(tree_get_nci(vars->tinfo, vars->nidx, &vars->local_nci, 0, &vars->nci_locked));
   if (!vars->tinfo->data_file)
     return TreeOpenDatafileR(vars->tinfo);
   return TreeSUCCESS;
@@ -327,7 +328,7 @@ static int open_datafile_write0(vars_t *vars) {
   status = TreeCallHook(PutData, vars->tinfo, *(int *)vars->nid_ptr);
   if (status && STATUS_NOT_OK) return status;
   TreeGetViewDate(&vars->saved_viewdate);
-  RETURN_IF_NOT_OK(tree_get_nci(vars->tinfo, vars->nidx, &vars->local_nci, &vars->nci_locked));
+  RETURN_IF_NOT_OK(tree_get_and_lock_nci(vars->tinfo, vars->nidx, &vars->local_nci, &vars->nci_locked));
   if (vars->dblist->shotid == -1) {
     if (vars->local_nci.flags & NciM_NO_WRITE_MODEL) return TreeNOWRITEMODEL;
   } else {
@@ -624,13 +625,9 @@ static void unlock_nci(void *vars_in) {
   vars_t *vars = (vars_t *)vars_in;
   tree_unlock_nci(vars->tinfo, 0, vars->nidx, &vars->nci_locked);
 }
-static int lock_nci(void *vars_in) {
-  vars_t *vars = (vars_t *)vars_in;
-  int deleted = TRUE;
-  return tree_lock_nci(vars->tinfo, 0, vars->nidx, &deleted, &vars->nci_locked);
-}
+
 #define CLEANUP_NCI_PUSH pthread_cleanup_push(unlock_nci, (void *)vars)
-#define CLEANUP_NCI_POP pthread_cleanup_pop(1)
+#define CLEANUP_NCI_POP pthread_cleanup_pop(vars->nci_locked)
 int _TreeGetXNci(void *dbid, int nid, const char *xnci, mdsdsc_xd_t *value) {
   if (!xnci) return TreeFAILURE;
   INIT_VARS;
@@ -850,7 +847,7 @@ inline static void begin_segment_index(vars_t *vars) {
   }
 }
 
-inline static int check_sinfo(vars_t *vars) {
+static int check_sinfo(vars_t *vars) {
   if (vars->idx < 0 || vars->idx > vars->shead.idx) return TreeFAILURE;
   for (vars->index_offset = vars->shead.index_offset;
        vars->idx < vars->sindex.first_idx &&
@@ -864,7 +861,8 @@ inline static int check_sinfo(vars_t *vars) {
   return TreeSUCCESS;
 }
 
-inline static int begin_sinfo(vars_t *vars, mdsdsc_a_t *initialValue,
+static int xnci_get_segment(void *dbid, int nid, const char *xnci, int idx, mdsdsc_xd_t *segment, mdsdsc_xd_t *dim, const int nci_locked);
+static int begin_sinfo(vars_t *vars, mdsdsc_a_t *initialValue,
                               int checkcompress(vars_t*vars,mdsdsc_xd_t*,mdsdsc_xd_t*,mdsdsc_a_t*)) {
   int status = TreeSUCCESS;
   vars->add_length = 0;
@@ -910,11 +908,7 @@ inline static int begin_sinfo(vars_t *vars, mdsdsc_a_t *initialValue,
     EMPTYXD(xd_data);
     EMPTYXD(xd_dim);
     vars->sinfo = &vars->sindex.segment[(vars->idx % SEGMENTS_PER_INDEX) - 1];
-    unlock_nci(vars);
-    status = _TreeXNciGetSegment(vars->dblist, *(int *)vars->nid_ptr,
-                                 vars->xnci, vars->idx - 1, &xd_data, &xd_dim);
-    if STATUS_OK
-      status = lock_nci(vars);
+    status = xnci_get_segment(vars->dblist, *(int *)vars->nid_ptr, vars->xnci, vars->idx - 1, &xd_data, &xd_dim, vars->nci_locked);
     if STATUS_OK
       status = checkcompress(vars, &xd_data, &xd_dim, initialValue);
     MdsFree1Dx(&xd_data, 0);
@@ -2099,7 +2093,8 @@ int TreeCopyExtended(PINO_DATABASE *dbid_in, PINO_DATABASE *dbid_out, int nid, N
                           compress);
   RETURN_IF_NOT_OK(TreePutExtendedAttributes(tinfo_out, &attr, &offset));
   SeekToRfa(offset, nci->DATA_INFO.DATA_LOCATION.rfa);
-  RETURN_IF_NOT_OK(tree_put_nci(tinfo_out, nid, nci, NULL));
+  int locked = 0;
+  RETURN_IF_NOT_OK(tree_put_nci(tinfo_out, nid, nci, &locked));
   return TreeSetViewDate(&now);
 }
 
@@ -2237,14 +2232,18 @@ int _TreeXNciGetSegmentLimits(void *dbid, int nid, const char *xnci, int idx,
   return get_segment_limits(vars, retStart, retEnd);
 }
 
-int _TreeXNciGetSegment(void *dbid, int nid, const char *xnci, int idx,
-                        mdsdsc_xd_t *segment, mdsdsc_xd_t *dim) {
+static int xnci_get_segment(void *dbid, int nid, const char *xnci, int idx, mdsdsc_xd_t *segment, mdsdsc_xd_t *dim, const int nci_locked)
+{
   INIT_VARS;
   vars->idx = idx;
+  vars->nci_locked = nci_locked;
   RETURN_IF_NOT_OK(get_segment(vars));
   return read_segment(dbid, vars->tinfo, nid, &vars->shead, vars->sinfo, vars->idx, segment, dim);
 }
 
+int _TreeXNciGetSegment(void *dbid, int nid, const char *xnci, int idx, mdsdsc_xd_t *segment, mdsdsc_xd_t *dim) {
+  return xnci_get_segment(dbid, nid, xnci, idx, segment, dim, 0);
+}
 int _TreeXNciGetSegmentInfo(void *dbid, int nid, const char *xnci, int idx,
                             char *dtype, char *dimct, int *dims,
                             int *next_row) {

--- a/treeshr/TreeSetNci.c
+++ b/treeshr/TreeSetNci.c
@@ -28,6 +28,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <treeshr.h>
 #include <ncidef.h>
 
+#define DEBUG
+
 extern void **TreeCtx();
 
 extern int SetNciRemote();
@@ -132,7 +134,6 @@ void tree_unlock_nci(TREE_INFO * info, int readonly, int nodenum, int *locked)
 {
   if (!info->header->readonly)
   {
-//#define DEBUG
 #ifdef DEBUG
     if (*locked<2) fprintf(stderr, "ERROR: tree_unlock_nci and *locked invalid: %d\n", *locked);
 #endif
@@ -357,6 +358,7 @@ int tree_get_and_lock_nci(TREE_INFO * info, int node_num, NCI * nci, int *locked
    the characteristics are just a memory reference
    away.
   *********************************************/
+    *locked += 2; // simulate lock
     memcpy(nci, info->edit->nci + node_num - info->edit->first_in_mem, sizeof(struct nci));
   }
 
@@ -512,7 +514,10 @@ int tree_put_nci(TREE_INFO * info, int node_num, NCI * nci, int *locked)
 *****************************/
 
   else
+  {
     memcpy(info->edit->nci + (node_num - info->edit->first_in_mem), nci, sizeof(*nci));
+    if (!*locked) *locked -= 2; // simulate unlock
+  }
   return status;
 }
 

--- a/treeshr/treeshrp.h
+++ b/treeshr/treeshrp.h
@@ -753,7 +753,6 @@ extern int TreeCopyExtended(PINO_DATABASE * dbid1, PINO_DATABASE * dbid2, int ni
 extern int TreeExpandNodes(PINO_DATABASE * db_ptr, int num_fixup, NODE *** fixup_nodes);
 extern int TreeFindParent(PINO_DATABASE * dblist, char *path_ptr, NODE ** node_ptrptr,
 	                  char **namedsc_ptr, int *chid);
-extern int TreeGetNciW(TREE_INFO * info, int node_number, NCI * nci, unsigned int version);
 extern int TreeInsertChild(NODE * parent_ptr, NODE * child_ptr, int sort);
 extern int TreeInsertMember(NODE * parent_ptr, NODE * member_ptr, int sort);
 extern int TreeIsChild(PINO_DATABASE * db, NODE * node);
@@ -789,9 +788,10 @@ extern int64_t TreeTimeInserted();
 extern int TreeSetTemplateNci(NCI * nci);
 
 extern int tree_lock_nci(TREE_INFO * info, int readonly, int nodenum, int *deleted, int *locked);
-extern int tree_unlock_nci(TREE_INFO * info, int readonly, int nodenum, int *locked);
-extern int tree_get_nci(TREE_INFO * info, int node_number, NCI * nci, int *locked);
-extern int tree_put_nci(TREE_INFO * info, int node_number, NCI * nci, int *locked);
+extern void tree_unlock_nci(TREE_INFO * info, int readonly, int nodenum, int *locked);
+extern int tree_get_and_lock_nci(TREE_INFO * info, int nodenum, NCI * nci, int *locked);
+extern int tree_put_nci(TREE_INFO * info, int nodenum, NCI * nci, int *locked);
+extern int tree_get_nci(TREE_INFO * info, int nodenum, NCI * nci, unsigned int version, int *locked);
 
 extern int TreeLockDatafile(TREE_INFO * info, int readonly, int64_t where);
 extern int TreeUnLockDatafile(TREE_INFO * info, int readonly, int64_t where);

--- a/treeshr/treeshrp.h
+++ b/treeshr/treeshrp.h
@@ -746,7 +746,6 @@ extern int GetDefaultNidRemote(PINO_DATABASE * dblist, int *nid);
 #endif
 extern int64_t RfaToSeek(uint8_t*rfa);
 void SeekToRfa(int64_t seek, uint8_t*rfa);
-extern int SetParentState(PINO_DATABASE * db, NODE * node, unsigned int state);
 extern void TreeCallHookFun(char *hookType, char *hookName, ...);
 extern int TreeMakeNidsLocal(struct descriptor *dsc_ptr, int nid);
 extern int TreeCloseFiles(TREE_INFO * info, int nci, int data);
@@ -755,10 +754,8 @@ extern int TreeExpandNodes(PINO_DATABASE * db_ptr, int num_fixup, NODE *** fixup
 extern int TreeFindParent(PINO_DATABASE * dblist, char *path_ptr, NODE ** node_ptrptr,
 	                  char **namedsc_ptr, int *chid);
 extern int TreeGetNciW(TREE_INFO * info, int node_number, NCI * nci, unsigned int version);
-extern int TreeGetNciLw(TREE_INFO * info, int node_number, NCI * nci);
 extern int TreeInsertChild(NODE * parent_ptr, NODE * child_ptr, int sort);
 extern int TreeInsertMember(NODE * parent_ptr, NODE * member_ptr, int sort);
-extern int TreePutNci(TREE_INFO * info, int node_number, NCI * nci, int flush);
 extern int TreeIsChild(PINO_DATABASE * db, NODE * node);
 extern struct descriptor *TreeSectionName(TREE_INFO * info);
 /* extern int TreeFindTag(PINO_DATABASE *db, NODE *node, const char *treename, char **search_string, NODE **node_in_out); */
@@ -790,8 +787,12 @@ extern void TreeSerializeNciIn(const char *in, NCI *out);
 extern void TreeSerializeNciOut(const NCI *in, char *out);
 extern int64_t TreeTimeInserted();
 extern int TreeSetTemplateNci(NCI * nci);
-extern int TreeLockNci(TREE_INFO * info, int readonly, int nodenum, int *deleted);
-extern int TreeUnLockNci(TREE_INFO * info, int readonly, int nodenum);
+
+extern int tree_lock_nci(TREE_INFO * info, int readonly, int nodenum, int *deleted, int *locked);
+extern int tree_unlock_nci(TREE_INFO * info, int readonly, int nodenum, int *locked);
+extern int tree_get_nci(TREE_INFO * info, int node_number, NCI * nci, int *locked);
+extern int tree_put_nci(TREE_INFO * info, int node_number, NCI * nci, int *locked);
+
 extern int TreeLockDatafile(TREE_INFO * info, int readonly, int64_t where);
 extern int TreeUnLockDatafile(TREE_INFO * info, int readonly, int64_t where);
 


### PR DESCRIPTION
Real issue is that some method lock and  call TreePutNci which locks as well.
the lock is not reentrant and does not keep track of number of locks.
```
LOCK = locked
protected access
{
  LOCK = locked
  protected access
  UNLOCK = unlocked
}
unprotected access - assumed to be protected
UNLOCK = fail
```