### PR TITLE
Acq435 hardware filter

### DIFF
--- a/pydevices/HtsDevices/acq435st.py
+++ b/pydevices/HtsDevices/acq435st.py
@@ -126,6 +126,10 @@ class ACQ435ST(MDSplus.Device):
             self.device_thread = self.DeviceWorker(self)
 
         def run(self):
+            import acq400_hapi
+            import ast
+            uut = acq400_hapi.Acq400(self.dev.node.data(), monitor=False)
+
             def lcm(a,b):
                 from fractions import gcd
                 return (a * b / gcd(int(a), int(b)))
@@ -142,10 +146,16 @@ class ACQ435ST(MDSplus.Device):
             event_name = self.dev.seg_event.data()
 
             trig = self.dev.trigger.data()
-            if self.dev.hw_filter.length > 0:
-                dt = 1./self.dev.freq.data() * 2 ** self.dev.hw_filter.data()
-            else:
-                dt = 1./self.dev.freq.data()
+            
+            # Retrive the actual value of NACC set in the ACQ box
+            nacc_str   = uut.s1.get_knob('nacc')
+            nacc_tuple = ast.literal_eval(nacc_str)
+            nacc       = nacc_tuple[0]
+            if self.dev.debug:
+                print("The ACQ NACC value was set to {}".format(nacc))
+
+            # nacc values are always between 1 and 16, set in the ACQ box by the INIT() function , therefore:
+            dt = 1./self.dev.freq.data() * nacc
 
             decimator = lcma(self.decim)
 
@@ -270,6 +280,7 @@ class ACQ435ST(MDSplus.Device):
         import tempfile
         import subprocess
         import acq400_hapi
+
         uut = acq400_hapi.Acq400(self.node.data(), monitor=False)
         uut.s0.set_knob('set_abort', '1')
 
@@ -282,7 +293,7 @@ class ACQ435ST(MDSplus.Device):
         uut.s1.set_knob('ACQ43X_SAMPLE_RATE', "%d"%freq)
         
         if self.debug:
-            print("Hardware Filter is {}".format(int(self.hw_filter.data())))
+            print("Hardware Filter (NACC) from tree node is {}".format(int(self.hw_filter.data())))
 
         nacc = int(self.hw_filter.data())
         if 0 <= nacc <= 4:
@@ -291,8 +302,8 @@ class ACQ435ST(MDSplus.Device):
             nacc_samp = ('%d'%nacc_samp).strip()
             uut.s1.set_knob('nacc', '%s,%s'%(nacc_samp, nacc,))
         else:
-            print("WARNING: Hardware Filter must be in range[0,4]. Set it to 1.")
-            uut.s1.set_knob('nacc', '1,1')
+            print("WARNING: Hardware Filter must be in the range [0,4]. Set it to 0.")
+            uut.s1.set_knob('nacc', '1,0')
 
         if self.trig_mode.data() == 'hard':
             uut.s1.set_knob('trg', '1,0,1')

--- a/pydevices/HtsDevices/acq435st.py
+++ b/pydevices/HtsDevices/acq435st.py
@@ -281,13 +281,16 @@ class ACQ435ST(MDSplus.Device):
         freq = int(self.freq.data())
         uut.s1.set_knob('ACQ43X_SAMPLE_RATE', "%d"%freq)
         
-        if 0 < self.hw_filter.length <= 4:
-            nacc = int(self.hw_filter.data())
+        if self.dev.debug:
+                print("Hardware Filter is {}".format(int(self.hw_filter.data()))
+
+        nacc = int(self.hw_filter.data())
+        if 0 < nacc <= 4:
             nacc_samp = 2**nacc
             nacc=('%d'%nacc).strip()
             nacc_samp = ('%d'%nacc_samp).strip()
             uut.s1.set_knob('nacc', '%s,%s'%(nacc_samp, nacc,))
-        elif self.hw_filter.length == 0:
+        elif nacc == 0:
             uut.s1.set_knob('nacc', '0,0')
         else:
             print("WARNING: Hardware Filter greater than 4!. Set it to 0.")

--- a/pydevices/HtsDevices/acq435st.py
+++ b/pydevices/HtsDevices/acq435st.py
@@ -280,14 +280,19 @@ class ACQ435ST(MDSplus.Device):
             uut.s0.set_knob('SYS_CLK_FPMUX', 'ZCLK')
         freq = int(self.freq.data())
         uut.s1.set_knob('ACQ43X_SAMPLE_RATE', "%d"%freq)
-        if self.hw_filter.length > 0:
+        
+        if 0 < self.hw_filter.length <= 4:
             nacc = int(self.hw_filter.data())
             nacc_samp = 2**nacc
             nacc=('%d'%nacc).strip()
             nacc_samp = ('%d'%nacc_samp).strip()
             uut.s1.set_knob('nacc', '%s,%s'%(nacc_samp, nacc,))
-        else :
+        elif self.hw_filter.length == 0:
             uut.s1.set_knob('nacc', '0,0')
+        else:
+            print("WARNING: Hardware Filter greater than 4!. Set it to 0.")
+            uut.s1.set_knob('nacc', '0,0')
+
         if self.trig_mode.data() == 'hard':
             uut.s1.set_knob('trg', '1,0,1')
         else:
@@ -300,7 +305,7 @@ class ACQ435ST(MDSplus.Device):
 #
 #        for chan in range(32):
 #
-        coeffs =  map(float, uut.s1.AI_CAL_ESLO.split(" ")[3:] )
+        coeffs  =  map(float, uut.s1.AI_CAL_ESLO.split(" ")[3:] )
         offsets =  map(float, uut.s1.AI_CAL_EOFF.split(" ")[3:] )
 
         for i in range(32):

--- a/pydevices/HtsDevices/acq435st.py
+++ b/pydevices/HtsDevices/acq435st.py
@@ -281,8 +281,8 @@ class ACQ435ST(MDSplus.Device):
         freq = int(self.freq.data())
         uut.s1.set_knob('ACQ43X_SAMPLE_RATE', "%d"%freq)
         
-        if self.dev.debug:
-                print("Hardware Filter is {}".format(int(self.hw_filter.data()))
+        if self.debug:
+            print("Hardware Filter is {}".format(int(self.hw_filter.data())))
 
         nacc = int(self.hw_filter.data())
         if 0 < nacc <= 4:

--- a/pydevices/HtsDevices/acq435st.py
+++ b/pydevices/HtsDevices/acq435st.py
@@ -285,16 +285,14 @@ class ACQ435ST(MDSplus.Device):
             print("Hardware Filter is {}".format(int(self.hw_filter.data())))
 
         nacc = int(self.hw_filter.data())
-        if 0 < nacc <= 4:
+        if 0 <= nacc <= 4:
             nacc_samp = 2**nacc
             nacc=('%d'%nacc).strip()
             nacc_samp = ('%d'%nacc_samp).strip()
             uut.s1.set_knob('nacc', '%s,%s'%(nacc_samp, nacc,))
-        elif nacc == 0:
-            uut.s1.set_knob('nacc', '0,0')
         else:
-            print("WARNING: Hardware Filter greater than 4!. Set it to 0.")
-            uut.s1.set_knob('nacc', '0,0')
+            print("WARNING: Hardware Filter must be in range[0,4]. Set it to 1.")
+            uut.s1.set_knob('nacc', '1,1')
 
         if self.trig_mode.data() == 'hard':
             uut.s1.set_knob('trg', '1,0,1')


### PR DESCRIPTION
These are modifications to the acq435st.py MDSplus pydevice to keep the hardware filter (aka hardware decimation or Accumulate/Decimate filter) inside a range of values between 0 and 4.

1- INIT function now check the value enter in the node of the tree for hardware filter to be inside the range. Then, set the value directly in the ACQ box using its knobs. If a value is outside the range, a warning is printed, and the decimation is set to 0, i.e no decimation.
2- The run function of the MDSWorker now reads the hardware decimation value that was set directly from the ACQ box. Then, the calculation of dt is perform.