### PR TITLE
Fix: mdstcpip missing include signal header

### DIFF
--- a/mdstcpip/ioroutinesx.h
+++ b/mdstcpip/ioroutinesx.h
@@ -20,7 +20,7 @@ static IoRoutines io_routines = {
     io_connect,   io_send,       io_recv,       io_flush,   io_listen,
     io_authorize, io_reuseCheck, io_disconnect, io_recv_to, io_check};
 #include <mdsshr.h>
-
+#include <signal.h>
 #include <inttypes.h>
 
 #define IP(addr) ((uint8_t *)&addr)


### PR DESCRIPTION
In Mac OS X Catalina, the build fails in:

/mdsplus/mdstcpip/ioroutinesx.h:93:3: error: implicit declaration of function 'raise' is invalid in C99
[-Werror,-Wimplicit-function-declaration]
raise(sig);

Solution:
Adding the missing header signal.h