### PR TITLE
fix: m4_docker_build failed in recent autoconf version

### DIFF
--- a/m4/m4_ax_docker_build.m4
+++ b/m4/m4_ax_docker_build.m4
@@ -50,7 +50,7 @@ AC_DEFUN([AX_DOCKER_BUILD],[
    AC_PUSH_LOCAL([m4_ax_docker_build])
 
    AS_VAR_SET_IF([HAVE_DOCKER],,
-      AC_CHECK_PROG([HAVE_DOCKER],[docker],[yes],[no]))
+      [AC_CHECK_PROG([HAVE_DOCKER],[docker],[yes],[no])])
 
    AC_ARG_WITH(docker-image,
                [AS_HELP_STRING([--with-docker-image],[specify docker images])],


### PR DESCRIPTION
With a recent version of autoconf the former version on line 53 in m4 macro for docker build ended up in this error:
../mdsplus/configure: line 3611: syntax error near unexpected token `newline'
../mdsplus/configure: line 3611: `    '''

properly handling line parentheses in m4 seem to fix the issue.