### PR TITLE
Fix: Rework on acq2106_435st trigger selection.

### DIFF
--- a/pydevices/HtsDevices/acq2106_435sc.py
+++ b/pydevices/HtsDevices/acq2106_435sc.py
@@ -72,29 +72,37 @@ class _ACQ2106_435SC(acq2106_435st._ACQ2106_435ST):
     ]
 
     def init(self):
-        uut = self.getUUT()
         self.slots = super(_ACQ2106_435SC, self).getSlots()
         
         for card in self.slots:
             if self.is_global.data() == 1:
                 # Global controls for GAINS and OFFSETS
                 self.slots[card].SC32_OFFSET_ALL = self.def_offset.data()
-                print("Site {} OFFSET ALL {}".format(card, self.def_offset.data()))
+
+                if self.debug:
+                    print("Site %s OFFSET ALL %d" % (card, int(self.def_offset.data())))
 
                 self.slots[card].SC32_G1_ALL     = self.def_gain1.data()
-                print("Site {} GAIN 1 ALL {}".format(card, self.def_gain1.data()))
+                
+                if self.debug:
+                    print("Site %s GAIN 1 ALL %d" % (card, int(self.def_gain1.data())))
 
                 self.slots[card].SC32_G2_ALL     = self.def_gain2.data()
-                print("Site {} GAIN 2 ALL {}".format(card, self.def_gain2.data()))
+                
+                if self.debug:
+                    print("Site %s GAIN 2 ALL %d" % (card, int(self.def_gain2.data())))
             else:
                 self.setGainsOffsets(card)
 
             self.slots[card].SC32_GAIN_COMMIT = 1
-            print("GAINs Committed for site {}".format(card))
+            
+            if self.debug:
+                print("GAINs Committed for site %s" % (card,))
+                
         # Here, the argument to the init of the superclass:
         # - init(True) => use resampling function:
         # makeSegmentResampled(begin, end, dim, b, resampled, res_factor)
-        super(_ACQ2106_435SC, self).init(resampling = True)
+        super(_ACQ2106_435SC, self).init(resampling=True)
 
     INIT=init
     
@@ -104,7 +112,6 @@ class _ACQ2106_435SC(acq2106_435st._ACQ2106_435ST):
         return uut
 
     def setGainsOffsets(self, card):
-        uut = self.getUUT()
         for ic in range(1,32+1):
             if card == 1:
                 setattr(self.slots[card], 'SC32_OFFSET_%2.2d' % (ic,), getattr(self, 'INPUT_%3.3d:SC_OFFSET' % (ic,)).data())
@@ -141,46 +148,46 @@ def assemble(cls):
                 'options': ('no_write_model', 'write_once',)
             },
             {
-                'path': ':INPUT_%3.3d:DECIMATE'%(i+1,),
+                'path': ':INPUT_%3.3d:DECIMATE' % (i+1,),
                 'type':'NUMERIC', 
                 'valueExpr':'head.def_dcim',
                 'options':('no_write_shot',)
             },           
             {
-                'path': ':INPUT_%3.3d:COEFFICIENT'%(i+1,), 
+                'path': ':INPUT_%3.3d:COEFFICIENT' % (i+1,), 
                 'type':'NUMERIC',
                 'options':('no_write_model', 
                 'write_once',)
             },
             {
-                'path': ':INPUT_%3.3d:OFFSET'%(i+1,),
+                'path': ':INPUT_%3.3d:OFFSET' % (i+1,),
                 'type':'NUMERIC',
                 'options':('no_write_model', 'write_once',)
             },
             {
                 # Local (per channel) SC gains
-                'path': ':INPUT_%3.3d:SC_GAIN1'%(i+1,),
+                'path': ':INPUT_%3.3d:SC_GAIN1' % (i+1,),
                 'type':'NUMERIC', 
                 'valueExpr':'head.def_gain1',
                 'options':('no_write_shot',)
             },
             {
                 # Local (per channel) SC gains
-                'path': ':INPUT_%3.3d:SC_GAIN2'%(i+1,),
+                'path': ':INPUT_%3.3d:SC_GAIN2' % (i+1,),
                 'type':'NUMERIC', 
                 'valueExpr':'head.def_gain2',
                 'options':('no_write_shot',)
             },
             {
                 # Local (per channel) SC offsets
-                'path': ':INPUT_%3.3d:SC_OFFSET'%(i+1,),
+                'path': ':INPUT_%3.3d:SC_OFFSET' % (i+1,),
                 'type':'NUMERIC', 
                 'valueExpr':'head.def_offset',
                 'options':('no_write_shot',)
             },   
             {
                  # Conditioned signal goes here:
-                'path': ':INPUT_%3.3d:SC_INPUT'%(i+1,),
+                'path': ':INPUT_%3.3d:SC_INPUT' % (i+1,),
                 'type': 'SIGNAL',
                 'valueExpr': 
                      'ADD(MULTIPLY(head.INPUT_%3.3d, MULTIPLY(head.INPUT_%3.3d.SC_GAIN1, head.INPUT_%3.3d.SC_GAIN2)), head.INPUT_%3.3d.SC_OFFSET)'

--- a/pydevices/HtsDevices/acq2106_435st.py
+++ b/pydevices/HtsDevices/acq2106_435st.py
@@ -178,19 +178,9 @@ class _ACQ2106_435ST(MDSplus.Device):
             'valueExpr': "Action(Dispatch('CAMAC_SERVER','STORE',50,None),Method(None,'STOP',head))",
             'options': ('no_write_shot',)
         },
-
-        #Trigger sources
-        {
-            'path':':TRIG_SRC',   
-            'type':'text',      
-            'value': 'NONE', 
-            'options':('no_write_shot',)
-        },
     ]
 
     data_socket = -1
-
-    trig_types = ['hard', 'soft', 'automatic']
 
     class MDSWorker(threading.Thread):
         NUM_BUFFERS = 20
@@ -222,10 +212,8 @@ class _ACQ2106_435ST(MDSplus.Device):
             self.device_thread = self.DeviceWorker(self)
 
         def run(self):
-            import acq400_hapi
             import ast
             import re
-            uut = acq400_hapi.Acq400(self.dev.node.data(), monitor=False)
 
             def lcm(a, b):
                 from fractions import gcd
@@ -389,29 +377,43 @@ class _ACQ2106_435ST(MDSplus.Device):
                         else:
                             self.full_buffers.put(buf)
 
-    def init(self, resampling = False):
-        import acq400_hapi
-        MIN_FREQUENCY = 10000
+    # The minimum frequency we can operate at                   
+    MIN_FREQUENCY = 10000
 
-        uut = acq400_hapi.Acq400(self.node.data(), monitor=False)
+    # These are partial lists of the options we support.
+    # For a complete list, consult D-Tacq
+
+    # Trigger Source Options for Signal Highway d0
+    TRIG_SRC_OPTS_0 = [
+        'ext',          # External Trigger
+        'hdmi',         # HDMI Trigger
+        'gpg0',         # Gateway Pulse Generator Trigger
+        'wrtt0'         # White Rabbit Trigger
+    ]
+
+    # Trigger Source Options for Signal Highway d1
+    TRIG_SRC_OPTS_1 = [
+        'strig',        # Software Trigger
+        'hdmi_gpio',    # HDMI General Purpose I/O Trigger
+        'gpg1',         # Gateway Pulse Generator Trigger
+        'fp_sync',      # Front Panel SYNC
+        'wrtt1'         # White Rabbit Trigger
+    ]
+
+    def init(self, resampling=False):
+        uut = self.getUUT()
         uut.s0.set_knob('set_abort', '1')
 
         if self.ext_clock.length > 0:
             raise Exception('External Clock is not supported')
 
-        # Initializing Sources to NONE:
-        # D0 signal:
-        uut.s0.SIG_SRC_TRG_0   = 'NONE'
-        # D1 signal:
-        uut.s0.SIG_SRC_TRG_1   = 'NONE'
-
         freq = int(self.freq.data())
         # D-Tacq Recommendation: the minimum sample rate is 10kHz.
-        if freq < MIN_FREQUENCY:
+        if freq < self.MIN_FREQUENCY:
             raise MDSplus.DevBAD_PARAMETER(
                 "Sample rate should be greater or equal than 10kHz")
 
-        mode = self.trig_mode.data()
+        mode = str(self.trig_mode.data()).lower()
         if mode == 'hard':
             role = 'master'
             trg = 'hard'
@@ -422,14 +424,27 @@ class _ACQ2106_435ST(MDSplus.Device):
             role = mode.split(":")[0]
             trg  = mode.split(":")[1]
 
-        print("Role is {} and {} trigger".format(role, trg))
+        if self.debug:
+            print("Role is %s and %s trigger" % (role, trg))
+
+
+        src_trg_0 = None
+        src_trg_1 = None
 
         if trg == 'hard':
             trg_dx = 'd0'
-        elif trg == 'automatic':
+            src_trg_0 = 'EXT' # External Trigger
+        elif trg == 'soft' or trg == 'automatic':
             trg_dx = 'd1'
-        elif trg == 'soft':
+            src_trg_1 = 'STRIG' # Soft Trigger
+        elif trg in self.TRIG_SRC_OPTS_0:
+            trg_dx = 'd0'
+            src_trg_0 = trg
+        elif trg in self.TRIG_SRC_OPTS_1:
             trg_dx = 'd1'
+            src_trg_1 = trg
+        elif trg != 'none':
+            raise MDSplus.DevBAD_PARAMETER("TRIG_MODE does not contain a valid trigger source")
 
         # USAGE sync_role {fpmaster|rpmaster|master|slave|solo} [CLKHZ] [FIN]
         # modifiers [CLK|TRG:SENSE=falling|rising] [CLK|TRG:DX=d0|d1]
@@ -437,24 +452,13 @@ class _ACQ2106_435ST(MDSplus.Device):
         # modifiers [CLKDIV=div]
         uut.s0.sync_role = '%s %s TRG:DX=%s' % (role, self.freq.data(), trg_dx)
 
-        # The following allows for any source to be chosen, among other things the WR source.
-        # Signal highway d0:
-        srcs_0 = ['EXT', 'HDMI', 'HOSTB', 'GPG0', 'DSP0', 'nc', 'WRTT0', 'NONE']
-        # Signal highway d1:
-        srcs_1 = ['STRIG', 'HOSTA', 'HDMI_GPIO', 'GPG1', 'DSP1', 'FP_SYNC', 'WRTT1', 'NONE']
+        # snyc_role will set a default trigger source, we need to override it to the selected trigger source
+        # These must be uppercase
+        if src_trg_0:
+            uut.s0.SIG_SRC_TRG_0 = src_trg_0.upper()
 
-        if trg_dx == 'd0':
-            if str(self.trig_src.data()) in srcs_0:
-                uut.s0.SIG_SRC_TRG_0   = str(self.trig_src.data())
-            else:
-                sys.exit("TRIG_SRC should be one of {}".format(srcs_0))
-                
-        elif trg_dx == 'd1':
-            if str(self.trig_src.data()) in srcs_1:
-                uut.s0.SIG_SRC_TRG_1   = str(self.trig_src.data())
-            else:
-                sys.exit("TRIG_SRC should be one of {}".format(srcs_1))
-
+        if src_trg_1:
+            uut.s0.SIG_SRC_TRG_1 = src_trg_1.upper()
 
         # Fetching all calibration information from every channel.
         uut.fetch_all_calibration()
@@ -473,26 +477,27 @@ class _ACQ2106_435ST(MDSplus.Device):
 
         # Hardware decimation:
         if self.debug:
-            print("Hardware Filter (NACC) from tree node is {}".format(
+            print("Hardware Filter (NACC) from tree node is %d" % (
                 int(self.hw_filter.data())))
 
         # Hardware Filter: Accumulate/Decimate filter. Accumulate nacc_samp samples, then output one value.
         nacc_samp = int(self.hw_filter.data())
-        print("Number of sites in use {}".format(self.sites))
+
+        if self.debug:
+            print("Number of sites in use %d" % (self.sites,))
 
         # Get the slots (aka sites, or cards) that are physically active in the chassis of the ACQ
         self.slots = self.getSlots()
 
-        for card in self.slots:
-            if 1 <= nacc_samp <= 32:
+        if nacc_samp >= 1 and nacc_samp <= 32:
+            for card in self.slots:
                 self.slots[card].nacc = ('%d' % nacc_samp).strip()
-            else:
-                print(
-                    "WARNING: Hardware Filter samples must be in the range [0,32]. 0 => Disabled == 1")
-                self.slots[card].nacc = '1'
+        else:
+            print("WARNING: Hardware Filter samples must be in the range [0,32]. 0 => Disabled == 1")
+            self.slots[card].nacc = '1'
 
         self.running.on = True
-        # If resampling=1, then resampling is used during streaming:
+        # If resampling == 1, then resampling is used during streaming:
         self.resampling = resampling
 
         thread = self.MDSWorker(self)
@@ -500,24 +505,24 @@ class _ACQ2106_435ST(MDSplus.Device):
     INIT = init
 
     def getSlots(self):
-        import acq400_hapi
-        uut = acq400_hapi.Acq400(self.node.data(), monitor=False)
+        uut = self.getUUT()
+        
         # Ask UUT what are the sites that are actually being populatee with a 435ELF
         slot_list = {}
-        for (site, module) in sorted(uut.modules.items()):
+        for (site, _) in sorted(uut.modules.items()):
             site_number = int(site)
             if site_number == 1:
-                slot_list[site_number]=uut.s1
+                slot_list[site_number] = uut.s1
             elif site_number == 2:
-                slot_list[site_number]=uut.s2
+                slot_list[site_number] = uut.s2
             elif site_number == 3:
-                slot_list[site_number]=uut.s3
+                slot_list[site_number] = uut.s3
             elif site_number == 4:
-                slot_list[site_number]=uut.s4
+                slot_list[site_number] = uut.s4
             elif site_number == 5:
-                slot_list[site_number]=uut.s5
+                slot_list[site_number] = uut.s5
             elif site_number == 6:
-                slot_list[site_number]=uut.s6
+                slot_list[site_number] = uut.s6
         return slot_list
 
     def stop(self):
@@ -525,10 +530,14 @@ class _ACQ2106_435ST(MDSplus.Device):
     STOP = stop
 
     def trig(self):
-        import acq400_hapi
-        uut = acq400_hapi.Acq400(self.node.data(), monitor=False)
+        uut = self.getUUT()
         uut.s0.set_knob('soft_trigger', '1')
     TRIG = trig
+
+    def getUUT(self):
+        import acq400_hapi
+        uut = acq400_hapi.Acq400(self.node.data(), monitor=False, has_wr=True)
+        return uut
 
     def setChanScale(self, num):
         chan = self.__getattr__('INPUT_%3.3d' % num)


### PR DESCRIPTION
Remove new `TRIG_SRC` node
Move functionality into existing `TRIG_MODE` node
`TRIG_MODE` can now be
* hard, soft
* master:hard, solo:soft, etc
* master:ext, solo:wrtt0, fpmaster:fp_sync, etc.

Refactor .format() to % format
Move `getUUT()` to parent 435st class (overridden in 435sc)

Removed legacy `trig_types`

Moved constants to class scope
* MIN_FREQUENCY
* TRIG_SRC_OPTS_0
* TRIG_SRC_OPTS_1

Removed initializing trigger sources to 'NONE'
Should be set automatically by sync_role

Wrap debug statements in `if self.debug`