### PR TITLE
Fix: building in macOS remove sed's dash

### DIFF
--- a/tdishr/yylex/TdiHash.gen
+++ b/tdishr/yylex/TdiHash.gen
@@ -42,7 +42,5 @@ int tdi_hash(const int len, const char *const pstring)
 }
 EOF_AFTER
 ) > $SRC
-${GPERF:-gperf} $SRC | (
 # remove '#line' decorators to simplify debugging
-sed '/^#line/d' -
-) > $OUT
+${GPERF:-gperf} $SRC | sed '/^#line/d' > $OUT


### PR DESCRIPTION
When executing bootstrap in a Mac OS X system:

tdishr/yylex/TdiHash.gen
sed: -: No such file or directory

Solution:
Remove the "-" from:

> $SRC
${GPERF:-gperf} $SRC | sed '/^#line/d' - 
> $OUT
In other words, the following works in Mac OS X as well as in Ubuntu Linux:

> $SRC
${GPERF:-gperf} $SRC | sed '/^#line/d' 
> $OUT