### PR TITLE
Fix:jTraverer and jScope fixes

### DIFF
--- a/java/jscope/src/main/java/mds/wave/Signal.java
+++ b/java/jscope/src/main/java/mds/wave/Signal.java
@@ -501,6 +501,8 @@ public class Signal implements WaveDataListener
 	private int x2D_points = 0;
 	private int y2D_points = 0;
 	private int z2D_points = 0;
+        
+        double prevSetXMin, prevSetXMax;
 
 	/**
 	 * Constructs a zero Signal with 100 points.
@@ -2767,7 +2769,14 @@ public class Signal implements WaveDataListener
 
 	public void setXLimits(double xmin, double xmax, int mode)
 	{
-		xLimitsInitialized = true;
+ 		if(xLimitsInitialized && prevSetXMin == xmin && prevSetXMax == xmax)
+                {
+                    return;
+                }
+                xLimitsInitialized = true;
+                prevSetXMin = xmin;
+                prevSetXMax = xmax;
+                
 		if (xmin != -Double.MAX_VALUE)
 		{
 			this.xmin = xmin;
@@ -2817,7 +2826,9 @@ public class Signal implements WaveDataListener
 			}
 			if (((mode & DO_NOT_UPDATE) == 0)
 					&& (currLower != saved_xmin || currUpper != saved_xmax || (mode & AT_CREATION) == 0))
+                        {
 				data.getDataAsync(currLower, currUpper, NUM_POINTS);
+                        }
 		}
 		// fireSignalUpdated();
 	}

--- a/java/jtraverser/src/main/java/mds/jtraverser/Node.java
+++ b/java/jtraverser/src/main/java/mds/jtraverser/Node.java
@@ -461,9 +461,10 @@ public class Node
 		cal.setTimeInMillis(time);
 		final SimpleDateFormat sdf = new SimpleDateFormat("dd-MMM-yyyy hh:mm:ss");
 		final String dateStr = sdf.format(cal.getTime());
-		return new NodeInfo(nid.getDclass(), nid.getDtype(), nid.getUsage(), nid.getNciFlags(), nid.getOwnerId(),
-				nid.getLength(), nid.getConglomerateNodes().size(), nid.getConglomerateElt(), dateStr,
+ 		NodeInfo info =  new NodeInfo(nid.getDclass(), nid.getDtype(), nid.getUsage(), nid.getNciFlags(), nid.getOwnerId(),
+				nid.getLength(), nid.getNumElts(), nid.getConglomerateElt(), dateStr,
 				nid.getNodeName(), nid.getFullPath(), nid.getMinPath(), nid.getPath(), nid.getNumSegments());
+                return info;
 	}
 
 	public final int getLength()


### PR DESCRIPTION
jTraverser: avoid reading conglomerate nodes for gettin number of conglomerate elements
jScope: avoid reprating Signal.setXLimits if the limits passed are the same as before. Avoid possible loops triggered by detDataAsync() calls