### PR TITLE
Build: fixed Ubuntu18 reprepro by adding explicit export

### DIFF
--- a/deploy/platform/debian/debian_docker_build.sh
+++ b/deploy/platform/debian/debian_docker_build.sh
@@ -181,33 +181,27 @@ EOF
 
 publish() {
     ### DO NOT CLEAN /publish as it may contain valid older release packages
-    major=$(echo ${RELEASE_VERSION} | cut -d. -f1)
-    minor=$(echo ${RELEASE_VERSION} | cut -d. -f2)
-    release=$(echo ${RELEASE_VERSION} | cut -d. -f3)
     mkdir -p /publish/${BRANCH}/DEBS
     rsync -a /release/${BRANCH}/DEBS/${ARCH} /publish/${BRANCH}/DEBS/
+    LAST_RELEASE_INFO=/publish/${BRANCH}_${OS}
     if [ ! -r /publish/repo ]
     then
-        :&& rsync -a /release/repo /publish/
+	:&& rsync -a /release/repo /publish/
 	checkstatus abort "Failure: Problem copying repo into publish area." $?
     else
 	pushd /publish/repo
 	rsync -a /release/repo/conf/distributions /publish/repo/conf/
 	reprepro clearvanished
-	if [ "${BRANCH}" = "stable" ]
-	then
-	    MAIN_PACKAGE="mdsplus"
-	else
-	    MAIN_PACKAGE="mdsplus-${BRANCH}"
-	fi
-	PREVIOUS_VERSION="$(reprepro -C ${BRANCH} -A ${ARCH} list MDSplus ${MAIN_PACKAGE} | awk '{print $3}' )"
+	:&& env HOME=/sign_keys reprepro -V --keepunused -C ${BRANCH} includedeb MDSplus ../${BRANCH}/DEBS/${ARCH}/*${RELEASE_VERSION}_* \
+	 || env HOME=/sign_keys reprepro export MDSplus
+	checkstatus abort "Failure: Problem installing ${BRANCH} into debian repository." $?
+	PREVIOUS_VERSION="$(cat ${LAST_RELEASE_INFO})"
 	echo "PREVIOUS_VERSION=${PREVIOUS_VERSION}"
-	:&& env HOME=/sign_keys reprepro -V --keepunused -C ${BRANCH} includedeb MDSplus ../${BRANCH}/DEBS/${ARCH}/*${major}\.${minor}\.${release}_*
-       	checkstatus abort "Failure: Problem installing debian into publish repository." $?
-	if [ ! -z "$PREVIOUS_VERSION" ]
+	if [ ! -z $PREVIOUS_VERSION ]
 	then
-	    :&& env HOME=/sign_keys reprepro -V --keepunused -C ${BRANCH} includedeb MDSplus-previous ../${BRANCH}/DEBS/${ARCH}/*${PREVIOUS_VERSION}_*
-       	    checkstatus abort "Failure: Problem installing debian into publish repository." $?
+	    :&& env HOME=/sign_keys reprepro -V --keepunused -C ${BRANCH} includedeb MDSplus-previous ../${BRANCH}/DEBS/${ARCH}/*${PREVIOUS_VERSION}_* \
+         || env HOME=/sign_keys reprepro export MDSplus-previous
+	    checkstatus abort "Failure: Problem installing previous ${BRANCH} into debian repository." $?
 	fi
 	popd
     fi


### PR DESCRIPTION
should fix the reprepro issue on ubuntu18 .. newer version refuse to export implicitly and return a non-zero errorcode.. causing publish to fail.

copied from alpha -  where it seems to work

@joshStillerman : if you could merge this before the next build.. otherwise the ubuntu18 repo needs manual fix again.