### PR TITLE
Fix: old FORTRAN programs pass 1 for len

### DIFF
--- a/mdslib/MdsLib.c
+++ b/mdslib/MdsLib.c
@@ -56,7 +56,7 @@ static int next = 0;
 
 #include <pthread.h>
 
-static inline chkptr(int *ptr) {
+static inline int chkptr(int *ptr) {
   int ans = 1;
   if (ptr) {
     if (*ptr == 1) {

--- a/mdslib/MdsLib.c
+++ b/mdslib/MdsLib.c
@@ -23,6 +23,7 @@ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
+#include <stdio.h>
 #include <mdsdescrip.h>
 #include <pthread_port.h>
 #define MDSLIB_NO_PROTOS
@@ -47,7 +48,6 @@ extern int TreeFindNode();
 extern int TreePutRecord();
 extern int TreeWait();
 extern int TdiDebug();
-
 short ArgLen(struct descrip *d);
 
 static int next = 0;
@@ -55,6 +55,21 @@ static int next = 0;
 #define MAXARGS 32
 
 #include <pthread.h>
+
+static inline chkptr(int *ptr) {
+  int ans = 1;
+  if (ptr) {
+    if (*ptr == 1) {
+      fprintf(stderr, "MdsValue deprecated behvior, Passing 1 by reference to signal missing arguement is deprecated, please update source to pass a NULL by value instead\n");
+      ans = 0;
+    }
+  } 
+  else 
+  {
+    ans = 0;
+  }
+  return ans;
+}
 
 static char *mds_value_remote_expression(char *expression,
                                          struct descriptor *dsc);
@@ -410,7 +425,7 @@ static inline int mds_value_vargs(va_list incrmtr, int connection,
   a_count--; /* subtract one for terminator of argument list */
 
   length = va_arg(incrmtr, int *);
-  if (length) {
+  if (chkptr(length)) {
     *length = 0;
   }
 
@@ -637,7 +652,7 @@ static inline int mds_value2_vargs(va_list incrmtr, int connection,
   a_count--; /* subtract one for terminator of argument list */
 
   length = va_arg(incrmtr, int *);
-  if (length) {
+  if (chkptr(length)) {
     *length = 0;
   }
 
@@ -1395,7 +1410,7 @@ static void mds_value_set(struct descriptor *outdsc, struct descriptor *indsc,
                           int *length) {
   char fill;
   if (indsc == 0) {
-    if (length)
+    if (chkptr(length))
       *length = 0;
     return;
   }
@@ -1414,7 +1429,7 @@ static void mds_value_set(struct descriptor *outdsc, struct descriptor *indsc,
                    mds_value_length(outdsc), outdsc->pointer);
   }
 
-  if (length) {
+  if (chkptr(length)) {
     if (indsc->class == CLASS_A)
       *length = MIN(((struct descriptor_a *)outdsc)->arsize / outdsc->length,
                     ((struct descriptor_a *)indsc)->arsize / indsc->length);

--- a/mdslib/testing/mdslib_fremotetest.f
+++ b/mdslib/testing/mdslib_fremotetest.f
@@ -21,7 +21,7 @@
       real    resultarr(20)
       real    array2d(nx,ny)
       character cresult*12
-
+      size = 0
       do i=1,nx
          do j=1,ny
             array2d(i,j) = i*10 + j
@@ -35,9 +35,9 @@
       end if
 
       dsc = descr(IDTYPE_FLOAT,result,0,0)
-      sts= MdsValueR(con, "1.23"//CHAR(0),dsc,0,size)
+      sts= MdsValueR(con, "1.23"//CHAR(0),dsc,0,1)
       if (abs(result-1.23) .gt. 1e-5) then
-        write (6,*) "MdsValue('1.23') : ",result,sts,size
+        write (6,*) "MdsValue('1.23') : ",result,sts
         stop 1
       end if
 
@@ -47,33 +47,38 @@
         write (6,*) "MdsValue('2. : 40. : 2.') : ",resultarr,sts,size
         stop 1
       end if
-
+      size = 0
       dsc = descr(IDTYPE_LONG,iresult,0)
       sts= MdsValueR(con,"_=SetEnv('test_path=.')"//CHAR(0),dsc,0,size)
       if (and(and(sts, iresult), 1) .ne. 1) then
         write (6,*) "setenv(): ",iresult,sts,size
         stop 1
       end if
+      size = 0
       sts= MdsValueR(con,"TreeOpenNew('test',1)"//CHAR(0),dsc,0,size)
       if (and(and(sts, iresult), 1) .ne. 1) then
         write (6,*) "TreeOpenNew(): ",iresult,sts,size
         stop 1
       end if
+      size = 0
       sts= MdsValueR(con,"TreeAddNode('A',_,'ANY')"//CHAR(0),dsc,0,size)
       if (and(and(sts, iresult), 1) .ne. 1) then
         write (6,*) "TreeAddNode: ",iresult,sts,size
         stop 1
       end if
+      size = 0
       sts= MdsValueR(con,"TreeWrite()"//CHAR(0),dsc,0,size)
       if (and(and(sts, iresult), 1) .ne. 1) then
         write (6,*) "TreeWrite(): ",iresult,sts,size
         stop 1
       end if
+      size = 0
       sts= MdsValueR(con,"TreeClose()"//CHAR(0),dsc,0,size)
       if (and(and(sts, iresult), 1) .ne. 1) then
         write (6,*) "TreeClose(): ",iresult,sts,size
         stop 1
       end if
+      size = 0
 
       dsc = descr(IDTYPE_CSTRING,cresult,0,12)
       sts= MdsValueR(con,"$EXPT"//CHAR(0),dsc,0,size)
@@ -81,6 +86,7 @@
         write (6,*) "MdsValue($EXPT)/*before*/: ",cresult,sts,size
         stop 1
       end if
+      size = 0
 
       sts= MdsOpenR(con,"test"//CHAR(0),1)
       if (and(sts, 1) .ne. 1) then
@@ -94,6 +100,7 @@
         write (6,*) "MdsValue($EXPT)/*after*/: ",cresult,sts,size
         stop 1
       end if
+      size = 0
 
       dsc = descr(IDTYPE_LONG,42042,0)
       sts= MdsPutR(con,"A"//CHAR(0),"$"//CHAR(0),dsc,0)
@@ -108,6 +115,7 @@
         write (6,*) "MdsValue('A')/*i*/: ",iresult,sts
         stop 1
       end if
+      size = 0
 
       dsc = descr(IDTYPE_FLOAT,resultarr,20,0)
       do i=1,20
@@ -124,6 +132,7 @@
         write (6,*) "MdsValue('A')/*/array*/: ",resultarr,sts,size
         stop 1
       end if
+      size = 0
 
       dsc = descr(IDTYPE_FLOAT,array2d,nx,ny,0)
       sts= MdsPutR(con,"A"//CHAR(0),"$"//CHAR(0),dsc,0)
@@ -137,6 +146,7 @@
         write (6,*) "MdsValue('A')/*/array2d*/: ",resultarr,sts,size
         stop 1
       end if
+      size = 0
 
       sts= MdsDisconnectR(con)
       if (sts.lt. 0) then

--- a/mdslib/testing/mdslib_ftest.f
+++ b/mdslib/testing/mdslib_ftest.f
@@ -19,7 +19,7 @@
       real    resultarr(20)
       real    array2d(nx,ny)
       character cresult*12
-
+      size = 0
       do i=1,nx
          do j=1,ny
             array2d(i,j) = i*10 + j
@@ -27,45 +27,51 @@
       enddo
 
       dsc = descr(IDTYPE_FLOAT,result,0,0)
-      sts = MdsValue("1.23"//CHAR(0),dsc,0,size)
+      sts = MdsValue("1.23"//CHAR(0),dsc,0, size)
       if (abs(result-1.23) .gt. 1e-5) then
         write (6,*) "MdsValue('1.23') : ",result,sts,size
         stop 1
       end if
+      size = 0
 
       dsc = descr(IDTYPE_FLOAT,resultarr,5,0)
-      sts = MdsValue("2.2 : 8. : 2."//CHAR(0),dsc,0,size)
+      sts = MdsValue("2.2 : 8. : 2."//CHAR(0),dsc,0, 1)
       if (abs(resultarr(1)-2.2) .gt. 1e-5) then
-        write (6,*) "MdsValue('2. : 40. : 2.') : ",resultarr,sts,size
+        write (6,*) "MdsValue('2. : 40. : 2.') : ",resultarr,sts
         stop 1
       end if
 
       dsc = descr(IDTYPE_LONG,iresult,0)
-      sts = MdsValue("_=SetEnv('test_path=.')"//CHAR(0),dsc,0,size)
+      sts = MdsValue("_=SetEnv('test_path=.')"//CHAR(0), dsc, 0, size)
       if (and(and(sts, iresult), 1) .ne. 1) then
         write (6,*) "setenv(): ",iresult,sts,size
         stop 1
       end if
+      size = 0
       sts = MdsValue("TreeOpenNew('test',1)"//CHAR(0),dsc,0,size)
       if (and(and(sts, iresult), 1) .ne. 1) then
         write (6,*) "TreeOpenNew(): ",iresult,sts,size
         stop 1
       end if
+      size = 0
       sts = MdsValue("TreeAddNode('A',_,'ANY')"//CHAR(0),dsc,0,size)
       if (and(and(sts, iresult), 1) .ne. 1) then
         write (6,*) "TreeAddNode: ",iresult,sts,size
         stop 1
       end if
+      size = 0
       sts = MdsValue("TreeWrite()"//CHAR(0),dsc,0,size)
       if (and(and(sts, iresult), 1) .ne. 1) then
         write (6,*) "TreeWrite(): ",iresult,sts,size
         stop 1
       end if
+      size = 0
       sts = MdsValue("TreeClose()"//CHAR(0),dsc,0,size)
       if (and(and(sts, iresult), 1) .ne. 1) then
         write (6,*) "TreeClose(): ",iresult,sts,size
         stop 1
       end if
+      size = 0
 
       dsc = descr(IDTYPE_CSTRING,cresult,0,12)
       sts = MdsValue("$EXPT"//CHAR(0),dsc,0,size)
@@ -73,6 +79,7 @@
         write (6,*) "MdsValue($EXPT)/*before*/: ",cresult,sts,size
         stop 1
       end if
+      size = 0
 
       sts = MdsOpen("test"//CHAR(0),1)
       if (and(sts, 1) .ne. 1) then
@@ -86,6 +93,7 @@
         write (6,*) "MdsValue($EXPT)/*after*/: ",cresult,sts,size
         stop 1
       end if
+      size = 0
 
       dsc = descr(IDTYPE_LONG,42042,0)
       sts = MdsPut("A"//CHAR(0),"$"//CHAR(0),dsc,0)
@@ -111,11 +119,13 @@
         stop 1
       end if
 
+      size = 0
       sts = MdsValue("A"//CHAR(0),dsc,0,size)
       if (and(sts, 1) .ne. 1) then
         write (6,*) "MdsValue('A')/*/array*/: ",resultarr,sts,size
         stop 1
       end if
+      size = 0
 
       dsc = descr(IDTYPE_FLOAT,array2d,nx,ny,0)
       sts = MdsPut("A"//CHAR(0),"$"//CHAR(0),dsc,0)


### PR DESCRIPTION
Old MDSplus documentation for the fortran interface stated that
when calling MdsValue and not interested in the return length
argument to pass a "1".

An ugly fix which may break non fortran callers? prints a warning,
and does not attempt to overwrite a 1 passed by reference as the
last argument to MdsValue.

Updated fortran test programs to reflect this.

closes https://github.com/MDSplus/mdsplus/issues/2259