### PR TITLE
Fix: move acq2106_435 from python 2 to python3

### DIFF
--- a/pydevices/HtsDevices/acq2106_435st.py
+++ b/pydevices/HtsDevices/acq2106_435st.py
@@ -321,8 +321,8 @@ class _ACQ2106_435ST(MDSplus.Device):
                 print("WARNING: Hardware Filter samples must be in the range [0,32]. 0 => Disabled == 1")
                 self.slots[card].nacc = '1'
 
-            coeffs  =  map(float, self.slots[card].AI_CAL_ESLO.split(" ")[3:] )
-            offsets =  map(float, uut.s1.AI_CAL_EOFF.split(" ")[3:] )
+            coeffs  =  list(map(float, self.slots[card].AI_CAL_ESLO.split(" ")[3:] ))
+            offsets =  list(map(float, uut.s1.AI_CAL_EOFF.split(" ")[3:] ))
             for i in range(32):
                 coeff = self.__getattr__('input_%3.3d_coefficient'%(card*32+i+1))
                 coeff.record = coeffs[i]


### PR DESCRIPTION
The current version of acq400_hapi from d-tacq is not python2
compatible.  Switching DAQ processes from python2 to python3
causes the error:
```
map object is not subscriptable
```
This is because the map is a generator.  The fix is to wrap the
2 map s in the code in list()