### PR TITLE
Fix: mdsip with compression fails to decode data

### DIFF
--- a/mdstcpip/GetMdsMsg.c
+++ b/mdstcpip/GetMdsMsg.c
@@ -108,6 +108,7 @@ Message *GetMdsMsgTOC(Connection *c, int *status, int to_msec) {
       if (IS_OK(*status) && IsCompressed(header.client_type)) {
         Message *m;
         memcpy(&msglen, msg->bytes, 4);
+        dlen = msglen - sizeof(MsgHdr);
         if (Endian(header.client_type) != Endian(ClientType()))
           FlipBytes(4, (char *)&msglen);
         m = malloc(msglen);

--- a/mdstcpip/GetMdsMsg.c
+++ b/mdstcpip/GetMdsMsg.c
@@ -101,7 +101,7 @@ Message *GetMdsMsgTOC(Connection *c, int *status, int to_msec) {
         *status = SsINTERNAL;
         return NULL;
       }
-      unsigned long dlen = msglen - sizeof(MsgHdr);
+      unsigned long dlen;
       msg = malloc(msglen);
       msg->h = header;
       *status = GetBytesTO(c, msg->bytes, msglen - sizeof(MsgHdr), 1000);


### PR DESCRIPTION
fixes MDSplus/mdsplus #2227

The code was using the dlen from the message header instead of the
one copied out of the first four bytes of the message body
#closes #2227