### PR TITLE
Fix: Allow thick to open from OLD servers

### DIFF
--- a/treeshr/RemoteAccess.c
+++ b/treeshr/RemoteAccess.c
@@ -1584,7 +1584,7 @@ inline static int io_open_one_remote(char *host,char *filepath,char* treename,in
 
 extern char* MaskReplace(char*,char*,int);
 #include <ctype.h>
-extern int MDS_IO_OPEN_ONE(char* filepath_in,char* treename_in,int shot, tree_type_t type, int new, int edit, char**filespec, int*speclen, int *idx){
+EXPORT int MDS_IO_OPEN_ONE(char* filepath_in,char* treename_in,int shot, tree_type_t type, int new, int edit, char**filespec, int*speclen, int *idx){
   int status;
   INIT_AND_FREE_ON_EXIT(char*,fullpath);
   status = TreeSUCCESS;

--- a/treeshr/RemoteAccess.c
+++ b/treeshr/RemoteAccess.c
@@ -1584,7 +1584,7 @@ inline static int io_open_one_remote(char *host,char *filepath,char* treename,in
 
 extern char* MaskReplace(char*,char*,int);
 #include <ctype.h>
-EXPORT int MDS_IO_OPEN_ONE(char* filepath_in,char* treename_in,int shot, tree_type_t type, int new, int edit, char**filespec, int*speclen, int *idx){
+extern int MDS_IO_OPEN_ONE(char* filepath_in,char* treename_in,int shot, tree_type_t type, int new, int edit, char**filespec, int*speclen, int *idx){
   int status;
   INIT_AND_FREE_ON_EXIT(char*,fullpath);
   status = TreeSUCCESS;
@@ -1622,7 +1622,8 @@ EXPORT int MDS_IO_OPEN_ONE(char* filepath_in,char* treename_in,int shot, tree_ty
 	fullpath = NULL;
 	status = io_open_one_remote(hostpart, filepart, treename, shot, type, new, edit, &fullpath, &conid, &fd, &enhanced);
 	if (fd < 0) {
-	  status = TreeSUCCESS;
+	  if (status != TreeUNSUPTHICKOP)
+	    status = TreeSUCCESS;
 	  conid = -1;
 	  enhanced = 0;
 	}

--- a/treeshr/TreeOpen.c
+++ b/treeshr/TreeOpen.c
@@ -795,37 +795,27 @@ EXPORT char *MaskReplace(char *path_in, char *tree, int shot)
       break;
     case 'n':
       fname = GetFname(tree, shot);
+      const size_t fname_len = strlen(fname);
       if ((strlen(tilde + 2) > 1) || ((strlen(tilde + 2) == 1) && (tilde[2] != '\\'))) {
 	tmp = strcpy(malloc(strlen(tilde + 2) + 1), tilde + 2);
-	tmp2 = strcpy(malloc(strlen(path) + 1 + strlen(fname)), path);
-	strcpy(tmp2 + (tilde - path) + strlen(fname), tmp);
+	tmp2 = strcpy(malloc(strlen(path) + 1 + fname_len), path);
+	strcpy(tmp2 + (tilde - path) + fname_len, tmp);
 	free(tmp);
-#pragma GCC diagnostic push
-#if defined __GNUC__ && 800 <= __GNUC__ * 100 + __GNUC_MINOR__
-    _Pragma ("GCC diagnostic ignored \"-Wstringop-overflow\"")
-    _Pragma ("GCC diagnostic ignored \"-Wstringop-truncation\"")
-#endif
-	strncpy(tmp2 + (tilde - path), fname, strlen(fname));
-#pragma GCC diagnostic pop
+	memcpy(tmp2 + (tilde - path), fname, fname_len);
       } else {
-	tmp2 = strcpy(malloc(strlen(path) + 1 + strlen(fname)), path);
-	strcpy(tmp2 + (tilde - path), fname);
+	tmp2 = strcpy(malloc(strlen(path) + 1 + fname_len), path);
+	memcpy(tmp2 + (tilde - path), fname, fname_len+1);
       }
       free(path);
       path = tmp2;
       break;
     case 't':
       tmp = strcpy(malloc(strlen(tilde + 2) + 1), tilde + 2);
-      tmp2 = strcpy(malloc(strlen(path) + 1 + strlen(tree)), path);
-      strcpy(tmp2 + (tilde - path) + strlen(tree), tmp);
+      const size_t tree_len = strlen(tree);
+      tmp2 = strcpy(malloc(strlen(path) + 1 + tree_len), path);
+      strcpy(tmp2 + (tilde - path) + tree_len, tmp);
       free(tmp);
-#pragma GCC diagnostic push
-#if defined __GNUC__ && 800 <= __GNUC__ * 100 + __GNUC_MINOR__
-    _Pragma ("GCC diagnostic ignored \"-Wstringop-overflow\"")
-    _Pragma ("GCC diagnostic ignored \"-Wstringop-truncation\"")
-#endif
-      strncpy(tmp2 + (tilde - path), tree, strlen(tree));
-#pragma GCC diagnostic pop
+      memcpy(tmp2 + (tilde - path), tree, tree_len);
       free(path);
       path = tmp2;
       break;

--- a/treeshr/treeshrp.h
+++ b/treeshr/treeshrp.h
@@ -808,7 +808,7 @@ extern int MDS_IO_FD(int fd);
 typedef int mode_t;
 #endif
 #endif
-extern int MDS_IO_OPEN(char *filename, int options, mode_t mode);
+EXPORT int MDS_IO_OPEN(char *filename, int options, mode_t mode);
 extern int MDS_IO_CLOSE(int fd);
 extern off_t MDS_IO_LSEEK(int fd, off_t offset, int whence);
 extern ssize_t MDS_IO_WRITE(int fd, void *buff, size_t count);


### PR DESCRIPTION
The current alpha can open trees served by very old servers via
thick client.  In particular ones served by mdsplus built from:
```
4352e8d4978c4d2f375b2d0094078295e826bbbb
```
This ports alpha's routines involved in this in TreeOpen and
RemoteAccess into stable.

Note:  once the tree is opened, not all operations work. This is
true for the current alpha also.
```
$mdstcl

TCL> set tree test
TCL> dir
Error message was: %TDI-E-UNKNOWN_VAR, Unknown/undefined variable name
mdsdcl: --> failed on line 'dir'

Total of 0 nodes.
```