### PR TITLE
Fix: fix exit condition in loop over tag links in _RemoveTagIdx

### DIFF
--- a/treeshr/TreeRemoveNodesTags.c
+++ b/treeshr/TreeRemoveNodesTags.c
@@ -138,7 +138,7 @@ static void _RemoveTagIdx(PINO_DATABASE *dblist, int tagidx) {
     for (tag_link = swapint32(&node_ptr->tag_link),
         info_ptr = dblist->tree_info->tag_info + tag_link - 1;
          (swapint32(&info_ptr->tag_link) != tagidx) &&
-         (swapint32(&info_ptr->tag_link) >= 0);
+         (swapint32(&info_ptr->tag_link) > 0);
          info_ptr =
              dblist->tree_info->tag_info + swapint32(&info_ptr->tag_link) - 1)
       ;


### PR DESCRIPTION
Fix for #2278.

As mentioned in the issue, this loop exit condition should never be reached for a healthy tree. I thought about returning an error in case we do reach it but the function has a `void` return type.