### PR TITLE
Fix: cpp not receiving new event based streams

### DIFF
--- a/include/mdsobjects.h
+++ b/include/mdsobjects.h
@@ -4186,7 +4186,7 @@ public:
 class EXPORT EventStream : public Event {
   std::vector<DataStreamListener *> listeners;
   std::vector<std::string> names;
-  std::string name;
+  const char *name;
   void handleJSONPayload(char *);
 public:
   virtual void run();

--- a/mdsobjects/cpp/mdsdatastreams.cpp
+++ b/mdsobjects/cpp/mdsdatastreams.cpp
@@ -477,10 +477,10 @@ EXPORT void EventStream::handleJSONPayload(char *payload)
 EXPORT void EventStream::registerListener(DataStreamListener *listener,  
                                           const char *inName) {
   listeners.push_back(listener);
-  names.push_back(std::string(inName));
+  names.push_back(inName);
 }
 EXPORT void EventStream::registerListener(DataStreamListener *listener) 
 {
   listeners.push_back(listener);
-  names.push_back(std::string(name));
+  names.push_back(name);
 }


### PR DESCRIPTION
This change from Darren Garnier changes the event name to a char*
from a c++ string.  Seems to fix the problem.

Note:  Now that each stream is its own event, it is its own thread
and all of the logic checking on, saving and sending the name is no
longer needed.  Ths PR does not address this.