### PR TITLE
Fix: mdstcpip memory issue with jscope

### DIFF
--- a/mdstcpip/mdsip.h
+++ b/mdstcpip/mdsip.h
@@ -101,12 +101,14 @@
 #define Endian(c) (c & BigEndian)
 #define CType(c) (c & 0x0f)
 #define IsCompressed(c) (c & COMPRESSED)
+
+// somewhat jScope only message->h.status
 #ifdef NOCOMPRESSION
 #define SUPPORTS_COMPRESSION 0
 #else
 #define SUPPORTS_COMPRESSION 0x8000
 #endif
-#define SupportsCompression(c) (c & SUPPORTS_COMPRESSION)
+#define SupportsCompression(s) (s & SUPPORTS_COMPRESSION)
 
 #define EVENTASTREQUEST "---EVENTAST---REQUEST---"
 #define EVENTCANREQUEST "---EVENTCAN---REQUEST---"

--- a/mdstcpip/mdsip_connections.h
+++ b/mdstcpip/mdsip_connections.h
@@ -192,12 +192,14 @@ typedef struct _io_routines
 #define Endian(c) (c & BigEndian)
 #define CType(c) (c & 0x0f)
 #define IsCompressed(c) (c & COMPRESSED)
+
+// somewhat jScope only message->h.status
 #ifdef NOCOMPRESSION
 #define SUPPORTS_COMPRESSION 0
 #else
 #define SUPPORTS_COMPRESSION 0x8000
 #endif
-#define SupportsCompression(c) (c & SUPPORTS_COMPRESSION)
+#define SupportsCompression(s) (s & SUPPORTS_COMPRESSION)
 
 #define FlipBytes(num, ptr)             \
   {                                     \

--- a/mdstcpip/mdsipshr/ProcessMessage.c
+++ b/mdstcpip/mdsipshr/ProcessMessage.c
@@ -482,14 +482,7 @@ static inline int _send_response(Connection *connection, Message *message, Messa
   const unsigned char message_id = connection->message_id;
   Message *m = NULL;
   int serial = STATUS_NOT_OK || (connection->descrip[0] && connection->descrip[0]->dtype == DTYPE_SERIAL);
-  mdsdsc_t *sd = NULL;
-  if (!serial && SupportsCompression(message->h.status))
-  {
-    EMPTYXD(xd);
-    status = MdsSerializeDscOut(d, &xd);
-    sd = d = xd.pointer;
-    serial = 1;
-  }
+  (void)message;
   if (serial && STATUS_OK && d->class == CLASS_A)
   {
     mdsdsc_a_t *array = (mdsdsc_a_t *)d;
@@ -555,7 +548,6 @@ static inline int _send_response(Connection *connection, Message *message, Messa
       break;
     }
   }
-  free(sd);
   return SendMdsMsgC(connection, m, 0);
 }
 

--- a/mdstcpip/mdsipshr/ProcessMessage.c
+++ b/mdstcpip/mdsipshr/ProcessMessage.c
@@ -476,24 +476,24 @@ static inline void convert_default(Message *m, int num, const mdsdsc_t *d, uint3
   }
 }
 
-static inline int _send_response(Connection *connection, Message **message, int status, mdsdsc_t *d)
+static inline int _send_response(Connection *connection, Message *message, Message **message_out, int status, mdsdsc_t *d)
 {
   const int client_type = connection->client_type;
   const unsigned char message_id = connection->message_id;
   Message *m = NULL;
   int serial = STATUS_NOT_OK || (connection->descrip[0] && connection->descrip[0]->dtype == DTYPE_SERIAL);
-  if (!serial && SupportsCompression(client_type))
+  mdsdsc_t *sd = NULL;
+  if (!serial && SupportsCompression(message->h.status))
   {
     EMPTYXD(xd);
     status = MdsSerializeDscOut(d, &xd);
-    MdsFreeDescriptor(d);
-    d = xd.pointer;
+    sd = d = xd.pointer;
     serial = 1;
   }
   if (serial && STATUS_OK && d->class == CLASS_A)
   {
     mdsdsc_a_t *array = (mdsdsc_a_t *)d;
-    *message = m = malloc(sizeof(MsgHdr) + array->arsize);
+    *message_out = m = malloc(sizeof(MsgHdr) + array->arsize);
     memset(&m->h, 0, sizeof(MsgHdr));
     m->h.msglen = sizeof(MsgHdr) + array->arsize;
     m->h.client_type = client_type;
@@ -510,7 +510,7 @@ static inline int _send_response(Connection *connection, Message **message, int 
     uint16_t length;
     uint32_t num;
     uint32_t nbytes = get_nbytes(&length, &num, client_type, d);
-    *message = m = malloc(sizeof(MsgHdr) + nbytes);
+    *message_out = m = malloc(sizeof(MsgHdr) + nbytes);
     memset(&m->h, 0, sizeof(MsgHdr));
     m->h.msglen = sizeof(MsgHdr) + nbytes;
     m->h.client_type = client_type;
@@ -555,6 +555,7 @@ static inline int _send_response(Connection *connection, Message **message, int 
       break;
     }
   }
+  free(sd);
   return SendMdsMsgC(connection, m, 0);
 }
 
@@ -563,7 +564,7 @@ static int send_response(Connection *connection, Message *message, const int sta
 {
   int status;
   INIT_AND_FREE_ON_EXIT(Message *, m);
-  status = _send_response(connection, &m, status_in, d);
+  status = _send_response(connection, message, &m, status_in, d);
   FREE_NOW(m);
   if (STATUS_NOT_OK)
     return FALSE; // no good close connection


### PR DESCRIPTION
There was a double free causing the crash. also SupportsCompression is not a flag of client_type but according to jScope a bit in the status filed. .. jScope seems to be the only client that cares about compression but does not support DTYPE DSC .. I assume the code that i tried to revive there was commented out for that reason. I removed it, whoever in two commit in case we want this back some day.
Fixes #2318 