### PR TITLE
Feature: New Signal Conditioning device for ACQ2106.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -116,9 +116,12 @@ trigger.opts
 # bootstrap output files
 LabView/Makefile.in
 configure
+ChangeLog
+MANIFEST.MF
 docs/Makefile.in
 dwscope/Makefile.in
 include/camshr_messages.h
+include/mdsplus/mdsconfig.h
 include/mdsdcl_messages.h
 include/mdsplus/mdsconfig.h.in
 include/mdsshr_messages.h
@@ -151,6 +154,7 @@ mdsdcl/dcllex.h
 mdsdcl/dclyacc.h
 mdsdcl/mdsdclDeltatimeToSeconds.c
 mdsdcl/ocldToXml.c
+mdsdcl/mdsdclVersionInfo.c
 mdslib/docs/Makefile.in
 mdslib/testing/Makefile.in
 mdsobjects/cpp/docs/Makefile.in
@@ -159,6 +163,7 @@ mdsobjects/cpp/testing/testutils/Makefile.in
 mdsshr/MdsGetStdMsg.c
 mdsshr/docs/Makefile.in
 mdsshr/testing/Makefile.in
+mdsshr/version.h
 mdstcpip/docs/Makefile.in
 mdstcpip/docs/img/Makefile.in
 mdstcpip/zlib/Makefile.in
@@ -182,3 +187,15 @@ testing/selftest/Makefile.in
 treeshr/testing/Makefile.in
 wfevent/Makefile.in
 
+# Generated Java binaries
+java/*/classes/
+java/jdispatcher/jDispatchMonitor
+java/jdispatcher/jDispatcherIp
+java/jdispatcher/jServer
+java/jscope/jScope
+java/jscope/jScope.properties
+java/jtraverser/CompileTree
+java/jtraverser/DecompileTree
+java/jtraverser/jTraverser
+java/jtraverser2/jTraverser2
+java/jtraverser2/setupDevice

--- a/deploy/packaging/debian/htsdevices.noarch
+++ b/deploy/packaging/debian/htsdevices.noarch
@@ -2,6 +2,7 @@
 ./usr/local/mdsplus/pydevices/HtsDevices/acq2106_423st.py
 ./usr/local/mdsplus/pydevices/HtsDevices/acq2106_435st.py
 ./usr/local/mdsplus/pydevices/HtsDevices/acq2106_WRPG.py
+./usr/local/mdsplus/pydevices/HtsDevices/acq2106_435sc.py
 ./usr/local/mdsplus/pydevices/HtsDevices/acq2106_WRTD.py
 ./usr/local/mdsplus/pydevices/HtsDevices/cryocon18i.py
 ./usr/local/mdsplus/pydevices/HtsDevices/cryocon24c.py

--- a/deploy/packaging/redhat/htsdevices.noarch
+++ b/deploy/packaging/redhat/htsdevices.noarch
@@ -3,6 +3,7 @@
 ./usr/local/mdsplus/pydevices/HtsDevices/acq2106_423st.py
 ./usr/local/mdsplus/pydevices/HtsDevices/acq2106_435st.py
 ./usr/local/mdsplus/pydevices/HtsDevices/acq2106_WRPG.py
+./usr/local/mdsplus/pydevices/HtsDevices/acq2106_435sc.py
 ./usr/local/mdsplus/pydevices/HtsDevices/acq2106_WRTD.py
 ./usr/local/mdsplus/pydevices/HtsDevices/cryocon18i.py
 ./usr/local/mdsplus/pydevices/HtsDevices/cryocon24c.py

--- a/pydevices/HtsDevices/acq2106_435sc.py
+++ b/pydevices/HtsDevices/acq2106_435sc.py
@@ -26,6 +26,7 @@
 import MDSplus
 import importlib
 import os
+import numbers
 
 acq2106_435st = importlib.import_module('acq2106_435st')
 acq400_hapi = importlib.import_module('acq400_hapi')  
@@ -36,26 +37,95 @@ class _ACQ2106_435SC(acq2106_435st._ACQ2106_435ST):
     """
 
     sc_parts = [
-        {'path':':DEF_GAIN1',  'type':'numeric', 'value': 1, 'options':('no_write_shot',)},
-        {'path':':DEF_GAIN2',  'type':'numeric', 'value': 1, 'options':('no_write_shot',)},
-        {'path':':DEF_OFFSET','type':'numeric', 'value': 0, 'options':('no_write_shot',)},
+        {'path':':DEF_GAIN1',  'type':'numeric', 'value': '1', 'options':('no_write_shot',)},
+        {'path':':DEF_GAIN2',  'type':'numeric', 'value': '1', 'options':('no_write_shot',)},
+        {'path':':DEF_OFFSET', 'type':'numeric', 'value': '0', 'options':('no_write_shot',)},
     ]
 
     def init(self):
         super(_ACQ2106_435SC, self).init()
         uut = acq400_hapi.Acq400(self.node.data(), monitor=False)
 
-        uut.s1.SC32_OFFSET_ALL = self.def_offset.data()
-        print("OFFSET ALL {}".format(self.def_offset.data()))
+        uut = acq400_hapi.Acq400(self.node.data(), monitor=False)
 
-        uut.s1.SC32_G1_ALL     = self.def_gain1.data()
-        print("GAIN 1 ALL {}".format(self.def_gain1.data()))
+        chans_sc  = []
+        nchannels = uut.nchan()
+        for ii in range(nchannels):
+            chans_sc.append(getattr(self, 'INPUT_%3.3d'%(ii+1)))
 
-        uut.s1.SC32_G2_ALL     = self.def_gain2.data()
-        print("GAIN 2 ALL {}".format(self.def_gain2.data()))
+        for site in range(1,6,2):
+            if site == 1:
+                for ic, ch in enumerate(chans_sc):
+                    if ic < 33:
+                        uut_s1_sc32_offset = uut.s1.__getattr__('SC32_OFFSET_%2.2d' %(ic+1))
+                        uut_s1_sc32_g1     = uut.s1.__getattr__('SC32_G1_%2.2d' %(ic+1))
+                        uut_s1_sc32_g2     = uut.s1.__getattr__('SC32_G2_%2.2d' %(ic+1))
+                        if ch.on:
+                            uut_s1_sc32_offset = self.__getattr__('INPUT_%3.3d:SC_GAIN1' %(ic+1)).data()
+                            uut_s1_sc32_g1     = self.__getattr__('INPUT_%3.3d:SC_GAIN2' %(ic+1)).data()
+                            uut_s1_sc32_g2     = self.__getattr__('INPUT_%3.3d:SC_OFFSET'%(ic+1)).data()
+                if isinstance(self.def_offset.data() , numbers.Number) and isinstance(self.def_gain1.data() , numbers.Number) and isinstance(self.def_gain2.data() , numbers.Number):
+                   # Global controls for GAINS and OFFSETS
+                    uut.s1.SC32_OFFSET_ALL = self.def_offset.data()
+                    print("OFFSET ALL {}".format(self.def_offset.data()))
 
-        uut.s1.SC32_GAIN_COMMIT = 1
-        print("GAIN Committed")
+                    uut.s1.SC32_G1_ALL     = self.def_gain1.data()
+                    print("GAIN 1 ALL {}".format(self.def_gain1.data()))
+
+                    uut.s1.SC32_G2_ALL     = self.def_gain2.data()
+                    print("GAIN 2 ALL {}".format(self.def_gain2.data()))
+
+                uut.s1.SC32_GAIN_COMMIT = 1
+                print("GAIN Committed for site {}".format(site))
+
+            elif site == 3:
+                for ic, ch in enumerate(chans_sc):
+                    if ic < 33:
+                        uut_s1_sc32_offset = uut.s3.__getattr__('SC32_OFFSET_%2.2d' %(ic+1))
+                        uut_s1_sc32_g1     = uut.s3.__getattr__('SC32_G1_%2.2d' %(ic+1))
+                        uut_s1_sc32_g2     = uut.s3.__getattr__('SC32_G2_%2.2d' %(ic+1))
+                        if ch.on:
+                            uut_s1_sc32_offset = self.__getattr__('INPUT_%3.3d:SC_GAIN1' %(ic+1)).data()
+                            uut_s1_sc32_g1     = self.__getattr__('INPUT_%3.3d:SC_GAIN2' %(ic+1)).data()
+                            uut_s1_sc32_g2     = self.__getattr__('INPUT_%3.3d:SC_OFFSET'%(ic+1)).data()
+                if isinstance(self.def_offset.data() , numbers.Number) and isinstance(self.def_gain1.data() , numbers.Number) and isinstance(self.def_gain2.data() , numbers.Number):
+                   # Global controls for GAINS and OFFSETS
+                    uut.s3.SC32_OFFSET_ALL = self.def_offset.data()
+                    print("OFFSET ALL {}".format(self.def_offset.data()))
+
+                    uut.s3.SC32_G1_ALL     = self.def_gain1.data()
+                    print("GAIN 1 ALL {}".format(self.def_gain1.data()))
+
+                    uut.s3.SC32_G2_ALL     = self.def_gain2.data()
+                    print("GAIN 2 ALL {}".format(self.def_gain2.data()))
+
+                uut.s3.SC32_GAIN_COMMIT = 1
+                print("GAIN Committed for site {}".format(site))
+
+            elif site == 5:
+                for ic, ch in enumerate(chans_sc):
+                    if ic < 33:
+                        uut_s5_sc32_offset = uut.s5.__getattr__('SC32_OFFSET_%2.2d' %(ic+1))
+                        uut_s5_sc32_g1     = uut.s5.__getattr__('SC32_G1_%2.2d' %(ic+1))
+                        uut_s5_sc32_g2     = uut.s5.__getattr__('SC32_G2_%2.2d' %(ic+1))
+                        if ch.on:
+                            uut_s5_sc32_offset = self.__getattr__('INPUT_%3.3d:SC_GAIN1' %(ic+1)).data()
+                            uut_s5_sc32_g1     = self.__getattr__('INPUT_%3.3d:SC_GAIN2' %(ic+1)).data()
+                            uut_s5_sc32_g2     = self.__getattr__('INPUT_%3.3d:SC_OFFSET'%(ic+1)).data()
+                if isinstance(self.def_offset.data() , numbers.Number) and isinstance(self.def_gain1.data() , numbers.Number) and isinstance(self.def_gain2.data() , numbers.Number):
+                   # Global controls for GAINS and OFFSETS
+                    uut.s5.SC32_OFFSET_ALL = self.def_offset.data()
+                    print("OFFSET ALL {}".format(self.def_offset.data()))
+
+                    uut.s5.SC32_G1_ALL     = self.def_gain1.data()
+                    print("GAIN 1 ALL {}".format(self.def_gain1.data()))
+
+                    uut.s5.SC32_G2_ALL     = self.def_gain2.data()
+                    print("GAIN 2 ALL {}".format(self.def_gain2.data()))
+
+                uut.s5.SC32_GAIN_COMMIT = 1
+                print("GAIN Committed for site {}".format(site))
+
 
     def store(self):
         uut = acq400_hapi.Acq400(self.node.data(), monitor=False)
@@ -86,9 +156,9 @@ def assemble(cls):
             {'path':':INPUT_%3.3d:DECIMATE'%(i+1,),    'type':'NUMERIC', 'valueExpr':'head.def_dcim',                'options':('no_write_shot',)},           
             {'path':':INPUT_%3.3d:COEFFICIENT'%(i+1,), 'type':'NUMERIC',                                             'options':('no_write_model', 'write_once',)},
             {'path':':INPUT_%3.3d:OFFSET'%(i+1,),      'type':'NUMERIC',                                             'options':('no_write_model', 'write_once',)},
-            {'path':':INPUT_%3.3d:SC_GAIN1'%(i+1,),    'type':'NUMERIC', 'valueExpr':'head.def_gain1',               'options':('no_write_shot', 'write_once',)},
-            {'path':':INPUT_%3.3d:SC_GAIN2'%(i+1,),    'type':'NUMERIC', 'valueExpr':'head.def_gain2',               'options':('no_write_shot', 'write_once',)},
-            {'path':':INPUT_%3.3d:SC_OFFSET'%(i+1,),   'type':'NUMERIC', 'valueExpr':'head.def_offset',              'options':('no_write_shot', 'write_once',)},   
+            {'path':':INPUT_%3.3d:SC_GAIN1'%(i+1,),    'type':'NUMERIC', 'valueExpr':'head.def_gain1',               'options':('no_write_shot',)},
+            {'path':':INPUT_%3.3d:SC_GAIN2'%(i+1,),    'type':'NUMERIC', 'valueExpr':'head.def_gain2',               'options':('no_write_shot',)},
+            {'path':':INPUT_%3.3d:SC_OFFSET'%(i+1,),   'type':'NUMERIC', 'valueExpr':'head.def_offset',              'options':('no_write_shot',)},   
             #{'path':':INPUT_%3.3d:NON_SC'%(i+1,),          'type':'SIGNAL',  'valueExpr':'SUBTRACT(DIVIDE(INPUT_%3.3d, MULTIPLY(INPUT_%3.3d_SC_GAIN1, INPUT_%3.3d_SC_GAIN2)), INPUT_%3.3d_SC_OFFSET)' %(i+1,i+1,i+1,i+1,), 'options':('no_write_model','write_once',)},
             {'path':':INPUT_%3.3d:NON_SC'%(i+1,),      'type':'SIGNAL',                                              'options':('no_write_model','write_once',)},
             {'path':':INPUT_%3.3d:LOW_RES'%(i+1,),     'type':'SIGNAL',                                              'options':('no_write_model','write_once',)},

--- a/pydevices/HtsDevices/acq2106_435sc.py
+++ b/pydevices/HtsDevices/acq2106_435sc.py
@@ -62,10 +62,20 @@ class _ACQ2106_435SC(acq2106_435st._ACQ2106_435ST):
             slot.SC32_GAIN_COMMIT = 1
             print("GAINs Committed for site {}".format(site))
 
+        # For testing purpose only. Set CLKDIV knowing the desired FREQ:
+        # mb_freq = uut.s0.SIG_CLK_MB_FREQ
+        mb_freq = 20000000.0 # 20 MHz MB clock
+        uut.s1.CLKDIV = "{}".format(mb_freq / self.freq.data())
+        
         super(_ACQ2106_435SC, self).init()
 
         # For testing purpose only. Set trigger source to external hard trigger:
         uut.s0.SIG_SRC_TRG_0 = 'EXT'
+
+        # For testing purpose only. Checking the final SR of the device
+        clkdiv  = uut.s1.CLKDIV
+        s1_freq = uut.s0.SIG_CLK_S1_FREQ
+        print("SR = {}".format(s1_freq))
 
     def store(self):
         uut = self.getUUT()

--- a/pydevices/HtsDevices/acq2106_435sc.py
+++ b/pydevices/HtsDevices/acq2106_435sc.py
@@ -32,10 +32,12 @@ class _ACQ2106_435SC(acq2106_435st._ACQ2106_435ST):
     """
     D-Tacq ACQ2106 Signal Conditioning support.
     """
-
+    
     sc_parts = [
-        {'path':':DEF_GAIN1',  'type':'numeric', 'value': 0, 'options':('no_write_shot',)},
-        {'path':':DEF_GAIN2',  'type':'numeric', 'value': 0, 'options':('no_write_shot',)},
+        # IS_GLOBAL controls if the GAINS and OFFSETS are set globally or per channel
+        {'path':':IS_GLOBAL',  'type':'numeric', 'value': 0, 'options':('no_write_shot',)},
+        {'path':':DEF_GAIN1',  'type':'numeric', 'value': 1, 'options':('no_write_shot',)},
+        {'path':':DEF_GAIN2',  'type':'numeric', 'value': 1, 'options':('no_write_shot',)},
         {'path':':DEF_OFFSET', 'type':'numeric', 'value': 0, 'options':('no_write_shot',)},
     ]
 
@@ -44,7 +46,7 @@ class _ACQ2106_435SC(acq2106_435st._ACQ2106_435ST):
 
         for site in range(1,6,2):
             slot = self.getSlot(site)
-            if self.def_gain1.data() != 0 or self.def_gain2.data() != 0:
+            if self.is_global.data() == 1:
                 # Global controls for GAINS and OFFSETS
                 slot.SC32_OFFSET_ALL = self.def_offset.data()
                 print("Site {} OFFSET ALL {}".format(site, self.def_offset.data()))
@@ -55,17 +57,28 @@ class _ACQ2106_435SC(acq2106_435st._ACQ2106_435ST):
                 slot.SC32_G2_ALL     = self.def_gain2.data()
                 print("Site {} GAIN 2 ALL {}".format(site, self.def_gain2.data()))
             else:
-                for ic in range(32):
-                    exec("uut.s%d.SC32_OFFSET_%2.2d = self.__getattr__('INPUT_%3.3d:SC_OFFSET').data()"%(site, ic+1, ic+1))
-                    exec("uut.s%d.SC32_G1_%2.2d     = self.__getattr__('INPUT_%3.3d:SC_GAIN1' ).data()"%(site, ic+1, ic+1))
-                    exec("uut.s%d.SC32_G2_%2.2d     = self.__getattr__('INPUT_%3.3d:SC_GAIN2' ).data()"%(site, ic+1, ic+1))
+                if site == 1:
+                    for ic in range(1,32):
+                        exec("uut.s1.SC32_OFFSET_%2.2d = self.__getattr__('INPUT_%3.3d:SC_OFFSET').data()"%(ic, ic))
+                        exec("uut.s1.SC32_G1_%2.2d     = self.__getattr__('INPUT_%3.3d:SC_GAIN1' ).data()"%(ic, ic))
+                        exec("uut.s1.SC32_G2_%2.2d     = self.__getattr__('INPUT_%3.3d:SC_GAIN2' ).data()"%(ic, ic))
+                elif site == 3:
+                    for ic, jc in zip(range(33,64), range(1, 32)):
+                        exec("uut.s3.SC32_OFFSET_%2.2d = self.__getattr__('INPUT_%3.3d:SC_OFFSET').data()"%(jc, ic))
+                        exec("uut.s3.SC32_G1_%2.2d     = self.__getattr__('INPUT_%3.3d:SC_GAIN1' ).data()"%(jc, ic))
+                        exec("uut.s3.SC32_G2_%2.2d     = self.__getattr__('INPUT_%3.3d:SC_GAIN2' ).data()"%(jc, ic))
+                elif site == 5:
+                    for ic, jc in zip(range(65,96), range(1, 32)):
+                        exec("uut.s5.SC32_OFFSET_%2.2d = self.__getattr__('INPUT_%3.3d:SC_OFFSET').data()"%(jc, ic))
+                        exec("uut.s5.SC32_G1_%2.2d     = self.__getattr__('INPUT_%3.3d:SC_GAIN1' ).data()"%(jc, ic))
+                        exec("uut.s5.SC32_G2_%2.2d     = self.__getattr__('INPUT_%3.3d:SC_GAIN2' ).data()"%(jc, ic))
 
             slot.SC32_GAIN_COMMIT = 1
             print("GAIN Committed for site {}".format(site))
 
         super(_ACQ2106_435SC, self).init()
 
-        # For testing purpose only:
+        # For testing purpose only. Set trigger source to external hard trigger:
         uut.s0.SIG_SRC_TRG_0 = 'EXT'
 
     def store(self):
@@ -84,7 +97,7 @@ class _ACQ2106_435SC(acq2106_435st._ACQ2106_435ST):
 
     def unConditioning(self,num):
         chan     = self.__getattr__('INPUT_%3.3d' % num)
-        chan_nonsc = self.__getattr__('INPUT_%3.3d:NON_SC' % num)
+        chan_nonsc = self.__getattr__('INPUT_%3.3d:NC_INPUT' % num)
         expr = MDSplus.SUBTRACT(MDSplus.DIVIDE(chan, MDSplus.MULTIPLY(chan.SC_GAIN1, chan.SC_GAIN2)), chan.SC_OFFSET)
 
     def setSmooth(self,num):
@@ -132,8 +145,8 @@ def assemble(cls):
             {'path':':INPUT_%3.3d:SC_GAIN1'%(i+1,),    'type':'NUMERIC', 'valueExpr':'head.def_gain1',               'options':('no_write_shot',)},
             {'path':':INPUT_%3.3d:SC_GAIN2'%(i+1,),    'type':'NUMERIC', 'valueExpr':'head.def_gain2',               'options':('no_write_shot',)},
             {'path':':INPUT_%3.3d:SC_OFFSET'%(i+1,),   'type':'NUMERIC', 'valueExpr':'head.def_offset',              'options':('no_write_shot',)},   
-            {'path':':INPUT_%3.3d:NC_INPUT'%(i+1,),      'type':'SIGNAL',                                            'options':('no_write_model','write_once',)},
-            {'path':':INPUT_%3.3d:LR_INPUT'%(i+1,),     'type':'SIGNAL', 'valueExpr':'head.setSmooth(%d)' %(i+1,)},
+            {'path':':INPUT_%3.3d:NC_INPUT'%(i+1,),    'type':'SIGNAL',                                            'options':('no_write_model','write_once',)},
+            {'path':':INPUT_%3.3d:LR_INPUT'%(i+1,),    'type':'SIGNAL', 'valueExpr':'head.setSmooth(%d)' %(i+1,)},
         ]
 
 class ACQ2106_435SC_1ST(_ACQ2106_435SC): sites=1

--- a/pydevices/HtsDevices/acq2106_435sc.py
+++ b/pydevices/HtsDevices/acq2106_435sc.py
@@ -149,10 +149,13 @@ def assemble(cls):
                 'path': ':INPUT_%3.3d:NC_INPUT'%(i+1,),
                 'type':'SIGNAL',
                 'options':('no_write_model','write_once',)},
+
             {
-                # Low-Resolution signal
-                'path': ':INPUT_%3.3d:LR_INPUT'%(i+1,),
-                'type':'SIGNAL'},
+                # Re-sampling streaming data:
+                'path': ':INPUT_%3.3d:RESAMPLED' % (i+1,),
+                'type': 'SIGNAL', 
+                'valueExpr': 'head.setChanScale("INPUT_%3.3d:RESAMPLED", %d)' % (i+1,i+1),
+                'options': ('no_write_model', 'write_once',)},
         ]
 
 class ACQ2106_435SC_1ST(_ACQ2106_435SC): 

--- a/pydevices/HtsDevices/acq2106_435sc.py
+++ b/pydevices/HtsDevices/acq2106_435sc.py
@@ -34,32 +34,36 @@ class _ACQ2106_435SC(acq2106_435st._ACQ2106_435ST):
     """
     
     sc_parts = [
-        # IS_GLOBAL controls if the GAINS and OFFSETS are set globally or per channel
         {
+            # IS_GLOBAL controls if the GAINS and OFFSETS are set globally or per channel
             'path': ':IS_GLOBAL',
             'type': 'numeric', 
-            'value': 1,
+            'value': 1, # mean, global settings are used in the D-Tacq SC device.
             'options': ('no_write_shot',)
         },
-        {
+        { 
+            # Global D-Tacq SC GAIN1
             'path': ':DEF_GAIN1',
             'type': 'numeric',
             'value': 1,
             'options': ('no_write_shot',)
         },
         {
+            # Global D-Tacq SC GAIN2
             'path': ':DEF_GAIN2',
             'type': 'numeric',
             'value': 1,
             'options': ('no_write_shot',)
         },
         {
+            # Global D-Tacq SC OFFSET
             'path': ':DEF_OFFSET',
             'type': 'numeric',
             'value': 0,
             'options': ('no_write_shot',)
         },
         {
+            # Resampling factor. This is used during streaming by makeSegmentResampled()
             'path': ':RES_FACTOR',
             'type': 'numeric',
             'value': 100,
@@ -156,25 +160,28 @@ def assemble(cls):
                 'options':('no_write_model', 'write_once',)
             },
             {
+                # Local (per channel) SC gains
                 'path': ':INPUT_%3.3d:SC_GAIN1'%(i+1,),
                 'type':'NUMERIC', 
                 'valueExpr':'head.def_gain1',
                 'options':('no_write_shot',)
             },
             {
+                # Local (per channel) SC gains
                 'path': ':INPUT_%3.3d:SC_GAIN2'%(i+1,),
                 'type':'NUMERIC', 
                 'valueExpr':'head.def_gain2',
                 'options':('no_write_shot',)
             },
             {
+                # Local (per channel) SC offsets
                 'path': ':INPUT_%3.3d:SC_OFFSET'%(i+1,),
                 'type':'NUMERIC', 
                 'valueExpr':'head.def_offset',
                 'options':('no_write_shot',)
             },   
             {
-                 # Conditioned signal
+                 # Conditioned signal goes here:
                 'path': ':INPUT_%3.3d:SC_INPUT'%(i+1,),
                 'type': 'SIGNAL',
                 'valueExpr': 
@@ -183,7 +190,7 @@ def assemble(cls):
                 'options': ('no_write_model','write_once',)
             },
             {
-                # Re-sampling streaming data:
+                # Re-sampling streaming data goes here:
                 'path': ':INPUT_%3.3d:RESAMPLED' % (i+1,),
                 'type': 'SIGNAL', 
                 'valueExpr': 'head.setChanScale("INPUT_%3.3d:RESAMPLED", %d)' % (i+1, i+1),

--- a/pydevices/HtsDevices/acq2106_435sc.py
+++ b/pydevices/HtsDevices/acq2106_435sc.py
@@ -95,22 +95,6 @@ class _ACQ2106_435SC(acq2106_435st._ACQ2106_435ST):
         # For testing purpose only. Set trigger source to external hard trigger:
         uut.s0.SIG_SRC_TRG_0 = 'EXT'
     INIT=init
-
-    # The following STORE method will UN-conditioned the signal so as to have in the tree node "NC_INPUT"
-    # the original input signal.
-    def store(self):
-        uut = self.getUUT()
-
-        chans_sc  = []
-        nchannels = uut.nchan()
-        for ii in range(nchannels):
-            chans_sc.append(getattr(self, 'INPUT_%3.3d'%(ii+1)))
-
-        for ic, ch in enumerate(chans_sc):
-            chan_unsc = self.__getattr__('INPUT_%3.3d:SC_INPUT' %(ic+1))
-            if ch.on:
-                chan_unsc.record = MDSplus.BUILD_SIGNAL(ch.data(), MDSplus.RAW_OF(ch), MDSplus.DIM_OF(ch))
-    STORE=store
     
     def getUUT(self):
         import acq400_hapi

--- a/pydevices/HtsDevices/acq2106_435sc.py
+++ b/pydevices/HtsDevices/acq2106_435sc.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# Copyright (c) 2017, Massachusetts Institute of Technology All rights reserved.
+# Copyright (c) 2021, Massachusetts Institute of Technology All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:
@@ -111,19 +111,19 @@ class _ACQ2106_435SC(acq2106_435st._ACQ2106_435ST):
 
     def setGainsOffsets(self, site):
         uut = self.getUUT()
-        for ic in range(1,32):
+        for ic in range(1,32+1):
             if site == 1:
-                exec("uut.s1.SC32_OFFSET_%2.2d = self.__getattr__('INPUT_%3.3d:SC_OFFSET').data()"%(ic, ic))
-                exec("uut.s1.SC32_G1_%2.2d     = self.__getattr__('INPUT_%3.3d:SC_GAIN1' ).data()"%(ic, ic))
-                exec("uut.s1.SC32_G2_%2.2d     = self.__getattr__('INPUT_%3.3d:SC_GAIN2' ).data()"%(ic, ic))
+                setattr(uut.s1, 'SC32_OFFSET_%2.2d' % (ic,), getattr(self, 'INPUT_%3.3d:SC_OFFSET' % (ic,)).data())
+                setattr(uut.s1, 'SC32_G1_%2.2d' % (ic,), getattr(self, 'INPUT_%3.3d:SC_GAIN1' % (ic,)).data())
+                setattr(uut.s1, 'SC32_G2_%2.2d' % (ic,), getattr(self, 'INPUT_%3.3d:SC_GAIN2' % (ic,)).data())
             elif site == 3:
-                exec("uut.s3.SC32_OFFSET_%2.2d = self.__getattr__('INPUT_%3.3d:SC_OFFSET').data()"%(ic, ic+32))
-                exec("uut.s3.SC32_G1_%2.2d     = self.__getattr__('INPUT_%3.3d:SC_GAIN1' ).data()"%(ic, ic+32))
-                exec("uut.s3.SC32_G2_%2.2d     = self.__getattr__('INPUT_%3.3d:SC_GAIN2' ).data()"%(ic, ic+32))
+                setattr(uut.s3, 'SC32_OFFSET_%2.2d' % (ic,), getattr(self, 'INPUT_%3.3d:SC_OFFSET' % (ic+32,)).data())
+                setattr(uut.s3, 'SC32_G1_%2.2d' % (ic,), getattr(self, 'INPUT_%3.3d:SC_GAIN1' % (ic+32,)).data())
+                setattr(uut.s3, 'SC32_G2_%2.2d' % (ic,), getattr(self, 'INPUT_%3.3d:SC_GAIN2' % (ic+32,)).data())
             elif site == 5:
-                exec("uut.s5.SC32_OFFSET_%2.2d = self.__getattr__('INPUT_%3.3d:SC_OFFSET').data()"%(ic, ic+64))
-                exec("uut.s5.SC32_G1_%2.2d     = self.__getattr__('INPUT_%3.3d:SC_GAIN1' ).data()"%(ic, ic+64))
-                exec("uut.s5.SC32_G2_%2.2d     = self.__getattr__('INPUT_%3.3d:SC_GAIN2' ).data()"%(ic, ic+64))  
+                setattr(uut.s5, 'SC32_OFFSET_%2.2d' % (ic,), getattr(self, 'INPUT_%3.3d:SC_OFFSET' % (ic+64,)).data())
+                setattr(uut.s5, 'SC32_G1_%2.2d' % (ic,), getattr(self, 'INPUT_%3.3d:SC_GAIN1' % (ic+64,)).data())
+                setattr(uut.s5, 'SC32_G2_%2.2d' % (ic,), getattr(self, 'INPUT_%3.3d:SC_GAIN2' % (ic+64,)).data())
 
     # TODO: a function to smooth data while being adquired
     # def setSmooth(self,num):

--- a/pydevices/HtsDevices/acq2106_435sc.py
+++ b/pydevices/HtsDevices/acq2106_435sc.py
@@ -62,20 +62,20 @@ class _ACQ2106_435SC(acq2106_435st._ACQ2106_435ST):
             slot.SC32_GAIN_COMMIT = 1
             print("GAINs Committed for site {}".format(site))
 
-        # For testing purpose only. Set CLKDIV knowing the desired FREQ:
-        # mb_freq = uut.s0.SIG_CLK_MB_FREQ
-        mb_freq = 20000000.0 # 20 MHz MB clock
-        uut.s1.CLKDIV = "{}".format(mb_freq / self.freq.data())
+        # For testing purpose only. Set CLKDIV knowing that:
+        # a special config in /mnt/local/rc.user gives a SR=40KHz at bootime:
+        # WR additions for WRCLK 20M
+        # cp /mnt/local/si5326_31M25-20M48.txt /etc/si5326.d/
+        # /usr/local/CARE/WR/set_clk_WR 20M48
+        # 20.48MHz / 512 => 40.0kHz
+        # To get a SR=20KHz, then:
+
+        uut.s1.CLKDIV = '2'
         
         super(_ACQ2106_435SC, self).init()
 
         # For testing purpose only. Set trigger source to external hard trigger:
         uut.s0.SIG_SRC_TRG_0 = 'EXT'
-
-        # For testing purpose only. Checking the final SR of the device
-        clkdiv  = uut.s1.CLKDIV
-        s1_freq = uut.s0.SIG_CLK_S1_FREQ
-        print("SR = {}".format(s1_freq))
 
     def store(self):
         uut = self.getUUT()

--- a/pydevices/HtsDevices/acq2106_435sc.py
+++ b/pydevices/HtsDevices/acq2106_435sc.py
@@ -25,8 +25,6 @@
 
 import MDSplus
 import importlib
-import os
-import numbers
 
 acq2106_435st = importlib.import_module('acq2106_435st')
 
@@ -53,10 +51,10 @@ class _ACQ2106_435SC(acq2106_435st._ACQ2106_435ST):
                 print("Site {} OFFSET ALL {}".format(site, self.def_offset.data()))
 
                 slot.SC32_G1_ALL     = self.def_gain1.data()
-                print("Site {} GAIN 1 ALL {}".format(self.def_gain1.data()))
+                print("Site {} GAIN 1 ALL {}".format(site, self.def_gain1.data()))
 
                 slot.SC32_G2_ALL     = self.def_gain2.data()
-                print("Site {} GAIN 2 ALL {}".format(self.def_gain2.data()))
+                print("Site {} GAIN 2 ALL {}".format(site, self.def_gain2.data()))
             else:
                 for ic in range(32):
                     exec("uut.s%d.SC32_OFFSET_%2.2d = self.__getattr__('INPUT_%3.3d:SC_OFFSET').data()"%(site, ic+1, ic+1))
@@ -64,7 +62,7 @@ class _ACQ2106_435SC(acq2106_435st._ACQ2106_435ST):
                     exec("uut.s%d.SC32_G2_%2.2d     = self.__getattr__('INPUT_%3.3d:SC_GAIN2' ).data()"%(site, ic+1, ic+1))
 
             # uut.s1.SC32_GAIN_COMMIT = 1
-            exec("uut.s%d.SC32_GAIN_COMMIT = 1" %(site))
+            slot.SC32_GAIN_COMMIT = 1
             print("GAIN Committed for site {}".format(site))
 
         super(_ACQ2106_435SC, self).init()
@@ -90,7 +88,7 @@ class _ACQ2106_435SC(acq2106_435st._ACQ2106_435ST):
 
     def setSmooth(self,num):
         chan = self.__getattr__('INPUT_%3.3d' % num)
-        chan_nonsc =self.__getattr__('INPUT_%3.3d:LOW_RES' % num)
+        chan_nonsc =self.__getattr__('INPUT_%3.3d:LR_INPUT' % num)
         chan_nonsc.setSegmentScale(MDSplus.SMOOTH(MDSplus.dVALUE(),100))
     
     def getSlot(self, site_number):
@@ -134,9 +132,8 @@ def assemble(cls):
             {'path':':INPUT_%3.3d:SC_GAIN1'%(i+1,),    'type':'NUMERIC', 'valueExpr':'head.def_gain1',               'options':('no_write_shot',)},
             {'path':':INPUT_%3.3d:SC_GAIN2'%(i+1,),    'type':'NUMERIC', 'valueExpr':'head.def_gain2',               'options':('no_write_shot',)},
             {'path':':INPUT_%3.3d:SC_OFFSET'%(i+1,),   'type':'NUMERIC', 'valueExpr':'head.def_offset',              'options':('no_write_shot',)},   
-            #{'path':':INPUT_%3.3d:NON_SC'%(i+1,),          'type':'SIGNAL',  'valueExpr':'SUBTRACT(DIVIDE(INPUT_%3.3d, MULTIPLY(INPUT_%3.3d_SC_GAIN1, INPUT_%3.3d_SC_GAIN2)), INPUT_%3.3d_SC_OFFSET)' %(i+1,i+1,i+1,i+1,), 'options':('no_write_model','write_once',)},
-            {'path':':INPUT_%3.3d:NON_SC'%(i+1,),      'type':'SIGNAL',                                              'options':('no_write_model','write_once',)},
-            {'path':':INPUT_%3.3d:LOW_RES'%(i+1,),     'type':'SIGNAL', 'valueExpr':'head.setSmooth(%d)' %(i+1,)},
+            {'path':':INPUT_%3.3d:NO_COND'%(i+1,),      'type':'SIGNAL',                                              'options':('no_write_model','write_once',)},
+            {'path':':INPUT_%3.3d:LR_INPUT'%(i+1,),     'type':'SIGNAL', 'valueExpr':'head.setSmooth(%d)' %(i+1,)},
         ]
 
 class ACQ2106_435SC_1ST(_ACQ2106_435SC): sites=1

--- a/pydevices/HtsDevices/acq2106_435sc.py
+++ b/pydevices/HtsDevices/acq2106_435sc.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python
+#
+# Copyright (c) 2017, Massachusetts Institute of Technology All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# Redistributions of source code must retain the above copyright notice, this
+# list of conditions and the following disclaimer.
+#
+# Redistributions in binary form must reproduce the above copyright notice, this
+# list of conditions and the following disclaimer in the documentation and/or
+# other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import MDSplus
+import importlib
+import os
+
+acq2106_435st = importlib.import_module('acq2106_435st')
+acq400_hapi = importlib.import_module('acq400_hapi')  
+
+class _ACQ2106_435SC(acq2106_435st._ACQ2106_435ST):
+    """
+    D-Tacq ACQ2106 Signal Conditioning support.
+    """
+
+    sc_parts = [
+        {'path':':DEF_GAIN',  'type':'numeric', 'value': 1, 'options':('no_write_shot',)},
+        {'path':':DEF_OFFSET','type':'numeric', 'value': 0, 'options':('no_write_shot',)},
+    ]
+
+    def init(self):
+        super(_ACQ2106_435SC, self).init()
+        uut = acq400_hapi.Acq400(self.node.data(), monitor=False)
+
+        uut.s1.sc32_offset_all = self.def_offset.data()
+        print("GAIN ALL {}".format(self.def_offset.data()))
+
+        uut.s1.sc32_g1_all     = self.def_gain.data()
+        print("OFFSET_ALL {}".format(self.def_gain.data()))
+
+        print("Commiting gains")
+        uut.s1.sc32_gain_commit
+        print("Finish commiting")
+
+    def setCalibration(self,num):
+        chan=self.__getattr__('INPUT_%3.3d:RAW' % num)
+        chan.setSegmentScale(MDSplus.ADD(MDSplus.MULTIPLY(chan.COEFFICIENT,MDSplus.dVALUE()),chan.OFFSET))
+
+    def noConditioning(self,num):
+        chan    = self.__getattr__('INPUT_%3.3d:RAW' % num)
+        chan_sc = self.__getattr__('INPUT_%3.3d' % num) 
+        chan_sc.setSegmentScale(MDSplus.SUBTRACT(MDSplus.DIVIDE(chan, chan_sc.GAIN_SC), chan_sc.OFFSET_SC))
+
+
+
+def assemble(cls):
+    cls.parts = list(_ACQ2106_435SC.carrier_parts + _ACQ2106_435SC.sc_parts)
+    for i in range(cls.sites*32):
+        cls.parts += [
+            {'path':':INPUT_%3.3d'%(i+1,),            'type':'SIGNAL', 'valueExpr':'head.noConditioning(%d)' %(i+1,),'options':('no_write_model','write_once',)}, 
+            {'path':':INPUT_%3.3d:GAIN_SC'%(i+1,),    'type':'NUMERIC',                                            'options':('no_write_model', 'write_once',)},
+            {'path':':INPUT_%3.3d:OFFSET_SC'%(i+1,),  'type':'NUMERIC',                                            'options':('no_write_model', 'write_once',)},  
+
+            {'path':':INPUT_%3.3d:RAW'%(i+1,), 'type':'SIGNAL',  'valueExpr':'head.setCalibration(%d)' %(i+1,), 'options':('no_write_model','write_once',)},
+            {'path':':INPUT_%3.3d:RAW:DECIMATE'%(i+1,),    'type':'NUMERIC', 'valueExpr':'head.def_dcim',               'options':('no_write_shot',)},           
+            {'path':':INPUT_%3.3d:RAW:COEFFICIENT'%(i+1,), 'type':'NUMERIC',                                            'options':('no_write_model', 'write_once',)},
+            {'path':':INPUT_%3.3d:RAW:OFFSET'%(i+1,),      'type':'NUMERIC',                                            'options':('no_write_model', 'write_once',)},
+      
+        ]
+
+class ACQ2106_435SC_1ST(_ACQ2106_435SC): sites=1
+assemble(ACQ2106_435SC_1ST)
+class ACQ2106_435SC_2ST(_ACQ2106_435SC): sites=2
+assemble(ACQ2106_435SC_2ST)
+class ACQ2106_435SC_3ST(_ACQ2106_435SC): sites=3
+assemble(ACQ2106_435SC_3ST)
+
+del(assemble)

--- a/pydevices/HtsDevices/acq2106_435sc.py
+++ b/pydevices/HtsDevices/acq2106_435sc.py
@@ -125,15 +125,11 @@ class _ACQ2106_435SC(acq2106_435st._ACQ2106_435ST):
                 exec("uut.s5.SC32_G1_%2.2d     = self.__getattr__('INPUT_%3.3d:SC_GAIN1' ).data()"%(ic, ic+64))
                 exec("uut.s5.SC32_G2_%2.2d     = self.__getattr__('INPUT_%3.3d:SC_GAIN2' ).data()"%(ic, ic+64))  
 
-    def unConditioning(self,num):
-        chan     = self.__getattr__('INPUT_%3.3d' % num)
-        chan_nonsc = self.__getattr__('INPUT_%3.3d:NC_INPUT' % num)
-        expr = MDSplus.SUBTRACT(MDSplus.DIVIDE(chan, MDSplus.MULTIPLY(chan.SC_GAIN1, chan.SC_GAIN2)), chan.SC_OFFSET)
-
-    def setSmooth(self,num):
-        chan = self.__getattr__('INPUT_%3.3d' % num)
-        chan_nonsc =self.__getattr__('INPUT_%3.3d:LR_INPUT' % num)
-        chan_nonsc.setSegmentScale(MDSplus.SMOOTH(MDSplus.dVALUE(),100))
+    # TODO: a function to smooth data while being adquired
+    # def setSmooth(self,num):
+    #     chan = self.__getattr__('INPUT_%3.3d' % num)
+    #     chan_nonsc =self.__getattr__('INPUT_%3.3d:LR_INPUT' % num)
+    #     chan_nonsc.setSegmentScale(MDSplus.SMOOTH(MDSplus.dVALUE(),100))
 
 def assemble(cls):
     cls.parts = list(_ACQ2106_435SC.carrier_parts + _ACQ2106_435SC.sc_parts)
@@ -146,8 +142,8 @@ def assemble(cls):
             {'path':':INPUT_%3.3d:SC_GAIN1'%(i+1,),    'type':'NUMERIC', 'valueExpr':'head.def_gain1',               'options':('no_write_shot',)},
             {'path':':INPUT_%3.3d:SC_GAIN2'%(i+1,),    'type':'NUMERIC', 'valueExpr':'head.def_gain2',               'options':('no_write_shot',)},
             {'path':':INPUT_%3.3d:SC_OFFSET'%(i+1,),   'type':'NUMERIC', 'valueExpr':'head.def_offset',              'options':('no_write_shot',)},   
-            {'path':':INPUT_%3.3d:NC_INPUT'%(i+1,),    'type':'SIGNAL',                                            'options':('no_write_model','write_once',)},
-            {'path':':INPUT_%3.3d:LR_INPUT'%(i+1,),    'type':'SIGNAL', 'valueExpr':'head.setSmooth(%d)' %(i+1,)},
+            {'path':':INPUT_%3.3d:NC_INPUT'%(i+1,),    'type':'SIGNAL',                                              'options':('no_write_model','write_once',)},
+            {'path':':INPUT_%3.3d:LR_INPUT'%(i+1,),    'type':'SIGNAL'},
         ]
 
 class ACQ2106_435SC_1ST(_ACQ2106_435SC): sites=1

--- a/pydevices/HtsDevices/acq2106_435sc.py
+++ b/pydevices/HtsDevices/acq2106_435sc.py
@@ -29,7 +29,6 @@ import os
 import numbers
 
 acq2106_435st = importlib.import_module('acq2106_435st')
-acq400_hapi = importlib.import_module('acq400_hapi')  
 
 class _ACQ2106_435SC(acq2106_435st._ACQ2106_435ST):
     """
@@ -37,98 +36,41 @@ class _ACQ2106_435SC(acq2106_435st._ACQ2106_435ST):
     """
 
     sc_parts = [
-        {'path':':DEF_GAIN1',  'type':'numeric', 'value': '1', 'options':('no_write_shot',)},
-        {'path':':DEF_GAIN2',  'type':'numeric', 'value': '1', 'options':('no_write_shot',)},
-        {'path':':DEF_OFFSET', 'type':'numeric', 'value': '0', 'options':('no_write_shot',)},
+        {'path':':DEF_GAIN1',  'type':'numeric', 'value': 0, 'options':('no_write_shot',)},
+        {'path':':DEF_GAIN2',  'type':'numeric', 'value': 0, 'options':('no_write_shot',)},
+        {'path':':DEF_OFFSET', 'type':'numeric', 'value': 0, 'options':('no_write_shot',)},
     ]
 
     def init(self):
-        super(_ACQ2106_435SC, self).init()
-        uut = acq400_hapi.Acq400(self.node.data(), monitor=False)
-
-        uut = acq400_hapi.Acq400(self.node.data(), monitor=False)
-
-        chans_sc  = []
-        nchannels = uut.nchan()
-        for ii in range(nchannels):
-            chans_sc.append(getattr(self, 'INPUT_%3.3d'%(ii+1)))
+        uut = self.getUUT()
 
         for site in range(1,6,2):
-            if site == 1:
-                for ic, ch in enumerate(chans_sc):
-                    if ic < 33:
-                        uut_s1_sc32_offset = uut.s1.__getattr__('SC32_OFFSET_%2.2d' %(ic+1))
-                        uut_s1_sc32_g1     = uut.s1.__getattr__('SC32_G1_%2.2d' %(ic+1))
-                        uut_s1_sc32_g2     = uut.s1.__getattr__('SC32_G2_%2.2d' %(ic+1))
-                        if ch.on:
-                            uut_s1_sc32_offset = self.__getattr__('INPUT_%3.3d:SC_GAIN1' %(ic+1)).data()
-                            uut_s1_sc32_g1     = self.__getattr__('INPUT_%3.3d:SC_GAIN2' %(ic+1)).data()
-                            uut_s1_sc32_g2     = self.__getattr__('INPUT_%3.3d:SC_OFFSET'%(ic+1)).data()
-                if isinstance(self.def_offset.data() , numbers.Number) and isinstance(self.def_gain1.data() , numbers.Number) and isinstance(self.def_gain2.data() , numbers.Number):
-                   # Global controls for GAINS and OFFSETS
-                    uut.s1.SC32_OFFSET_ALL = self.def_offset.data()
-                    print("OFFSET ALL {}".format(self.def_offset.data()))
+            slot = self.getSlot(site)
+            if self.def_gain1.data() != 0 or self.def_gain2.data() != 0:
+                # Global controls for GAINS and OFFSETS
 
-                    uut.s1.SC32_G1_ALL     = self.def_gain1.data()
-                    print("GAIN 1 ALL {}".format(self.def_gain1.data()))
+                slot.SC32_OFFSET_ALL = self.def_offset.data()
+                print("Site {} OFFSET ALL {}".format(site, self.def_offset.data()))
 
-                    uut.s1.SC32_G2_ALL     = self.def_gain2.data()
-                    print("GAIN 2 ALL {}".format(self.def_gain2.data()))
+                slot.SC32_G1_ALL     = self.def_gain1.data()
+                print("Site {} GAIN 1 ALL {}".format(self.def_gain1.data()))
 
-                uut.s1.SC32_GAIN_COMMIT = 1
-                print("GAIN Committed for site {}".format(site))
+                slot.SC32_G2_ALL     = self.def_gain2.data()
+                print("Site {} GAIN 2 ALL {}".format(self.def_gain2.data()))
+            else:
+                for ic in range(32):
+                    exec("uut.s%d.SC32_OFFSET_%2.2d = self.__getattr__('INPUT_%3.3d:SC_OFFSET').data()"%(site, ic+1, ic+1))
+                    exec("uut.s%d.SC32_G1_%2.2d     = self.__getattr__('INPUT_%3.3d:SC_GAIN1' ).data()"%(site, ic+1, ic+1))
+                    exec("uut.s%d.SC32_G2_%2.2d     = self.__getattr__('INPUT_%3.3d:SC_GAIN2' ).data()"%(site, ic+1, ic+1))
 
-            elif site == 3:
-                for ic, ch in enumerate(chans_sc):
-                    if ic < 33:
-                        uut_s1_sc32_offset = uut.s3.__getattr__('SC32_OFFSET_%2.2d' %(ic+1))
-                        uut_s1_sc32_g1     = uut.s3.__getattr__('SC32_G1_%2.2d' %(ic+1))
-                        uut_s1_sc32_g2     = uut.s3.__getattr__('SC32_G2_%2.2d' %(ic+1))
-                        if ch.on:
-                            uut_s1_sc32_offset = self.__getattr__('INPUT_%3.3d:SC_GAIN1' %(ic+1)).data()
-                            uut_s1_sc32_g1     = self.__getattr__('INPUT_%3.3d:SC_GAIN2' %(ic+1)).data()
-                            uut_s1_sc32_g2     = self.__getattr__('INPUT_%3.3d:SC_OFFSET'%(ic+1)).data()
-                if isinstance(self.def_offset.data() , numbers.Number) and isinstance(self.def_gain1.data() , numbers.Number) and isinstance(self.def_gain2.data() , numbers.Number):
-                   # Global controls for GAINS and OFFSETS
-                    uut.s3.SC32_OFFSET_ALL = self.def_offset.data()
-                    print("OFFSET ALL {}".format(self.def_offset.data()))
+            # uut.s1.SC32_GAIN_COMMIT = 1
+            exec("uut.s%d.SC32_GAIN_COMMIT = 1" %(site))
+            print("GAIN Committed for site {}".format(site))
 
-                    uut.s3.SC32_G1_ALL     = self.def_gain1.data()
-                    print("GAIN 1 ALL {}".format(self.def_gain1.data()))
-
-                    uut.s3.SC32_G2_ALL     = self.def_gain2.data()
-                    print("GAIN 2 ALL {}".format(self.def_gain2.data()))
-
-                uut.s3.SC32_GAIN_COMMIT = 1
-                print("GAIN Committed for site {}".format(site))
-
-            elif site == 5:
-                for ic, ch in enumerate(chans_sc):
-                    if ic < 33:
-                        uut_s5_sc32_offset = uut.s5.__getattr__('SC32_OFFSET_%2.2d' %(ic+1))
-                        uut_s5_sc32_g1     = uut.s5.__getattr__('SC32_G1_%2.2d' %(ic+1))
-                        uut_s5_sc32_g2     = uut.s5.__getattr__('SC32_G2_%2.2d' %(ic+1))
-                        if ch.on:
-                            uut_s5_sc32_offset = self.__getattr__('INPUT_%3.3d:SC_GAIN1' %(ic+1)).data()
-                            uut_s5_sc32_g1     = self.__getattr__('INPUT_%3.3d:SC_GAIN2' %(ic+1)).data()
-                            uut_s5_sc32_g2     = self.__getattr__('INPUT_%3.3d:SC_OFFSET'%(ic+1)).data()
-                if isinstance(self.def_offset.data() , numbers.Number) and isinstance(self.def_gain1.data() , numbers.Number) and isinstance(self.def_gain2.data() , numbers.Number):
-                   # Global controls for GAINS and OFFSETS
-                    uut.s5.SC32_OFFSET_ALL = self.def_offset.data()
-                    print("OFFSET ALL {}".format(self.def_offset.data()))
-
-                    uut.s5.SC32_G1_ALL     = self.def_gain1.data()
-                    print("GAIN 1 ALL {}".format(self.def_gain1.data()))
-
-                    uut.s5.SC32_G2_ALL     = self.def_gain2.data()
-                    print("GAIN 2 ALL {}".format(self.def_gain2.data()))
-
-                uut.s5.SC32_GAIN_COMMIT = 1
-                print("GAIN Committed for site {}".format(site))
-
+        super(_ACQ2106_435SC, self).init()
 
     def store(self):
-        uut = acq400_hapi.Acq400(self.node.data(), monitor=False)
+        uut = self.getUUT()
 
         chans_sc  = []
         nchannels = uut.nchan()
@@ -139,14 +81,47 @@ class _ACQ2106_435SC(acq2106_435st._ACQ2106_435ST):
             chan_unsc = self.__getattr__('INPUT_%3.3d:NON_SC' %(ic+1))
             if ch.on:
                 chan_unsc.record = MDSplus.BUILD_SIGNAL(ch.data() * (1.0/ch.SC_GAIN1 * ch.SC_GAIN2) - ch.SC_OFFSET, MDSplus.RAW_OF(ch), MDSplus.DIM_OF(ch))
-
     STORE=store
-
 
     def unConditioning(self,num):
         chan     = self.__getattr__('INPUT_%3.3d' % num)
-        chan_raw = self.__getattr__('INPUT_%3.3d:NON_SC' % num)
+        chan_nonsc = self.__getattr__('INPUT_%3.3d:NON_SC' % num)
         expr = MDSplus.SUBTRACT(MDSplus.DIVIDE(chan, MDSplus.MULTIPLY(chan.SC_GAIN1, chan.SC_GAIN2)), chan.SC_OFFSET)
+
+    def setSmooth(self,num):
+        chan = self.__getattr__('INPUT_%3.3d' % num)
+        chan_nonsc =self.__getattr__('INPUT_%3.3d:LOW_RES' % num)
+        chan_nonsc.setSegmentScale(MDSplus.SMOOTH(MDSplus.dVALUE(),100))
+    
+    def getSlot(self, site_number):
+        uut = self.getUUT()
+
+        try:
+            if site_number   == 0: 
+                slot = uut.s0
+            elif site_number == 1:
+                slot = uut.s1
+            elif site_number == 2:
+                slot = uut.s2
+            elif site_number == 3:
+                slot = uut.s3
+            elif site_number == 4:
+                slot = uut.s4
+            elif site_number == 5:
+                slot = uut.s5
+            elif site_number == 6:
+                slot = uut.s6
+        except:
+            pass
+        
+        return slot
+    
+    def getUUT(self):
+        import acq400_hapi
+
+        uut = acq400_hapi.Acq2106(self.node.data(), monitor=False, has_wr=True)
+        return uut
+
 
 def assemble(cls):
     cls.parts = list(_ACQ2106_435SC.carrier_parts + _ACQ2106_435SC.sc_parts)
@@ -161,7 +136,7 @@ def assemble(cls):
             {'path':':INPUT_%3.3d:SC_OFFSET'%(i+1,),   'type':'NUMERIC', 'valueExpr':'head.def_offset',              'options':('no_write_shot',)},   
             #{'path':':INPUT_%3.3d:NON_SC'%(i+1,),          'type':'SIGNAL',  'valueExpr':'SUBTRACT(DIVIDE(INPUT_%3.3d, MULTIPLY(INPUT_%3.3d_SC_GAIN1, INPUT_%3.3d_SC_GAIN2)), INPUT_%3.3d_SC_OFFSET)' %(i+1,i+1,i+1,i+1,), 'options':('no_write_model','write_once',)},
             {'path':':INPUT_%3.3d:NON_SC'%(i+1,),      'type':'SIGNAL',                                              'options':('no_write_model','write_once',)},
-            {'path':':INPUT_%3.3d:LOW_RES'%(i+1,),     'type':'SIGNAL',                                              'options':('no_write_model','write_once',)},
+            {'path':':INPUT_%3.3d:LOW_RES'%(i+1,),     'type':'SIGNAL', 'valueExpr':'head.setSmooth(%d)' %(i+1,)},
         ]
 
 class ACQ2106_435SC_1ST(_ACQ2106_435SC): sites=1

--- a/pydevices/HtsDevices/acq2106_435sc.py
+++ b/pydevices/HtsDevices/acq2106_435sc.py
@@ -96,8 +96,6 @@ class _ACQ2106_435SC(acq2106_435st._ACQ2106_435ST):
         # makeSegmentResampled(begin, end, dim, b, resampled, res_factor)
         super(_ACQ2106_435SC, self).init(1)
 
-        # For testing purpose only. Set trigger source to external hard trigger:
-        uut.s0.SIG_SRC_TRG_0 = 'EXT'
     INIT=init
     
     def getUUT(self):

--- a/pydevices/HtsDevices/acq2106_435sc.py
+++ b/pydevices/HtsDevices/acq2106_435sc.py
@@ -43,24 +43,25 @@ class _ACQ2106_435SC(acq2106_435st._ACQ2106_435ST):
 
     def init(self):
         uut = self.getUUT()
+        slots = super(_ACQ2106_435SC, self).getSlots()
 
-        for site in range(1,6,2):
-            slot = self.getSlot(site)
+        for card in range(self.sites):
+
             if self.is_global.data() == 1:
                 # Global controls for GAINS and OFFSETS
-                slot.SC32_OFFSET_ALL = self.def_offset.data()
-                print("Site {} OFFSET ALL {}".format(site, self.def_offset.data()))
+                slots[card].SC32_OFFSET_ALL = self.def_offset.data()
+                print("Site {} OFFSET ALL {}".format(card, self.def_offset.data()))
 
-                slot.SC32_G1_ALL     = self.def_gain1.data()
-                print("Site {} GAIN 1 ALL {}".format(site, self.def_gain1.data()))
+                slots[card].SC32_G1_ALL     = self.def_gain1.data()
+                print("Site {} GAIN 1 ALL {}".format(card, self.def_gain1.data()))
 
-                slot.SC32_G2_ALL     = self.def_gain2.data()
-                print("Site {} GAIN 2 ALL {}".format(site, self.def_gain2.data()))
+                slots[card].SC32_G2_ALL     = self.def_gain2.data()
+                print("Site {} GAIN 2 ALL {}".format(card, self.def_gain2.data()))
             else:
-                self.setGainsOffsets(site)
+                self.setGainsOffsets(card)
 
-            slot.SC32_GAIN_COMMIT = 1
-            print("GAINs Committed for site {}".format(site))
+            slots[card].SC32_GAIN_COMMIT = 1
+            print("GAINs Committed for site {}".format(card))
 
         # TODO: Choose between possible SR
         # For testing purpose only. Set CLKDIV knowing that:
@@ -95,29 +96,6 @@ class _ACQ2106_435SC(acq2106_435st._ACQ2106_435ST):
                 chan_unsc.record = MDSplus.BUILD_SIGNAL(ch.data() * (1.0/(ch.SC_GAIN1 * ch.SC_GAIN2)) - ch.SC_OFFSET, MDSplus.RAW_OF(ch), MDSplus.DIM_OF(ch))
     STORE=store
     
-    def getSlot(self, site_number):
-        uut = self.getUUT()
-
-        try:
-            if site_number   == 0: 
-                slot = uut.s0
-            elif site_number == 1:
-                slot = uut.s1
-            elif site_number == 2:
-                slot = uut.s2
-            elif site_number == 3:
-                slot = uut.s3
-            elif site_number == 4:
-                slot = uut.s4
-            elif site_number == 5:
-                slot = uut.s5
-            elif site_number == 6:
-                slot = uut.s6
-        except:
-            pass
-        
-        return slot
-    
     def getUUT(self):
         import acq400_hapi
         uut = acq400_hapi.Acq2106(self.node.data(), monitor=False, has_wr=True)
@@ -139,7 +117,7 @@ class _ACQ2106_435SC(acq2106_435st._ACQ2106_435ST):
                 setattr(uut.s5, 'SC32_G1_%2.2d' % (ic,), getattr(self, 'INPUT_%3.3d:SC_GAIN1' % (ic+64,)).data())
                 setattr(uut.s5, 'SC32_G2_%2.2d' % (ic,), getattr(self, 'INPUT_%3.3d:SC_GAIN2' % (ic+64,)).data())
 
-    # TODO: a function to smooth data while being adquired
+    # TODO: a function to smooth/filter data while being adquired
     # def setSmooth(self,num):
     #     chan = self.__getattr__('INPUT_%3.3d' % num)
     #     chan_nonsc =self.__getattr__('INPUT_%3.3d:LR_INPUT' % num)

--- a/pydevices/HtsDevices/acq2106_435sc.py
+++ b/pydevices/HtsDevices/acq2106_435sc.py
@@ -69,10 +69,9 @@ class _ACQ2106_435SC(acq2106_435st._ACQ2106_435ST):
 
     def init(self):
         uut = self.getUUT()
-        slots = super(_ACQ2106_435SC, self).getSlots()
-
-        for card in range(self.sites):
-
+        self.slots = super(_ACQ2106_435SC, self).getSlots()
+        
+        for card in self.slots:
             if self.is_global.data() == 1:
                 # Global controls for GAINS and OFFSETS
                 slots[card].SC32_OFFSET_ALL = self.def_offset.data()
@@ -86,7 +85,7 @@ class _ACQ2106_435SC(acq2106_435st._ACQ2106_435ST):
             else:
                 self.setGainsOffsets(card)
 
-            slots[card].SC32_GAIN_COMMIT = 1
+            self.slots[card].SC32_GAIN_COMMIT = 1
             print("GAINs Committed for site {}".format(card))
         # Here, the argument to the init of the superclass:
         # - init(1) => use resampling function:
@@ -118,21 +117,21 @@ class _ACQ2106_435SC(acq2106_435st._ACQ2106_435ST):
         uut = acq400_hapi.Acq2106(self.node.data(), monitor=False, has_wr=True)
         return uut
 
-    def setGainsOffsets(self, site):
+    def setGainsOffsets(self, card):
         uut = self.getUUT()
         for ic in range(1,32+1):
-            if site == 1:
-                setattr(uut.s1, 'SC32_OFFSET_%2.2d' % (ic,), getattr(self, 'INPUT_%3.3d:SC_OFFSET' % (ic,)).data())
-                setattr(uut.s1, 'SC32_G1_%2.2d' % (ic,), getattr(self, 'INPUT_%3.3d:SC_GAIN1' % (ic,)).data())
-                setattr(uut.s1, 'SC32_G2_%2.2d' % (ic,), getattr(self, 'INPUT_%3.3d:SC_GAIN2' % (ic,)).data())
-            elif site == 3:
-                setattr(uut.s3, 'SC32_OFFSET_%2.2d' % (ic,), getattr(self, 'INPUT_%3.3d:SC_OFFSET' % (ic+32,)).data())
-                setattr(uut.s3, 'SC32_G1_%2.2d' % (ic,), getattr(self, 'INPUT_%3.3d:SC_GAIN1' % (ic+32,)).data())
-                setattr(uut.s3, 'SC32_G2_%2.2d' % (ic,), getattr(self, 'INPUT_%3.3d:SC_GAIN2' % (ic+32,)).data())
-            elif site == 5:
-                setattr(uut.s5, 'SC32_OFFSET_%2.2d' % (ic,), getattr(self, 'INPUT_%3.3d:SC_OFFSET' % (ic+64,)).data())
-                setattr(uut.s5, 'SC32_G1_%2.2d' % (ic,), getattr(self, 'INPUT_%3.3d:SC_GAIN1' % (ic+64,)).data())
-                setattr(uut.s5, 'SC32_G2_%2.2d' % (ic,), getattr(self, 'INPUT_%3.3d:SC_GAIN2' % (ic+64,)).data())
+            if card == 1:
+                setattr(self.slots[card], 'SC32_OFFSET_%2.2d' % (ic,), getattr(self, 'INPUT_%3.3d:SC_OFFSET' % (ic,)).data())
+                setattr(self.slots[card], 'SC32_G1_%2.2d' % (ic,), getattr(self, 'INPUT_%3.3d:SC_GAIN1' % (ic,)).data())
+                setattr(self.slots[card], 'SC32_G2_%2.2d' % (ic,), getattr(self, 'INPUT_%3.3d:SC_GAIN2' % (ic,)).data())
+            elif card == 3:
+                setattr(self.slots[card], 'SC32_OFFSET_%2.2d' % (ic,), getattr(self, 'INPUT_%3.3d:SC_OFFSET' % (ic+32,)).data())
+                setattr(self.slots[card], 'SC32_G1_%2.2d' % (ic,), getattr(self, 'INPUT_%3.3d:SC_GAIN1' % (ic+32,)).data())
+                setattr(self.slots[card], 'SC32_G2_%2.2d' % (ic,), getattr(self, 'INPUT_%3.3d:SC_GAIN2' % (ic+32,)).data())
+            elif card == 5:
+                setattr(self.slots[card], 'SC32_OFFSET_%2.2d' % (ic,), getattr(self, 'INPUT_%3.3d:SC_OFFSET' % (ic+64,)).data())
+                setattr(self.slots[card], 'SC32_G1_%2.2d' % (ic,), getattr(self, 'INPUT_%3.3d:SC_GAIN1' % (ic+64,)).data())
+                setattr(self.slots[card], 'SC32_G2_%2.2d' % (ic,), getattr(self, 'INPUT_%3.3d:SC_GAIN2' % (ic+64,)).data())
 
     def setChanScale(self, node, num):
         chan     = self.__getattr__('INPUT_%3.3d' % num)

--- a/pydevices/HtsDevices/acq2106_435sc.py
+++ b/pydevices/HtsDevices/acq2106_435sc.py
@@ -68,8 +68,9 @@ class _ACQ2106_435SC(acq2106_435st._ACQ2106_435ST):
         # cp /mnt/local/si5326_31M25-20M48.txt /etc/si5326.d/
         # /usr/local/CARE/WR/set_clk_WR 20M48
         # 20.48MHz / 512 => 40.0kHz
+        # => uut.s1.CLKDIV = '1'
+        
         # To get a SR=20KHz, then:
-
         uut.s1.CLKDIV = '2'
         
         super(_ACQ2106_435SC, self).init()

--- a/pydevices/HtsDevices/acq2106_435sc.py
+++ b/pydevices/HtsDevices/acq2106_435sc.py
@@ -57,24 +57,10 @@ class _ACQ2106_435SC(acq2106_435st._ACQ2106_435ST):
                 slot.SC32_G2_ALL     = self.def_gain2.data()
                 print("Site {} GAIN 2 ALL {}".format(site, self.def_gain2.data()))
             else:
-                if site == 1:
-                    for ic in range(1,32):
-                        exec("uut.s1.SC32_OFFSET_%2.2d = self.__getattr__('INPUT_%3.3d:SC_OFFSET').data()"%(ic, ic))
-                        exec("uut.s1.SC32_G1_%2.2d     = self.__getattr__('INPUT_%3.3d:SC_GAIN1' ).data()"%(ic, ic))
-                        exec("uut.s1.SC32_G2_%2.2d     = self.__getattr__('INPUT_%3.3d:SC_GAIN2' ).data()"%(ic, ic))
-                elif site == 3:
-                    for ic, jc in zip(range(33,64), range(1, 32)):
-                        exec("uut.s3.SC32_OFFSET_%2.2d = self.__getattr__('INPUT_%3.3d:SC_OFFSET').data()"%(jc, ic))
-                        exec("uut.s3.SC32_G1_%2.2d     = self.__getattr__('INPUT_%3.3d:SC_GAIN1' ).data()"%(jc, ic))
-                        exec("uut.s3.SC32_G2_%2.2d     = self.__getattr__('INPUT_%3.3d:SC_GAIN2' ).data()"%(jc, ic))
-                elif site == 5:
-                    for ic, jc in zip(range(65,96), range(1, 32)):
-                        exec("uut.s5.SC32_OFFSET_%2.2d = self.__getattr__('INPUT_%3.3d:SC_OFFSET').data()"%(jc, ic))
-                        exec("uut.s5.SC32_G1_%2.2d     = self.__getattr__('INPUT_%3.3d:SC_GAIN1' ).data()"%(jc, ic))
-                        exec("uut.s5.SC32_G2_%2.2d     = self.__getattr__('INPUT_%3.3d:SC_GAIN2' ).data()"%(jc, ic))
+                self.setGainsOffsets(site)
 
             slot.SC32_GAIN_COMMIT = 1
-            print("GAIN Committed for site {}".format(site))
+            print("GAINs Committed for site {}".format(site))
 
         super(_ACQ2106_435SC, self).init()
 
@@ -94,16 +80,6 @@ class _ACQ2106_435SC(acq2106_435st._ACQ2106_435ST):
             if ch.on:
                 chan_unsc.record = MDSplus.BUILD_SIGNAL(ch.data() * (1.0/(ch.SC_GAIN1 * ch.SC_GAIN2)) - ch.SC_OFFSET, MDSplus.RAW_OF(ch), MDSplus.DIM_OF(ch))
     STORE=store
-
-    def unConditioning(self,num):
-        chan     = self.__getattr__('INPUT_%3.3d' % num)
-        chan_nonsc = self.__getattr__('INPUT_%3.3d:NC_INPUT' % num)
-        expr = MDSplus.SUBTRACT(MDSplus.DIVIDE(chan, MDSplus.MULTIPLY(chan.SC_GAIN1, chan.SC_GAIN2)), chan.SC_OFFSET)
-
-    def setSmooth(self,num):
-        chan = self.__getattr__('INPUT_%3.3d' % num)
-        chan_nonsc =self.__getattr__('INPUT_%3.3d:LR_INPUT' % num)
-        chan_nonsc.setSegmentScale(MDSplus.SMOOTH(MDSplus.dVALUE(),100))
     
     def getSlot(self, site_number):
         uut = self.getUUT()
@@ -133,6 +109,33 @@ class _ACQ2106_435SC(acq2106_435st._ACQ2106_435ST):
         uut = acq400_hapi.Acq2106(self.node.data(), monitor=False, has_wr=True)
         return uut
 
+    def setGainsOffsets(self, site):
+        uut = self.getUUT()
+        if site == 1:
+            for ic in range(1,32):
+                exec("uut.s1.SC32_OFFSET_%2.2d = self.__getattr__('INPUT_%3.3d:SC_OFFSET').data()"%(ic, ic))
+                exec("uut.s1.SC32_G1_%2.2d     = self.__getattr__('INPUT_%3.3d:SC_GAIN1' ).data()"%(ic, ic))
+                exec("uut.s1.SC32_G2_%2.2d     = self.__getattr__('INPUT_%3.3d:SC_GAIN2' ).data()"%(ic, ic))
+        elif site == 3:
+            for ic, jc in zip(range(33,64), range(1, 32)):
+                exec("uut.s3.SC32_OFFSET_%2.2d = self.__getattr__('INPUT_%3.3d:SC_OFFSET').data()"%(jc, ic))
+                exec("uut.s3.SC32_G1_%2.2d     = self.__getattr__('INPUT_%3.3d:SC_GAIN1' ).data()"%(jc, ic))
+                exec("uut.s3.SC32_G2_%2.2d     = self.__getattr__('INPUT_%3.3d:SC_GAIN2' ).data()"%(jc, ic))
+        elif site == 5:
+            for ic, jc in zip(range(65,96), range(1, 32)):
+                exec("uut.s5.SC32_OFFSET_%2.2d = self.__getattr__('INPUT_%3.3d:SC_OFFSET').data()"%(jc, ic))
+                exec("uut.s5.SC32_G1_%2.2d     = self.__getattr__('INPUT_%3.3d:SC_GAIN1' ).data()"%(jc, ic))
+                exec("uut.s5.SC32_G2_%2.2d     = self.__getattr__('INPUT_%3.3d:SC_GAIN2' ).data()"%(jc, ic))  
+
+    def unConditioning(self,num):
+        chan     = self.__getattr__('INPUT_%3.3d' % num)
+        chan_nonsc = self.__getattr__('INPUT_%3.3d:NC_INPUT' % num)
+        expr = MDSplus.SUBTRACT(MDSplus.DIVIDE(chan, MDSplus.MULTIPLY(chan.SC_GAIN1, chan.SC_GAIN2)), chan.SC_OFFSET)
+
+    def setSmooth(self,num):
+        chan = self.__getattr__('INPUT_%3.3d' % num)
+        chan_nonsc =self.__getattr__('INPUT_%3.3d:LR_INPUT' % num)
+        chan_nonsc.setSegmentScale(MDSplus.SMOOTH(MDSplus.dVALUE(),100))
 
 def assemble(cls):
     cls.parts = list(_ACQ2106_435SC.carrier_parts + _ACQ2106_435SC.sc_parts)

--- a/pydevices/HtsDevices/acq2106_435sc.py
+++ b/pydevices/HtsDevices/acq2106_435sc.py
@@ -111,21 +111,19 @@ class _ACQ2106_435SC(acq2106_435st._ACQ2106_435ST):
 
     def setGainsOffsets(self, site):
         uut = self.getUUT()
-        if site == 1:
-            for ic in range(1,32):
+        for ic in range(1,32):
+            if site == 1:
                 exec("uut.s1.SC32_OFFSET_%2.2d = self.__getattr__('INPUT_%3.3d:SC_OFFSET').data()"%(ic, ic))
                 exec("uut.s1.SC32_G1_%2.2d     = self.__getattr__('INPUT_%3.3d:SC_GAIN1' ).data()"%(ic, ic))
                 exec("uut.s1.SC32_G2_%2.2d     = self.__getattr__('INPUT_%3.3d:SC_GAIN2' ).data()"%(ic, ic))
-        elif site == 3:
-            for ic, jc in zip(range(33,64), range(1, 32)):
-                exec("uut.s3.SC32_OFFSET_%2.2d = self.__getattr__('INPUT_%3.3d:SC_OFFSET').data()"%(jc, ic))
-                exec("uut.s3.SC32_G1_%2.2d     = self.__getattr__('INPUT_%3.3d:SC_GAIN1' ).data()"%(jc, ic))
-                exec("uut.s3.SC32_G2_%2.2d     = self.__getattr__('INPUT_%3.3d:SC_GAIN2' ).data()"%(jc, ic))
-        elif site == 5:
-            for ic, jc in zip(range(65,96), range(1, 32)):
-                exec("uut.s5.SC32_OFFSET_%2.2d = self.__getattr__('INPUT_%3.3d:SC_OFFSET').data()"%(jc, ic))
-                exec("uut.s5.SC32_G1_%2.2d     = self.__getattr__('INPUT_%3.3d:SC_GAIN1' ).data()"%(jc, ic))
-                exec("uut.s5.SC32_G2_%2.2d     = self.__getattr__('INPUT_%3.3d:SC_GAIN2' ).data()"%(jc, ic))  
+            elif site == 3:
+                exec("uut.s3.SC32_OFFSET_%2.2d = self.__getattr__('INPUT_%3.3d:SC_OFFSET').data()"%(ic, ic+32))
+                exec("uut.s3.SC32_G1_%2.2d     = self.__getattr__('INPUT_%3.3d:SC_GAIN1' ).data()"%(ic, ic+32))
+                exec("uut.s3.SC32_G2_%2.2d     = self.__getattr__('INPUT_%3.3d:SC_GAIN2' ).data()"%(ic, ic+32))
+            elif site == 5:
+                exec("uut.s5.SC32_OFFSET_%2.2d = self.__getattr__('INPUT_%3.3d:SC_OFFSET').data()"%(ic, ic+64))
+                exec("uut.s5.SC32_G1_%2.2d     = self.__getattr__('INPUT_%3.3d:SC_GAIN1' ).data()"%(ic, ic+64))
+                exec("uut.s5.SC32_G2_%2.2d     = self.__getattr__('INPUT_%3.3d:SC_GAIN2' ).data()"%(ic, ic+64))  
 
     def unConditioning(self,num):
         chan     = self.__getattr__('INPUT_%3.3d' % num)

--- a/pydevices/HtsDevices/acq2106_435sc.py
+++ b/pydevices/HtsDevices/acq2106_435sc.py
@@ -88,8 +88,10 @@ class _ACQ2106_435SC(acq2106_435st._ACQ2106_435ST):
 
             slots[card].SC32_GAIN_COMMIT = 1
             print("GAINs Committed for site {}".format(card))
-        
-        super(_ACQ2106_435SC, self).init()
+        # Here, the argument to the init of the superclass:
+        # - init(1) => use resampling function:
+        # makeSegmentResampled(begin, end, dim, b, resampled, res_factor)
+        super(_ACQ2106_435SC, self).init(1)
 
         # For testing purpose only. Set trigger source to external hard trigger:
         uut.s0.SIG_SRC_TRG_0 = 'EXT'

--- a/pydevices/HtsDevices/acq2106_435sc.py
+++ b/pydevices/HtsDevices/acq2106_435sc.py
@@ -35,10 +35,30 @@ class _ACQ2106_435SC(acq2106_435st._ACQ2106_435ST):
     
     sc_parts = [
         # IS_GLOBAL controls if the GAINS and OFFSETS are set globally or per channel
-        {'path':':IS_GLOBAL',  'type':'numeric', 'value': 0, 'options':('no_write_shot',)},
-        {'path':':DEF_GAIN1',  'type':'numeric', 'value': 1, 'options':('no_write_shot',)},
-        {'path':':DEF_GAIN2',  'type':'numeric', 'value': 1, 'options':('no_write_shot',)},
-        {'path':':DEF_OFFSET', 'type':'numeric', 'value': 0, 'options':('no_write_shot',)},
+        {
+            'path': ':IS_GLOBAL',
+            'type': 'numeric', 
+            'value': 0,
+            'options': ('no_write_shot',)
+        },
+        {
+            'path': ':DEF_GAIN1',
+            'type': 'numeric',
+            'value': 1,
+            'options': ('no_write_shot',)
+        },
+        {
+            'path': ':DEF_GAIN2',
+            'type': 'numeric',
+            'value': 1,
+            'options': ('no_write_shot',)
+        },
+        {
+            'path': ':DEF_OFFSET',
+            'type': 'numeric',
+            'value': 0,
+            'options': ('no_write_shot',)
+        },
     ]
 
     def init(self):
@@ -114,48 +134,57 @@ def assemble(cls):
                 'path': ':INPUT_%3.3d'%(i+1,),
                 'type':'SIGNAL',  
                 'valueExpr':'head.setChanScale(%d)' %(i+1,),
-                'options':('no_write_model','write_once',)}, 
+                'options':('no_write_model','write_once',)
+            }, 
             {
                 'path': ':INPUT_%3.3d:DECIMATE'%(i+1,),
                 'type':'NUMERIC', 
                 'valueExpr':'head.def_dcim',
-                'options':('no_write_shot',)},           
+                'options':('no_write_shot',)
+            },           
             {
                 'path': ':INPUT_%3.3d:COEFFICIENT'%(i+1,), 
                 'type':'NUMERIC',
                 'options':('no_write_model', 
-                'write_once',)},
+                'write_once',)
+            },
             {
                 'path': ':INPUT_%3.3d:OFFSET'%(i+1,),
                 'type':'NUMERIC',
-                'options':('no_write_model', 'write_once',)},
+                'options':('no_write_model', 'write_once',)
+            },
             {
                 'path': ':INPUT_%3.3d:SC_GAIN1'%(i+1,),
                 'type':'NUMERIC', 
                 'valueExpr':'head.def_gain1',
-                'options':('no_write_shot',)},
+                'options':('no_write_shot',)
+            },
             {
                 'path': ':INPUT_%3.3d:SC_GAIN2'%(i+1,),
                 'type':'NUMERIC', 
                 'valueExpr':'head.def_gain2',
-                'options':('no_write_shot',)},
+                'options':('no_write_shot',)
+            },
             {
                 'path': ':INPUT_%3.3d:SC_OFFSET'%(i+1,),
                 'type':'NUMERIC', 
                 'valueExpr':'head.def_offset',
-                'options':('no_write_shot',)},   
+                'options':('no_write_shot',)
+            },   
             {
                  # Non-Conditioned signal
                 'path': ':INPUT_%3.3d:NC_INPUT'%(i+1,),
                 'type':'SIGNAL',
-                'options':('no_write_model','write_once',)},
+                'options':('no_write_model','write_once',)
+            },
 
             {
                 # Re-sampling streaming data:
                 'path': ':INPUT_%3.3d:RESAMPLED' % (i+1,),
                 'type': 'SIGNAL', 
                 'valueExpr': 'head.setChanScale("INPUT_%3.3d:RESAMPLED", %d)' % (i+1,i+1),
-                'options': ('no_write_model', 'write_once',)},
+                'options': ('no_write_model', 'write_once',)
+            },
         ]
 
 class ACQ2106_435SC_1ST(_ACQ2106_435SC): 

--- a/pydevices/HtsDevices/acq2106_435sc.py
+++ b/pydevices/HtsDevices/acq2106_435sc.py
@@ -62,6 +62,7 @@ class _ACQ2106_435SC(acq2106_435st._ACQ2106_435ST):
             slot.SC32_GAIN_COMMIT = 1
             print("GAINs Committed for site {}".format(site))
 
+        # TODO: Choose between possible SR
         # For testing purpose only. Set CLKDIV knowing that:
         # a special config in /mnt/local/rc.user gives a SR=40KHz at bootime:
         # WR additions for WRCLK 20M
@@ -69,14 +70,16 @@ class _ACQ2106_435SC(acq2106_435st._ACQ2106_435ST):
         # /usr/local/CARE/WR/set_clk_WR 20M48
         # 20.48MHz / 512 => 40.0kHz
         # => uut.s1.CLKDIV = '1'
-        
+        # To get a SR=40KHz, then:
+        #uut.s1.CLKDIV = '1'
         # To get a SR=20KHz, then:
-        uut.s1.CLKDIV = '2'
+        #uut.s1.CLKDIV = '2'
         
         super(_ACQ2106_435SC, self).init()
 
         # For testing purpose only. Set trigger source to external hard trigger:
         uut.s0.SIG_SRC_TRG_0 = 'EXT'
+    INIT=init
 
     def store(self):
         uut = self.getUUT()

--- a/pydevices/HtsDevices/acq2106_435st.py
+++ b/pydevices/HtsDevices/acq2106_435st.py
@@ -152,7 +152,7 @@ class _ACQ2106_435ST(MDSplus.Device):
 
             event_name = self.dev.seg_event.data()
 
-            for card in range(self.dev.sites):
+            for card in self.dev.slots:
                 # Retrive the actual value of NACC (samples) already set in the ACQ box
                 # nacc_str = uut.s1.get_knob('nacc')
                 nacc_str = self.dev.slots[card].nacc
@@ -368,7 +368,7 @@ class _ACQ2106_435ST(MDSplus.Device):
         # Get the slots (aka sites, or cards) that are physically active in the chassis of the ACQ
         self.slots = self.getSlots()
 
-        for card in range(self.sites):
+        for card in self.slots:
             if 1 <= nacc_samp <= 32:
                 self.slots[card].nacc = ('%d' % nacc_samp).strip()
             else:
@@ -386,21 +386,21 @@ class _ACQ2106_435ST(MDSplus.Device):
         import acq400_hapi
         uut = acq400_hapi.Acq400(self.node.data(), monitor=False)
         # Ask UUT what are the sites that are actually being populatee with a 435ELF
-        slot_list = []
+        slot_list = {}
         for (site, module) in sorted(uut.modules.items()):
             site_number = int(site)
             if site_number == 1:
-                slot_list.append(uut.s1)
+                slot_list[site_number]=uut.s1
             elif site_number == 2:
-                slot_list.append(uut.s2)
+                slot_list[site_number]=uut.s2
             elif site_number == 3:
-                slot_list.append(uut.s3)
+                slot_list[site_number]=uut.s3
             elif site_number == 4:
-                slot_list.append(uut.s4)
+                slot_list[site_number]=uut.s4
             elif site_number == 5:
-                slot_list.append(uut.s5)
+                slot_list[site_number]=uut.s5
             elif site_number == 6:
-                slot_list.append(uut.s6)
+                slot_list[site_number]=uut.s6
         return slot_list
 
     def stop(self):

--- a/pydevices/HtsDevices/acq2106_435st.py
+++ b/pydevices/HtsDevices/acq2106_435st.py
@@ -351,22 +351,8 @@ class _ACQ2106_435ST(MDSplus.Device):
         nacc_samp = int(self.hw_filter.data())
         print("Number of sites in use {}".format(self.sites))
 
-        # Ask UUT what are the sites that are actually being populatee with a 435ELF
-        self.slots = []
-        for (site, module) in sorted(uut.modules.items()):
-            site_number = int(site)
-            if site_number == 1:
-                self.slots.append(uut.s1)
-            elif site_number == 2:
-                self.slots.append(uut.s2)
-            elif site_number == 3:
-                self.slots.append(uut.s3)
-            elif site_number == 4:
-                self.slots.append(uut.s4)
-            elif site_number == 5:
-                self.slots.append(uut.s5)
-            elif site_number == 6:
-                self.slots.append(uut.s6)
+        # Get the slots (aka sites, or cards) that are physically active in the chassis of the ACQ
+        self.slots = self.getSlots()
 
         for card in range(self.sites):
             if 1 <= nacc_samp <= 32:
@@ -380,6 +366,27 @@ class _ACQ2106_435ST(MDSplus.Device):
         thread = self.MDSWorker(self)
         thread.start()
     INIT = init
+
+    def getSlots(self):
+        import acq400_hapi
+        uut = acq400_hapi.Acq400(self.node.data(), monitor=False)
+        # Ask UUT what are the sites that are actually being populatee with a 435ELF
+        slot_list = []
+        for (site, module) in sorted(uut.modules.items()):
+            site_number = int(site)
+            if site_number == 1:
+                slot_list.append(uut.s1)
+            elif site_number == 2:
+                slot_list.append(uut.s2)
+            elif site_number == 3:
+                slot_list.append(uut.s3)
+            elif site_number == 4:
+                slot_list.append(uut.s4)
+            elif site_number == 5:
+                slot_list.append(uut.s5)
+            elif site_number == 6:
+                slot_list.append(uut.s6)
+        return slot_list
 
     def stop(self):
         self.running.on = False

--- a/pydevices/HtsDevices/acq2106_435st.py
+++ b/pydevices/HtsDevices/acq2106_435st.py
@@ -459,7 +459,9 @@ class _ACQ2106_435ST(MDSplus.Device):
                 self.slots[card].nacc = '1'
 
         self.running.on = True
+        # If resampling=1, then resampling is used during streaming:
         self.resampling = resampling
+        
         thread = self.MDSWorker(self)
         thread.start()
     INIT = init

--- a/pydevices/HtsDevices/acq2106_435st.py
+++ b/pydevices/HtsDevices/acq2106_435st.py
@@ -57,45 +57,127 @@ class _ACQ2106_435ST(MDSplus.Device):
     """
 
     carrier_parts = [
-        {'path': ':NODE', 'type': 'text', 'value': '192.168.0.254',
-            'options': ('no_write_shot',)},
-        {'path': ':SITE', 'type': 'numeric',
-            'value': 1, 'options': ('no_write_shot',)},
-        {'path': ':COMMENT', 'type': 'text', 'options': ('no_write_shot',)},
-        {'path': ':TRIGGER', 'type': 'numeric',
-            'value': 0.0, 'options': ('no_write_shot',)},
-        {'path': ':TRIG_MODE', 'type': 'text',
-            'value': 'master:hard', 'options': ('no_write_shot',)},
-        {'path': ':EXT_CLOCK', 'type': 'axis', 'options': ('no_write_shot',)},
-        {'path': ':FREQ', 'type': 'numeric',
-            'value': 16000, 'options': ('no_write_shot',)},
-        {'path': ':HW_FILTER', 'type': 'numeric',
-            'value': 0, 'options': ('no_write_shot',)},
-        {'path': ':DEF_DCIM', 'type': 'numeric',
-            'value': 1, 'options': ('no_write_shot',)},
-        {'path': ':SEG_LENGTH', 'type': 'numeric',
-            'value': 8000, 'options': ('no_write_shot',)},
-        {'path': ':MAX_SEGMENTS', 'type': 'numeric',
-            'value': 1000, 'options': ('no_write_shot',)},
-        {'path': ':SEG_EVENT', 'type': 'text',
-            'value': 'STREAM', 'options': ('no_write_shot',)},
-        {'path': ':STATUS_CMDS', 'type': 'text', 'value': MDSplus.makeArray(
-            ['cat /proc/cmdline', 'get.d-tacq.release']), 'options':('no_write_shot',)},
-        {'path': ':STATUS_OUT', 'type': 'signal', 'options': ('write_shot',)},
-        {'path': ':TRIG_TIME', 'type': 'numeric', 'options': ('write_shot',)},
-        {'path': ':TRIG_STR', 'type': 'text', 'options': (
-            'nowrite_shot',), 'valueExpr': "EXT_FUNCTION(None,'ctime',head.TRIG_TIME)"},
-        {'path': ':RUNNING', 'type': 'any', 'options': ('no_write_model',)},
-        {'path': ':LOG_OUTPUT', 'type': 'text', 'options': (
-            'no_write_model', 'write_once', 'write_shot')},
-        {'path': ':GIVEUP_TIME', 'type': 'numeric',
-            'value': 180.0, 'options': ('no_write_shot',)},
-        {'path': ':INIT_ACTION', 'type': 'action',
-         'valueExpr': "Action(Dispatch('CAMAC_SERVER','INIT',50,None),Method(None,'INIT',head,'auto'))",
-         'options': ('no_write_shot',)},
-        {'path': ':STOP_ACTION', 'type': 'action',
-         'valueExpr': "Action(Dispatch('CAMAC_SERVER','STORE',50,None),Method(None,'STOP',head))",
-         'options': ('no_write_shot',)},
+        {
+            'path': ':NODE',
+            'type': 'text',
+            'value': '192.168.0.254',
+            'options': ('no_write_shot',)
+        },
+        {
+            'path': ':SITE',
+            'type': 'numeric',
+            'value': 1,
+            'options': ('no_write_shot',)
+        },
+        {
+            'path': ':COMMENT', 
+            'type': 'text', 
+            'options': ('no_write_shot',)
+        },
+        {
+            'path': ':TRIGGER',
+            'type': 'numeric',
+            'value': 0.0,
+            'options': ('no_write_shot',)
+        },
+        {
+            'path': ':TRIG_MODE',
+            'type': 'text',
+            'value': 'master:hard',
+            'options': ('no_write_shot',)
+        },
+        {
+            'path': ':EXT_CLOCK',
+            'type': 'axis',
+            'options': ('no_write_shot',)
+        },
+        {
+            'path': ':FREQ',
+            'type': 'numeric',
+            'value': 16000,
+            'options': ('no_write_shot',)
+        },
+        {
+            'path': ':HW_FILTER',
+            'type': 'numeric',
+            'value': 0,
+            'options': ('no_write_shot',)
+        },
+        {
+            'path': ':DEF_DCIM',
+            'type': 'numeric',
+            'value': 1,
+            'options': ('no_write_shot',)
+        },
+        {
+            'path': ':SEG_LENGTH',
+            'type': 'numeric',
+            'value': 8000,
+            'options': ('no_write_shot',)
+        },
+        {
+            'path': ':MAX_SEGMENTS',
+            'type': 'numeric',
+            'value': 1000,
+            'options': ('no_write_shot',)
+        },
+        {
+            'path': ':SEG_EVENT', 
+            'type': 'text',
+            'value': 'STREAM',
+            'options': ('no_write_shot',)
+        },
+        {
+            'path': ':STATUS_CMDS',
+            'type': 'text', 
+            'value': MDSplus.makeArray(['cat /proc/cmdline', 'get.d-tacq.release']), 
+            'options':('no_write_shot',)
+        },
+        {
+            'path': ':STATUS_OUT',
+            'type': 'signal',
+            'options': ('write_shot',)
+        },
+        {
+            'path': ':TRIG_TIME',
+            'type': 'numeric',
+            'options': ('write_shot',)
+        },
+        {
+            'path': ':TRIG_STR',
+            'type': 'text',
+            'options': ('nowrite_shot',), 
+            'valueExpr': "EXT_FUNCTION(None,'ctime',head.TRIG_TIME)"
+        },
+        {
+            'path': ':RUNNING',
+            'type': 'any',
+            'options': ('no_write_model',)
+        },
+        {
+            'path': ':LOG_OUTPUT',
+            'type': 'text',
+            'options': (
+            'no_write_model', 'write_once', 'write_shot')
+        },
+        {
+            'path': ':GIVEUP_TIME',
+            'type': 'numeric',
+            'value': 180.0,
+            'options': ('no_write_shot',)
+        },
+        {
+            'path': ':INIT_ACTION',
+            'type': 'action',
+            'valueExpr': "Action(Dispatch('CAMAC_SERVER','INIT',50,None),Method(None,'INIT',head,'auto'))",
+            'options': ('no_write_shot',)
+        },
+        {
+            'path': ':STOP_ACTION',
+            'type': 'action',
+            'valueExpr': "Action(Dispatch('CAMAC_SERVER','STORE',50,None),Method(None,'STOP',head))",
+            'options': ('no_write_shot',)
+        },
     ]
 
     data_socket = -1

--- a/pydevices/HtsDevices/acq2106_435st.py
+++ b/pydevices/HtsDevices/acq2106_435st.py
@@ -267,7 +267,7 @@ class _ACQ2106_435ST(MDSplus.Device):
             running = self.dev.running
             max_segments = self.dev.max_segments.data()
 
-            # If resampling is choosen, then the res_factor is read from the tree node:
+            # If resampling is choosen, i.e. self.resampling=1, then the res_factor is read from the tree node:
             if self.resampling: 
                 res_factor = self.dev.res_factor.data()
 
@@ -461,7 +461,7 @@ class _ACQ2106_435ST(MDSplus.Device):
         self.running.on = True
         # If resampling=1, then resampling is used during streaming:
         self.resampling = resampling
-        
+
         thread = self.MDSWorker(self)
         thread.start()
     INIT = init


### PR DESCRIPTION
This is a new ACQ2106_435 device for use on the new D-Tacq ACQ2106 SC32 (Signal Conditioning 32 Chans per site).

The new MDSplus device is a subclass of ACQ2106_435ST that add the following functionality:
1- Add control on the Global and Local (channel level) Gains and Offsets knobs. (if the actual device doesn't offset the signal, the knobs will still be there, but they will not do anything.)
3- Add a tree node called :INPUT_xxx:RESAMPLED, where the lower resolution, ie. re-sampled data will be store.
4- Add to the superclass, i.e. _ACQ2106_435ST, a method to find out which cards/sites are actually physically active.
5- Add to the init method of the superclass, a boolean argument to select if resampling will be used.

TODO:
- Add functionality to be able to select different Sample Rates. For now it uses the fix rate from the ACQ2106 SC32 (i.e. at 40KHz). this can be changed by changing the CLKDIV knobs, and so get lower sample rates:
  CLKDIV = 2 ---> SR = 20 KHz
  CLKDIV = 4 ---> SR = 10 KHz
This will depend on the final D-Tacq solution for this device.
 
