### PR TITLE
Feature: Changes to acq2106 435st.py so that a trigger source can be manually chosen.

### DIFF
--- a/pydevices/HtsDevices/acq2106_435sc.py
+++ b/pydevices/HtsDevices/acq2106_435sc.py
@@ -92,9 +92,9 @@ class _ACQ2106_435SC(acq2106_435st._ACQ2106_435ST):
             self.slots[card].SC32_GAIN_COMMIT = 1
             print("GAINs Committed for site {}".format(card))
         # Here, the argument to the init of the superclass:
-        # - init(1) => use resampling function:
+        # - init(True) => use resampling function:
         # makeSegmentResampled(begin, end, dim, b, resampled, res_factor)
-        super(_ACQ2106_435SC, self).init(1)
+        super(_ACQ2106_435SC, self).init(resampling = True)
 
     INIT=init
     

--- a/pydevices/HtsDevices/acq2106_435st.py
+++ b/pydevices/HtsDevices/acq2106_435st.py
@@ -178,6 +178,14 @@ class _ACQ2106_435ST(MDSplus.Device):
             'valueExpr': "Action(Dispatch('CAMAC_SERVER','STORE',50,None),Method(None,'STOP',head))",
             'options': ('no_write_shot',)
         },
+
+        #Trigger sources
+        {
+            'path':':TRIG_SRC',   
+            'type':'text',      
+            'value': 'NONE', 
+            'options':('no_write_shot',)
+        },
     ]
 
     data_socket = -1
@@ -391,6 +399,12 @@ class _ACQ2106_435ST(MDSplus.Device):
         if self.ext_clock.length > 0:
             raise Exception('External Clock is not supported')
 
+        # Initializing Sources to NONE:
+        # D0 signal:
+        uut.s0.SIG_SRC_TRG_0   = 'NONE'
+        # D1 signal:
+        uut.s0.SIG_SRC_TRG_1   = 'NONE'
+
         freq = int(self.freq.data())
         # D-Tacq Recommendation: the minimum sample rate is 10kHz.
         if freq < MIN_FREQUENCY:
@@ -406,7 +420,7 @@ class _ACQ2106_435ST(MDSplus.Device):
             trg = 'soft'
         else:
             role = mode.split(":")[0]
-            trg = mode.split(":")[1]
+            trg  = mode.split(":")[1]
 
         print("Role is {} and {} trigger".format(role, trg))
 
@@ -422,6 +436,26 @@ class _ACQ2106_435ST(MDSplus.Device):
         # modifiers [TRG=int|ext]
         # modifiers [CLKDIV=div]
         uut.s0.sync_role = '%s %s TRG:DX=%s' % (role, self.freq.data(), trg_dx)
+
+        # The following allows for WR sources to be chosen.
+        # Non-WR sources:
+        # d0:
+        srcs_0 = ['EXT', 'HDMI', 'HOSTB', 'GPG0', 'DSP0', 'nc', 'WRTT0', 'NONE']
+        # d1:
+        srcs_1 = ['STRIG', 'HOSTA', 'HDMI_GPIO', 'GPG1', 'DSP1', 'FP_SYNC', 'WRTT1', 'NONE']
+
+        if trg_dx == 'd0':
+            if str(self.trig_src.data()) in srcs_0:
+                uut.s0.SIG_SRC_TRG_0   = str(self.trig_src.data())
+            else:
+                sys.exit("TRIG_SRC should be one of {}".format(srcs_0))
+                
+        elif trg_dx == 'd1':
+            if str(self.trig_src.data()) in srcs_1:
+                uut.s0.SIG_SRC_TRG_1   = str(self.trig_src.data())
+            else:
+                sys.exit("TRIG_SRC should be one of {}".format(srcs_1))
+
 
         # Fetching all calibration information from every channel.
         uut.fetch_all_calibration()

--- a/pydevices/HtsDevices/acq2106_435st.py
+++ b/pydevices/HtsDevices/acq2106_435st.py
@@ -389,7 +389,7 @@ class _ACQ2106_435ST(MDSplus.Device):
                         else:
                             self.full_buffers.put(buf)
 
-    def init(self, resampling=0):
+    def init(self, resampling = False):
         import acq400_hapi
         MIN_FREQUENCY = 10000
 
@@ -437,7 +437,7 @@ class _ACQ2106_435ST(MDSplus.Device):
         # modifiers [CLKDIV=div]
         uut.s0.sync_role = '%s %s TRG:DX=%s' % (role, self.freq.data(), trg_dx)
 
-        # The following allows for any source to be chosen, amount others the WR source.
+        # The following allows for any source to be chosen, among other things the WR source.
         # Signal highway d0:
         srcs_0 = ['EXT', 'HDMI', 'HOSTB', 'GPG0', 'DSP0', 'nc', 'WRTT0', 'NONE']
         # Signal highway d1:

--- a/pydevices/HtsDevices/acq2106_435st.py
+++ b/pydevices/HtsDevices/acq2106_435st.py
@@ -437,11 +437,10 @@ class _ACQ2106_435ST(MDSplus.Device):
         # modifiers [CLKDIV=div]
         uut.s0.sync_role = '%s %s TRG:DX=%s' % (role, self.freq.data(), trg_dx)
 
-        # The following allows for WR sources to be chosen.
-        # Non-WR sources:
-        # d0:
+        # The following allows for any source to be chosen, amount others the WR source.
+        # Signal highway d0:
         srcs_0 = ['EXT', 'HDMI', 'HOSTB', 'GPG0', 'DSP0', 'nc', 'WRTT0', 'NONE']
-        # d1:
+        # Signal highway d1:
         srcs_1 = ['STRIG', 'HOSTA', 'HDMI_GPIO', 'GPG1', 'DSP1', 'FP_SYNC', 'WRTT1', 'NONE']
 
         if trg_dx == 'd0':


### PR DESCRIPTION
Changes to the device acq2106_435st.py were done so that the trigger sources can be selected "manually" by:
adding a node in the tree, where the source name can be written. The source that can be selected, will be one of the following, depending on the signal highway (d0 or d1):

        # Signal highway d0:
        srcs_0 = ['EXT', 'HDMI', 'HOSTB', 'GPG0', 'DSP0', 'nc', 'WRTT0', 'NONE']
        # Signal highway d1:
        srcs_1 = ['STRIG', 'HOSTA', 'HDMI_GPIO', 'GPG1', 'DSP1', 'FP_SYNC', 'WRTT1', 'NONE']

Even those the ACQ's sync_role is able to set the system clocks and signal, it relies on the default setting of the source, since it's not able to set it itself. In other words, sync_role() will use the trigger source that has been set by default, in general, this will be for 'd0', 'EXT', and for 'd1', 'STRIG'. The changes made here to the device allow for the selection of any of the above trigger source options. Including WR trigger source, WRTT0 or WRTT1.