### PR TITLE
Feature: New ACQ2106 WRTD device

### DIFF
--- a/deploy/packaging/debian/htsdevices.noarch
+++ b/deploy/packaging/debian/htsdevices.noarch
@@ -1,6 +1,7 @@
 ./usr/local/mdsplus/pydevices/HtsDevices/_version.py
 ./usr/local/mdsplus/pydevices/HtsDevices/acq2106_423st.py
 ./usr/local/mdsplus/pydevices/HtsDevices/acq2106_435st.py
+./usr/local/mdsplus/pydevices/HtsDevices/acq2106_WRPG.py
 ./usr/local/mdsplus/pydevices/HtsDevices/cryocon18i.py
 ./usr/local/mdsplus/pydevices/HtsDevices/cryocon24c.py
 ./usr/local/mdsplus/pydevices/HtsDevices/influxhistorian.py

--- a/deploy/packaging/debian/htsdevices.noarch
+++ b/deploy/packaging/debian/htsdevices.noarch
@@ -1,7 +1,7 @@
 ./usr/local/mdsplus/pydevices/HtsDevices/_version.py
 ./usr/local/mdsplus/pydevices/HtsDevices/acq2106_423st.py
 ./usr/local/mdsplus/pydevices/HtsDevices/acq2106_435st.py
-./usr/local/mdsplus/pydevices/HtsDevices/acq2106_WRPG.py
+./usr/local/mdsplus/pydevices/HtsDevices/acq2106_WRTD.py
 ./usr/local/mdsplus/pydevices/HtsDevices/cryocon18i.py
 ./usr/local/mdsplus/pydevices/HtsDevices/cryocon24c.py
 ./usr/local/mdsplus/pydevices/HtsDevices/influxhistorian.py

--- a/deploy/packaging/redhat/htsdevices.noarch
+++ b/deploy/packaging/redhat/htsdevices.noarch
@@ -2,7 +2,7 @@
 ./usr/local/mdsplus/pydevices/HtsDevices/_version.py
 ./usr/local/mdsplus/pydevices/HtsDevices/acq2106_423st.py
 ./usr/local/mdsplus/pydevices/HtsDevices/acq2106_435st.py
-./usr/local/mdsplus/pydevices/HtsDevices/acq2106_WRPG.py
+./usr/local/mdsplus/pydevices/HtsDevices/acq2106_WRTD.py
 ./usr/local/mdsplus/pydevices/HtsDevices/cryocon18i.py
 ./usr/local/mdsplus/pydevices/HtsDevices/cryocon24c.py
 ./usr/local/mdsplus/pydevices/HtsDevices/influxhistorian.py

--- a/deploy/packaging/redhat/htsdevices.noarch
+++ b/deploy/packaging/redhat/htsdevices.noarch
@@ -2,6 +2,7 @@
 ./usr/local/mdsplus/pydevices/HtsDevices/_version.py
 ./usr/local/mdsplus/pydevices/HtsDevices/acq2106_423st.py
 ./usr/local/mdsplus/pydevices/HtsDevices/acq2106_435st.py
+./usr/local/mdsplus/pydevices/HtsDevices/acq2106_WRPG.py
 ./usr/local/mdsplus/pydevices/HtsDevices/cryocon18i.py
 ./usr/local/mdsplus/pydevices/HtsDevices/cryocon24c.py
 ./usr/local/mdsplus/pydevices/HtsDevices/influxhistorian.py

--- a/pydevices/HtsDevices/acq2106_WRTD.py
+++ b/pydevices/HtsDevices/acq2106_WRTD.py
@@ -47,7 +47,7 @@ class ACQ2106_WRTD(MDSplus.Device):
         # If DIO-PG is present:
         {'path':':DIO_SITE',    'type':'numeric', 'value': 0.,       'options':('write_shot',)},
         # A DIO-PG source can be one of [d0...d5, TRGIN, WRTT]
-        {'path':':DIO_TRIG_SRC','type':'text',    'value': 'dx', 'options':('write_shot',)},
+        {'path':':PG_TRIG_SRC','type':'text',    'value': 'dx', 'options':('write_shot',)},
         
         {'path':':WR_INIT',     'type':'text',   'options':('write_shot',)},
             # ns per tick. (tick size in ns). uut.cC.WRTD_TICKNS: For SR=20MHz. It's the Si5326 tick at 20MHz ..
@@ -145,7 +145,7 @@ class ACQ2106_WRTD(MDSplus.Device):
 
         if not message.strip():
             # Set WRTD_ID: message to be transmitted from this device if FTTRG or HDMI is used to trigger.
-            print("WRTD_ID={} will be used. Waiting for external trigger ({})...".format(str(self.wr_init_wrtd_id.data()), str(self.trig_src.data())))
+            print("WRTD_ID={} will be used. Waiting for external trigger ({})...".format(str(self.wr_init_wrtd_id_glb.data()), str(self.trig_src.data())))
             uut.cC.WRTD_ID = str(self.wr_init_wrtd_id_glb.data())
             # Set trigger input on (FTTRG or HDMI)
             uut.s0.WR_TRG    = 1

--- a/pydevices/HtsDevices/acq2106_WRTD.py
+++ b/pydevices/HtsDevices/acq2106_WRTD.py
@@ -89,6 +89,9 @@ class ACQ2106_WRTD(MDSplus.Device):
         print("WRTD_ID {}".format(str(self.wr_init_wrtd_id.data())))
         uut.cC.WRTD_ID = str(self.wr_init_wrtd_id.data())
 
+        # Sets WR "safe time for broadcasts" the message
+        uut.cC.WRTD_DELTA_NS=self.wr_init_wrtd_dns.data()
+
         # Receiver:
         # Turn on RX
         uut.cC.WRTD_RX = int(self.wr_init_wrtd_rx.data())

--- a/pydevices/HtsDevices/acq2106_WRTD.py
+++ b/pydevices/HtsDevices/acq2106_WRTD.py
@@ -75,15 +75,6 @@ class ACQ2106_WRTD(MDSplus.Device):
         import acq400_hapi
         uut = acq400_hapi.Acq2106(self.node.data(), has_wr=True)
 
-        # WR TRIGGER SOURCE:
-        print("WR TRG Source {}".format(str(self.trig_src.data())))
-        uut.s0.WR_TRG_DX = str(self.trig_src.data())
-
-        # Global WR settings:
-        # Set WRTD_ID: message to be transmitted from this device if FTTRG or HDMI triggered.
-        print("WRTD_ID {}".format(str(self.wr_init_wrtd_id.data())))
-        uut.s11.WRTD_ID = str(self.wr_init_wrtd_id.data())
-
         # Sets WR "safe time for broadcasts" the message, i.e. WRTT_TAI = TAI_TIME_NOW + WRTD_DELTA_NS
         uut.s11.WRTD_DELTA_NS = self.wr_init_wrtd_dns.data()
 
@@ -128,8 +119,10 @@ class ACQ2106_WRTD(MDSplus.Device):
             self.running.on = False
 
         if not message.strip():
-            # Set trigger input:
-            print('Trigger has no message. Setting external trigger source. Waiting for trigger...')
+            # Set WRTD_ID: message to be transmitted from this device if FTTRG or HDMI is used to trigger.
+            print("WRTD_ID {} will be used. Waiting for trigger...".format(str(self.wr_init_wrtd_id.data())))
+            uut.s11.WRTD_ID = str(self.wr_init_wrtd_id.data())
+            # Set trigger input (FTTRG or HDMI)
             uut.s0.WR_TRG_DX = str(self.trig_src.data())
         else:
             # send immediate WRTD message

--- a/pydevices/HtsDevices/acq2106_WRTD.py
+++ b/pydevices/HtsDevices/acq2106_WRTD.py
@@ -46,17 +46,17 @@ class ACQ2106_WRTD(MDSplus.Device):
         {'path':':TRIG_TIME',   'type':'numeric', 'value': 0.,       'options':('write_shot',)},
         {'path':':T0',          'type':'numeric', 'value': 0.,       'options':('write_shot',)},
         {'path':':WR_INIT',     'type':'text',   'options':('write_shot',)},
-            # ns per tick. (tick size in ns). uut.11.WRTD_TICKNS: For SR=20MHz. It's the Si5326 tick at 20MHz ..
+            # ns per tick. (tick size in ns). uut.s11.WRTD_TICKNS: For SR=20MHz. It's the Si5326 tick at 20MHz ..
             {'path':':WR_INIT:WRTD_TICKNS', 'type':'numeric', 'value': 50, 'options':('write_shot',)}, 
-            # 50msec - our "safe time for broadcast". From uut.11.WRTD_DELTA_NS
+            # 50msec - our "safe time for broadcast". From uut.s11.WRTD_DELTA_NS
             {'path':':WR_INIT:WRTD_DNS',    'type':'numeric', 'value': 50000000, 'options':('write_shot',)}, 
-            # uut.11.WRTD_VERBOSE: use for debugging - eg logread -f or nc localhost 4280
+            # uut.s11.WRTD_VERBOSE: use for debugging - eg logread -f or nc localhost 4280
             {'path':':WR_INIT:WRTD_VBOSE',  'type':'numeric', 'value': 2, 'options':('write_shot',)},        
-            # uut.11.WRTD_RX_MATCHES: match any of these triggers to initiate WRTT0
+            # uut.s11.WRTD_RX_MATCHES: match any of these triggers to initiate WRTT0
             {'path':':WR_INIT:WRTD_RX_M',   'type':'text', 'value': "acq2106_999", 'options':('write_shot',)},
-            # uut.11.WRTD_RX_MATCHES1: match any of these triggers to initiate WRTT1
+            # uut.s11.WRTD_RX_MATCHES1: match any of these triggers to initiate WRTT1
             {'path':':WR_INIT:WRTD_RX_M1',  'type':'text', 'value': "acq2106_999", 'options':('write_shot',)},
-            # From uut.11.WRTD_DELAY01: WRTD_RX_DOUBLETAP: match any of these triggers to initiate a
+            # From uut.s11.WRTD_DELAY01: WRTD_RX_DOUBLETAP: match any of these triggers to initiate a
             # “Double Tap, which is:
             # 1. WRTT0
             # 2. Delay WRTD_DELAY01 nsec.
@@ -83,30 +83,30 @@ class ACQ2106_WRTD(MDSplus.Device):
         # Global WR settings:
         # Set WRTD_ID: message to be transmitted from this device if FTTRG or HDMI triggered.
         print("WRTD_ID {}".format(str(self.wr_init_wrtd_id.data())))
-        uut.11.WRTD_ID = str(self.wr_init_wrtd_id.data())
+        uut.s11.WRTD_ID = str(self.wr_init_wrtd_id.data())
 
         # Sets WR "safe time for broadcasts" the message, i.e. WRTT_TAI = TAI_TIME_NOW + WRTD_DELTA_NS
-        uut.11.WRTD_DELTA_NS = self.wr_init_wrtd_dns.data()
+        uut.s11.WRTD_DELTA_NS = self.wr_init_wrtd_dns.data()
 
         # Receiver:
         # Turn on RX
-        uut.11.WRTD_RX = int(self.wr_init_wrtd_rx.data())
+        uut.s11.WRTD_RX = int(self.wr_init_wrtd_rx.data())
         # Define RX matches
         matches  = str(self.wr_init_wrtd_rx_m.data())
         matches1 = str(self.wr_init_wrtd_rx_m1.data())
         print("Messages are {} and {}".format(matches, matches1))
 
-        uut.11.WRTD_RX_MATCHES  = matches
-        uut.11.WRTD_RX_MATCHES1 = matches1
+        uut.s11.WRTD_RX_MATCHES  = matches
+        uut.s11.WRTD_RX_MATCHES1 = matches1
         
         #Commit the changes for WRTD RX
-        uut.11.wrtd_commit_rx = 1
+        uut.s11.wrtd_commit_rx = 1
 
         # Transmiter:
         # Turn on TX
-        uut.11.WRTD_TX = int(self.wr_init_wrtd_tx.data())
+        uut.s11.WRTD_TX = int(self.wr_init_wrtd_tx.data())
         #Commit the changes for WRTD TX
-        uut.11.wrtd_commit_tx = 1
+        uut.s11.wrtd_commit_tx = 1
 
     INIT=init
 
@@ -118,10 +118,10 @@ class ACQ2106_WRTD(MDSplus.Device):
         
         self.TRIG_MSG.record = message
 
-        if message in uut.11.WRTD_RX_MATCHES:
+        if message in uut.s11.WRTD_RX_MATCHES:
             # To be sure that the EVENT bus is set to TRG
             uut.s0.SIG_EVENT_SRC_0 = 'TRG'
-        elif message in uut.11.WRTD_RX_MATCHES1:
+        elif message in uut.s11.WRTD_RX_MATCHES1:
             # To be sure that the EVENT bus is set to TRG
             uut.s0.SIG_EVENT_SRC_1 = 'TRG'      
         else:
@@ -137,7 +137,7 @@ class ACQ2106_WRTD(MDSplus.Device):
             # The timestamp in the packet is:
             # WRTT_TAI = TAI_TIME_NOW + WRTD_DELTA_NS
             print("Message to be sent is {}".format(message))
-            uut.11.wrtd_txi = message
+            uut.s11.wrtd_txi = message
 
 
         # WR TAI Trigger time:
@@ -146,6 +146,6 @@ class ACQ2106_WRTD(MDSplus.Device):
 
         # Reseting the RX matches to its orignal default values found in the acq2106:
         # /mnt/local/sysconfig/wr.sh
-        # uut.11.wrtd_reset_tx = 1
+        # uut.s11.wrtd_reset_tx = 1
 
     TRIG=trig

--- a/pydevices/HtsDevices/acq2106_WRTD.py
+++ b/pydevices/HtsDevices/acq2106_WRTD.py
@@ -31,7 +31,7 @@ class ACQ2106_WRTD(MDSplus.Device):
     White Rabbitt Trigger Distribution Device
 
     MDSplus.Device.debug - Controlled by environment variable DEBUG_DEVICES
-		MDSplus.Device.dprint(debuglevel, fmt, args)
+        MDSplus.Device.dprint(debuglevel, fmt, args)
          - print if debuglevel >= MDSplus.Device.debug
 
     """
@@ -45,26 +45,26 @@ class ACQ2106_WRTD(MDSplus.Device):
         {'path':':TRIG_TIME',   'type':'numeric', 'value': 0.,       'options':('write_shot',)},
         {'path':':T0',          'type':'numeric', 'value': 0.,       'options':('write_shot',)},
         {'path':':WR_INIT',     'type':'text',   'options':('write_shot',)},
-            # ns per tick. (tick size in ns). uut.s11.WRTD_TICKNS: For SR=20MHz. It's the Si5326 tick at 20MHz ..
+            # ns per tick. (tick size in ns). uut.cC.WRTD_TICKNS: For SR=20MHz. It's the Si5326 tick at 20MHz ..
             {'path':':WR_INIT:WRTD_TICKNS', 'type':'numeric', 'value': 50, 'options':('write_shot',)}, 
-            # 50msec - our "safe time for broadcast". From uut.s11.WRTD_DELTA_NS
+            # 50msec - our "safe time for broadcast". From uut.cC.WRTD_DELTA_NS
             {'path':':WR_INIT:WRTD_DNS',    'type':'numeric', 'value': 50000000, 'options':('write_shot',)}, 
-            # uut.s11.WRTD_VERBOSE: use for debugging - eg logread -f or nc localhost 4280
+            # uut.cC.WRTD_VERBOSE: use for debugging - eg logread -f or nc localhost 4280
             {'path':':WR_INIT:WRTD_VBOSE',  'type':'numeric', 'value': 2, 'options':('write_shot',)},        
-            # uut.s11.WRTD_RX_MATCHES: match any of these triggers to initiate WRTT0
+            # uut.cC.WRTD_RX_MATCHES: match any of these triggers to initiate WRTT0
             {'path':':WR_INIT:WRTD_RX_M',   'type':'text', 'value': "acq2106_999", 'options':('write_shot',)},
-            # uut.s11.WRTD_RX_MATCHES1: match any of these triggers to initiate WRTT1
+            # uut.cC.WRTD_RX_MATCHES1: match any of these triggers to initiate WRTT1
             {'path':':WR_INIT:WRTD_RX_M1',  'type':'text', 'value': "acq2106_999", 'options':('write_shot',)},
-            # From uut.s11.WRTD_DELAY01: WRTD_RX_DOUBLETAP: match any of these triggers to initiate a
-            # “Double Tap, which is:
+            # From uut.cC.WRTD_DELAY01: WRTD_RX_DOUBLETAP: match any of these triggers to initiate a
+            # Double Tap, which is:
             # 1. WRTT0
             # 2. Delay WRTD_DELAY01 nsec.
             # 3. WRTT1
             {'path':':WR_INIT:WRTD_RX_DTP', 'type':'text', 'value': "acq2106_999", 'options':('write_shot',)},
             {'path':':WR_INIT:WRTD_DELAY',  'type':'numeric', 'value': 5000000, 'options':('write_shot',)},   
             {'path':':WR_INIT:WRTD_ID',     'type':'text', 'value': "acq2106_999", 'options':('write_shot',)},
-            {'path':':WR_INIT:WRTD_TX',     'type':'numeric', 'value': 0, 'options':('write_shot',)},
-            {'path':':WR_INIT:WRTD_RX',     'type':'numeric', 'value': 0, 'options':('write_shot',)},
+            {'path':':WR_INIT:WRTD_TX',     'type':'numeric', 'value': 1, 'options':('write_shot',)},
+            {'path':':WR_INIT:WRTD_RX',     'type':'numeric', 'value': 1, 'options':('write_shot',)},
 
         {'path':':RUNNING',     'type':'numeric', 'options':('no_write_model',)},
         {'path':':LOG_OUTPUT',  'type':'text',    'options':('no_write_model', 'write_once', 'write_shot',)},
@@ -76,27 +76,27 @@ class ACQ2106_WRTD(MDSplus.Device):
         uut = acq400_hapi.Acq2106(self.node.data(), has_wr=True)
 
         # Sets WR "safe time for broadcasts" the message, i.e. WRTT_TAI = TAI_TIME_NOW + WRTD_DELTA_NS
-        uut.s11.WRTD_DELTA_NS = self.wr_init_wrtd_dns.data()
+        uut.cC.WRTD_DELTA_NS = self.wr_init_wrtd_dns.data()
 
         # Receiver:
         # Turn on RX
-        uut.s11.WRTD_RX = int(self.wr_init_wrtd_rx.data())
+        uut.cC.WRTD_RX = int(self.wr_init_wrtd_rx.data())
         # Define RX matches
         matches  = str(self.wr_init_wrtd_rx_m.data())
         matches1 = str(self.wr_init_wrtd_rx_m1.data())
         print("Messages are {} and {}".format(matches, matches1))
 
-        uut.s11.WRTD_RX_MATCHES  = matches
-        uut.s11.WRTD_RX_MATCHES1 = matches1
+        uut.cC.WRTD_RX_MATCHES  = matches
+        uut.cC.WRTD_RX_MATCHES1 = matches1
         
         #Commit the changes for WRTD RX
-        uut.s11.wrtd_commit_rx = 1
+        uut.cC.wrtd_commit_rx = 1
 
         # Transmiter:
         # Turn on TX
-        uut.s11.WRTD_TX = int(self.wr_init_wrtd_tx.data())
+        uut.cC.WRTD_TX = int(self.wr_init_wrtd_tx.data())
         #Commit the changes for WRTD TX
-        uut.s11.wrtd_commit_tx = 1
+        uut.cC.wrtd_commit_tx = 1
 
     INIT=init
 
@@ -108,10 +108,10 @@ class ACQ2106_WRTD(MDSplus.Device):
         
         self.TRIG_MSG.record = message
 
-        if message in uut.s11.WRTD_RX_MATCHES:
+        if message in uut.cC.WRTD_RX_MATCHES:
             # To be sure that the EVENT bus is set to TRG
             uut.s0.SIG_EVENT_SRC_0 = 'TRG'
-        elif message in uut.s11.WRTD_RX_MATCHES1:
+        elif message in uut.cC.WRTD_RX_MATCHES1:
             # To be sure that the EVENT bus is set to TRG
             uut.s0.SIG_EVENT_SRC_1 = 'TRG'      
         else:
@@ -120,16 +120,17 @@ class ACQ2106_WRTD(MDSplus.Device):
 
         if not message.strip():
             # Set WRTD_ID: message to be transmitted from this device if FTTRG or HDMI is used to trigger.
-            print("WRTD_ID {} will be used. Waiting for trigger...".format(str(self.wr_init_wrtd_id.data())))
-            uut.s11.WRTD_ID = str(self.wr_init_wrtd_id.data())
-            # Set trigger input (FTTRG or HDMI)
+            print("WRTD_ID={} will be used. Waiting for external trigger ({})...".format(str(self.wr_init_wrtd_id.data()), str(self.trig_src.data())))
+            uut.cC.WRTD_ID = str(self.wr_init_wrtd_id.data())
+            # Set trigger input on (FTTRG or HDMI)
+            uut.s0.WR_TRG = 1
             uut.s0.WR_TRG_DX = str(self.trig_src.data())
         else:
             # send immediate WRTD message
             # The timestamp in the packet is:
             # WRTT_TAI = TAI_TIME_NOW + WRTD_DELTA_NS
-            print("Message to be sent is {}".format(message))
-            uut.s11.wrtd_txi = message
+            print("Message sent: {}".format(message))
+            uut.cC.wrtd_txi = message
 
 
         # WR TAI Trigger time:
@@ -138,6 +139,6 @@ class ACQ2106_WRTD(MDSplus.Device):
 
         # Reseting the RX matches to its orignal default values found in the acq2106:
         # /mnt/local/sysconfig/wr.sh
-        # uut.s11.wrtd_reset_tx = 1
+        # uut.cC.wrtd_reset_tx = 1
 
     TRIG=trig

--- a/pydevices/HtsDevices/acq2106_WRTD.py
+++ b/pydevices/HtsDevices/acq2106_WRTD.py
@@ -69,9 +69,12 @@ class ACQ2106_WRTD(MDSplus.Device):
         import acq400_hapi
         uut = acq400_hapi.Acq2106(self.node.data(), has_wr=True)
 
-        msgs  = str(newmsg)
-        wrmgs = msgs.split(":")
-        print("Messages are {} and {}".format(str(wrmgs[0]), str(wrmgs[1])))
+        if ":" in newmsg:
+            msgs  = str(newmsg)
+            wrmgs = msgs.split(":")
+            print("Messages are {} and {}".format(str(wrmgs[0]), str(wrmgs[1])))
+        else:
+            raise Exception("Argument needs to be of the following format: [d0msg1, d0msg2,]:[d1msg1, d1msg2,]")
 
         #Record the state of the WRTD environment:
         self.wr_init_wrtd_rx_m.record   = str(wrmgs[0]) # Matches for WRTT0

--- a/pydevices/HtsDevices/acq2106_WRTD.py
+++ b/pydevices/HtsDevices/acq2106_WRTD.py
@@ -145,7 +145,7 @@ class ACQ2106_WRTD(MDSplus.Device):
 
         if not message.strip():
             # Set WRTD_ID: message to be transmitted from this device if FTTRG or HDMI is used to trigger.
-            print("WRTD_ID={} will be used. Waiting for external trigger ({})...".format(str(self.wr_init_wrtd_id_glb.data()), str(self.trig_src.data())))
+            print("Waiting for external trigger ({})...".format(str(self.wr_init_wrtd_id_glb.data()), str(self.trig_src.data())))
             uut.cC.WRTD_ID = str(self.wr_init_wrtd_id_glb.data())
             # Set trigger input on (FTTRG or HDMI)
             uut.s0.WR_TRG    = 1
@@ -171,6 +171,24 @@ class ACQ2106_WRTD(MDSplus.Device):
         # WR TAI Trigger time:
         # TODO: convert wr_tai_trg (or wr_tai_stamp) to tai time in seconds
         # self.trig_time.putData(MDSplus.Int64(uut.s0.wr_tai_trg))
+
+        # wr_tai_current = float(uut.s0.wr_tai_cur)       # in secs
+
+        # latched_time_stamp = uut.s0.wr_tai_stamp # in secs + nsecs
+        # trigger_time       = uut.s0.wr_tai_trg   # in secs + nsecs. This is: latch time stamp + WRTD_DELTA_NS (in our case 50 msec)
+
+        # time_stamp_secs  = float(latched_time_stamp.split()[1])
+        # time_stamp_nsecs = float(latched_time_stamp.split()[2])
+        # time_stamp       = time_stamp_secs + time_stamp_nsecs / 1E+9
+        # tt = wr_tai_current + time_stamp + self.wr_init_wrtd_dns.data() / 1E+9
+
+        # # Trigger times already has the delta time in the future in it.
+        # trigger_time_secs  = float(trigger_time.split()[1])
+        # trigger_time_nsecs = float(trigger_time.split()[2])
+        # trigger_time       = wr_tai_current + trigger_time_secs + trigger_time_nsecs / 1E+9
+
+        # print("TS {} and TT {}".format(time_stamp, tt))
+        # print("Trigger time {}".format(trigger_time))
 
         # Reseting the RX matches to its orignal default values found in the acq2106:
         # /mnt/local/sysconfig/wr.sh

--- a/pydevices/HtsDevices/acq2106_WRTD.py
+++ b/pydevices/HtsDevices/acq2106_WRTD.py
@@ -46,13 +46,23 @@ class ACQ2106_WRTD(MDSplus.Device):
         {'path':':TRIG_TIME',   'type':'numeric', 'value': 0.,       'options':('write_shot',)},
         {'path':':T0',          'type':'numeric', 'value': 0.,       'options':('write_shot',)},
         {'path':':WR_INIT',     'type':'text',   'options':('write_shot',)},
-            {'path':':WR_INIT:WRTD_TICKNS', 'type':'numeric', 'value': 50, 'options':('write_shot',)},       # ns per tick. (tick size in ns). uut.cC.WRTD_TICKNS: For SR=20MHz, for ACQ423, this number will be much bigger. It's the Si5326 tick at 20MHz ..
-            {'path':':WR_INIT:WRTD_DNS',    'type':'numeric', 'value': 50000000, 'options':('write_shot',)}, # 50msec - our "safe time for broadcast". From uut.cC.WRTD_DELTA_NS
-            {'path':':WR_INIT:WRTD_VBOSE',  'type':'numeric', 'value': 2, 'options':('write_shot',)},        # uut.cC.WRTD_VERBOSE: use for debugging - eg logread -f or nc localhost 4280
+            # ns per tick. (tick size in ns). uut.cC.WRTD_TICKNS: For SR=20MHz. It's the Si5326 tick at 20MHz ..
+            {'path':':WR_INIT:WRTD_TICKNS', 'type':'numeric', 'value': 50, 'options':('write_shot',)}, 
+            # 50msec - our "safe time for broadcast". From uut.cC.WRTD_DELTA_NS
+            {'path':':WR_INIT:WRTD_DNS',    'type':'numeric', 'value': 50000000, 'options':('write_shot',)}, 
+            # uut.cC.WRTD_VERBOSE: use for debugging - eg logread -f or nc localhost 4280
+            {'path':':WR_INIT:WRTD_VBOSE',  'type':'numeric', 'value': 2, 'options':('write_shot',)},        
+            # uut.cC.WRTD_RX_MATCHES: match any of these triggers to initiate WRTT0
             {'path':':WR_INIT:WRTD_RX_M',   'type':'text', 'value': "acq2106_999", 'options':('write_shot',)},
+            # uut.cC.WRTD_RX_MATCHES1: match any of these triggers to initiate WRTT1
             {'path':':WR_INIT:WRTD_RX_M1',  'type':'text', 'value': "acq2106_999", 'options':('write_shot',)},
+            # From uut.cC.WRTD_DELAY01: WRTD_RX_DOUBLETAP: match any of these triggers to initiate a
+            # “Double Tap, which is:
+            # 1. WRTT0
+            # 2. Delay WRTD_DELAY01 nsec.
+            # 3. WRTT1
             {'path':':WR_INIT:WRTD_RX_DTP', 'type':'text', 'value': "acq2106_999", 'options':('write_shot',)},
-            {'path':':WR_INIT:WRTD_DELAY',  'type':'numeric', 'value': 5000000, 'options':('write_shot',)},   # From uut.cC.WRTD_DELAY01
+            {'path':':WR_INIT:WRTD_DELAY',  'type':'numeric', 'value': 5000000, 'options':('write_shot',)},   
             {'path':':WR_INIT:WRTD_ID',     'type':'text', 'value': "acq2106_999", 'options':('write_shot',)},
             {'path':':WR_INIT:WRTD_TX',     'type':'numeric', 'value': 0, 'options':('write_shot',)},
             {'path':':WR_INIT:WRTD_RX',     'type':'numeric', 'value': 0, 'options':('write_shot',)},
@@ -133,7 +143,10 @@ class ACQ2106_WRTD(MDSplus.Device):
         else:
             print('Message does not match either of the WRTTs available')
             self.running.on = False
-
+            
+        # send immediate WRTD message
+        # The timestamp in the packet is:
+        # WRTT_TAI = TAI_TIME_NOW + WRTD_DELTA_NS
         uut.cC.wrtd_txi = message
 
         self.trig_time.putData(MDSplus.Int64(uut.s0.wr_tai_cur))

--- a/pydevices/HtsDevices/acq2106_WRTD.py
+++ b/pydevices/HtsDevices/acq2106_WRTD.py
@@ -23,7 +23,6 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 import MDSplus
-import time
 import threading
 
 class ACQ2106_WRTD(MDSplus.Device):
@@ -47,10 +46,9 @@ class ACQ2106_WRTD(MDSplus.Device):
         {'path':':TRIG_TIME',   'type':'numeric', 'value': 0.,       'options':('write_shot',)},
         {'path':':T0',          'type':'numeric', 'value': 0.,       'options':('write_shot',)},
         {'path':':WR_INIT',     'type':'text',   'options':('write_shot',)},
-            {'path':':WR_INIT:WRTD_TICKNS', 'type':'numeric', 'value': 50, 'options':('write_shot',)},       # uut.cC.WRTD_TICKNS: For SR=20MHz, for ACQ423, this number will be much bigger. It's the Si5326 tick at 20MHz ..
+            {'path':':WR_INIT:WRTD_TICKNS', 'type':'numeric', 'value': 50, 'options':('write_shot',)},       # ns per tick. (tick size in ns). uut.cC.WRTD_TICKNS: For SR=20MHz, for ACQ423, this number will be much bigger. It's the Si5326 tick at 20MHz ..
             {'path':':WR_INIT:WRTD_DNS',    'type':'numeric', 'value': 50000000, 'options':('write_shot',)}, # 50msec - our "safe time for broadcast". From uut.cC.WRTD_DELTA_NS
             {'path':':WR_INIT:WRTD_VBOSE',  'type':'numeric', 'value': 2, 'options':('write_shot',)},        # uut.cC.WRTD_VERBOSE: use for debugging - eg logread -f or nc localhost 4280
-            {'path':':WR_INIT:WRTD_RTP',    'type':'numeric', 'value': 15, 'options':('write_shot',)},
             {'path':':WR_INIT:WRTD_RX_M',   'type':'text', 'value': "acq2106_999", 'options':('write_shot',)},
             {'path':':WR_INIT:WRTD_RX_M1',  'type':'text', 'value': "acq2106_999", 'options':('write_shot',)},
             {'path':':WR_INIT:WRTD_RX_DTP', 'type':'text', 'value': "acq2106_999", 'options':('write_shot',)},
@@ -62,7 +60,6 @@ class ACQ2106_WRTD(MDSplus.Device):
         {'path':':RUNNING',     'type':'numeric', 'options':('no_write_model',)},
         {'path':':LOG_OUTPUT',  'type':'text',    'options':('no_write_model', 'write_once', 'write_shot',)},
         {'path':':INIT_ACTION', 'type':'action',  'valueExpr':"Action(Dispatch('CAMAC_SERVER','INIT',50,None),Method(None,'INIT',head))", 'options':('no_write_shot',)},
-        {'path':':STOP_ACTION', 'type':'action',  'valueExpr':"Action(Dispatch('CAMAC_SERVER','STORE',50,None),Method(None,'STOP',head))",'options':('no_write_shot',)},
         ]
 
     def init(self, newmsg=''):
@@ -137,7 +134,7 @@ class ACQ2106_WRTD(MDSplus.Device):
             print('Message does not match either of the WRTTs available')
             self.running.on = False
 
-        uut.s0.wrtd_tx_immediate = message
+        uut.cC.wrtd_txi = message
 
         self.trig_time.putData(MDSplus.Int64(uut.s0.wr_tai_cur))
 

--- a/pydevices/HtsDevices/acq2106_WRTD.py
+++ b/pydevices/HtsDevices/acq2106_WRTD.py
@@ -46,8 +46,6 @@ class ACQ2106_WRTD(MDSplus.Device):
         {'path':':TRIG_SRC',    'type':'text',    'value': 'FPTRG', 'options':('write_shot',)},
         {'path':':TRIG_TIME',   'type':'numeric', 'value': 0.,       'options':('write_shot',)},
         {'path':':T0',          'type':'numeric', 'value': 0.,       'options':('write_shot',)},
-        {'path':':WRTT0_MSG',   'type':'text', 'value': "acq2106_999", 'options':('write_shot',)},
-        {'path':':WRTT1_MSG',   'type':'text', 'value': "acq2106_999", 'options':('write_shot',)},
         {'path':':WR_INIT',     'type':'text',   'options':('write_shot',)},
             {'path':':WR_INIT:WRTD_TICKNS', 'type':'numeric', 'value': 50, 'options':('write_shot',)},       # uut.cC.WRTD_TICKNS: For SR=20MHz, for ACQ423, this number will be much bigger. It's the Si5326 tick at 20MHz ..
             {'path':':WR_INIT:WRTD_DNS',    'type':'numeric', 'value': 50000000, 'options':('write_shot',)}, # 50msec - our "safe time for broadcast". From uut.cC.WRTD_DELTA_NS
@@ -74,9 +72,6 @@ class ACQ2106_WRTD(MDSplus.Device):
         msgs  = str(newmsg)
         wrmgs = msgs.split(":")
         print("Messages are {} and {}".format(str(wrmgs[0]), str(wrmgs[1])))
-
-        self.wrtt0_msg.record = str(wrmgs[0])
-        self.wrtt1_msg.record = str(wrmgs[1])
 
         #Record the state of the WRTD environment:
         self.wr_init_wrtd_rx_m.record   = str(wrmgs[0]) # Matches for WRTT0

--- a/pydevices/HtsDevices/acq2106_WRTD.py
+++ b/pydevices/HtsDevices/acq2106_WRTD.py
@@ -44,6 +44,11 @@ class ACQ2106_WRTD(MDSplus.Device):
         {'path':':TRIG_SRC',    'type':'text',    'value': 'FPTRG', 'options':('write_shot',)},
         {'path':':TRIG_TIME',   'type':'numeric', 'value': 0.,       'options':('write_shot',)},
         {'path':':T0',          'type':'numeric', 'value': 0.,       'options':('write_shot',)},
+        # If DIO-PG is present:
+        {'path':':DIO_SITE',    'type':'numeric', 'value': 0.,       'options':('write_shot',)},
+        # A DIO-PG source can be one of [d0...d5, TRGIN, WRTT]
+        {'path':':DIO_TRIG_SRC','type':'text',    'value': 'dx', 'options':('write_shot',)},
+        
         {'path':':WR_INIT',     'type':'text',   'options':('write_shot',)},
             # ns per tick. (tick size in ns). uut.cC.WRTD_TICKNS: For SR=20MHz. It's the Si5326 tick at 20MHz ..
             {'path':':WR_INIT:WRTD_TICKNS', 'type':'numeric', 'value': 50, 'options':('write_shot',)}, 
@@ -61,10 +66,16 @@ class ACQ2106_WRTD(MDSplus.Device):
             # 2. Delay WRTD_DELAY01 nsec.
             # 3. WRTT1
             {'path':':WR_INIT:WRTD_RX_DTP', 'type':'text', 'value': "acq2106_999", 'options':('write_shot',)},
-            {'path':':WR_INIT:WRTD_DELAY',  'type':'numeric', 'value': 5000000, 'options':('write_shot',)},   
-            {'path':':WR_INIT:WRTD_ID',     'type':'text', 'value': "acq2106_999", 'options':('write_shot',)},
+            {'path':':WR_INIT:WRTD_DELAY',  'type':'numeric', 'value': 5000000, 'options':('write_shot',)}, 
+            # WRTD_ID
+            # For Global ID
+            {'path':':WR_INIT:WRTD_ID_GLB',     'type':'text', 'value': "acq2106_999", 'options':('write_shot',)},
+            #For an individual DIO 482 site WRTD ID. This is used only in TIGA systems.
+            {'path':':WR_INIT:WRTD_ID_TIGA',    'type':'text', 'value': "acq2106_999", 'options':('write_shot',)},
+
             {'path':':WR_INIT:WRTD_TX',     'type':'numeric', 'value': 1, 'options':('write_shot',)},
             {'path':':WR_INIT:WRTD_RX',     'type':'numeric', 'value': 1, 'options':('write_shot',)},
+        
 
         {'path':':RUNNING',     'type':'numeric', 'options':('no_write_model',)},
         {'path':':LOG_OUTPUT',  'type':'text',    'options':('no_write_model', 'write_once', 'write_shot',)},
@@ -72,8 +83,7 @@ class ACQ2106_WRTD(MDSplus.Device):
         ]
 
     def init(self):
-        import acq400_hapi
-        uut = acq400_hapi.Acq2106(self.node.data(), has_wr=True)
+        uut = self.getUUT()
 
         # Sets WR "safe time for broadcasts" the message, i.e. WRTT_TAI = TAI_TIME_NOW + WRTD_DELTA_NS
         uut.cC.WRTD_DELTA_NS = self.wr_init_wrtd_dns.data()
@@ -101,8 +111,23 @@ class ACQ2106_WRTD(MDSplus.Device):
     INIT=init
 
     def trig(self, msg=''):
-        import acq400_hapi
-        uut = acq400_hapi.Acq2106(self.node.data(), has_wr=True)
+        uut = self.getUUT()
+        dio_slot = self.getDioSlot()
+
+        # Is the System a TIGA system?
+        # In embedded software there is also a command:
+        # /usr/local/bin/is_tiga
+        #
+        # it's not a knob and it's totally silent, it contains the following:
+        # #!/bin/sh
+        # [ -e /dev/acq400.0.knobs/wr_tai_trg_s1 ] && exit 0
+        # exit 1
+        #
+        # We can emulate that in HAPI the following way:
+        try:
+            is_tiga = uut.s0.wr_tai_trg_s1 is not None
+        except:
+            is_tiga = False
 
         message = str(msg)
         
@@ -121,10 +146,20 @@ class ACQ2106_WRTD(MDSplus.Device):
         if not message.strip():
             # Set WRTD_ID: message to be transmitted from this device if FTTRG or HDMI is used to trigger.
             print("WRTD_ID={} will be used. Waiting for external trigger ({})...".format(str(self.wr_init_wrtd_id.data()), str(self.trig_src.data())))
-            uut.cC.WRTD_ID = str(self.wr_init_wrtd_id.data())
+            uut.cC.WRTD_ID = str(self.wr_init_wrtd_id_glb.data())
             # Set trigger input on (FTTRG or HDMI)
-            uut.s0.WR_TRG = 1
+            uut.s0.WR_TRG    = 1
             uut.s0.WR_TRG_DX = str(self.trig_src.data())
+
+            if is_tiga:
+                # Define the WRTD_ID for a particular DIO site in a TIGA system.
+                # A DIO-PG can be triggered by TRGIN, and a WR message could be sent with the following ID:
+                dio_slot.WRTD_ID = str(self.wr_init_wrtd_id_tiga.data())
+                # Define the WRTD_MASK:
+                # WRTD_TX_MASK selects the DIO units that respond
+                dio_slot.WRTD_TX_MASK = (1<<(int(self.dio_site.data())+1))
+                dio_slot.TRG    = 1
+                dio_slot.TRG_DX = str(self.dio_trig_src.data())
         else:
             # send immediate WRTD message
             # The timestamp in the packet is:
@@ -142,3 +177,36 @@ class ACQ2106_WRTD(MDSplus.Device):
         # uut.cC.wrtd_reset_tx = 1
 
     TRIG=trig
+
+    def getUUT(self):
+        import acq400_hapi
+        uut = acq400_hapi.Acq2106(self.node.data(), has_wr=True)
+        return uut
+
+    def getDioSlot(self):
+        uut = self.getUUT()
+        site_number  = int(self.dio_site.data())
+
+        # Verify site_number is a valid int between 1 and 6
+        # if site_number in range(1, 7):
+        #     self.slot = uut.__getattr__('s' + self.dio_site.data())
+
+        try:
+            if site_number   == 0: 
+                slot = uut.s0    # Only for a GPG system.
+            elif site_number == 1:
+                slot = uut.s1
+            elif site_number == 2:
+                slot = uut.s2
+            elif site_number == 3:
+                slot = uut.s3
+            elif site_number == 4:
+                slot = uut.s4
+            elif site_number == 5:
+                slot = uut.s5
+            elif site_number == 6:
+                slot = uut.s6
+        except:
+            pass
+        
+        return slot

--- a/pydevices/HtsDevices/acq2106_WRTD.py
+++ b/pydevices/HtsDevices/acq2106_WRTD.py
@@ -1,0 +1,147 @@
+#
+# Copyright (c) 2020, Massachusetts Institute of Technology All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# Redistributions of source code must retain the above copyright notice, this
+# list of conditions and the following disclaimer.
+#
+# Redistributions in binary form must reproduce the above copyright notice, this
+# list of conditions and the following disclaimer in the documentation and/or
+# other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+import MDSplus
+import time
+import threading
+
+class ACQ2106_WRTD(MDSplus.Device):
+    """
+    D-Tacq ACQ2106 with ACQ423 Digitizers (up to 6)  real time streaming support.
+
+    White Rabbitt Trigger Distribution Device
+
+    MDSplus.Device.debug - Controlled by environment variable DEBUG_DEVICES
+		MDSplus.Device.dprint(debuglevel, fmt, args)
+         - print if debuglevel >= MDSplus.Device.debug
+
+    """
+
+    parts=[
+        {'path':':NODE',        'type':'text',    'options':('no_write_shot',)},
+        {'path':':HOSTNAME',    'type':'text',    'options':('no_write_shot',)},
+        {'path':':COMMENT',     'type':'text',    'options':('no_write_shot',)},
+        {'path':':TRIG_MSG',    'type':'text',    'options':('write_shot',)},
+        {'path':':TRIG_SRC',    'type':'text',    'value': 'FPTRG', 'options':('write_shot',)},
+        {'path':':TRIG_TIME',   'type':'numeric', 'value': 0.,       'options':('write_shot',)},
+        {'path':':T0',          'type':'numeric', 'value': 0.,       'options':('write_shot',)},
+        {'path':':WRTT0_MSG',   'type':'text', 'value': "acq2106_999", 'options':('write_shot',)},
+        {'path':':WRTT1_MSG',   'type':'text', 'value': "acq2106_999", 'options':('write_shot',)},
+        {'path':':WR_INIT',     'type':'text',   'options':('write_shot',)},
+            {'path':':WR_INIT:WRTD_TICKNS', 'type':'numeric', 'value': 50, 'options':('write_shot',)},       # uut.cC.WRTD_TICKNS: For SR=20MHz, for ACQ423, this number will be much bigger. It's the Si5326 tick at 20MHz ..
+            {'path':':WR_INIT:WRTD_DNS',    'type':'numeric', 'value': 50000000, 'options':('write_shot',)}, # 50msec - our "safe time for broadcast". From uut.cC.WRTD_DELTA_NS
+            {'path':':WR_INIT:WRTD_VBOSE',  'type':'numeric', 'value': 2, 'options':('write_shot',)},        # uut.cC.WRTD_VERBOSE: use for debugging - eg logread -f or nc localhost 4280
+            {'path':':WR_INIT:WRTD_RTP',    'type':'numeric', 'value': 15, 'options':('write_shot',)},
+            {'path':':WR_INIT:WRTD_RX_M',   'type':'text', 'value': "acq2106_999", 'options':('write_shot',)},
+            {'path':':WR_INIT:WRTD_RX_M1',  'type':'text', 'value': "acq2106_999", 'options':('write_shot',)},
+            {'path':':WR_INIT:WRTD_RX_DTP', 'type':'text', 'value': "acq2106_999", 'options':('write_shot',)},
+            {'path':':WR_INIT:WRTD_DELAY',  'type':'numeric', 'value': 5000000, 'options':('write_shot',)},   # From uut.cC.WRTD_DELAY01
+            {'path':':WR_INIT:WRTD_ID',     'type':'text', 'value': "acq2106_999", 'options':('write_shot',)},
+            {'path':':WR_INIT:WRTD_TX',     'type':'numeric', 'value': 0, 'options':('write_shot',)},
+            {'path':':WR_INIT:WRTD_RX',     'type':'numeric', 'value': 0, 'options':('write_shot',)},
+
+        {'path':':RUNNING',     'type':'numeric', 'options':('no_write_model',)},
+        {'path':':LOG_OUTPUT',  'type':'text',    'options':('no_write_model', 'write_once', 'write_shot',)},
+        {'path':':INIT_ACTION', 'type':'action',  'valueExpr':"Action(Dispatch('CAMAC_SERVER','INIT',50,None),Method(None,'INIT',head))", 'options':('no_write_shot',)},
+        {'path':':STOP_ACTION', 'type':'action',  'valueExpr':"Action(Dispatch('CAMAC_SERVER','STORE',50,None),Method(None,'STOP',head))",'options':('no_write_shot',)},
+        ]
+
+    def init(self, newmsg=''):
+        import acq400_hapi
+        uut = acq400_hapi.Acq2106(self.node.data(), has_wr=True)
+
+        msgs  = str(newmsg)
+        wrmgs = msgs.split(":")
+        print("Messages are {} and {}".format(str(wrmgs[0]), str(wrmgs[1])))
+
+        self.wrtt0_msg.record = str(wrmgs[0])
+        self.wrtt1_msg.record = str(wrmgs[1])
+
+        #Record the state of the WRTD environment:
+        self.wr_init_wrtd_rx_m.record   = str(wrmgs[0]) # Matches for WRTT0
+        self.wr_init_wrtd_rx_m1.record  = str(wrmgs[1]) # Matches for WRTT1
+
+        # WR TRIGGER SOURCE:
+        print("WR TRG Source {}".format(str(self.trig_src.data())))
+        uut.s0.WR_TRG_DX = str(self.trig_src.data())
+
+        # Global WR settings:
+        # Set WRTD_ID
+        print("WRTD_ID {}".format(str(self.wr_init_wrtd_id.data())))
+        uut.cC.WRTD_ID = str(self.wr_init_wrtd_id.data())
+
+        # Receiver:
+        # Turn on RX
+        uut.cC.WRTD_RX = int(self.wr_init_wrtd_rx.data())
+        # Define RX matches
+        uut.cC.WRTD_RX_MATCHES  = str(wrmgs[0])
+        uut.cC.WRTD_RX_MATCHES1 = str(wrmgs[1])
+        #Commit the changes for WRTD RX
+        uut.cC.wrtd_commit_rx = 1
+
+        # Transmiter:
+        # Turn on TX
+        uut.cC.WRTD_TX = int(self.wr_init_wrtd_tx.data())
+        #Commit the changes for WRTD TX
+        uut.cC.wrtd_commit_tx = 1
+
+    INIT=init
+
+    def trig(self, msg=''):
+        thread = threading.Thread(target = self._trig, args=(msg))
+        thread.start()
+        return None
+    TRIG=trig
+
+
+    def _trig(self, msg=''):
+        import acq400_hapi
+        uut = acq400_hapi.Acq2106(self.node.data(), has_wr=True)
+
+        message = str(msg)
+
+        self.TRIG_MSG.record = message
+
+        # Choose the source (eg. WRTT0 or WRTT1) that use go through the bus (TRG, EVENT) and the signal (d0, d1)
+        if message in uut.cC.WRTD_RX_MATCHES:
+            # To be sure that the EVENT bus is set to TRG
+            uut.s0.SIG_EVENT_SRC_0 = 'TRG'
+
+        elif message in uut.cC.WRTD_RX_MATCHES1:
+            # To be sure that the EVENT bus is set to TRG
+            uut.s0.SIG_EVENT_SRC_1 = 'TRG'
+        
+        else:
+            print('Message does not match either of the WRTTs available')
+            self.running.on = False
+
+        uut.s0.wrtd_tx_immediate = message
+
+        self.trig_time.putData(MDSplus.Int64(uut.s0.wr_tai_cur))
+
+        # Reseting the RX matches to its orignal default values found in the acq2106:
+        # /mnt/local/sysconfig/wr.sh
+        # uut.cC.wrtd_reset_tx = 1
+
+    _TRIG=_trig

--- a/pydevices/HtsDevices/acq2106_WRTD.py
+++ b/pydevices/HtsDevices/acq2106_WRTD.py
@@ -112,7 +112,7 @@ class ACQ2106_WRTD(MDSplus.Device):
 
     def trig(self, msg=''):
         uut = self.getUUT()
-        dio_slot = self.getDioSlot()
+        pg_slot = self.getDioSlot()
 
         # Is the System a TIGA system?
         # In embedded software there is also a command:
@@ -154,12 +154,12 @@ class ACQ2106_WRTD(MDSplus.Device):
             if is_tiga:
                 # Define the WRTD_ID for a particular DIO site in a TIGA system.
                 # A DIO-PG can be triggered by TRGIN, and a WR message could be sent with the following ID:
-                dio_slot.WRTD_ID = str(self.wr_init_wrtd_id_tiga.data())
+                pg_slot.WRTD_ID = str(self.wr_init_wrtd_id_tiga.data())
                 # Define the WRTD_MASK:
                 # WRTD_TX_MASK selects the DIO units that respond
-                dio_slot.WRTD_TX_MASK = (1<<(int(self.dio_site.data())+1))
-                dio_slot.TRG    = 1
-                dio_slot.TRG_DX = str(self.dio_trig_src.data())
+                pg_slot.WRTD_TX_MASK = (1<<(int(self.dio_site.data())+1))
+                pg_slot.TRG    = 1
+                pg_slot.TRG_DX = str(self.pg_trig_src.data())
         else:
             # send immediate WRTD message
             # The timestamp in the packet is:

--- a/pydevices/HtsDevices/acq2106_WRTD.py
+++ b/pydevices/HtsDevices/acq2106_WRTD.py
@@ -167,33 +167,6 @@ class ACQ2106_WRTD(MDSplus.Device):
             print("Message sent: {}".format(message))
             uut.cC.wrtd_txi = message
 
-
-        # WR TAI Trigger time:
-        # TODO: convert wr_tai_trg (or wr_tai_stamp) to tai time in seconds
-        # self.trig_time.putData(MDSplus.Int64(uut.s0.wr_tai_trg))
-
-        # wr_tai_current = float(uut.s0.wr_tai_cur)       # in secs
-
-        # latched_time_stamp = uut.s0.wr_tai_stamp # in secs + nsecs
-        # trigger_time       = uut.s0.wr_tai_trg   # in secs + nsecs. This is: latch time stamp + WRTD_DELTA_NS (in our case 50 msec)
-
-        # time_stamp_secs  = float(latched_time_stamp.split()[1])
-        # time_stamp_nsecs = float(latched_time_stamp.split()[2])
-        # time_stamp       = time_stamp_secs + time_stamp_nsecs / 1E+9
-        # tt = wr_tai_current + time_stamp + self.wr_init_wrtd_dns.data() / 1E+9
-
-        # # Trigger times already has the delta time in the future in it.
-        # trigger_time_secs  = float(trigger_time.split()[1])
-        # trigger_time_nsecs = float(trigger_time.split()[2])
-        # trigger_time       = wr_tai_current + trigger_time_secs + trigger_time_nsecs / 1E+9
-
-        # print("TS {} and TT {}".format(time_stamp, tt))
-        # print("Trigger time {}".format(trigger_time))
-
-        # Reseting the RX matches to its orignal default values found in the acq2106:
-        # /mnt/local/sysconfig/wr.sh
-        # uut.cC.wrtd_reset_tx = 1
-
     TRIG=trig
 
     def getUUT(self):

--- a/pydevices/HtsDevices/acq2106_WRTD.py
+++ b/pydevices/HtsDevices/acq2106_WRTD.py
@@ -23,7 +23,6 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 import MDSplus
-import threading
 
 class ACQ2106_WRTD(MDSplus.Device):
     """

--- a/pydevices/HtsDevices/acq2106_WRTD.py
+++ b/pydevices/HtsDevices/acq2106_WRTD.py
@@ -46,17 +46,17 @@ class ACQ2106_WRTD(MDSplus.Device):
         {'path':':TRIG_TIME',   'type':'numeric', 'value': 0.,       'options':('write_shot',)},
         {'path':':T0',          'type':'numeric', 'value': 0.,       'options':('write_shot',)},
         {'path':':WR_INIT',     'type':'text',   'options':('write_shot',)},
-            # ns per tick. (tick size in ns). uut.cC.WRTD_TICKNS: For SR=20MHz. It's the Si5326 tick at 20MHz ..
+            # ns per tick. (tick size in ns). uut.11.WRTD_TICKNS: For SR=20MHz. It's the Si5326 tick at 20MHz ..
             {'path':':WR_INIT:WRTD_TICKNS', 'type':'numeric', 'value': 50, 'options':('write_shot',)}, 
-            # 50msec - our "safe time for broadcast". From uut.cC.WRTD_DELTA_NS
+            # 50msec - our "safe time for broadcast". From uut.11.WRTD_DELTA_NS
             {'path':':WR_INIT:WRTD_DNS',    'type':'numeric', 'value': 50000000, 'options':('write_shot',)}, 
-            # uut.cC.WRTD_VERBOSE: use for debugging - eg logread -f or nc localhost 4280
+            # uut.11.WRTD_VERBOSE: use for debugging - eg logread -f or nc localhost 4280
             {'path':':WR_INIT:WRTD_VBOSE',  'type':'numeric', 'value': 2, 'options':('write_shot',)},        
-            # uut.cC.WRTD_RX_MATCHES: match any of these triggers to initiate WRTT0
+            # uut.11.WRTD_RX_MATCHES: match any of these triggers to initiate WRTT0
             {'path':':WR_INIT:WRTD_RX_M',   'type':'text', 'value': "acq2106_999", 'options':('write_shot',)},
-            # uut.cC.WRTD_RX_MATCHES1: match any of these triggers to initiate WRTT1
+            # uut.11.WRTD_RX_MATCHES1: match any of these triggers to initiate WRTT1
             {'path':':WR_INIT:WRTD_RX_M1',  'type':'text', 'value': "acq2106_999", 'options':('write_shot',)},
-            # From uut.cC.WRTD_DELAY01: WRTD_RX_DOUBLETAP: match any of these triggers to initiate a
+            # From uut.11.WRTD_DELAY01: WRTD_RX_DOUBLETAP: match any of these triggers to initiate a
             # “Double Tap, which is:
             # 1. WRTT0
             # 2. Delay WRTD_DELAY01 nsec.
@@ -83,30 +83,30 @@ class ACQ2106_WRTD(MDSplus.Device):
         # Global WR settings:
         # Set WRTD_ID: message to be transmitted from this device if FTTRG or HDMI triggered.
         print("WRTD_ID {}".format(str(self.wr_init_wrtd_id.data())))
-        uut.cC.WRTD_ID = str(self.wr_init_wrtd_id.data())
+        uut.11.WRTD_ID = str(self.wr_init_wrtd_id.data())
 
         # Sets WR "safe time for broadcasts" the message, i.e. WRTT_TAI = TAI_TIME_NOW + WRTD_DELTA_NS
-        uut.cC.WRTD_DELTA_NS = self.wr_init_wrtd_dns.data()
+        uut.11.WRTD_DELTA_NS = self.wr_init_wrtd_dns.data()
 
         # Receiver:
         # Turn on RX
-        uut.cC.WRTD_RX = int(self.wr_init_wrtd_rx.data())
+        uut.11.WRTD_RX = int(self.wr_init_wrtd_rx.data())
         # Define RX matches
         matches  = str(self.wr_init_wrtd_rx_m.data())
         matches1 = str(self.wr_init_wrtd_rx_m1.data())
         print("Messages are {} and {}".format(matches, matches1))
 
-        uut.cC.WRTD_RX_MATCHES  = matches
-        uut.cC.WRTD_RX_MATCHES1 = matches1
+        uut.11.WRTD_RX_MATCHES  = matches
+        uut.11.WRTD_RX_MATCHES1 = matches1
         
         #Commit the changes for WRTD RX
-        uut.cC.wrtd_commit_rx = 1
+        uut.11.wrtd_commit_rx = 1
 
         # Transmiter:
         # Turn on TX
-        uut.cC.WRTD_TX = int(self.wr_init_wrtd_tx.data())
+        uut.11.WRTD_TX = int(self.wr_init_wrtd_tx.data())
         #Commit the changes for WRTD TX
-        uut.cC.wrtd_commit_tx = 1
+        uut.11.wrtd_commit_tx = 1
 
     INIT=init
 
@@ -118,10 +118,10 @@ class ACQ2106_WRTD(MDSplus.Device):
         
         self.TRIG_MSG.record = message
 
-        if message in uut.cC.WRTD_RX_MATCHES:
+        if message in uut.11.WRTD_RX_MATCHES:
             # To be sure that the EVENT bus is set to TRG
             uut.s0.SIG_EVENT_SRC_0 = 'TRG'
-        elif message in uut.cC.WRTD_RX_MATCHES1:
+        elif message in uut.11.WRTD_RX_MATCHES1:
             # To be sure that the EVENT bus is set to TRG
             uut.s0.SIG_EVENT_SRC_1 = 'TRG'      
         else:
@@ -137,7 +137,7 @@ class ACQ2106_WRTD(MDSplus.Device):
             # The timestamp in the packet is:
             # WRTT_TAI = TAI_TIME_NOW + WRTD_DELTA_NS
             print("Message to be sent is {}".format(message))
-            uut.cC.wrtd_txi = message
+            uut.11.wrtd_txi = message
 
 
         # WR TAI Trigger time:
@@ -146,6 +146,6 @@ class ACQ2106_WRTD(MDSplus.Device):
 
         # Reseting the RX matches to its orignal default values found in the acq2106:
         # /mnt/local/sysconfig/wr.sh
-        # uut.cC.wrtd_reset_tx = 1
+        # uut.11.wrtd_reset_tx = 1
 
     TRIG=trig


### PR DESCRIPTION
This is a new WRTD device for ACQ2106.

The device:
1- Sets the global WR trigger message, or WR_ID
2- Defines the WR RX matches: i.e. the messages the receiver will respond to.
3- Sets the WR receiver (RX) and and transmitter (TX)
4- Sets the WR trigger source, i.e. FPTRG or HDMI

Usage:
TCL> do /meth wrtd init
For hardware trigger (FPTRG or HDMI):
TCL> do /meth wrtd trig
For immediate transmit of specific message:
TCL> do /meth wrtd trig /ARG="""shared_all"""
