### PR TITLE
Build: there are no globus 32bit RHEL8 rpms

### DIFF
--- a/deploy/platform/redhat/redhat_docker_build.sh
+++ b/deploy/platform/redhat/redhat_docker_build.sh
@@ -30,7 +30,12 @@ do_createrepo() {
 srcdir=$(readlink -e $(dirname ${0})/../..)
 
 test64="64 x86_64-linux bin64 lib64 --with-gsi=/usr:gcc64"
-test32="32 i686-linux   bin32 lib32 --with-gsi=/usr:gcc32 --with-valgrind-lib=/usr/lib64/valgrind"
+if [ $OS = rhel8 ]; then
+  test32="32 i686-linux   bin32 lib32 --with-valgrind-lib=/usr/lib64/valgrind"
+else
+  test32="32 i686-linux   bin32 lib32 --with-gsi=/usr:gcc32 --with-valgrind-lib=/usr/lib64/valgrind"
+fi
+
 makelist(){
     rpm2cpio $1 | \
         cpio --list --quiet | \


### PR DESCRIPTION
Remove the -with-gsi 32 bit tests for RHEL8 since there are no
32 bit globus RPMS