### PR TITLE
Fix: Refactor out _MOVC3 macro

### DIFF
--- a/mdsshr/MdsXdRoutines.c
+++ b/mdsshr/MdsXdRoutines.c
@@ -52,7 +52,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define LibVM_EXTEND_AREA 32
 #define LibVM_TAIL_LARGE 128
 #define compression_threshold 128
-#define _MOVC3(a, b, c) memcpy(c, b, (size_t)(a))
 
 inline static size_t _sizeAligned(const size_t bytes)
 {
@@ -214,7 +213,7 @@ static int copy_dx(const mdsdsc_xd_t *const in_dsc_ptr,
         *po = in;
         po->class = CLASS_XS;
         po->pointer = (mdsdsc_t *)po + sizeof(in);
-        _MOVC3(in.l_length, in.pointer, po->pointer);
+        memcpy(po->pointer, in.pointer, in.l_length);
       }
       if (path.pointer)
         StrFree1Dx(&path);
@@ -230,11 +229,11 @@ static int copy_dx(const mdsdsc_xd_t *const in_dsc_ptr,
               (pi->ndesc - 1u) * (uint32_t)sizeof(mdsdsc_t *);
       if (po)
       {
-        _MOVC3(bytes, (char *)pi, (char *)po);
+        memcpy((char *)po, (char *)pi, bytes);
         if (pi->length > 0)
         {
           po->pointer = (unsigned char *)po + bytes;
-          _MOVC3(pi->length, (char *)pi->pointer, (char *)po->pointer);
+          memcpy((char *)po->pointer, (char *)pi->pointer, pi->length);
         }
       }
       bytes = (uint32_t)_sizeAligned(bytes + pi->length);
@@ -265,9 +264,9 @@ static int copy_dx(const mdsdsc_xd_t *const in_dsc_ptr,
           (pi->aflags.bounds ? (uint32_t)sizeof(int) * pi->dimct * 2u : 0u);
       if (po)
       {
-        _MOVC3(bytes, (char *)pi, (char *)po);
+        memcpy((char *)po, (char *)pi, bytes);
         po->pointer = (char *)po + bytes;
-        _MOVC3(pi->arsize, pi->pointer, po->pointer);
+        memcpy(po->pointer, pi->pointer, pi->arsize);
         if (pi->aflags.coeff)
           po->a0 = po->pointer + (pi->a0 - pi->pointer);
       }
@@ -295,10 +294,10 @@ static int copy_dx(const mdsdsc_xd_t *const in_dsc_ptr,
       bytes = dscsize + pi->arsize + align_size;
       if (po)
       {
-        _MOVC3(dscsize, (char *)pi, (char *)po);
+        memcpy((char *)po, (char *)pi, dscsize);
         po->pointer = _align((char *)po, dscsize, align_size);
         if (pi->arsize > 0 && pi->pointer != NULL)
-          _MOVC3(pi->arsize, pi->pointer, po->pointer);
+          memcpy(po->pointer, pi->pointer, pi->arsize);
         if (pi->aflags.coeff)
           po->a0 = po->pointer + (pi->a0 - pi->pointer);
       }
@@ -324,7 +323,7 @@ static int copy_dx(const mdsdsc_xd_t *const in_dsc_ptr,
               (pi->aflags.bounds ? (uint32_t)sizeof(int) * pi->dimct * 2u : 0u);
       if (po)
       {
-        _MOVC3(bytes, (char *)pi, (char *)po);
+        memcpy((char *)po, (char *)pi, bytes);
         pdo = (mdsdsc_t **)(po->pointer = (char *)po + bytes);
       }
       bytes = (uint32_t)_sizeAligned(bytes + pi->arsize);
@@ -357,7 +356,7 @@ static int copy_dx(const mdsdsc_xd_t *const in_dsc_ptr,
           (pi->aflags.bounds ? (uint32_t)sizeof(int) * pi->dimct * 2u : 0u));
       if (po)
       {
-        _MOVC3(bytes, (char *)pi, (char *)po);
+        memcpy((char *)po, (char *)pi, bytes);
         if (pi->pointer)
           po->pointer = _align((char *)po, bytes, sizeof(void *));
         else

--- a/tdishr/TdiIntrinsic.c
+++ b/tdishr/TdiIntrinsic.c
@@ -70,7 +70,6 @@ typedef struct _bounds
   int u;
 } BOUNDS;
 
-#define _MOVC3(a, b, c) memcpy(c, b, a)
 extern int TdiFaultHandlerNoFixup();
 extern int Tdi0Decompile();
 extern int TdiConvert();
@@ -315,8 +314,8 @@ EXPORT int TdiIntrinsic(opcode_t opcode, int narg, mdsdsc_t *list[],
           {
             out_ptr->dtype = dsc_ptr->dtype;
             if ((out_ptr->length > 0) && (dsc_ptr != NULL))
-              _MOVC3(out_ptr->length, dsc_ptr->pointer,
-                     (char *)out_ptr->pointer);
+              memcpy((char *)out_ptr->pointer, dsc_ptr->pointer,
+                     out_ptr->length);
           }
           break;
         default:

--- a/tdishr/TdiMatrix.c
+++ b/tdishr/TdiMatrix.c
@@ -30,7 +30,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
         Ken Klare, LANL CTR-7   (c)1990
 */
 
-#define _MOVC3(a, b, c) memcpy(c, b, a)
 #include "tdinelements.h"
 #include "tdirefcat.h"
 #include "tdirefstandard.h"
@@ -72,7 +71,7 @@ static int copy(int len, int n, char *x, int incx, char *y, int incy)
     break;
   default:
     for (; --n >= 0; x += incx, y += incy)
-      _MOVC3(len, x, y);
+      memcpy(y, x, len);
     break;
   }
   return 1;

--- a/tdishr/TdiPower.c
+++ b/tdishr/TdiPower.c
@@ -31,7 +31,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
    use double. Ken Klare, LANL P-4     (c)1990,1991
 */
 #include <string.h>
-#define _MOVC3(a, b, c) memcpy(c, b, a)
 #include "tdinelements.h"
 #include <mdsdescrip.h>
 #include <tdishr_messages.h>
@@ -92,9 +91,9 @@ int Tdi3Power(struct descriptor *x, struct descriptor *y,
     for (; !(yy & 1) && STATUS_OK; yy >>= 1)
       status = Tdi3Multiply(x, x, x);
     if (x->class != CLASS_A)
-      _MOVC3(z->length, x->pointer, z->pointer);
+      memcpy(z->pointer, x->pointer, z->length);
     else
-      _MOVC3(z->arsize, x->pointer, z->pointer);
+      memcpy(z->pointer, x->pointer, z->arsize);
     for (; (yy >>= 1) > 0 && STATUS_OK;)
     {
       status = Tdi3Multiply(x, x, x);
@@ -128,12 +127,12 @@ int Tdi3Power(struct descriptor *x, struct descriptor *y,
       status = TdiConvert(&one_dsc, &duno);
     for (; --n >= 0 && STATUS_OK; px += incx, dz.pointer += incz)
     {
-      _MOVC3(dx.length, px, xx);
+      memcpy(xx, px, dx.length);
       if ((int)(yy = *py++) <= 0)
       {
         if (yy == 0)
         {
-          _MOVC3(dz.length, uno, dz.pointer);
+          memcpy(dz.pointer, uno, dz.length);
           continue;
         }
         yy = -yy;
@@ -141,7 +140,7 @@ int Tdi3Power(struct descriptor *x, struct descriptor *y,
       }
       for (; !(yy & 1) && STATUS_OK; yy >>= 1)
         status = Tdi3Multiply(&dx, &dx, &dx);
-      _MOVC3(dz.length, dx.pointer, dz.pointer);
+      memcpy(dz.pointer, dx.pointer, dz.length);
       for (; (yy >>= 1) > 0 && STATUS_OK;)
       {
         status = Tdi3Multiply(&dx, &dx, &dx);
@@ -223,9 +222,9 @@ int Tdi3Merge(struct descriptor_a *pdtrue, struct descriptor_a *pdfalse,
       int sm = stepm, st = stept, sf = stepf;
       for (; --n >= 0; pm += sm, pt += st, pf += sf, po += len)
         if (*pm & 1)
-          _MOVC3(len, pt, po);
+          memcpy(po, pt, len);
         else
-          _MOVC3(len, pf, po);
+          memcpy(po, pf, len);
     }
     break;
     }

--- a/tdishr/TdiScalar.c
+++ b/tdishr/TdiScalar.c
@@ -32,7 +32,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
         Ken Klare, LANL P-4     (c)1989,1990,1991
 */
 
-#define _MOVC3(a, b, c) memcpy(c, b, a)
 #include "tdinelements.h"
 #include "tdirefcat.h"
 #include "tdireffunction.h"
@@ -725,7 +724,7 @@ int Tdi3DotProduct(struct descriptor_a *in1_ptr, struct descriptor_a *in2_ptr,
         status = TdiSum(in2_ptr, &tmp MDS_END_ARG);
     }
     if (STATUS_OK)
-      _MOVC3(out_ptr->length, tmp.pointer->pointer, out_ptr->pointer);
+      memcpy(out_ptr->pointer, tmp.pointer->pointer, out_ptr->length);
     break;
   }
   MdsFree1Dx(&tmp, 0);

--- a/tdishr/TdiSort.c
+++ b/tdishr/TdiSort.c
@@ -60,8 +60,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <strroutines.h>
 #include <tdishr_messages.h>
 
-#define _MOVC3(a, b, c) memcpy(c, b, a)
-
 extern int TdiGetArgs();
 extern int TdiCvtArgs();
 extern int TdiMasterData();
@@ -788,7 +786,7 @@ int Tdi1Union(opcode_t opcode __attribute__((unused)), int narg,
           if (j < len)
           {
             po += len;
-            _MOVC3(len, pi, po);
+            memcpy(po, pi, len);
           }
         }
         break;
@@ -802,7 +800,7 @@ int Tdi1Union(opcode_t opcode __attribute__((unused)), int narg,
           if (j < len)
           {
             po += len;
-            _MOVC3(len, pi, po);
+            memcpy(po, pi, len);
           }
         }
         break;
@@ -816,7 +814,7 @@ int Tdi1Union(opcode_t opcode __attribute__((unused)), int narg,
           if (j < len)
           {
             po += len;
-            _MOVC3(len, pi, po);
+            memcpy(po, pi, len);
           }
         }
         break;

--- a/tdishr/TdiSql.c
+++ b/tdishr/TdiSql.c
@@ -43,7 +43,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
         Ken Klare, LANL P-4     (c)1991,1992
 */
 #include <mdstypes.h>
-#define _MOVC3(a, b, c) memcpy(c, b, a)
 #include "tdirefstandard.h"
 #include <libroutines.h>
 #include <math.h> /*for pow definition */

--- a/tdishr/TdiSubscript.c
+++ b/tdishr/TdiSubscript.c
@@ -66,8 +66,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <string.h>
 #include <tdishr_messages.h>
 
-#define _MOVC3(a, b, c) memcpy(c, b, a)
-
 extern int TdiGetArgs();
 extern int TdiMasterData();
 extern int TdiIcull();
@@ -321,7 +319,7 @@ int Tdi1Subscript(opcode_t opcode, int narg, struct descriptor *list[],
     else
       status = MdsGet1DxS(&llen, &dtype, out_ptr);
     if (STATUS_OK)
-      _MOVC3(len, pin, out_ptr->pointer->pointer);
+      memcpy(out_ptr->pointer->pointer, pin, len);
   }
   else
   {
@@ -344,8 +342,10 @@ int Tdi1Subscript(opcode_t opcode, int narg, struct descriptor *list[],
     pin -= len * *px[0];
     row = arr.m[0] * sizeof(int);
   inner:
-    for (j = 0; j < row; j += sizeof(int))
-      _MOVC3(len, pin + len * *(int *)((char *)px[0] + j), pout), pout += len;
+    for (j = 0; j < row; j += sizeof(int)) {
+      memcpy(pout, pin + len * *(int *)((char *)px[0] + j), len);
+      pout += len;
+    }
     /******************************************************
     Find the index to increment, reset those that overflow.
     Must avoid reading beyond end of vector.
@@ -530,7 +530,7 @@ int Tdi1Map(opcode_t opcode, int narg __attribute__((unused)),
     default:
       while (--n >= 0)
       {
-        _MOVC3(len, (char *)abase + (len * *pindex++), po);
+        memcpy(po, (char *)abase + (len * *pindex++), len);
         po += len;
       }
       break;

--- a/tdishr/TdiTrans.c
+++ b/tdishr/TdiTrans.c
@@ -78,7 +78,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
         NEED to know about REPLICATE and SPREAD with subscript ranges.
 */
 
-#define _MOVC3(a, b, c) memcpy(c, b, a)
 #ifdef WORDS_BIGENDIAN
 #define MaskTrue (pi0[leni - 1] & 1)
 #else
@@ -293,11 +292,11 @@ int Tdi1Trans(int opcode, int narg, mdsdsc_t *list[], mdsdsc_xd_t *out_ptr)
     pmask = (mdsdsc_t *)&ncopies;
     /** scalar to simple vector **/
     if (rank == 0)
-      _MOVC3(head, (char *)pa, (char *)&arr);
+      memcpy((char *)&arr, (char *)pa, head);
     /** simple and coefficient vector **/
     else
     {
-      _MOVC3(head, (char *)pa, (char *)&arr);
+      memcpy((char *)&arr, (char *)pa, head);
       arr.m[dim] *= ncopies;
     }
     arr.arsize *= ncopies;
@@ -329,18 +328,18 @@ int Tdi1Trans(int opcode, int narg, mdsdsc_t *list[], mdsdsc_xd_t *out_ptr)
     pmask = (mdsdsc_t *)&ncopies;
     /** scalar to simple vector **/
     if (rank == 0)
-      _MOVC3(head, (char *)pa, (char *)&arr);
+      memcpy((char *)&arr, (char *)pa, head);
     else if (rank >= MAX_DIMS)
       status = TdiNDIM_OVER;
     /** coefficient vector **/
     else if (pa->aflags.coeff)
     {
-      _MOVC3(head, (char *)pa, (char *)&arr);
-      _MOVC3((short)(sizeof(int) * (rank - dim) * 2),
+      memcpy((char *)&arr, (char *)pa, head);
+      memcpy((char *)&arr.m[rank + 2 * dim + 3],
              (char *)&arr.m[rank + 2 * dim],
-             (char *)&arr.m[rank + 2 * dim + 3]);
-      _MOVC3((short)(sizeof(int) * (rank - dim)), (char *)&arr.m[dim],
-             (char *)&arr.m[dim + 1]);
+             (short)(sizeof(int) * (rank - dim) * 2));
+      memcpy((char *)&arr.m[dim + 1], (char *)&arr.m[dim],
+             (short)(sizeof(int) * (rank - dim)));
       arr.m[dim] = ncopies;
       arr.m[rank + 2 * dim + 1] = 0;
       arr.m[rank + 2 * dim + 2] = ncopies - 1;
@@ -349,7 +348,7 @@ int Tdi1Trans(int opcode, int narg, mdsdsc_t *list[], mdsdsc_xd_t *out_ptr)
     /** simple vector to 2-D **/
     else
     {
-      _MOVC3(head, (char *)pa, (char *)&arr);
+      memcpy((char *)&arr, (char *)pa, head);
       arr.dimct = 2;
       arr.aflags.coeff = 1;
       arr.a0 = arr.pointer;
@@ -385,7 +384,7 @@ int Tdi1Trans(int opcode, int narg, mdsdsc_t *list[], mdsdsc_xd_t *out_ptr)
   else if (pfun->f2 == Tdi2Mask2)
   {
     psig = 0;
-    _MOVC3(head, (char *)pa, (char *)&arr);
+    memcpy((char *)&arr, (char *)pa, head);
     arr.arsize = pa->length * rank;
     status = MdsGet1DxA((mdsdsc_a_t *)&arr, &digits, &out_dtype, out_ptr);
   }
@@ -398,13 +397,13 @@ int Tdi1Trans(int opcode, int narg, mdsdsc_t *list[], mdsdsc_xd_t *out_ptr)
       --psig->ndesc;
     for (j = dim; ++j < ndim;)
       psig->dimensions[j - 1] = psig->dimensions[j];
-    _MOVC3(head, (char *)pa, (char *)&arr);
+    memcpy((char *)&arr, (char *)pa, head);
     arr.arsize /= arr.m[dim];
-    _MOVC3((short)(sizeof(int) * (rank - dim - 1)), (char *)&arr.m[dim + 1],
-           (char *)&arr.m[dim]);
-    _MOVC3((short)(sizeof(int) * (rank - dim - 1) * 2),
+    memcpy((char *)&arr.m[dim], (char *)&arr.m[dim + 1],
+           (short)(sizeof(int) * (rank - dim - 1)));
+    memcpy((char *)&arr.m[rank + 2 * dim - 1],
            (char *)&arr.m[rank + 2 * dim + 2],
-           (char *)&arr.m[rank + 2 * dim - 1]);
+           (short)(sizeof(int) * (rank - dim - 1) * 2));
     --arr.dimct;
     status = MdsGet1DxA((mdsdsc_a_t *)&arr, &digits, &out_dtype, out_ptr);
   }


### PR DESCRIPTION
Replace all instances of _MOVC3(a, b, c) with memcpy(c, b, a)