### PR TITLE
Fix: jtraverser crash

### DIFF
--- a/java/devicebeans/src/main/java/DeviceChoice.java
+++ b/java/devicebeans/src/main/java/DeviceChoice.java
@@ -122,13 +122,18 @@ public class DeviceChoice extends DeviceComponent
 		else
 			try
 			{
-				final String data_value = subtree.getString(data);
-				for (int i = 0; i < choiceItems.length; i++)
+				if(data == null)
+					comboB.setSelectedIndex(-1);
+				else
 				{
-					if (choiceItems[i].equals(data_value))
+					final String data_value = subtree.getString(data);
+					for (int i = 0; i < choiceItems.length; i++)
 					{
-						comboB.setSelectedIndex(i);
-						break;
+						if (choiceItems[i].equals(data_value))
+						{
+							comboB.setSelectedIndex(i);
+							break;
+						}
 					}
 				}
 			}

--- a/java/mdsobjects/src/main/java/MDSplus/Tree.java
+++ b/java/mdsobjects/src/main/java/MDSplus/Tree.java
@@ -522,30 +522,20 @@ public class Tree
 		return size;
 	}
 
-	public Data tdiCompile(java.lang.String expr, Data args[])
+	public Data tdiCompile(java.lang.String expr, Data... args)
 	{
+		if (expr == null || expr.isEmpty())
+			return new Data();
 		final Data retData = compile(ctx, expr, args);
 		retData.setCtxTree(this);
 		return retData;
 	}
 
-	public Data tdiCompile(java.lang.String expr)
+	public Data tdiExecute(java.lang.String expr, Data... args)
 	{
-		final Data retData = compile(ctx, expr, new Data[0]);
-		retData.setCtxTree(this);
-		return retData;
-	}
-
-	public Data tdiExecute(java.lang.String expr, Data args[])
-	{
+		if (expr == null || expr.isEmpty())
+			return new Data();
 		final Data retData = execute(ctx, expr, args);
-		retData.setCtxTree(this);
-		return retData;
-	}
-
-	public Data tdiExecute(java.lang.String expr)
-	{
-		final Data retData = execute(ctx, expr, new Data[0]);
 		retData.setCtxTree(this);
 		return retData;
 	}

--- a/java/mdsobjects/src/test/java/MDSplus/MdsTreeTest.java
+++ b/java/mdsobjects/src/test/java/MDSplus/MdsTreeTest.java
@@ -33,6 +33,10 @@ public class MdsTreeTest
 		tree.write();
 		tree.close();
 		tree = new MDSplus.Tree("java_test0", -1, "NORMAL");
+		Assert.assertEquals(tree.tdiCompile(null).toString(), "*");
+		Assert.assertEquals(tree.tdiCompile("").toString(), "*");
+		Assert.assertEquals(tree.tdiExecute(null).toString(), "*");
+		Assert.assertEquals(tree.tdiExecute("").toString(), "*");
 		tree.close();
 		tree = new MDSplus.Tree("java_test0", -1, "READONLY");
 		Assert.assertEquals(true, tree.isReadOnly());


### PR DESCRIPTION
Handle empty nodes in DeviceChoice avoiding jTraverser crash