### PR TITLE
Feature: Add extern entrypoint CamXlateLogicalname

### DIFF
--- a/camshr/xlate_logicalname.c
+++ b/camshr/xlate_logicalname.c
@@ -104,3 +104,7 @@ Xlate_LogicalName_Exit:
 
   return status;
 }
+EXPORT int CamXlateLogicalname(char *Name, CamKey *key) 
+{
+  return xlate_logicalname(Name, key);
+}

--- a/include/camshr.h
+++ b/include/camshr.h
@@ -25,3 +25,13 @@ extern int CamPiow(char *name, int a, int f, void *data, int mem,
 extern int CamPioQrepw(char *name, int a, int f, void *data, int mem,
                        unsigned short *iosb);
 extern int CamVerbose(int mode);
+
+typedef struct
+{
+  char scsi_port;
+  char scsi_address;
+  char slot;
+  char crate;
+} CamKey;
+
+extern int CamXlateLogicalname(char *Name, CamKey *key);


### PR DESCRIPTION
A user wants to call xlate_logicalname in camshr.  New entrypoint
added to expose this routine.

Closes issue:
https://github.com/MDSplus/mdsplus/issues/2319