### PR TITLE
Fix: python3 sockets take bytes not strings

### DIFF
--- a/pydevices/HtsDevices/cryocon18i.py
+++ b/pydevices/HtsDevices/cryocon18i.py
@@ -85,12 +85,14 @@ class CRYOCON18I_TREND(CRYOCON18I):
     ]
 
     def sendCommand(self,s,cmd):
-        s.send((cmd + "\r\n").encode())
+        from MDSplus.version import tobytes
+        s.send(tobytes(cmd + "\r\n"))
 
     def recvResponse(self,s):
+        from MDSlus.version import tounicode
         msg = ""
         while True:
-            c = s.recv(1).decode(encoding='UTF-8')
+            c = tounicode(s.recv(1))
             if c == "\r":
                 continue
             if c == "\n":

--- a/pydevices/HtsDevices/cryocon18i.py
+++ b/pydevices/HtsDevices/cryocon18i.py
@@ -29,6 +29,17 @@ import time
 import datetime
 import numpy as np
 
+if MDSplus.version.ispy2:
+    def tostr(x):
+        return x
+    def tobytes(x):
+        return x
+else:
+    def tostr(x):
+        return b if isinstance(b, str) else b.decode('utf-8')
+    def tobytes(x):
+        return s if isinstance(s, bytes) else s.encode('utf-8')
+
 class CRYOCON18I(MDSplus.Device):
     """
     8 channel Cryocon temperature monitor
@@ -85,14 +96,13 @@ class CRYOCON18I_TREND(CRYOCON18I):
     ]
 
     def sendCommand(self,s,cmd):
-        from MDSplus.version import tobytes
         s.send(tobytes(cmd + "\r\n"))
 
     def recvResponse(self,s):
         from MDSlus.version import tounicode
         msg = ""
         while True:
-            c = tounicode(s.recv(1))
+            c = tostr(s.recv(1))
             if c == "\r":
                 continue
             if c == "\n":

--- a/pydevices/HtsDevices/cryocon18i.py
+++ b/pydevices/HtsDevices/cryocon18i.py
@@ -85,12 +85,12 @@ class CRYOCON18I_TREND(CRYOCON18I):
     ]
 
     def sendCommand(self,s,cmd):
-        s.send(cmd + "\r\n")
+        s.send((cmd + "\r\n").encode())
 
     def recvResponse(self,s):
         msg = ""
         while True:
-            c = s.recv(1)
+            c = s.recv(1).decode(encoding='UTF-8')
             if c == "\r":
                 continue
             if c == "\n":

--- a/pydevices/HtsDevices/cryocon18i.py
+++ b/pydevices/HtsDevices/cryocon18i.py
@@ -99,7 +99,6 @@ class CRYOCON18I_TREND(CRYOCON18I):
         s.send(tobytes(cmd + "\r\n"))
 
     def recvResponse(self,s):
-        from MDSlus.version import tounicode
         msg = ""
         while True:
             c = tostr(s.recv(1))

--- a/pydevices/HtsDevices/cryocon24c.py
+++ b/pydevices/HtsDevices/cryocon24c.py
@@ -86,12 +86,14 @@ class CRYOCON24C_TREND(CRYOCON24C):
     ])
 
     def sendCommand(self,s,cmd):
-        s.send(cmd + "\r\n")
+        from MDSplus.version import tobytes
+        s.send(tobytes(cmd + "\r\n"))
 
     def recvResponse(self,s):
+        from MDSplus.version import tounicode
         msg = ""
         while True:
-            c = s.recv(1)
+            c = tounicode(s.recv(1))
             if c == "\r":
                 continue
             if c == "\n":

--- a/pydevices/HtsDevices/cryocon24c.py
+++ b/pydevices/HtsDevices/cryocon24c.py
@@ -5,6 +5,17 @@ import time
 import datetime
 import numpy as np
 
+if MDSplus.version.ispy2:
+    def tostr(x):
+        return x
+    def tobytes(x):
+        return x
+else:
+    def tostr(x):
+        return b if isinstance(b, str) else b.decode('utf-8')
+    def tobytes(x):
+        return s if isinstance(s, bytes) else s.encode('utf-8')
+
 class CRYOCON24C(MDSplus.Device):
     """
      4 channel Cryocon temperature monitor
@@ -86,14 +97,12 @@ class CRYOCON24C_TREND(CRYOCON24C):
     ])
 
     def sendCommand(self,s,cmd):
-        from MDSplus.version import tobytes
         s.send(tobytes(cmd + "\r\n"))
 
     def recvResponse(self,s):
-        from MDSplus.version import tounicode
         msg = ""
         while True:
-            c = tounicode(s.recv(1))
+            c = tostr(s.recv(1))
             if c == "\r":
                 continue
             if c == "\n":


### PR DESCRIPTION
The HtsDevices are now run using Python3.  The socket calls in the
crycon18i device needs to send bytes, and receive bytes instead of
strings