### PR TITLE
Fix: Add statement so that the value of the tree node for trigger mode is back compatible.

### DIFF
--- a/pydevices/HtsDevices/acq2106_423st.py
+++ b/pydevices/HtsDevices/acq2106_423st.py
@@ -251,8 +251,12 @@ class _ACQ2106_423ST(MDSplus.Device):
             raise MDSplus.DevBAD_PARAMETER(" Sample rate should be greater or equal than 10kHz")
 
         mode = self.trig_mode.data()
-        role = mode.split(":")[0]
-        trg  = mode.split(":")[1]
+        if mode == 'hard':
+            role = 'master'
+            trg  = 'hard'
+        else: 
+            role = mode.split(":")[0]
+            trg  = mode.split(":")[1]
 
         print("Role is {} and {} trigger".format(role, trg))
 

--- a/pydevices/HtsDevices/acq2106_423st.py
+++ b/pydevices/HtsDevices/acq2106_423st.py
@@ -254,6 +254,9 @@ class _ACQ2106_423ST(MDSplus.Device):
         if mode == 'hard':
             role = 'master'
             trg  = 'hard'
+        elif mode == 'soft':
+            role = 'master'
+            trg  = 'hard'
         else: 
             role = mode.split(":")[0]
             trg  = mode.split(":")[1]

--- a/pydevices/HtsDevices/acq2106_423st.py
+++ b/pydevices/HtsDevices/acq2106_423st.py
@@ -256,7 +256,7 @@ class _ACQ2106_423ST(MDSplus.Device):
             trg  = 'hard'
         elif mode == 'soft':
             role = 'master'
-            trg  = 'hard'
+            trg  = 'soft'
         else: 
             role = mode.split(":")[0]
             trg  = mode.split(":")[1]


### PR DESCRIPTION
Added some statement so that if the tree node containing the trigger mode is set to "hard" then, the code uses "master"/"hard". If it's "soft" then "master/"soft" is used.
Otherwise, it will be any combination allowed by "sync_role()", for example, master:hard, slave:hard, etc.