### PR TITLE
Fix: fallback to old locking schema if new not available

### DIFF
--- a/treeshr/RemoteAccess.c
+++ b/treeshr/RemoteAccess.c
@@ -35,9 +35,10 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *
  * workaround: define flock so linux/fcntl.h will define lx_flock instead
  */
-# define flock lx_flock
-# include <linux/fcntl.h>
-# undef flock
+//// alpine does not linux/fcntl.h
+// # define flock lx_flock
+// # include <linux/fcntl.h>
+// # undef flock
 # ifndef F_OFD_SETLK
 #  define F_OFD_GETLK   36
 #  define F_OFD_SETLK   37

--- a/treeshr/RemoteAccess.c
+++ b/treeshr/RemoteAccess.c
@@ -22,6 +22,8 @@ CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
+
+#include <mdsplus/mdsconfig.h>
 #ifdef _WIN32
 # include <winsock2.h>
 # include <ws2tcpip.h>
@@ -30,13 +32,13 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #else
 /* Debian Bug report logs - #639078
  * pommed: FTBFS: fcntl.h:172:8: error: redefinition of 'struct flock'
+ *
+ * workaround: define flock so linux/fcntl.h will define lx_flock instead
  */
-// #include <linux/fcntl.h>
-# define F_OFD_GETLK	36
-# define F_OFD_SETLK	37
-# define F_OFD_SETLKW	38
+# define flock lx_flock
+# include <linux/fcntl.h>
+# undef flock
 #endif
-#include <mdsplus/mdsconfig.h>
 #include <mdstypes.h>
 #include <pthread.h>
 #include <mds_stdarg.h>
@@ -1323,7 +1325,6 @@ inline static int io_lock_remote(fdinfo_t fdinfo, off_t offset, size_t size, int
   return ret;
 }
 
-
 static int io_lock_local(fdinfo_t fdinfo, off_t offset, size_t size, int mode_in, int *deleted) {
   int fd = fdinfo.fd;
   int err;
@@ -1360,8 +1361,14 @@ static int io_lock_local(fdinfo_t fdinfo, off_t offset, size_t size, int mode_in
   flock.l_whence = (mode == 0) ? SEEK_SET : ((offset >= 0) ? SEEK_SET : SEEK_END);
   flock.l_start = (mode == 0) ? 0 : ((offset >= 0) ? offset : 0);
   flock.l_len = (mode == 0) ? 0 : size;
+# ifdef F_OFD_SETLK
   flock.l_pid = 0;
   err = fcntl(fd, nowait ? F_OFD_SETLK : F_OFD_SETLKW, &flock) == -1;
+# else
+# pragma message("FILE LOCKS WONT BE THREADSAFE!")
+  flock.l_pid = getpid();
+  err = fcntl(fd, nowait ? F_SETLK : F_SETLKW, &flock) == -1;
+# endif
   fstat(fd, &stat);
   if (deleted) *deleted = stat.st_nlink <= 0;
 #endif


### PR DESCRIPTION
not using a mutex yet.

file locking is kind of broken in the sense of how rwlocks work.. 

How old file locks work in threads
```
Thread1: lock file for write - get file lock
Thread2: lock file for read- no operation as process already has lock of higher quality 
Thread2: release lock - process releases lock
Thread1: may still be writing in now unprotected file section
Thread1: release lock - unlock error (suppressed)
```

Only way to fix this is to have a mutex making the file exclusive;
Using one shared mutex would make all file io exclusive though.

Any other way would basically require us to implement the OFD_LOCKS ourselves just to support it for OSes that we will drop in the future.
 