### PR TITLE
Fix: move imports in tdi/dev_support/*.py, so they may survive module…

### DIFF
--- a/tdi/dev_support/DevAddPythonDevice.py
+++ b/tdi/dev_support/DevAddPythonDevice.py
@@ -23,11 +23,10 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 
-from MDSplus import Data, Tree, Device, Ident, Int32
-from MDSplus import DevPYDEVICE_NOT_FOUND,MDSplusException,MDSplusERROR,TreeSUCCESS
-import sys
+
 def DevAddPythonDevice(path, model, nidout=None):
-    """Add a python device to the tree by:
+    """Add a python device to the tree.
+
     1) finding the model in the list defined by
        the tdi function, MdsDevices.
     2) try importing the package for the model and calling its Add method.
@@ -37,15 +36,20 @@ def DevAddPythonDevice(path, model, nidout=None):
     containing blank filled values containing an \0 character embedded.
     These Strings have to be manipulated to produce simple str() values.
     """
+
+    import sys
+    import MDSplus
+
     model = str(model.data()).strip()
-    path  = str(path.data()).strip()
+    path = str(path.data()).strip()
     try:
-        node = Device.PyDevice(model).Add(Tree(),path)
-        if isinstance(nidout,(Ident,)):
-            Data.execute("$=$",nidout,Int32(node.nid))
-        return TreeSUCCESS.status
-    except MDSplusException:
+        node = MDSplus.Device.PyDevice(model).Add(MDSplus.Tree(), path)
+        if isinstance(nidout, (MDSplus.Ident,)):
+            MDSplus.Data.execute("$=$", nidout, MDSplus.Int32(node.nid))
+        return MDSplus.TreeSUCCESS.status
+    except MDSplus.MDSplusException:
         return sys.exc_info()[1].status
-    except:
-        print ("Error adding device instance of %s: %s" % (model, sys.exc_info()[1]))
-        return MDSplusERROR.status
+    except Exception:
+        print("Error adding device instance of %s: %s" % (
+            model, sys.exc_info()[1]))
+        return MDSplus.MDSplusERROR.status

--- a/tdi/dev_support/DevHelp.py
+++ b/tdi/dev_support/DevHelp.py
@@ -1,50 +1,71 @@
-from MDSplus import Device,Data,TreeNode
+#
+# Copyright (c) 2017, Massachusetts Institute of Technology All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# Redistributions of source code must retain the above copyright notice, this
+# list of conditions and the following disclaimer.
+#
+# Redistributions in binary form must reproduce the above copyright notice, this
+# list of conditions and the following disclaimer in the documentation and/or
+# other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
 
-_device_list = None
 
-def _devHelpDevtype(devtype, full):
-  from pydoc import TextDoc
-  global _device_list
-  if _device_list is None:
-    alldevices=Data.execute('MDSDEVICES()')
-    _device_list=[item[0].strip() for item in alldevices]
-  if ('*' in devtype) or ('?' in devtype):
-    devnames=[]
-    for device in _device_list:
-      if (Data.execute('MdsShr->StrMatchWild(descr($),descr($))',(device.upper(),devtype.upper())) & 1) == 1:
-        devnames.append(DevHelp(device,-1))
-    return '\n'.join(devnames)
-  else:
-    try:
-        cls = Device.PyDevice(devtype)
-        if full == 1:
-          return TextDoc().docclass(cls)
-        elif full == -1:
-          return "%s: python device" % devtype
-        else:
-          return cls.__doc__
-    except:
-      for device in _device_list:
-        if device.upper() == devtype.upper():
-          return "%s: tdi, java or shared library device" % device
-      return "Error obtaining help on device " + devtype
+def DevHelp(arg, full=0, device_list=[None]):
+    import pydoc
+    import MDSplus
 
-def _devHelpNode(node,full):
-  try:
-    elt = int(node.conglomerate_elt)
-    if elt == 0:
-      return ""
-    if elt == 1:
-      return DevHelp(node.record.model,full)
+    if isinstance(arg, MDSplus.TreeNode):
+        try:
+            elt = int(arg.conglomerate_elt)
+            if elt == 0:
+                return ""
+            if elt == 1:
+                return DevHelp(arg.record.model, full)
+            else:
+                cls = arg.head.record.getDevice()
+                return cls.parts[elt-2].get('help', "")
+        except Exception as e:
+            return "ERROR: %s" % (e,)
     else:
-      cls = node.head.record.getDevice()
-      return cls.parts[elt-2].get('help',"")
-  except Exception as e:
-    return "ERROR: %s"%(str(e),)
-
-def DevHelp(dev,full=0):
-  if isinstance(dev,TreeNode):
-    return _devHelpNode(dev,int(full))
-  else:
-    return _devHelpDevtype(str(dev),int(full))
-
+        full = int(full)
+        devtype = arg.upper()
+        if device_list[0] is None:
+            alldevices = MDSplus.Data.execute('MDSDEVICES()')
+            device_list[0] = [item[0].strip() for item in alldevices]
+        if ('*' in devtype) or ('?' in devtype):
+            devnames = []
+            for device in device_list[0]:
+                if MDSplus.Data.execute(
+                        'MdsShr->StrMatchWild(descr($), descr($))',
+                        (device.upper(), devtype)) & 1:
+                    devnames.append(DevHelp(device, -1))
+            return '\n'.join(devnames)
+        else:
+            try:
+                cls = MDSplus.Device.PyDevice(devtype)
+                if full == 1:
+                    return pydoc.TextDoc().docclass(cls)
+                elif full == -1:
+                    return "%s: python device" % devtype
+                else:
+                    return cls.__doc__
+            except Exception as e:
+                for device in device_list[0]:
+                    if device.upper() == devtype:
+                        return "%s: tdi, java or shared library device" % (
+                                device,)
+                return "Error obtaining help on device %s: %s" % (devtype, e)

--- a/tdi/dev_support/MDSDEVICES.py
+++ b/tdi/dev_support/MDSDEVICES.py
@@ -1,30 +1,74 @@
-from threading import Lock
+#
+# Copyright (c) 2017, Massachusetts Institute of Technology All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# Redistributions of source code must retain the above copyright notice, this
+# list of conditions and the following disclaimer.
+#
+# Redistributions in binary form must reproduce the above copyright notice, this
+# list of conditions and the following disclaimer in the documentation and/or
+# other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
 
- # locks the cache
-def MDSDEVICES(lock=Lock(), cache=[None]):
-  with lock:
-   if cache[0] is None:
-    from MDSplus import Device,tdi,version,getenv
-    from numpy import array
-    def importDevices(name):
-        bname = version.tobytes(name)
-        try:
-            module = __import__(name)
-            ans = [[version.tobytes(k),bname] for k,v in module.__dict__.items() if isinstance(v,int.__class__) and issubclass(v,Device)]
-        except (ImportError, ImportWarning): ans = []
-        tdidev = tdi("if_error(%s(),*)"%name)
-        if tdidev is None: return ans
-        tdidev = [[k.rstrip(), v.rstrip()] for k,v in tdidev.value.reshape((int(tdidev.value.size/2),2)).tolist()]
-        return tdidev+ans
-    ans = [[version.tobytes(d),b'pydevice'] for d in Device.findPyDevices().keys()]
-    mdsdevs=getenv('MDS_DEVICES')
-    if mdsdevs is not None:
-      modules=mdsdevs.split(':')
-    else:
-      modules=["KbsiDevices","MitDevices","RfxDevices","W7xDevices"]
-    for module in modules:
-        ans += importDevices(module)
-    ans = array(list(dict(ans).items()))
-    ans.view('%s,%s'%(ans.dtype,ans.dtype)).sort(order=['f0'], axis=0)
-    cache[0] = ans
-   return cache[0]
+
+import threading
+
+
+# locks the cache
+def MDSDEVICES(lock=threading.Lock(), cache=[None]):
+    with lock:
+        if cache[0] is None:
+            import numpy
+            import MDSplus
+
+            def importDevices(name):
+                bname = MDSplus.version.tobytes(name)
+                try:
+                    module = __import__(name)
+                    ans = [
+                        [MDSplus.version.tobytes(k), bname]
+                        for k, v in module.__dict__.items()
+                        if (isinstance(v, int.__class__)
+                            and issubclass(v, MDSplus.Device))
+                    ]
+                except (ImportError, ImportWarning):
+                    ans = []
+                tdidev = MDSplus.tdi("if_error(%s(),*)" % name)
+                if tdidev is None:
+                    return ans
+                tdidev = [
+                    [k.rstrip(), v.rstrip()]
+                    for k, v in tdidev.value.reshape(
+                            (int(tdidev.value.size/2), 2)).tolist()
+                ]
+                return tdidev+ans
+            ans = [
+                [MDSplus.version.tobytes(d), b'pydevice']
+                for d in MDSplus.Device.findPyDevices().keys()
+            ]
+            mdsdevs = MDSplus.getenv('MDS_DEVICES')
+            if mdsdevs is not None:
+                modules = mdsdevs.split(':')
+            else:
+                modules = [
+                    "KbsiDevices", "MitDevices", "RfxDevices", "W7xDevices"]
+            for module in modules:
+                ans += importDevices(module)
+            ans = numpy.array(list(dict(ans).items()))
+            ans.view('%s,%s' % (
+                    ans.dtype, ans.dtype)).sort(order=['f0'], axis=0)
+            cache[0] = ans
+    return cache[0]


### PR DESCRIPTION
… reloads and co.

not trivial with original layout when it is loaded from libpython withing python. MDSplus objects unloaded but reload was not triggered as import was outside of function definition. this is due to the way we import and cache pythonic tdi funs.