### PR TITLE
Fix: TREE proper AutoClosable and mode it enum

### DIFF
--- a/java/jtraverser2/src/main/java/mds/devices/Device.java
+++ b/java/jtraverser2/src/main/java/mds/devices/Device.java
@@ -26,9 +26,8 @@ public class Device implements Interface
 	public static void showDeviceSetup(String experiment, int shot, String path) throws Exception
 	{
 		final MdsIp mds = new MdsIp();
-		try (final TREE tree = new TREE(mds, experiment, shot))
+		try (final TREE tree = new TREE(mds, experiment, shot, TREE.NORMAL))
 		{
-			tree.open(TREE.NORMAL);
 			final Nid nid = tree.getNode(path);
 			final JDialog dialog = showDialog(null, nid, !tree.is_readonly());
 			if (dialog != null)

--- a/java/jtraverser2/src/main/java/mds/devices/acq4xx/ACQ1001.java
+++ b/java/jtraverser2/src/main/java/mds/devices/acq4xx/ACQ1001.java
@@ -23,7 +23,6 @@ public class ACQ1001 extends Device
 		final Mds mds = new MdsIp();
 		try (final TREE tree = new TREE(mds, "test", 1, TREE.NEW))
 		{
-			tree.open();
 			final Nid dev = tree.getTop().addConglom("DEVICE", "ACQ2106_ACQ480x4");
 			new ACQ1001(null, dev, true, ACQ480.class).showDialog();
 		}

--- a/java/jtraverser2/src/main/java/mds/jtraverser/MdsView.java
+++ b/java/jtraverser2/src/main/java/mds/jtraverser/MdsView.java
@@ -253,7 +253,7 @@ public class MdsView extends JTabbedPane implements TransferEventListener
 		}
 	}
 
-	public final void openTree(final String expt, int shot, final int mode)
+	public final void openTree(final String expt, int shot, final TREE.MODE mode)
 	{
 		// first we need to check if the tree is already open
 		if (shot == 0)

--- a/java/jtraverser2/src/main/java/mds/jtraverser/TreeManager.java
+++ b/java/jtraverser2/src/main/java/mds/jtraverser/TreeManager.java
@@ -1271,7 +1271,7 @@ public class TreeManager extends JPanel
 		return this.addMds(mds);
 	}
 
-	public final void openTree(final String expt, final int shot, final int mode)
+	public final void openTree(final String expt, final int shot, final TREE.MODE mode)
 	{
 		this.opentree_dialog.setFields(expt, shot);
 		final MdsView mdsview = this.getCurrentMdsView();

--- a/java/jtraverser2/src/main/java/mds/jtraverser/TreeView.java
+++ b/java/jtraverser2/src/main/java/mds/jtraverser/TreeView.java
@@ -142,28 +142,28 @@ public final class TreeView extends JTree implements TreeSelectionListener, Data
 	private String lastName;
 	private DefaultMutableTreeNode top;
 
-	public TreeView(final Mds mds, final String expt, final int shot, final int mode) throws MdsException
+	public TreeView(final Mds mds, final String expt, final int shot, final TREE.MODE mode) throws MdsException
 	{
-		this(new TREE(mds, expt, shot, mode));
+		this(new TREE(mds, expt, shot), mode);
 	}
 
-	public TreeView(final MdsView mdsview, final String expt, final int shot, final int mode) throws MdsException
+	public TreeView(final MdsView mdsview, final String expt, final int shot, final TREE.MODE mode) throws MdsException
 	{
 		this(mdsview.getMds(), expt, shot, mode);
 		this.addMouseListener(mdsview.treeman.getContextMenu());
 	}
 
-	public TreeView(final TREE tree) throws MdsException
+	public TreeView(final TREE tree, TREE.MODE mode) throws MdsException
 	{
 		super();
 		this.tree = tree;
 		try
 		{
-			this.tree.open();
+			this.tree.open(mode);
 		}
 		catch (final MdsException me)
 		{
-			if (tree.getMode() != TREE.EDITABLE || me.getStatus() != MdsException.TreeFOPENW)
+			if (mode != TREE.EDITABLE || me.getStatus() != MdsException.TreeFOPENW)
 				throw me;
 			final int n = JOptionPane.showConfirmDialog(JOptionPane.getRootFrame(), //
 					String.format("Tree %s cannot be opened in edit mode. Create new instead?", tree.expt), //
@@ -488,7 +488,7 @@ public final class TreeView extends JTree implements TreeSelectionListener, Data
 	public final Mds getMds()
 	{ return this.tree.getMds(); }
 
-	public final int getMode()
+	public final TREE.MODE getMode()
 	{ return this.tree.getMode(); }
 
 	public final int getShot()

--- a/java/jtraverser2/src/main/java/mds/jtraverser/dialogs/OpenTreeDialog.java
+++ b/java/jtraverser2/src/main/java/mds/jtraverser/dialogs/OpenTreeDialog.java
@@ -249,7 +249,7 @@ public class OpenTreeDialog extends JDialog
 				return;
 			}
 		this.setVisible(false);
-		final int mode;
+		final TREE.MODE mode;
 		if (this.edit.isSelected())
 			mode = TREE.EDITABLE;
 		else if (this.readonly.isSelected())

--- a/java/jtraverser2/src/main/java/mds/jtraverser/jTraverserFacade.java
+++ b/java/jtraverser2/src/main/java/mds/jtraverser/jTraverserFacade.java
@@ -58,7 +58,7 @@ public final class jTraverserFacade extends JFrame
 	{
 		JOptionPane.setRootFrame(this);
 		this.setTitle("jTraverser - no tree open");
-		int mode = TREE.READONLY;
+		TREE.MODE mode = TREE.READONLY;
 		if (access != null && !access.isEmpty())
 		{
 			access = access.toLowerCase();

--- a/java/jtraverser2/src/main/java/mds/jtraverser/tools/DecompileTree.java
+++ b/java/jtraverser2/src/main/java/mds/jtraverser/tools/DecompileTree.java
@@ -74,10 +74,11 @@ public class DecompileTree
 	public final int decompile(final String provider, final String expt, final int shot, final String filename,
 			final boolean isFull) throws MdsException
 	{
-		final TREE subtree = new TREE(new MdsIp(provider), expt, shot);
-		subtree.open();
-		final int result = this.decompile(subtree, filename, isFull);
-		subtree.close();
+		final int result;
+		try(final TREE subtree = new TREE(new MdsIp(provider), expt, shot, TREE.READONLY))
+		{
+			result = this.decompile(subtree, filename, isFull);
+		}
 		return result;
 	}
 

--- a/java/mdsplus-api/src/main/java/mds/data/TREE.java
+++ b/java/mdsplus-api/src/main/java/mds/data/TREE.java
@@ -18,6 +18,10 @@ import mds.mdsip.MdsIp;
 
 public final class TREE implements ContextEventListener, CTX, AutoCloseable
 {
+	public enum MODE
+	{
+		CLOSED, READONLY, NORMAL, EDITABLE, NEW;
+	}
 	public final static class NodeInfo
 	{
 		public static final String members = "IF_ERROR(GETNCI(GETNCI(_n,'MEMBER_NIDS'),'NID_NUMBER'),[])";
@@ -180,10 +184,11 @@ public final class TREE implements ContextEventListener, CTX, AutoCloseable
 		}
 	}
 
-	public static final int EDITABLE = 2;
-	public static final int NEW = 3;
-	public static final int NORMAL = 1;
-	public static final int READONLY = 0;
+	public static final MODE EDITABLE = MODE.EDITABLE;
+	public static final MODE NEW = MODE.NEW;
+	public static final MODE NORMAL = MODE.NORMAL;
+	public static final MODE READONLY = MODE.READONLY;
+	public static final MODE CLOSED = MODE.CLOSED;
 	private static TREE active = null;
 	public static final String NCI_BROTHER = "BROTHER";
 	public static final String NCI_CHILD = "CHILD";
@@ -257,17 +262,12 @@ public final class TREE implements ContextEventListener, CTX, AutoCloseable
 	private final Mds mds;
 	public final String expt;
 	public final String exptlist;
-	private int mode;
+	private MODE mode;
 	public final MdsApi api;
 	public boolean opened = false;
 	private boolean ready;
 
-	public TREE(final Mds mds, final String expt, final int shot)
-	{
-		this(mds, expt, shot, TREE.READONLY);
-	}
-
-	public TREE(final Mds mds, final String expt, int shot, final int mode)
+	public TREE(final Mds mds, final String expt, int shot)
 	{
 		this.mds = mds;
 		this.ready = mds.isReady() == null;
@@ -282,8 +282,18 @@ public final class TREE implements ContextEventListener, CTX, AutoCloseable
 		catch (final MdsException e)
 		{/**/}
 		this.shot = shot;
-		this.mode = mode;
+		this.mode = TREE.CLOSED;
 		this.def_nid = this.getTop();
+	}
+
+	public TREE(final Mds mds, final String expt, int shot, final MODE mode) throws MdsException
+	{
+		this(mds, expt, shot);
+		if (mode != CLOSED)
+		{
+			this.mode = mode;
+			this._open();
+		}
 	}
 
 	private final Descriptor<?> _getNci(final int nid, final String name) throws MdsException
@@ -300,18 +310,18 @@ public final class TREE implements ContextEventListener, CTX, AutoCloseable
 		final int status;
 		switch (this.mode)
 		{
-		case TREE.NEW:
-			this.mode = TREE.EDITABLE;
+		case NEW:
+			this.mode = EDITABLE;
 			status = this.api.treeOpenNew(this.ctx, this.expt, this.shot);
 			break;
-		case TREE.EDITABLE:
+		case EDITABLE:
 			status = this.api.treeOpenEdit(this.ctx, this.expt, this.shot);
 			break;
 		default:
-			this.mode = TREE.READONLY;
+			this.mode = READONLY;
 			//$FALL-THROUGH$
-		case TREE.READONLY:
-		case TREE.NORMAL:
+		case READONLY:
+		case NORMAL:
 			status = this.api.treeOpen(this.ctx, this.exptlist, this.shot, this.is_readonly());
 		}
 		MdsException.handleStatus(status);
@@ -592,7 +602,7 @@ public final class TREE implements ContextEventListener, CTX, AutoCloseable
 	public final Mds getMds()
 	{ return this.mds; }
 
-	public final int getMode()
+	public final MODE getMode()
 	{ return this.mode; }
 
 	public final Descriptor<?> getNci(final int nid, final String name) throws MdsException
@@ -1036,7 +1046,7 @@ public final class TREE implements ContextEventListener, CTX, AutoCloseable
 		return this.setActive()._open();
 	}
 
-	public final TREE open(final int in_mode) throws MdsException
+	public final TREE open(final MODE in_mode) throws MdsException
 	{
 		this.mode = in_mode;
 		return this.open();

--- a/java/mdsplus-api/src/test/java/mds/data/TREE_Test.java
+++ b/java/mdsplus-api/src/test/java/mds/data/TREE_Test.java
@@ -111,7 +111,6 @@ public class TREE_Test
 	{
 		try (TREE tree = new TREE(TREE_Test.mds, TREE_Test.expt, TREE_Test.shot, TREE.NEW))
 		{
-			tree.open();
 			tree.setVersioning(false, true);
 			System.out.println(tree.api.tdiExecute(tree, "TCL('SHOW VERSIONS')"));
 			// TODO: test verisoning ala


### PR DESCRIPTION
constructor may fail if mode is not CLOSED which is typical for AutoClosable
no extra this.open() required if mode other than CLOSED is provided to Constructor
providing no Mode or mode CLOSED will not open TREE in constructor.. useful if only passed as reference e.g. in jtraverser2