### PR TITLE
Build: remove dependencies on /usr/bin/python

### DIFF
--- a/deploy/packaging/linux-rhel8.xml
+++ b/deploy/packaging/linux-rhel8.xml
@@ -1,0 +1,1018 @@
+<?xml version="1.0"?>
+<!--
+     Copyright (c) 2017, Massachusetts Institute of Technology All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+Redistributions of source code must retain the above copyright notice, this
+list of conditions and the following disclaimer.
+
+Redistributions in binary form must reproduce the above copyright notice, this
+list of conditions and the following disclaimer in the documentation and/or
+other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+-->
+<deploy>
+ <packages>
+  <package name="MDSplus" arch="bin" summary="MDSplus Data Acquisition System" description="MDSplus Data Acquisition System">
+    <requires package="kernel"/>
+    <requires package="java"/>
+    <requires package="python"/>
+    <requires package="motif"/>
+  </package>
+
+  <package name="java" arch="noarch" summary="Java Applications" description="Java applications and classes">
+    <requires package="java_bin"/>
+    <requires package="kernel"/>
+    <requires package="java" external="True"/>
+    <include dir="/usr/local/mdsplus/java"/>
+    <include dir="/usr/local/mdsplus/desktop/java"/>
+    <exclude file="/usr/local/mdsplus/java/classes/jDevices.jar"/>
+    <include file="/usr/local/mdsplus/pixmaps/jscope.png"/>
+    <include file="/usr/local/mdsplus/pixmaps/jtraverser.png"/>
+    <include file="/usr/local/mdsplus/pixmaps/jtraverser2.png"/>
+
+    <!-- rpm scripts -->
+    <post>
+if [ -d /usr/share/applications/mdsplus ]
+then
+  ln -sf $RPM_INSTALL_PREFIX/mdsplus/desktop/java /usr/share/applications/mdsplus/
+fi
+    </post>
+    <postun>
+
+if [ "$1" == "0" ]
+then
+   rm -f /usr/share/applications/mdsplus/java 2&gt;&amp;1
+fi
+    </postun>
+    <!-- end rpm scripts -->
+
+    <!-- deb scripts -->
+    <postinst>
+if [ -d /usr/share/applications/mdsplus ]
+then
+  ln -sf /usr/local/mdsplus/desktop/java /usr/share/applications/mdsplus/
+fi
+    </postinst>
+    <prerm>
+rm -f /usr/share/applications/mdsplus/java 2&gt;&amp;1
+    </prerm>
+    <!-- end deb scripts -->
+
+  </package>
+
+  <package name="java_bin" arch="bin" summary="Java libraries" description="Java libraries to connect to MDSplus">
+    <include file="/usr/local/mdsplus/bin/jDispatch*"/>
+    <include file="/usr/local/mdsplus/bin/jScope"/>
+    <include file="/usr/local/mdsplus/bin/jServer"/>
+    <include file="/usr/local/mdsplus/bin/jTraverser"/>
+    <include file="/usr/local/mdsplus/lib/libJava*"/>
+
+    <!-- rpm scripts -->
+    <post>ldconfig -n /etc/ld.so.conf.d/mdsplus.conf</post>
+    <postun>
+
+if [ "$1" == "0" ]
+then
+  rm -f /usr/share/applications/mdsplus/java 2&gt;/dev/null
+  ldconfig -n /etc/ld.so.conf.d/mdsplus.conf
+fi
+
+    </postun>
+    <!-- end rpm scripts -->
+
+    <!-- deb scripts -->
+    <postinst>ldconfig -n /etc/ld.so.conf.d/mdsplus.conf</postinst>
+    <prerm>
+
+rm -f /usr/share/applications/mdsplus/java 2&gt;/dev/null
+ldconfig -n /etc/ld.so.conf.d/mdsplus.conf
+
+    </prerm>
+    <!-- end deb scripts -->
+
+  </package>
+
+  <package name="mitdevices" arch="noarch" summary="Support for MIT Data acquisition devices" description="Support for MIT Data acquisition devices">
+    <requires package="kernel"/>
+    <requires package="camac"/>
+    <requires package="python"/>
+    <requires package="motif"/>
+    <requires package="mitdevices_bin"/>
+    <include dir="/usr/local/mdsplus/tdi/MitDevices"/>
+    <include dir="/usr/local/mdsplus/pydevices/MitDevices"/>
+
+    <!-- rpm scripts -->
+    <pre>
+      $RPM_INSTALL_PREFIX/mdsplus/rpm/removePythonModule.sh MitDevices
+    </pre>
+    <post>
+
+python2 -m compileall -q $RPM_INSTALL_PREFIX/mdsplus/pydevices/MitDevices &gt;/dev/null 2&gt;&amp;1
+
+    </post>
+    <postun>
+      if [ "$1" == "0" ]
+      then
+        rm -Rf $RPM_INSTALL_PREFIX/mdsplus/pydevices/MitDevices
+      fi
+    </postun>
+    <!-- end rpm scripts -->
+
+    <!-- deb scripts -->
+    <preinst>
+      /usr/local/mdsplus/rpm/removePythonModule.sh MitDevices
+    </preinst>
+    <postinst>
+
+python2 -m compileall -q /usr/local/mdsplus/pydevices/MitDevices &gt;/dev/null 2&gt;&amp;1
+
+    </postinst>
+    <prerm>rm -Rf /usr/local/mdsplus/pydevices/MitDevices</prerm>
+    <!-- end rpm scripts -->
+
+    <!-- alpine scripts -->
+    <pre-install>
+      /mdsplus/rpm/removePythonModule.sh MitDevices
+    </pre-install>
+    <post-install>
+
+python2 -m compileall -q /mdsplus/pydevices/MitDevices &gt;/dev/null 2&gt;&amp;1
+
+    </post-install>
+    <post-deinstall> rm -Rf /mdsplus/pydevices/MitDevices</post-deinstall>
+    <!-- end alpine scripts -->
+
+  </package>
+
+  <package name="mitdevices_bin" arch="bin" summary="Libraries used for mitdevices" description="Libraries used for mitdevices">
+    <include file="/usr/local/mdsplus/bin/reboot_dtaq_satelite"/>
+    <include file="/usr/local/mdsplus/bin/dtaq_update_board.sh"/>
+    <include file="/usr/local/mdsplus/bin/MonitorCpciData*"/>
+    <include file="/usr/local/mdsplus/lib/libMit*"/>
+    <include file="/usr/local/mdsplus/lib/libMIT*"/>
+    <include file="/usr/local/mdsplus/lib/libdc1394_support*"/>
+    <include file="/usr/local/mdsplus/lib/libdc1394_support*.so"/>
+    <include file="/usr/local/mdsplus/lib/acq_root_filesystem*"/>
+    <include file="/usr/local/mdsplus/uid/A*"/>
+    <include file="/usr/local/mdsplus/uid/B*"/>
+    <include file="/usr/local/mdsplus/uid/C*"/>
+    <include file="/usr/local/mdsplus/uid/D*"/>
+    <include file="/usr/local/mdsplus/uid/E*"/>
+    <include file="/usr/local/mdsplus/uid/F*"/>
+    <include file="/usr/local/mdsplus/uid/H*"/>
+    <include file="/usr/local/mdsplus/uid/I*"/>
+    <include file="/usr/local/mdsplus/uid/J*"/>
+    <include file="/usr/local/mdsplus/uid/L*"/>
+    <include file="/usr/local/mdsplus/uid/M*"/>
+    <include file="/usr/local/mdsplus/uid/P*"/>
+    <include file="/usr/local/mdsplus/uid/R*"/>
+    <include file="/usr/local/mdsplus/uid/T*"/>
+    <include file="/usr/local/mdsplus/uid/U*"/>
+    <exclude_staticlibs/>
+    <postinst>ldconfig -n /etc/ld.so.conf.d/mdsplus.conf</postinst>
+    <prerm>ldconfig -n /etc/ld.so.conf.d/mdsplus.conf</prerm>
+  </package>
+
+  <package name="idl" arch="noarch" summary="ITT IDL extensions" description="IDL (ITT Interactive Data Language) extensions for MDSplus">
+    <requires package="kernel"/>
+    <requires package="idl_bin"/>
+    <include dir="/usr/local/mdsplus/idl"/>
+    <exclude dir="/usr/local/mdsplus/idl/camac"/>
+  </package>
+
+  <package name="idl_bin" arch="bin" summary="ITT IDL Binary Extensions" description="IDL Intereactive Data Language libraries">
+    <include file="/usr/local/mdsplus/lib/lib*Idl*"/>
+    <exclude file="/usr/local/mdsplus/lib/*Sql*"/>
+    <exclude_staticlibs/>
+    <postinst>ldconfig -n /etc/ld.so.conf.d/mdsplus.conf</postinst>
+    <prerm>ldconfig -n /etc/ld.so.conf.d/mdsplus.conf</prerm>
+  </package>
+
+  <package name="gsi" arch="noarch" summary="Globus Security Ifrastructure Support" description="Support for secure MDSplus and Fusiongrid">
+    <requires package="gsi_bin"/>
+    <requires package="kernel"/>
+    <include dir="/usr/local/mdsplus/tdi/roam"/>
+  </package>
+
+  <package name="gsi_bin" arch="bin" summary="Libraries for GSI" description="Libraries for GSI">
+    <include file="/usr/local/mdsplus/bin/roam_check_access"/>
+    <include file="/usr/local/mdsplus/bin/mdsipsd"/>
+    <include file="/usr/local/mdsplus/lib/libRoam*"/>
+    <include file="/usr/local/mdsplus/lib/libMdsIpGSI*"/>
+    <exclude_staticlibs/>
+
+    <!-- rpm scripts -->
+    <post>
+
+ldconfig -n /etc/ld.so.conf.d/mdsplus.conf
+if [ ! -r /etc/xinetd.d/mdsips ]
+then
+  cp $RPM_INSTALL_PREFIX/mdsplus/rpm/mdsipsd.xinetd /etc/xinetd.d/mdsips
+  if ( ! grep '^mdsips[[:space:]]' /etc/services &gt;/dev/null 2&gt;&amp;1)
+  then
+    echo 'mdsips 8200/tcp # MDSplus mdsip service' &gt;&gt; /etc/services
+  fi
+fi
+    </post>
+    <postun>ldconfig -n /etc/ld.so.conf.d/mdsplus.conf</postun>
+    <!-- end rpm scripts -->
+
+    <!-- deb scripts -->
+    <postinst>
+
+ldconfig -n /etc/ld.so.conf.d/mdsplus.conf
+if [ ! -r /etc/xinetd.d/mdsips ]
+then
+  cp /usr/local/mdsplus/rpm/mdsipsd.xinetd /etc/xinetd.d/mdsips
+  if ( ! grep '^mdsips[[:space:]]' /etc/services &gt;/dev/null 2&gt;&amp;1)
+  then
+    echo 'mdsips 8200/tcp # MDSplus mdsip service' &gt;&gt; /etc/services
+  fi
+fi
+    </postinst>
+    <prerm>ldconfig -n /etc/ld.so.conf.d/mdsplus.conf</prerm>
+    <!-- end deb scripts -->
+
+  </package>
+
+  <package name="labview" arch="noarch" summary="National Instruments Labview extensions" description="National Instruments Labview extensions">
+    <requires package="labview_bin"/>
+    <requires package="kernel"/>
+    <include dir="/usr/local/mdsplus/LabView"/>
+  </package>
+
+  <package name="labview_bin" arch="bin" summary="Libraries required for LabView interface" description="Libraries required for LabView interface">
+    <include file="/usr/local/mdsplus/lib/*LV*"/>
+    <exclude_staticlibs/>
+    <postinst>ldconfig -n /etc/ld.so.conf.d/mdsplus.conf</postinst>
+    <prerm>ldconfig -n /etc/ld.so.conf.d/mdsplus.conf</prerm>
+  </package>
+
+  <package name="motif" arch="noarch" summary="X-Windows Motif based applications" description="X-Windows Motif based applications such as dwscope, dwpad, traverser,actions, and actmon">
+    <requires package="motif_bin"/>
+    <requires package="kernel"/>
+    <include dir="/usr/local/mdsplus/desktop/motif"/>
+    <include file="/usr/local/mdsplus/pixmaps/actlog.png"/>
+    <include file="/usr/local/mdsplus/pixmaps/dwpad.png"/>
+    <include file="/usr/local/mdsplus/pixmaps/dwscope.png"/>
+    <include file="/usr/local/mdsplus/pixmaps/traverser.png"/>
+
+    <!-- rpm scripts -->
+    <post>
+
+if [ -d /usr/share/applications/mdsplus ]
+then
+  ln -sf $RPM_INSTALL_PREFIX/mdsplus/desktop/motif /usr/share/applications/mdsplus/
+fi
+
+    </post>
+    <postun>
+
+if [ "$1" == "0" ]
+then
+  rm -f /usr/share/applications/mdsplus/motif 2&gt;/dev/null
+fi
+
+    </postun>
+    <!-- end rpm scripts -->
+
+    <!-- deb scripts -->
+    <postinst>
+
+if [ -d /usr/share/applications/mdsplus ]
+then
+  ln -sf /usr/local/mdsplus/desktop/motif /usr/share/applications/mdsplus/
+fi
+
+    </postinst>
+    <prerm>
+rm -f /usr/share/applications/mdsplus/motif 2&gt;/dev/null
+
+    </prerm>
+    <!-- end deb scripts -->
+
+  </package>
+
+  <package name="motif_bin" arch="bin" summary="Libraries, UIDS and binary applications required for Motif APS" description="Libraries, UIDS and binary applications required for Motif APS">
+    <include file="/usr/local/mdsplus/bin/dw*"/>
+    <include file="/usr/local/mdsplus/bin/ScopePrinters"/>
+    <include file="/usr/local/mdsplus/bin/actmon"/>
+    <include file="/usr/local/mdsplus/bin/actions"/>
+    <include file="/usr/local/mdsplus/bin/traverser"/>
+    <include file="/usr/local/mdsplus/lib/libXmds*"/>
+    <include file="/usr/local/mdsplus/lib/dwscope_setup.ps"/>
+    <include dir="/usr/local/mdsplus/uid"/>
+    <exclude file="/usr/local/mdsplus/uid/A*"/>
+    <exclude file="/usr/local/mdsplus/uid/B*"/>
+    <exclude file="/usr/local/mdsplus/uid/C*"/>
+    <exclude file="/usr/local/mdsplus/uid/D*"/>
+    <exclude file="/usr/local/mdsplus/uid/E*"/>
+    <exclude file="/usr/local/mdsplus/uid/F*"/>
+    <exclude file="/usr/local/mdsplus/uid/H*"/>
+    <exclude file="/usr/local/mdsplus/uid/I*"/>
+    <exclude file="/usr/local/mdsplus/uid/J*"/>
+    <exclude file="/usr/local/mdsplus/uid/L*"/>
+    <exclude file="/usr/local/mdsplus/uid/M*"/>
+    <exclude file="/usr/local/mdsplus/uid/P*"/>
+    <exclude file="/usr/local/mdsplus/uid/R*"/>
+    <exclude file="/usr/local/mdsplus/uid/T*"/>
+    <exclude file="/usr/local/mdsplus/uid/U*"/>
+    <exclude_staticlibs/>
+
+    <!-- rpm scripts -->
+    <post>
+
+if [ ! -d $RPM_INSTALL_PREFIX/mdsplus/uid ]
+then
+  if [ -d $RPM_INSTALL_PREFIX/mdsplus/uid64 ]
+  then
+    ln -sf uid64 $RPM_INSTALL_PREFIX/mdsplus/uid
+  else
+    ln -sf uid32 $RPM_INSTALL_PREFIX/mdsplus/uid
+  fi
+fi
+ldconfig -n /etc/ld.so.conf.d/mdsplus.conf
+
+    </post>
+    <preun>
+
+if [ "$1" == "0" -a -h $RPM_INSTALL_PREFIX/mdsplus/uid ]
+then
+  rm -f $RPM_INSTALL_PREFIX/mdsplus/uid
+fi
+
+    </preun>
+    <postun>ldconfig -n /etc/ld.so.conf.d/mdsplus.conf</postun>
+    <!-- end rpm scripts -->
+
+    <!-- deb scripts -->
+    <postinst>
+
+if [ ! -d /usr/local/mdsplus/uid ]
+then
+  if [ -d /usr/local/mdsplus/uid64 ]
+  then
+    ln -sf uid64 /usr/local/mdsplus/uid
+  else
+    ln -sf uid32 /usr/local/mdsplus/uid
+  fi
+fi
+ldconfig -n /etc/ld.so.conf.d/mdsplus.conf
+
+    </postinst>
+    <prerm>
+
+if [ -h /usr/local/mdsplus/uid ]
+then
+  rm -f /usr/local/mdsplus/uid
+fi
+
+    </prerm>
+    <prerm>ldconfig -n /etc/ld.so.conf.d/mdsplus.conf</prerm>
+    <!-- end deb scripts -->
+
+  </package>
+
+  <package name="hdf5" arch="noarch" summary="MDSplus/HDF5 integration" description="MDSplus/HDF5 integration">
+    <requires package="hdf5_bin"/>
+    <requires package="kernel"/>
+    <include dir="/usr/local/mdsplus/tdi/hdf5"/>
+  </package>
+
+  <package name="hdf5_bin" arch="bin" summary="Binary libraries and applications for HDF5 integration" description="Binary libraries and applications for HDF5 integration">
+    <include file="/usr/local/mdsplus/lib/libhdf5*"/>
+    <include file="/usr/local/mdsplus/bin/hdf5ToMds"/>
+    <include file="/usr/local/mdsplus/bin/MDSplus2HDF5"/>
+    <exclude_staticlibs/>
+    <postinst>ldconfig -n /etc/ld.so.conf.d/mdsplus.conf</postinst>
+    <prerm>ldconfig -n /etc/ld.so.conf.d/mdsplus.conf</prerm>
+  </package>
+
+  <package name="devel" arch="noarch" summary="Header files for code development" description="Header files for code development">
+    <requires package="devel_bin"/>
+    <include dir="/usr/local/mdsplus/include"/>
+  </package>
+
+  <package name="devel_bin" arch="bin" summary="Static Libraries for code development" description="Static libraries for code development">
+    <include_staticlibs/>
+  </package>
+
+  <package name="camac" arch="noarch" summary="Support for CAMAC devices" description="Support for CAMAC devices">
+    <requires package="camac_bin"/>
+    <requires package="kernel"/>
+    <include dir="/usr/local/mdsplus/idl/camac"/>
+    <include dir="/usr/local/mdsplus/tdi/camac"/>
+  </package>
+
+  <package name="camac_bin" arch="bin" summary="Binary libraries for CAMAC access" description="Binary libraries for CAMAC access">
+    <include file="/usr/local/mdsplus/bin/mdsccl"/>
+    <include file="/usr/local/mdsplus/bin/mdscts"/>
+    <include file="/usr/local/mdsplus/lib/libCam*"/>
+    <include file="/usr/local/mdsplus/lib/libcts_commands*"/>
+    <include file="/usr/local/mdsplus/lib/libccl_commands*"/>
+    <include file="/usr/local/mdsplus/lib/libRemCam*"/>
+    <exclude_staticlibs/>
+    <postinst>ldconfig -n /etc/ld.so.conf.d/mdsplus.conf</postinst>
+    <prerm>ldconfig -n /etc/ld.so.conf.d/mdsplus.conf</prerm>
+  </package>
+
+  <package name="kernel" arch="noarch" summary="MDSplus core system" description="MDSplus core system">
+    <requires package="kernel_bin"/>
+    <requires external="True" package="xinetd"/>
+    <include dironly="/usr/local/mdsplus/idl"/>
+    <include file="/usr/local/mdsplus/MDSplus-License.txt"/>
+<!--    <include file="/usr/local/mdsplus/ChangeLog"/> -->
+    <include dir="/usr/local/mdsplus/etc"/>
+    <include dir="/usr/local/mdsplus/share"/>
+    <include dir="/usr/local/mdsplus/rpm"/>
+    <include dir="/usr/local/mdsplus/xml"/>
+    <include file="/usr/local/mdsplus/setup.*"/>
+    <include dir="/usr/local/mdsplus/tdi"/>
+    <include dir="/usr/local/mdsplus/trees"/>
+    <include file="/usr/local/mdsplus/desktop/mdsplus.directory"/>
+    <include file="/usr/local/mdsplus/desktop/mdsplus.menu"/>
+    <include dir="/usr/local/mdsplus/desktop/kernel"/>
+    <include file="/usr/local/mdsplus/pixmaps/mdstcl.png"/>
+    <include file="/usr/local/mdsplus/pixmaps/small_mdsplus_logo.jpg"/>
+    <include file="/usr/local/mdsplus/pixmaps/tdi.png"/>
+    <include dir="/usr/local/mdsplus/nodejs"/>
+    <exclude dir="/usr/local/mdsplus/tdi/MitDevices"/>
+    <exclude dir="/usr/local/mdsplus/pydevices"/>
+    <exclude dir="/usr/local/mdsplus/tdi/RfxDevices"/>
+    <exclude dir="/usr/local/mdsplus/tdi/KbsiDevices"/>
+    <exclude dir="/usr/local/mdsplus/tdi/camac"/>
+    <exclude dir="/usr/local/mdsplus/tdi/d3d"/>
+    <exclude dir="/usr/local/mdsplus/tdi/roam"/>
+    <exclude dir="/usr/local/mdsplus/tdi/hdf5"/>
+
+    <!-- rpm scripts -->
+    <post>
+
+if [ -d /etc/profile.d ]
+then
+  ln -sf $RPM_INSTALL_PREFIX/mdsplus/setup.sh /etc/profile.d/mdsplus.sh
+  ln -sf $RPM_INSTALL_PREFIX/mdsplus/setup.csh /etc/profile.d/mdsplus.csh
+fi
+if [ -d /etc/xdg/menus/applications-merged ]
+then
+  ln -sf $RPM_INSTALL_PREFIX/mdsplus/desktop/mdsplus.menu /etc/xdg/menus/applications-merged/
+fi
+if [ -d /usr/share/desktop-directories ]
+then
+  ln -sf $RPM_INSTALL_PREFIX/mdsplus/desktop/mdsplus.directory /usr/share/desktop-directories/
+fi
+if [ -d /usr/share/applications ]
+then
+  mkdir -p /usr/share/applications/mdsplus
+  ln -sf $RPM_INSTALL_PREFIX/mdsplus/desktop/kernel /usr/share/applications/mdsplus/
+fi
+if [ ! -r /etc/xinetd.d/mdsip ]
+then
+  cp $RPM_INSTALL_PREFIX/mdsplus/rpm/mdsipd.xinetd /etc/xinetd.d/mdsip
+  if ( ! grep '^mdsip[[:space:]]' /etc/services &gt;/dev/null 2&gt;&amp;1)
+  then
+    echo 'mdsip 8000/tcp # MDSplus mdsip service' &gt;&gt; /etc/services
+  fi
+fi
+    </post>
+    <preun>
+
+if [ "$1" == "0" ]
+then
+  rm -f /etc/profile.d/mdsplus.sh 2&gt;/dev/null
+  rm -f /etc/profile.d/mdsplus.csh 2&gt;/dev/null
+  rm -f /etc/.mdsplus_dir 2&gt;/dev/null
+  rm -f /etc/xdg/menus/applications-merged/mdsplus.menu
+  rm -f /usr/share/desktop-directories/mdsplus.directory
+  rm -Rf /usr/share/applications/mdsplus
+  if [ -r /etc/xinetd.d/mdsip ]
+  then
+    if ( diff -q /etc/xinetd.d/mdsip $RPM_INSTALL_PREFIX/mdsplus/rpm/mdsipd.xinetd &gt; /dev/null )
+    then
+      rm -f /etc/xinetd.d/mdsip
+      if [ -x /sbin/service ]
+      then
+        /sbin/service xinetd reload
+      fi
+    fi
+  fi
+  if ( grep '^mdsip[[:space::]]' /etc/services &gt;/dev/null 2&gt;&amp;1 )
+  then
+    tmpfile=$(mktemp)
+    if ( grep -v '^mdsip[[:space::]]' /etc/services &gt; $tmpfile )
+    then
+      mv /etc/services /etc/services.rpmsave
+      mv $tmpfile /etc/services
+    fi
+  fi
+fi
+
+    </preun>
+    <postun>
+
+if [ "$1" == "0" ]
+then
+  rm -Rf $RPM_INSTALL_PREFIX/mdsplus/{desktop,pixmaps}
+fi
+
+    </postun>
+    <!-- end rpm scripts -->
+
+    <!-- deb scripts -->
+    <postinst>
+
+if [ -d /etc/profile.d ]
+then
+  ln -sf /usr/local/mdsplus/setup.sh /etc/profile.d/mdsplus.sh
+  ln -sf /usr/local/mdsplus/setup.csh /etc/profile.d/mdsplus.csh
+fi
+if [ -d /etc/xdg/menus/applications-merged ]
+then
+  ln -sf /usr/local/mdsplus/desktop/mdsplus.menu /etc/xdg/menus/applications-merged/
+fi
+if [ -d /usr/share/desktop-directories ]
+then
+  ln -sf /usr/local/mdsplus/desktop/mdsplus.directory /usr/share/desktop-directories/
+fi
+if [ -d /usr/share/applications ]
+then
+  mkdir -p /usr/share/applications/mdsplus
+  ln -sf /usr/local/mdsplus/desktop/kernel /usr/share/applications/mdsplus/
+fi
+if [ ! -r /etc/xinetd.d/mdsip ]
+then
+  cp /usr/local/mdsplus/rpm/mdsipd.xinetd /etc/xinetd.d/mdsip
+  if ( ! grep '^mdsip[[:space:]]' /etc/services &gt;/dev/null 2&gt;&amp;1)
+  then
+    echo 'mdsip 8000/tcp # MDSplus mdsip service' &gt;&gt; /etc/services
+  fi
+fi
+    </postinst>
+    <prerm>
+
+rm -f /etc/profile.d/mdsplus.sh 2&gt;/dev/null
+rm -f /etc/profile.d/mdsplus.csh 2&gt;/dev/null
+rm -f /etc/.mdsplus_dir 2&gt;/dev/null
+rm -f /etc/xdg/menus/applications-merged/mdsplus.menu
+rm -f /usr/share/desktop-directories/mdsplus.directory
+rm -Rf /usr/share/applications/mdsplus
+rm -Rf /usr/local/mdsplus/{desktop,pixmaps}
+if [ -r /etc/xinetd.d/mdsip ]
+then
+  if ( diff -q /etc/xinetd.d/mdsip /usr/local/mdsplus/rpm/mdsipd.xinetd &gt; /dev/null )
+  then
+    rm -f /etc/xinetd.d/mdsip
+    if [ -x /sbin/service ]
+    then
+      /sbin/service xinetd reload
+    fi
+  fi
+fi
+if ( grep '^mdsip[[:space::]]' /etc/services &gt;/dev/null 2&gt;&amp;1 )
+then
+  tmpfile=$(mktemp)
+  if ( grep -v '^mdsip[[:space::]]' /etc/services &gt; $tmpfile )
+  then
+    mv /etc/services /etc/services.save
+    mv $tmpfile /etc/services
+  fi
+fi
+
+
+    </prerm>
+    <!-- end deb scripts -->
+
+    <!-- alpine scripts -->
+    <post-install>
+ln -sf /mdsplus /usr/local/
+ln -sf /usr/local/mdsplus/setup.sh /etc/profile.d/mdsplus.sh
+ln -sf /usr/local/mdsplus/setup.csh /etc/profile.d/mdsplus.csh
+    </post-install>
+    <pre-deinstall>
+rm -f /usr/local/mdsplus
+rm -f /etc/profile.d/mdsplus.sh
+rm -f /etc/profile.d/mdsplus.csh
+    </pre-deinstall>
+
+  </package>
+
+  <package name="kernel_bin" arch="bin" summary="MDSplus core binaries" description="MDSplus core binaries">
+    <include dir="/usr/local/mdsplus/bin"/>
+    <exclude file="/usr/local/mdsplus/bin/ScopePrinters"/>
+    <exclude file="/usr/local/mdsplus/bin/dw*"/>
+    <exclude file="/usr/local/mdsplus/bin/actmon"/>
+    <exclude file="/usr/local/mdsplus/bin/actions"/>
+    <exclude file="/usr/local/mdsplus/bin/traverser*"/>
+    <exclude file="/usr/local/mdsplus/bin/jScope"/>
+    <exclude file="/usr/local/mdsplus/bin/jServer"/>
+    <exclude file="/usr/local/mdsplus/bin/jTraverser"/>
+    <exclude file="/usr/local/mdsplus/bin/mdsccl"/>
+    <exclude file="/usr/local/mdsplus/bin/mdscts"/>
+    <exclude file="/usr/local/mdsplus/bin/reboot_dtaq_satelite"/>
+    <exclude file="/usr/local/mdsplus/bin/hdf5*"/>
+    <exclude file="/usr/local/mdsplus/bin/*HDF5"/>
+    <exclude file="/usr/local/mdsplus/bin/jDispatch*"/>
+    <exclude file="/usr/local/mdsplus/bin/dtaq_update_board.sh"/>
+    <exclude file="/usr/local/mdsplus/bin/dtaq_update_board.sh"/>
+    <exclude file="/usr/local/mdsplus/bin/roam_check_access"/>
+    <exclude file="/usr/local/mdsplus/bin/mdsipsd"/>
+    <exclude file="/usr/local/mdsplus/bin/MonitorCpciData*"/>
+    <include dir="/usr/local/mdsplus/lib"/>
+    <exclude file="/usr/local/mdsplus/lib/libXmds*"/>
+    <exclude file="/usr/local/mdsplus/lib/libJava*"/>
+    <exclude file="/usr/local/mdsplus/lib/*LV*"/>
+    <exclude file="/usr/local/mdsplus/lib/libCam*"/>
+    <exclude file="/usr/local/mdsplus/lib/libcts*"/>
+    <exclude file="/usr/local/mdsplus/lib/libccl*"/>
+    <exclude file="/usr/local/mdsplus/lib/libRemCam*"/>
+    <exclude file="/usr/local/mdsplus/lib/lib*Idl*"/>
+    <exclude file="/usr/local/mdsplus/lib/lib*Sql*"/>
+    <exclude file="/usr/local/mdsplus/lib/libMit*"/>
+    <exclude file="/usr/local/mdsplus/lib/libMIT*"/>
+    <exclude file="/usr/local/mdsplus/lib/libdc1394_support*"/>
+    <exclude file="/usr/local/mdsplus/lib/libRoam*"/>
+    <exclude file="/usr/local/mdsplus/lib/libMdsIpGSI*"/>
+    <exclude file="/usr/local/mdsplus/lib/libhdf5*"/>
+    <exclude file="/usr/local/mdsplus/lib/acq_root_filesystem*"/>
+    <exclude file="/usr/local/mdsplus/lib/dwscope_setup.ps"/>
+    <exclude_staticlibs/>
+
+    <!-- rpm scripts -->
+    <post>
+
+if [ -d /etc/ld.so.conf.d ]
+then
+  rm -f /etc/ld.so.conf.d/mdsplus.conf 2&gt;/dev/null
+  touch /etc/ld.so.conf.d/mdsplus.conf
+  for l in lib lib32 lib64
+  do
+    if [ ! -h $RPM_INSTALL_PREFIX/mdsplus/$l -a -d $RPM_INSTALL_PREFIX/mdsplus/$l ]
+    then
+      echo "$RPM_INSTALL_PREFIX/mdsplus/$l" &gt;&gt; /etc/ld.so.conf.d/mdsplus.conf
+    fi
+  done
+  ldconfig -n /etc/ld.so.conf.d/mdsplus.conf
+fi
+if [ -d $RPM_INSTALL_PREFIX/mdsplus/bin64 ]
+then
+  bits=64
+else
+  bits=32
+fi
+if [ -d $RPM_INSTALL_PREFIX/mdsplus/bin${bits} ]
+then
+  if [ ! -h $RPM_INSTALL_PREFIX/mdsplus/bin ]
+  then
+    ln -sf bin${bits} $RPM_INSTALL_PREFIX/mdsplus/bin
+  fi
+fi
+if [ -d $RPM_INSTALL_PREFIX/mdsplus/lib${bits} ]
+then
+  if [ ! -h $RPM_INSTALL_PREFIX/mdsplus/lib ]
+  then
+    ln -sf lib${bits} $RPM_INSTALL_PREFIX/mdsplus/lib
+  fi
+fi
+
+    </post>
+    <preun>
+
+if [ "$1" == "0" ]
+then
+  rm -f $RPM_INSTALL_PREFIX/mdsplus/bin
+  rm -f $RPM_INSTALL_PREFIX/mdsplus/lib
+fi
+
+    </preun>
+    <postun>
+
+if [ "$1" == "0" ]
+then
+  ldconfig -n /etc/ld.so.conf.d/mdsplus.conf
+  rm -f /etc/ld.so.conf.d/mdsplus.conf 2&gt;/dev/null
+fi
+
+    </postun>
+    <!-- end rpm scripts -->
+
+    <!-- deb scripts -->
+    <postinst>
+
+if [ -d /etc/ld.so.conf.d ]
+then
+  rm -f /etc/ld.so.conf.d/mdsplus.conf 2&gt;/dev/null
+  touch /etc/ld.so.conf.d/mdsplus.conf
+  for l in lib lib32 lib64
+  do
+    if [ ! -h /usr/local/mdsplus/$l -a -d /usr/local/mdsplus/$l ]
+    then
+      echo "/usr/local/mdsplus/$l" &gt;&gt; /etc/ld.so.conf.d/mdsplus.conf
+    fi
+  done
+  ldconfig -n /etc/ld.so.conf.d/mdsplus.conf
+fi
+if [ -d /usr/local/mdsplus/bin64 ]
+then
+  bits=64
+else
+  bits=32
+fi
+if [ -d /usr/local/mdsplus/bin${bits} ]
+then
+  if [ ! -h /usr/local/mdsplus/bin ]
+  then
+    ln -sf bin${bits} /usr/local/mdsplus/bin
+  fi
+fi
+if [ -d /usr/local/mdsplus/lib${bits} ]
+then
+  if [ ! -h /usr/local/mdsplus/lib ]
+  then
+    ln -sf lib${bits} /usr/local/mdsplus/lib
+  fi
+fi
+
+    </postinst>
+    <prerm>
+
+for d in bin lib
+do
+  if [ -h /usr/local/mdsplus/$d ]
+  then
+    rm -f /usr/local/mdsplus/$d
+  fi
+done
+ldconfig -n /etc/ld.so.conf.d/mdsplus.conf
+rm -f /etc/ld.so.conf.d/mdsplus.conf 2&gt;/dev/null
+    </prerm>
+   <!-- end deb scripts -->
+
+  </package>
+
+  <package name="mssql" arch="bin" summary="Interface to mssql databases" description="Interface to mssql databases">
+    <requires package="kernel"/>
+    <include file="/usr/local/mdsplus/lib/lib*Sql*"/>
+    <exclude_staticlibs/>
+    <postinst>ldconfig -n /etc/ld.so.conf.d/mdsplus.conf</postinst>
+    <prerm>ldconfig -n /etc/ld.so.conf.d/mdsplus.conf</prerm>
+  </package>
+
+  <package name="epics" arch="noarch" summary="MDSplus/EPICS integration" description="MDSplus/EPICS integration">
+    <requires package="kernel"/>
+    <include dir="/usr/local/mdsplus/epics"/>
+  </package>
+
+  <package name="rfxdevices" arch="noarch" summary="Support for RFX data acquisition devices" description="Support for RFX data acquisition devices">
+    <requires package="java"/>
+    <requires package="python"/>
+    <include dir="/usr/local/mdsplus/tdi/RfxDevices"/>
+    <include dir="/usr/local/mdsplus/pydevices/RfxDevices"/>
+    <include file="/usr/local/mdsplus/java/classes/jDevices.jar"/>
+
+    <!-- rpm scripts -->
+    <pre>$RPM_INSTALL_PREFIX/mdsplus/rpm/removePythonModule.sh RfxDevices</pre>
+    <post>python2 -m compileall -q $RPM_INSTALL_PREFIX/mdsplus/pydevices/RfxDevices &gt;/dev/null 2&gt;&amp;1</post>
+    <postun>
+if [ "$1" == "0" ]
+then
+  rm -Rf $RPM_INSTALL_PREFIX/mdsplus/pydevices/RfxDevices
+fi
+    </postun>
+    <!-- end rpm scripts -->
+
+    <!-- deb scripts -->
+    <preinst>/usr/local/mdsplus/rpm/removePythonModule.sh RfxDevices</preinst>
+    <postinst>python2 -m compileall -q /usr/local/mdsplus/pydevices/RfxDevices &gt;/dev/null 2&gt;&amp;1</postinst>
+    <prerm>rm -Rf /usr/local/mdsplus/pydevices/RfxDevices</prerm>
+    <!-- end deb scripts -->
+
+    <!-- alpine scripts -->
+    <pre-install>/mdsplus/rpm/removePythonModule.sh RfxDevices</pre-install>
+    <post-install>python2 -m compileall -q /mdsplus/pydevices/RfxDevices &gt;/dev/null 2&gt;&amp;1</post-install>
+    <post-deinstall> rm -Rf /mdsplus/pydevices/RfxDevices</post-deinstall>
+    <!-- end alpine scripts -->
+
+  </package>
+  <package name="w7xdevices" arch="noarch" summary="Support for W7x data acquisition devices" description="Support for W7x data acquisition devices">
+    <requires package="python"/>
+    <include dir="/usr/local/mdsplus/pydevices/W7xDevices"/>
+
+    <!-- rpm scripts -->
+    <pre>$RPM_INSTALL_PREFIX/mdsplus/rpm/removePythonModule.sh W7xDevices</pre>
+    <post>python2 -m compileall -q $RPM_INSTALL_PREFIX/mdsplus/pydevices/W7xDevices &gt;/dev/null 2&gt;&amp;1</post>
+    <postun>
+
+if [ "$1" == "0" ]
+then
+  rm -Rf $RPM_INSTALL_PREFIX/mdsplus/pydevices/W7Devices
+fi
+
+    </postun>
+    <!-- end rpm scripts -->
+
+    <!-- deb scripts -->
+    <preinst>/usr/local/mdsplus/rpm/removePythonModule.sh W7xDevices</preinst>
+    <postinst>python2 -m compileall -q /usr/local/mdsplus/pydevices/W7xDevices &gt;/dev/null 2&gt;&amp;1</postinst>
+    <prerm>rm -Rf /usr/local/mdsplus/pydevices/W7xDevices</prerm>
+    <!-- end deb scripts -->
+
+    <!-- alpine scripts -->
+    <pre-install>/mdsplus/rpm/removePythonModule.sh W7xDevices</pre-install>
+    <post-install>python2 -m compileall -q /mdsplus/pydevices/W7xDevices &gt;/dev/null 2&gt;&amp;1</post-install>
+    <post-deinstall> rm -Rf /mdsplus/pydevices/W7xDevices</post-deinstall>
+    <!-- end alpine scripts -->
+  </package>
+
+  <package name="htsdevices" arch="noarch" summary="Support for HTS data acquisition devices" description="Support for HTS data acquisition devices">
+    <requires package="python"/>
+    <include dir="/usr/local/mdsplus/pydevices/HtsDevices"/>
+    <!-- rpm scripts -->
+    <pre>$RPM_INSTALL_PREFIX/mdsplus/rpm/removePythonModule.sh HtsDevices</pre>
+    <post>python2 -m compileall -q $RPM_INSTALL_PREFIX/mdsplus/pydevices/HtsDevices &gt;/dev/null 2&gt;&amp;1</post>
+    <postun>
+
+if [ "$1" == "0" ]
+then
+  rm -Rf $RPM_INSTALL_PREFIX/mdsplus/pydevices/W7Devices
+fi
+    </postun>
+    <!-- end rpm scripts -->
+
+    <!-- deb scripts -->
+    <preinst>/usr/local/mdsplus/rpm/removePythonModule.sh HtsDevices</preinst>
+    <postinst>python2 -m compileall -q /usr/local/mdsplus/pydevices/HtsDevices &gt;/dev/null 2&gt;&amp;1</postinst>
+    <prerm>rm -Rf /usr/local/mdsplus/pydevices/HtsDevices</prerm>
+    <!-- end deb scripts -->
+
+    <!-- alpine scripts -->
+    <pre-install>/mdsplus/rpm/removePythonModule.sh HtsDevices</pre-install>
+    <post-install>python2 -m compileall -q /mdsplus/pydevices/HtsDevices &gt;/dev/null 2&gt;&amp;1</post-install>
+    <post-deinstall> rm -Rf /mdsplus/pydevices/HtsDevices</post-deinstall>
+    <!-- end alpine scripts -->
+  </package>
+
+
+  <package name="kbsidevices" arch="noarch" summary="Support for KBSI data acquisition devices" description="Support for KBSI data acquisition devices">
+    <include dir="/usr/local/mdsplus/tdi/KbsiDevices"/>
+  </package>
+
+  <package name="matlab" arch="noarch" summary="Mathworks MATLAB extensions" description="Mathworks MATLAB extensions">
+    <requires package="java"/>
+    <include dir="/usr/local/mdsplus/matlab"/>
+  </package>
+
+  <package name="python" arch="noarch" summary="Python interface to MDSplus" description="Python interface to MDSplus">
+    <requires package="kernel"/>
+    <!-- requires external="true" package="setuptools"/ -->
+    <requires external="true" package="python2"/>
+    <requires external="true" package="python2-numpy"/>
+    <include dir="/usr/local/mdsplus/python/MDSplus"/>
+    <exclude file="/usr/local/mdsplus/python/MDSplus/makedoc.sh"/>
+
+    <!-- rpm scripts -->
+    <post>
+      $RPM_INSTALL_PREFIX/mdsplus/rpm/removePythonModule.sh MDSplus
+      find $RPM_INSTALL_PREFIX/mdsplus/python -name '*egg-info' -delete
+      for py in python2 python3
+      do
+        if ( ${py} -c exit\(\) &gt;/dev/null 2&gt;&amp;1 )
+        then
+          ${py} -m compileall -q -f $RPM_INSTALL_PREFIX/mdsplus/python &gt;/dev/null 2&gt;&amp;1
+          ${py} $RPM_INSTALL_PREFIX/mdsplus/python/MDSplus/setup.py -q install &gt;/dev/null 2&gt;&amp;1
+	fi
+      done
+    </post>
+    <preun>
+      if [ "$1" == "0" ]
+      then
+        $RPM_INSTALL_PREFIX/mdsplus/rpm/removePythonModule.sh MDSplus
+        rm -Rf $RPM_INSTALL_PREFIX/mdsplus/python
+      fi
+    </preun>
+    <!-- end rpm scripts -->
+
+    <!-- deb scripts -->
+    <postinst>
+      if test ! -z $(/usr/local/mdsplus/rpm/removePythonModule.sh MDSplus y)
+      then setup_install=y
+      elif echo $PYTHONPATH|grep /usr/local/mdsplus/python>/dev/null
+      then setup_install=n
+      else read -t 10 -p "Do you wish to run setup.py install? (y/N) " setup_install
+      fi
+      find /usr/local/mdsplus/python -name '*egg-info' -delete
+
+      for py in python2 python3
+      do
+        if ( ${py} -c exit\(\) &gt;/dev/null 2&gt;&amp;1 )
+        then
+          ${py} -m compileall -q -f /usr/local/mdsplus/python &gt;/dev/null 2&gt;&amp;1
+          if test "$setup_install" = "y"
+          then
+            if ! ${py} /usr/local/mdsplus/python/MDSplus/setup.py -q install &gt;/dev/null
+            then echo "Could not 'setup.py install' MDSplus for ${py}"
+            fi
+          fi
+        fi
+      done
+    </postinst>
+    <prerm>
+      /usr/local/mdsplus/rpm/removePythonModule.sh MDSplus
+      rm -Rf /usr/local/mdsplus/python
+    </prerm>
+    <!-- end deb scripts -->
+
+    <!-- alpine scripts -->
+    <post-install>
+      python2 -m compileall -q -f /mdsplus/python &gt;/dev/null 2&gt;&amp;1
+      python2 /mdsplus/python/MDSplus/setup.py -q install
+      rm -Rf build dist MDSplus.egg-info
+    </post-install>
+    <pre-deinstall>
+      /mdsplus/rpm/removePythonModule.sh MDSplus
+      rm -Rf /mdsplus/python
+    </pre-deinstall>
+    <pre-upgrade>
+      /mdsplus/rpm/removePythonModule.sh MDSplus
+    </pre-upgrade>
+    <!-- end alpine scripts -->
+
+  </package>
+
+  <package name="d3d" arch="noarch" summary="TDI functions used at D3D experiment at General Atomics" description="TDI functions used at D3D experiment at General Atomics">
+    <include dir="/usr/local/mdsplus/tdi/d3d"/>
+  </package>
+
+  <package name="php" arch="noarch" summary="php interface to MDSplus" description="php interface to MDSplus">
+    <include dir="/usr/local/mdsplus/php"/>
+  </package>
+
+  <package name="repo" arch="noarch" summary="Yum Repository Setup for MDSplus" description="Yum Repository Setup for MDSplus">
+    <include file="/etc/yum.repos.d/mdsplus%(bname)s.repo"/>
+    <include file="/etc/pki/rpm-gpg/RPM-GPG-KEY-MDSplus"/>
+    <post>
+      rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-MDSplus &gt;/dev/null 2&gt;/dev/null || true
+    </post>
+    <postun>
+      if [ "$1" == "0" ]
+      then
+        nohup rpm -e gpg-pubkey-b09cb563 &gt;/dev/null 2&gt;&amp;1 &amp;
+      fi
+    </postun>
+  </package>
+
+ </packages>
+ <rpm>
+   <spec_start>
+
+%%define debug_package %%{nil}
+%%global _missing_build_ids_terminate_build 0
+%%global _unpackaged_files_terminate_build 0
+Name: mdsplus%(bname)s%(packagename)s
+Version: %(major)d.%(minor)d
+Release: %(release)s.%(distname)s
+License: BSD Open Source - Copyright (c) 2010, Massachusetts Institute of Technology All rights reserved.
+Source: https://github.com/MDSplus/mdsplus/archive/%(branch)s_release-%(major)d-%(minor)d-%(release)d.tar.gz
+URL: http://www.mdsplus.org
+Vendor: Massachusetts Institute of Technology
+Packager: Plasma Science and Fusion Center &lt;mdsplus@www.mdsplus.org&gt;
+Summary: %(summary)s
+Group: Applications/Archiving
+Prefix: /usr/local
+AutoReqProv: yes
+
+   </spec_start>
+ </rpm>
+ <ubuntu>
+ </ubuntu>
+ <external_packages platform="redhat">
+   <setuptools package="python2-setuptools"/>
+   <python package="python2"/>
+   <numpy/>
+   <xinetd/>
+   <java/>
+ </external_packages>
+ <external_packages platform="alpine">
+   <setuptools package="py-setuptools"/>
+   <numpy/>
+   <java/>
+ </external_packages>
+ <external_packages platform="debian">
+   <setuptools package="python-setuptools"/>
+   <numpy package="python-numpy"/>
+   <xinetd package="busybox"/>
+   <java package="java-runtime"/>
+ </external_packages>
+</deploy>

--- a/deploy/platform/redhat/redhat_build_rpms.py
+++ b/deploy/platform/redhat/redhat_build_rpms.py
@@ -1,4 +1,4 @@
-#!/bin/env python
+#!/bin/env python2
 #
 # Copyright (c) 2017, Massachusetts Institute of Technology All rights reserved.
 #
@@ -70,6 +70,7 @@ def doRequire(info, out, root, require):
     if 'external' in require.attrib:
         pkg=externalPackage(info,root,require.attrib['package'])
         if pkg is not None:
+            print('***************** REQUIRES ***********',pkg,'*******************')
             doWrite(out,"Requires: %s\n" % pkg)
     else:
         info['reqpkg']=require.attrib['package']
@@ -86,7 +87,11 @@ def buildRpms():
     info['buildroot']=os.environ['BUILDROOT']
     info['bname']=os.environ['BNAME']
     info['platform']=os.environ['PLATFORM']
-    tree=ET.parse(srcdir+'/deploy/packaging/linux.xml')
+    print('******** DISTNAME is *************', info['distname'])
+    if info['distname'] != 'el8':
+      tree=ET.parse(srcdir+'/deploy/packaging/linux.xml')
+    else:
+      tree=ET.parse(srcdir+'/deploy/packaging/linux-rhel8.xml')
     root=tree.getroot()
     rpmspec=root.find('rpm').find('spec_start').text
     s=rpmspec.split('\n')
@@ -104,7 +109,6 @@ def buildRpms():
         else:
             bin_packages.append(package)
     architectures = [{"target":"x86_64-linux","bits":64,"arch_t":".x86_64"}]
-    print('******************** the DISTNAME is ', os.environ['DISTNAME'], '***********************')
     if os.environ['DISTNAME'] != 'el8':
         architectures.append({"target":"i686-linux","bits":32,"arch_t":".i686"})
       

--- a/mdstcpip/mdsip-client-http
+++ b/mdstcpip/mdsip-client-http
@@ -1,4 +1,4 @@
-#!/usr/bin/python -u
+#!/usr/bin/env python -u
 import struct
 import os
 import sys

--- a/mdstcpip/mdsip-server-http
+++ b/mdstcpip/mdsip-server-http
@@ -1,4 +1,4 @@
-#!/usr/bin/python -u
+#!/usr/bin/env python -u
 from socket import socket,SHUT_RDWR
 import struct
 import os

--- a/pydevices/MitDevices/acq200.py
+++ b/pydevices/MitDevices/acq200.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # Copyright (c) 2017, Massachusetts Institute of Technology All rights reserved.
 #

--- a/pydevices/MitDevices/dt100.py
+++ b/pydevices/MitDevices/dt100.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # Copyright (c) 2017, Massachusetts Institute of Technology All rights reserved.
 #

--- a/python/MDSplus/tests/_UnitTest.py
+++ b/python/MDSplus/tests/_UnitTest.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Copyright (c) 2017, Massachusetts Institute of Technology All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/python/MDSplus/tests/connectionUnitTest.py
+++ b/python/MDSplus/tests/connectionUnitTest.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Copyright (c) 2017, Massachusetts Institute of Technology All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/python/MDSplus/tests/dataUnitTest.py
+++ b/python/MDSplus/tests/dataUnitTest.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Copyright (c) 2017, Massachusetts Institute of Technology All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/python/MDSplus/tests/dclUnitTest.py
+++ b/python/MDSplus/tests/dclUnitTest.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Copyright (c) 2017, Massachusetts Institute of Technology All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/python/MDSplus/tests/devicesUnitTest.py
+++ b/python/MDSplus/tests/devicesUnitTest.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Copyright (c) 2017, Massachusetts Institute of Technology All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/python/MDSplus/tests/exceptionUnitTest.py
+++ b/python/MDSplus/tests/exceptionUnitTest.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Copyright (c) 2017, Massachusetts Institute of Technology All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/python/MDSplus/tests/segmentsUnitTest.py
+++ b/python/MDSplus/tests/segmentsUnitTest.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Copyright (c) 2017, Massachusetts Institute of Technology All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/python/MDSplus/tests/taskUnitTest.py
+++ b/python/MDSplus/tests/taskUnitTest.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Copyright (c) 2017, Massachusetts Institute of Technology All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/python/MDSplus/tests/threadsUnitTest.py
+++ b/python/MDSplus/tests/threadsUnitTest.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Copyright (c) 2017, Massachusetts Institute of Technology All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/python/MDSplus/tests/treeUnitTest.py
+++ b/python/MDSplus/tests/treeUnitTest.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Copyright (c) 2017, Massachusetts Institute of Technology All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/scripts/MonitorCpciData.py
+++ b/scripts/MonitorCpciData.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # Copyright (c) 2017, Massachusetts Institute of Technology All rights reserved.
 #


### PR DESCRIPTION
RPM seems to search the code and decide we need /usr/bin/python which
does not exist on rhel8