### PR TITLE
Fix:Wrong shell files

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -387,6 +387,7 @@ MAKELIBDIR="\$(top_builddir)/lib/"
 JDK_LIVECONNECT="$with_jdk/jre/lib/plugin.jar"
 TAR_EXCLUDE="-e"
 HUP_TO_XINETD=""
+HUP_TO_XINETD_SERVICE=""
 HUP_TO_INETD=""
 JRE="jre"
 UILCMD="uil"
@@ -489,6 +490,7 @@ case "$host" in
        jni_inc_dir="$with_jdk/include";
        jni_md_inc_dir="$with_jdk/include/linux";
        HUP_TO_XINETD="/etc/rc.d/init.d/xinetd restart";
+       HUP_TO_XINETD_SERVICE="service xinetd restart";
        HUP_TO_INETD="kill -HUP \`/sbin/pidof inetd\`";
        ;;
 *arm-xilinx-linux-gnueabi) echo "configuring for Xylinx zynq board (arm cortex a9)";
@@ -519,6 +521,7 @@ case "$host" in
        jni_inc_dir="$with_jdk/include";
        jni_md_inc_dir="$with_jdk/include/linux";
        HUP_TO_XINETD="/etc/rc.d/init.d/xinetd restart";
+       HUP_TO_XINETD_SERVICE="service xinetd restart";
        HUP_TO_INETD="kill -HUP \`/sbin/pidof inetd\`";;
 *linux*) CFLAGS="$CFLAGS -fpic -fsigned-char -shared-libgcc -fno-strict-aliasing";
        FCFLAGS="$FCFLAGS -fno-range-check";
@@ -538,6 +541,7 @@ case "$host" in
        jni_inc_dir="$with_jdk/include";
        jni_md_inc_dir="$with_jdk/include/linux";
        HUP_TO_XINETD="/etc/rc.d/init.d/xinetd restart";
+       HUP_TO_XINETD_SERVICE="service xinetd restart";
        HUP_TO_INETD="kill -HUP \`/sbin/pidof inetd\`";;
 *apple-darwin*) echo "Configuring for MacOS X";
        THREAD=""
@@ -1291,6 +1295,7 @@ AC_SUBST(HDF5_LIBS)
 AC_SUBST(HDF5_APS)
 AC_SUBST(HUP_TO_INETD)
 AC_SUBST(HUP_TO_XINETD)
+AC_SUBST(HUP_TO_XINETD_SERVICE)
 AC_SUBST(IDL_INC)
 AC_SUBST(IDL_LIB)
 AC_SUBST(IDLMDSEVENT)

--- a/java/jtraverser/CompileTree.template
+++ b/java/jtraverser/CompileTree.template
@@ -19,4 +19,4 @@ DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH:$MDSPLUS_DIR/${lib} \
 CLASSPATH=\
 $MDSPLUS_DIR/java/classes/jTraverser.jar:\
 $MDSPLUS_DIR/java/classes/mdsobjects.jar \
-java -Xss5M -Djava.library.path=$MDSPLUS_DIR/${lib} CompileTree $1 $2 
+java -Xss5M -Djava.library.path=$MDSPLUS_DIR/${lib} mds.jtraverser.CompileTree $1 $2 

--- a/java/jtraverser/DecompileTree.template
+++ b/java/jtraverser/DecompileTree.template
@@ -19,4 +19,4 @@ DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH:$MDSPLUS_DIR/${lib} \
 CLASSPATH=\
 $MDSPLUS_DIR/java/classes/jTraverser.jar:\
 $MDSPLUS_DIR/java/classes/mdsobjects.jar \
-java -Xss5M -Djava.library.path=$MDSPLUS_DIR/${lib} DecompileTree $1 $2 
+java -Xss5M -Djava.library.path=$MDSPLUS_DIR/${lib} mds.jtraverser.DecompileTree $1 $2 

--- a/rpm/post_install_script.in
+++ b/rpm/post_install_script.in
@@ -202,7 +202,11 @@ then
     else
       cp $MDSPLUS_DIR/rpm/mdsipd.xinetd /etc/xinetd.d/mdsip
     fi
-    @HUP_TO_XINETD@
+    if [ -r /etc/rc.d/init.d/xinetd ] ; then
+      @HUP_TO_XINETD@
+    else  #Use service instead
+      @HUP_TO_XINETD_SERVICE@
+    fi
   else
     echo Adding mdsipd service to /etc/inetd.conf
     if grep "^mdsip " /etc/inetd.conf > /dev/null
@@ -219,6 +223,14 @@ then
   echo Adding $product login scripts
   if [ -r /etc/profile.d ]
   then
+    if [ -r /etc/profile.d/mdsplus.csh ]
+    then
+      rm /etc/profile.d/mdsplus.csh
+    fi
+    if [ -r /etc/profile.d/mdsplus.sh ]
+    then
+      rm /etc/profile.d/mdsplus.sh
+    fi
     ln -s $MDSPLUS_DIR/setup.csh /etc/profile.d/mdsplus.csh
     ln -s $MDSPLUS_DIR/setup.sh /etc/profile.d/mdsplus.sh
   else


### PR DESCRIPTION
Shell files CompileTree and DecompileTree did not make correct reference to java classes (now in mds.jtraverser package)

On many linux systems xinetd /etc/rc.d/init.d/xinetd  does not exist anymore and service command must be called instead.

post_install_script failed if symbolic links already /etc/profile.d/mdsplus.csh and /etc/profile.d/mdsplus.sh already present