### PR TITLE
Fix: Add unique ID to event name in MdsEventTest

### DIFF
--- a/java/mdsobjects/src/test/java/MDSplus/MdsEventTest.java
+++ b/java/mdsobjects/src/test/java/MDSplus/MdsEventTest.java
@@ -1,6 +1,7 @@
 package MDSplus;
 
 import org.junit.*;
+import java.util.Random;
 
 public class MdsEventTest
 {
@@ -20,6 +21,18 @@ public class MdsEventTest
 	}
 
 	static boolean eventReceived = false;
+	
+	private static java.lang.String getRandomID(int length) throws Exception
+	{
+		java.lang.String chars = new java.lang.String("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789");
+		java.lang.StringBuilder builder = new java.lang.StringBuilder();
+		Random rnd = new Random();
+		while (builder.length() < length) {
+			int index = (int)(rnd.nextFloat() * chars.length());
+			builder.append(chars.charAt(index));
+		}
+		return builder.toString();
+	}
 
 	@BeforeClass
 	public static void setUpBeforeClass() throws Exception
@@ -40,21 +53,23 @@ public class MdsEventTest
 	@Test
 	public void testData() throws Exception
 	{
-		final EventReceiver eventRec = new EventReceiver("TEST_EVENT");
+		final java.lang.String eventName = new java.lang.String("TEST_EVENT_") + getRandomID(8);
+		
+		final EventReceiver eventRec = new EventReceiver(eventName);
 		eventReceived = false;
-		MDSplus.Event.setEvent("TEST_EVENT");
+		MDSplus.Event.setEvent(eventName);
 		Thread.sleep(1000);
 		Assert.assertEquals("Event not received", eventReceived, true);
 		final byte[] rawMsg = "raw message".getBytes();
 		eventReceived = false;
-		MDSplus.Event.setEventRaw("TEST_EVENT", rawMsg);
+		MDSplus.Event.setEventRaw(eventName, rawMsg);
 		Thread.sleep(1000);
 		Assert.assertEquals("Raw Event not received", eventReceived, true);
 		final java.lang.String rawStr = new java.lang.String(eventRec.getRaw());
 		Assert.assertEquals("raw message", rawStr);
 		final MDSplus.Data dataMsg = new MDSplus.String("data message");
 		eventReceived = false;
-		MDSplus.Event.setEvent("TEST_EVENT", dataMsg);
+		MDSplus.Event.setEvent(eventName, dataMsg);
 		Thread.sleep(1000);
 		Assert.assertEquals("Data Event not received", eventReceived, true);
 		Assert.assertEquals("data message", eventRec.getData().getString());


### PR DESCRIPTION
We believe that, when run on an machine with multiple executors, that these tests are leaking and causing each other to fail.
This adds a unique identifier to each event name, hoping to prevent that.