### PR TITLE
Feature: Add to 435st device the master/slave choices to trigger mode, and calibration coefficients are fetched from each UUT channel.

### DIFF
--- a/pydevices/HtsDevices/acq2106_435st.py
+++ b/pydevices/HtsDevices/acq2106_435st.py
@@ -296,6 +296,9 @@ class _ACQ2106_435ST(MDSplus.Device):
         if mode == 'hard':
             role = 'master'
             trg  = 'hard'
+        elif mode == 'soft':
+            role = 'master'
+            trg  = 'hard'
         else: 
             role = mode.split(":")[0]
             trg  = mode.split(":")[1]

--- a/pydevices/HtsDevices/acq2106_435st.py
+++ b/pydevices/HtsDevices/acq2106_435st.py
@@ -61,7 +61,7 @@ class _ACQ2106_435ST(MDSplus.Device):
         {'path':':SITE','type':'numeric', 'value': 1, 'options':('no_write_shot',)},
         {'path':':COMMENT','type':'text', 'options':('no_write_shot',)},
         {'path':':TRIGGER','type':'numeric', 'value': 0.0, 'options':('no_write_shot',)},
-        {'path':':TRIG_MODE','type':'text', 'value': 'hard', 'options':('no_write_shot',)},
+        {'path':':TRIG_MODE','type':'text', 'value': 'master:hard', 'options':('no_write_shot',)},
         {'path':':EXT_CLOCK','type':'axis', 'options':('no_write_shot',)},
         {'path':':FREQ','type':'numeric', 'value': 16000, 'options':('no_write_shot',)},
         {'path':':HW_FILTER','type':'numeric', 'value':0, 'options':('no_write_shot',)},
@@ -298,7 +298,7 @@ class _ACQ2106_435ST(MDSplus.Device):
             trg  = 'hard'
         elif mode == 'soft':
             role = 'master'
-            trg  = 'hard'
+            trg  = 'soft'
         else: 
             role = mode.split(":")[0]
             trg  = mode.split(":")[1]

--- a/pydevices/HtsDevices/acq2106_435st.py
+++ b/pydevices/HtsDevices/acq2106_435st.py
@@ -293,8 +293,12 @@ class _ACQ2106_435ST(MDSplus.Device):
             raise MDSplus.DevBAD_PARAMETER("Sample rate should be greater or equal than 10kHz")
 
         mode = self.trig_mode.data()
-        role = mode.split(":")[0]
-        trg  = mode.split(":")[1]
+        if mode == 'hard':
+            role = 'master'
+            trg  = 'hard'
+        else: 
+            role = mode.split(":")[0]
+            trg  = mode.split(":")[1]
 
         print("Role is {} and {} trigger".format(role, trg))
 


### PR DESCRIPTION
The following are the two changes to the 435st device code:

1- a backward compatible changes to the trigger mode, to account for the choices of master or slave, plus hard or soft triggers.
2- Each channel calibration coefficients are read directly by asking the UUT API: i.e. uut.fetch_all_calibration()
