### PR TITLE
Fix: Improve HW filtering (this also fixes a bad merge)

### DIFF
--- a/pydevices/HtsDevices/acq435st.py
+++ b/pydevices/HtsDevices/acq435st.py
@@ -147,7 +147,7 @@ class ACQ435ST(MDSplus.Device):
 
             trig = self.dev.trigger.data()
             
-            # Retrive the actual value of NACC (samples) set in the ACQ box
+            # Retrive the actual value of NACC (samples) already set in the ACQ box
             nacc_str   = uut.s1.get_knob('nacc')
             if nacc_str == '0,0,0':
                 nacc_sample = 1
@@ -158,7 +158,7 @@ class ACQ435ST(MDSplus.Device):
             if self.dev.debug:
                 print("The ACQ NACC sample value was set to {}".format(nacc_sample))
 
-            # nacc_sample values are always between 1 and 32, set in the ACQ box by the INIT() function , therefore:
+            # nacc_sample values are always between 1 and 32, set in the ACQ box by the device INIT() function, therefore:
             dt = 1./self.dev.freq.data() * nacc_sample
 
             decimator = lcma(self.decim)
@@ -315,7 +315,7 @@ class ACQ435ST(MDSplus.Device):
         if 1 <= nacc_samp <= 32:
             uut.s1.nacc = ('%d'%nacc_samp).strip()
         else:
-            print("WARNING: Hardware Filter samples must be in the range [1,32]. It is now set it to 1 --> No Hardware decimation")
+            print("WARNING: Hardware Filter samples must be in the range [0,32]. 0 => Disabled == 1")
             uut.s1.nacc = '1'
 #
 #  Read the coeffients and offsets

--- a/pydevices/HtsDevices/acq435st.py
+++ b/pydevices/HtsDevices/acq435st.py
@@ -158,7 +158,7 @@ class ACQ435ST(MDSplus.Device):
             if self.dev.debug:
                 print("The ACQ NACC sample value was set to {}".format(nacc_sample))
 
-            # nacc_sample values are always between 1 and 16 (ie 2^0 to 2^4, see nacc in INIT), set in the ACQ box by the INIT() function , therefore:
+            # nacc_sample values are always between 1 and 32, set in the ACQ box by the INIT() function , therefore:
             dt = 1./self.dev.freq.data() * nacc_sample
 
             decimator = lcma(self.decim)

--- a/pydevices/HtsDevices/acq435st.py
+++ b/pydevices/HtsDevices/acq435st.py
@@ -310,15 +310,13 @@ class ACQ435ST(MDSplus.Device):
         if self.debug:
             print("Hardware Filter (NACC) from tree node is {}".format(int(self.hw_filter.data())))
 
-        nacc = int(self.hw_filter.data())
-        if 0 <= nacc <= 4:
-            nacc_samp = 2**nacc
-            nacc=('%d'%nacc).strip()
-            nacc_samp = ('%d'%nacc_samp).strip()
-            uut.s1.set_knob('nacc', '%s,%s'%(nacc_samp, nacc,))
+        # Hardware Filter: Accumulate/Decimate filter. Accumulate nacc_samp samples, then output one value.
+        nacc_samp = int(self.hw_filter.data())
+        if 1 <= nacc_samp <= 32:
+            uut.s1.nacc = ('%d'%nacc_samp).strip()
         else:
-            print("WARNING: Hardware Filter must be in the range [0,4]. Set it to 0.")
-            uut.s1.set_knob('nacc', '1,0')
+            print("WARNING: Hardware Filter samples must be in the range [1,32]. It is now set it to 1 --> No Hardware decimation")
+            uut.s1.nacc = '1'
 #
 #  Read the coeffients and offsets
 #  for each channel


### PR DESCRIPTION
Just a small changes to the HW filtering algorithm. Also, this PR will fix a bad merge/build of the version of the acq435st.py that is currently in "Release:  alpha_release_7.111.1"

1- there a check has been added to be sure that if the acq435 returns a HW filter = 0, that this is set to 1 instead, which. means: no hardware decimation.
2- the bad merge code that was in the INIT() is now the correct one, where the HW_filter is set.
3- The hardware filter tree node  now is not a power of 2. Instead it is the actual hardware sample decimation. It is in the range of [1,32] where 1 (and 0) means "decimation disabled")
4- We read the value set in the INIT() function directly from the box when using it in the MDSworker.
