### PR TITLE
Fix: Remove bug from super().__init__() in DeviceWorker class

### DIFF
--- a/pydevices/HtsDevices/acq2106_423st.py
+++ b/pydevices/HtsDevices/acq2106_423st.py
@@ -165,7 +165,7 @@ class _ACQ2106_423ST(MDSplus.Device):
             running = False
 
             def __init__(self,mds):
-                super(_ACQ2106_423ST.DeviceWorker, self).__init__()
+                super(_ACQ2106_423ST.MDSWorker.DeviceWorker, self).__init__()
                 self.debug = mds.dev.debug
                 self.node_addr = mds.dev.node.data()
                 self.seg_length = mds.dev.seg_length.data()

--- a/pydevices/HtsDevices/acq2106_435st.py
+++ b/pydevices/HtsDevices/acq2106_435st.py
@@ -197,7 +197,7 @@ class _ACQ2106_435ST(MDSplus.Device):
             running = False
 
             def __init__(self,mds):
-                super(_ACQ2106_435ST.DeviceWorker, self).__init__()
+                super(_ACQ2106_435ST.MDSWorker.DeviceWorker, self).__init__()
                 self.debug = mds.dev.debug
                 self.node_addr = mds.dev.node.data()
                 self.seg_length = mds.dev.seg_length.data()


### PR DESCRIPTION
The code in the DeviceWorker class had a missing class name in the call to:

super(_ACQ2106_423ST.MDSWorker.DeviceWorker, self).__init__()

i.e. 'MDSWorker' was missing in that call.