### PR TITLE
Build: add a rhel8 (centos8)

### DIFF
--- a/deploy/os/rhel8.opts
+++ b/deploy/os/rhel8.opts
@@ -1,0 +1,1 @@
+--platform=redhat --valgrind=memcheck,helgrind --sanitize=address,undefined,thread --dockerimage=mdsplus/builder:rhel8 --distname=el8


### PR DESCRIPTION
Once the PR for the Docker Builder for RHEL8 is approved and build/pushed 
(I am a little fuzzy on this)
This can be built as a platform.

It fails one test not finding the a12(4?)__part_name.fun function.

Presumably something has to be done to add this platform to jenkins.