### PR TITLE
Fix: System.arraycopy argument order in TdiShr.java

### DIFF
--- a/java/mdsplus-api/src/main/java/mds/TdiShr.java
+++ b/java/mdsplus-api/src/main/java/mds/TdiShr.java
@@ -159,7 +159,7 @@ public class TdiShr extends TreeShr
 	{
 		final Descriptor<?>[] args = new Descriptor<?>[args1.length + 1];
 		args[0] = arg0;
-		System.arraycopy(args, 1, args1, 0, args1.length);
+		System.arraycopy(args1, 0, args, 1, args1.length);
 		return this.tdiIntrinsic(ctx, opcode, args);
 	}
 }


### PR DESCRIPTION
Fix a bug which could cause a NullPointerException when calling tdiCompile because of the misuse of arraycopy, where it should copy the elements of "args1" to "args", instead of the other way round.