### PR TITLE
Acq400s minimum sample rate requirement

### DIFF
--- a/pydevices/HtsDevices/acq2106_423st.py
+++ b/pydevices/HtsDevices/acq2106_423st.py
@@ -258,13 +258,14 @@ class _ACQ2106_423ST(MDSplus.Device):
         except:
             pass
         for card in range(self.sites):
-            coeffs =  map(float, slots[card].AI_CAL_ESLO.split(" ")[3:] )
+            coeffs  =  map(float, slots[card].AI_CAL_ESLO.split(" ")[3:] )
             offsets =  map(float, uut.s1.AI_CAL_EOFF.split(" ")[3:] )
             for i in range(32):
                 coeff = self.__getattr__('input_%3.3d_coefficient'%(card*32+i+1))
                 coeff.record = coeffs[i]
                 offset = self.__getattr__('input_%3.3d_offset'%(card*32+i+1))
                 offset.record = offsets[i]
+                
         if self.trig_mode.data() == 'hard':
             uut.s1.set_knob('trg', '1,0,1')
         else:

--- a/pydevices/HtsDevices/acq2106_423st.py
+++ b/pydevices/HtsDevices/acq2106_423st.py
@@ -245,7 +245,12 @@ class _ACQ2106_423ST(MDSplus.Device):
             uut.s0.set_knob('SIG_CLK_MB_FIN', '1000000')
         else:
             uut.s0.set_knob('SYS_CLK_FPMUX', 'ZCLK')
+        
         freq = int(self.freq.data())
+        #D-Tacq Recommendation: the minimum sample rate is 10kHz.
+        if  freq < 10000:
+            raise ValueError("The sample rate frequency should be greater or equal than 10kHz")
+
         uut.s0.set_knob('sync_role', 'master %d TRG:DX=d0' % freq)
 
         try:

--- a/pydevices/HtsDevices/acq2106_423st.py
+++ b/pydevices/HtsDevices/acq2106_423st.py
@@ -238,6 +238,8 @@ class _ACQ2106_423ST(MDSplus.Device):
 
     def init(self):
         import acq400_hapi
+        MIN_FREQUENCY = 10000
+
         uut = acq400_hapi.Acq400(self.node.data(), monitor=False)
         uut.s0.set_knob('set_abort', '1')
         if self.ext_clock.length > 0:
@@ -248,8 +250,8 @@ class _ACQ2106_423ST(MDSplus.Device):
         
         freq = int(self.freq.data())
         #D-Tacq Recommendation: the minimum sample rate is 10kHz.
-        if  freq < 10000:
-            raise ValueError("The sample rate frequency should be greater or equal than 10kHz")
+        if  freq < MIN_FREQUENCY:
+            raise MDSplus.DevBAD_PARAMETER("Sample rate should be greater or equal than 10kHz")
 
         uut.s0.set_knob('sync_role', 'master %d TRG:DX=d0' % freq)
 

--- a/pydevices/HtsDevices/acq2106_435st.py
+++ b/pydevices/HtsDevices/acq2106_435st.py
@@ -286,6 +286,10 @@ class _ACQ2106_435ST(MDSplus.Device):
         if self.ext_clock.length > 0:
             raise Exception('External Clock is not supported')
 
+        #D-Tacq Recommendation: the minimum sample rate is 10kHz.
+        if  self.freq.data() < 10000:
+            raise ValueError("The minimum sample rate should be greater or equal to 10kHz")
+
         trg = self.trig_mode.data()
 
         if trg == 'hard':

--- a/pydevices/HtsDevices/acq2106_435st.py
+++ b/pydevices/HtsDevices/acq2106_435st.py
@@ -270,6 +270,8 @@ class _ACQ2106_435ST(MDSplus.Device):
 
     def init(self):
         import acq400_hapi
+        MIN_FREQUENCY = 10000
+
         uut = acq400_hapi.Acq400(self.node.data(), monitor=False)
         uut.s0.set_knob('set_abort', '1')
 
@@ -286,9 +288,10 @@ class _ACQ2106_435ST(MDSplus.Device):
         if self.ext_clock.length > 0:
             raise Exception('External Clock is not supported')
 
+        freq = int(self.freq.data())
         #D-Tacq Recommendation: the minimum sample rate is 10kHz.
-        if  self.freq.data() < 10000:
-            raise ValueError("The sample rate frequency should be greater or equal than 10kHz")
+        if  freq < MIN_FREQUENCY:
+            raise MDSplus.DevBAD_PARAMETER("Sample rate should be greater or equal than 10kHz")
 
         trg = self.trig_mode.data()
 

--- a/pydevices/HtsDevices/acq2106_435st.py
+++ b/pydevices/HtsDevices/acq2106_435st.py
@@ -288,7 +288,7 @@ class _ACQ2106_435ST(MDSplus.Device):
 
         #D-Tacq Recommendation: the minimum sample rate is 10kHz.
         if  self.freq.data() < 10000:
-            raise ValueError("The minimum sample rate should be greater or equal to 10kHz")
+            raise ValueError("The sample rate frequency should be greater or equal than 10kHz")
 
         trg = self.trig_mode.data()
 


### PR DESCRIPTION
A simple error check has been added to both 423ELF and 435ELF. The minimum recommended value from D-Tacq to execute this devices is 10KHz.

From email conversations with Peter Milne, from D-Tacq:

"For lower rate output, the ACQ435 logic does include a simple
accumulate and decimate filter:

http://www.d-tacq.com/resources/d-tacq-4G-acq4xx-UserGuide-r33.pdf
13.1

set.site 1 NACC 8
decimate by 8, 10kHz becomes 1.25kHz.

It's best to keep to powers of 2, then voltage scaling is preserved.
If that is too much of a restriction, ACQ42x does have a filter that preserves scaling for any value of NACC.

The NACC filter means that the ADC logic can run at acceptable speeds, but since it does reduce DMA data rate, if your plan is to run at very low rates, then it's a good idea to reduce the DMA buffer length. It's best to run with > 10 DMA buffers/second, both for responsiveness, and to avoid DMA timeouts.
To set buffer len: 4GUG#28.2.7"