### PR TITLE
Fix: change boostrap to look for python

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -15,11 +15,22 @@ then
 fi
 }
 
+
+if [ `which python3` ] 
+then   
+  PYTHON=python3 
+elif [ `which python2` ] 
+then   
+  PYTHON=python2 
+else   
+  PYTHON=python 
+fi
+
 testprog aclocal	automake
 testprog autoheader	autoconf
 testprog automake	automake
 testprog autoconf	autoconf
-testprog python		python2 or python3
+testprog $PYTHON        python2 or python3
 testprog bison		bison
 testprog flex		flex
 
@@ -40,8 +51,8 @@ automake --add-missing
 
 autoconf
 
-python deploy/gen_messages.py
-python deploy/gen_compound_opcbuiltins.py
+$PYTHON deploy/gen_messages.py
+$PYTHON deploy/gen_compound_opcbuiltins.py
 
 deploy/yylex.gen tdishr
 deploy/yylex.gen mdsdcl


### PR DESCRIPTION
Since Timo did not like the previous solution:
  'assume python3'

Script now looks to see which python is installed.
Tries:
  python3
  python2
  python