### PR TITLE
Feature: Add choices of master and slave to the sync_role call for acq2106_423st.py

### DIFF
--- a/pydevices/HtsDevices/acq2106_423st.py
+++ b/pydevices/HtsDevices/acq2106_423st.py
@@ -255,7 +255,7 @@ class _ACQ2106_423ST(MDSplus.Device):
         role = mode.split(":")[0]
         trg  = mode.split(":")[1]
 
-        print("Role is {} and Trigger is {}".format(role, trg))
+        print("Role is {} and {} trigger".format(role, trg))
 
         if trg == 'hard':
             trg_dx = 'd0'
@@ -274,6 +274,11 @@ class _ACQ2106_423ST(MDSplus.Device):
         uut.fetch_all_calibration()
         coeffs = uut.cal_eslo[1:]
         eoff = uut.cal_eoff[1:]
+
+        self.chans = []
+        nchans = uut.nchan()
+        for ii in range(nchans):
+            self.chans.append(getattr(self, 'INPUT_%3.3d'%(ii+1)))
 
         for ic, ch in enumerate(self.chans):
             if ch.on:

--- a/pydevices/HtsDevices/acq2106_423st.py
+++ b/pydevices/HtsDevices/acq2106_423st.py
@@ -270,7 +270,7 @@ class _ACQ2106_423ST(MDSplus.Device):
         # modifiers [CLKDIV=div]  
         uut.s0.sync_role = '%s %s TRG:DX=%s' % (role, self.freq.data(), trg_dx)
         
-        #Fetching all calibration information from every channel. Save it in INPUT_XXX:CAL_INPUT
+        #Fetching all calibration information from every channel.
         uut.fetch_all_calibration()
         coeffs = uut.cal_eslo[1:]
         eoff = uut.cal_eoff[1:]


### PR DESCRIPTION
The following are the changes to acq2106_423st.py:

1- Without changing the structure of the tree nodes, now the TRIG_NODE now accept the strings: "master" or "slave" in the following way:

{'path':':TRIG_MODE',   'type':'text',    'value': 'master:hard', 'options':('no_write_shot',)},

i.e. 

role:trig_mode

I'm wondering if this is a good idea or not. In this way we don't need to add another node, called for example, ROLE.

2- Getting and setting of the calibration variables are now done using the call to: 

uut.fetch_all_calibration()

So there is no need to loop through the cards to set the coefficients.
