### PR TITLE
Using sync_role() to set SR and triggers

### DIFF
--- a/pydevices/HtsDevices/acq435st.py
+++ b/pydevices/HtsDevices/acq435st.py
@@ -284,21 +284,24 @@ class ACQ435ST(MDSplus.Device):
         uut = acq400_hapi.Acq400(self.node.data(), monitor=False)
         uut.s0.set_knob('set_abort', '1')
 
+        if self.ext_clock.length > 0:
+            raise Exception('Ext. Clock is not supported')
+
         trg = self.trig_mode.data()
 
         if trg == 'hard':
-            trg_dx = 0
+            trg_dx = 'd0'
         elif trg == 'automatic':
-            trg_dx = 1
+            trg_dx = 'd1'
         elif trg == 'soft':
-            trg_dx = 1
+            trg_dx = 'd1'
 
         # USAGE sync_role {fpmaster|rpmaster|master|slave|solo} [CLKHZ] [FIN]
         # modifiers [CLK|TRG:SENSE=falling|rising] [CLK|TRG:DX=d0|d1]
         # modifiers [TRG=int|ext]
         # modifiers [CLKDIV=div]  
         # If the user has specified a trigger.
-        uut.s0.sync_role = '%s %s TRG:DX=%s' % ('master', self.freq.data(), 'd'+str(trg_dx))
+        uut.s0.sync_role = '%s %s TRG:DX=%s' % ('master', self.freq.data(), trg_dx)
 
         if self.hw_filter.length > 0:
             nacc = int(self.hw_filter.data())

--- a/pydevices/HtsDevices/acq435st.py
+++ b/pydevices/HtsDevices/acq435st.py
@@ -284,31 +284,46 @@ class ACQ435ST(MDSplus.Device):
         uut = acq400_hapi.Acq400(self.node.data(), monitor=False)
         uut.s0.set_knob('set_abort', '1')
 
-        if self.ext_clock.length > 0:
-            uut.s0.set_knob('SYS_CLK_FPMUX', 'FPCLK')
-            uut.s0.set_knob('SIG_CLK_MB_FIN', '1000000')
-        else:
-            uut.s0.set_knob('SYS_CLK_FPMUX', 'ZCLK')
-        freq = int(self.freq.data())
-        uut.s1.set_knob('ACQ43X_SAMPLE_RATE', "%d"%freq)
-        
-        if self.debug:
-            print("Hardware Filter (NACC) from tree node is {}".format(int(self.hw_filter.data())))
+        # if self.ext_clock.length > 0:
+        #     uut.s0.set_knob('SYS_CLK_FPMUX', 'FPCLK')
+        #     uut.s0.set_knob('SIG_CLK_MB_FIN', '1000000')
+        # else:
+        #     uut.s0.set_knob('SYS_CLK_FPMUX', 'ZCLK')
+        # freq = int(self.freq.data())
+        # uut.s1.set_knob('ACQ43X_SAMPLE_RATE', "%d"%freq)
 
-        nacc = int(self.hw_filter.data())
-        if 0 <= nacc <= 4:
+        # if self.trig_mode.data() == 'hard':
+        #     uut.s1.set_knob('trg', '1,0,1')
+        # else:
+        #     uut.s1.set_knob('trg', '1,1,1')
+
+        rig_types=[ 'hard', 'soft', 'automatic']
+        trg = self.trig_mode.data()
+
+        if trg == 'hard':
+            trg_dx = 0
+        elif trg == 'automatic':
+            trg_dx = 1
+        elif trg == 'soft':
+            trg_dx = 1
+
+        role = 'master'
+        if self.trig_mode.data() == 'role_default':
+            uut.s0.sync_role = "%s %s" % (role, self.freq.data())
+        else:
+            # If the user has specified a trigger.
+            uut.s0.sync_role = '%s %s TRG:DX=%s' % (role, self.freq.data(), 'd'+str(trg_dx))
+
+
+        if self.hw_filter.length > 0:
+            nacc = int(self.hw_filter.data())
             nacc_samp = 2**nacc
             nacc=('%d'%nacc).strip()
             nacc_samp = ('%d'%nacc_samp).strip()
             uut.s1.set_knob('nacc', '%s,%s'%(nacc_samp, nacc,))
-        else:
-            print("WARNING: Hardware Filter must be in the range [0,4]. Set it to 0.")
-            uut.s1.set_knob('nacc', '1,0')
+        else :
+            uut.s1.set_knob('nacc', '0,0')
 
-        if self.trig_mode.data() == 'hard':
-            uut.s1.set_knob('trg', '1,0,1')
-        else:
-            uut.s1.set_knob('trg', '1,1,1')
 
 #
 #  Read the coeffients and offsets

--- a/pydevices/HtsDevices/acq435st.py
+++ b/pydevices/HtsDevices/acq435st.py
@@ -285,7 +285,7 @@ class ACQ435ST(MDSplus.Device):
         uut.s0.set_knob('set_abort', '1')
 
         if self.ext_clock.length > 0:
-            raise Exception('Ext. Clock is not supported')
+            raise Exception('External Clock is not supported')
 
         trg = self.trig_mode.data()
 

--- a/pydevices/HtsDevices/acq435st.py
+++ b/pydevices/HtsDevices/acq435st.py
@@ -245,14 +245,14 @@ class ACQ435ST(MDSplus.Device):
                             toread -= nbytes
 
                     except socket.timeout as e:
-                        print("We have Got a timeout.")
+                        # print("We have Got a timeout.")
                         err = e.args[0]
                         # this next if/else is a bit redundant, but illustrates how the
                         # timeout exception is setup
 
                         if err == 'timed out':
                             time.sleep(1)
-                            print (' received timed out, retry later')
+                            # print (' received timed out, retry later')
                             continue
                         else:
                             print (e)
@@ -296,11 +296,9 @@ class ACQ435ST(MDSplus.Device):
         # USAGE sync_role {fpmaster|rpmaster|master|slave|solo} [CLKHZ] [FIN]
         # modifiers [CLK|TRG:SENSE=falling|rising] [CLK|TRG:DX=d0|d1]
         # modifiers [TRG=int|ext]
-        # modifiers [CLKDIV=div]
-
+        # modifiers [CLKDIV=div]  
         # If the user has specified a trigger.
         uut.s0.sync_role = '%s %s TRG:DX=%s' % ('master', self.freq.data(), 'd'+str(trg_dx))
-
 
         if self.hw_filter.length > 0:
             nacc = int(self.hw_filter.data())
@@ -310,8 +308,6 @@ class ACQ435ST(MDSplus.Device):
             uut.s1.set_knob('nacc', '%s,%s'%(nacc_samp, nacc,))
         else :
             uut.s1.set_knob('nacc', '0,0')
-
-
 #
 #  Read the coeffients and offsets
 #  for each channel

--- a/pydevices/HtsDevices/acq435st.py
+++ b/pydevices/HtsDevices/acq435st.py
@@ -245,14 +245,14 @@ class ACQ435ST(MDSplus.Device):
                             toread -= nbytes
 
                     except socket.timeout as e:
-                        # print("We have Got a timeout.")
+                        print("We have Got a timeout.")
                         err = e.args[0]
                         # this next if/else is a bit redundant, but illustrates how the
                         # timeout exception is setup
 
                         if err == 'timed out':
                             time.sleep(1)
-                            # print (' received timed out, retry later')
+                            print (' received timed out, retry later')
                             continue
                         else:
                             print (e)

--- a/pydevices/HtsDevices/acq435st.py
+++ b/pydevices/HtsDevices/acq435st.py
@@ -75,7 +75,7 @@ class ACQ435ST(MDSplus.Device):
         {'path':':TRIG_STR','type':'text', 'options':('nowrite_shot',),'valueExpr':"EXT_FUNCTION(None,'ctime',head.TRIG_TIME)"},
         {'path':':RUNNING','type':'any', 'options':('no_write_model',)},
         {'path':':LOG_OUTPUT','type':'text', 'options':('no_write_model','write_once','write_shot')},
-        {'path': ':GIVEUP_TIME', 'type': 'numeric', 'value': 180.0, 'options': ('no_write_shot',)},
+        {'path':':GIVEUP_TIME', 'type': 'numeric', 'value': 180.0, 'options': ('no_write_shot',)},
         {'path':':INIT_ACTION','type':'action',
          'valueExpr':"Action(Dispatch('CAMAC_SERVER','INIT',50,None),Method(None,'INIT',head,'auto'))",
          'options':('no_write_shot',)},
@@ -284,20 +284,6 @@ class ACQ435ST(MDSplus.Device):
         uut = acq400_hapi.Acq400(self.node.data(), monitor=False)
         uut.s0.set_knob('set_abort', '1')
 
-        # if self.ext_clock.length > 0:
-        #     uut.s0.set_knob('SYS_CLK_FPMUX', 'FPCLK')
-        #     uut.s0.set_knob('SIG_CLK_MB_FIN', '1000000')
-        # else:
-        #     uut.s0.set_knob('SYS_CLK_FPMUX', 'ZCLK')
-        # freq = int(self.freq.data())
-        # uut.s1.set_knob('ACQ43X_SAMPLE_RATE', "%d"%freq)
-
-        # if self.trig_mode.data() == 'hard':
-        #     uut.s1.set_knob('trg', '1,0,1')
-        # else:
-        #     uut.s1.set_knob('trg', '1,1,1')
-
-        rig_types=[ 'hard', 'soft', 'automatic']
         trg = self.trig_mode.data()
 
         if trg == 'hard':
@@ -307,12 +293,13 @@ class ACQ435ST(MDSplus.Device):
         elif trg == 'soft':
             trg_dx = 1
 
-        role = 'master'
-        if self.trig_mode.data() == 'role_default':
-            uut.s0.sync_role = "%s %s" % (role, self.freq.data())
-        else:
-            # If the user has specified a trigger.
-            uut.s0.sync_role = '%s %s TRG:DX=%s' % (role, self.freq.data(), 'd'+str(trg_dx))
+        # USAGE sync_role {fpmaster|rpmaster|master|slave|solo} [CLKHZ] [FIN]
+        # modifiers [CLK|TRG:SENSE=falling|rising] [CLK|TRG:DX=d0|d1]
+        # modifiers [TRG=int|ext]
+        # modifiers [CLKDIV=div]
+
+        # If the user has specified a trigger.
+        uut.s0.sync_role = '%s %s TRG:DX=%s' % ('master', self.freq.data(), 'd'+str(trg_dx))
 
 
         if self.hw_filter.length > 0:


### PR DESCRIPTION
We have replaced the calls to set the sample rate and the trigger with a new function: sync_role().

        # USAGE sync_role {fpmaster|rpmaster|master|slave|solo} [CLKHZ] [FIN]
        # modifiers [CLK|TRG:SENSE=falling|rising] [CLK|TRG:DX=d0|d1]
        # modifiers [TRG=int|ext]
        # modifiers [CLKDIV=div]  
