### PR TITLE
Fix: Compare ctx.value instead of ctx, fixes #2325 (#2326)

### DIFF
--- a/python/MDSplus/tree.py
+++ b/python/MDSplus/tree.py
@@ -694,7 +694,7 @@ class Tree(object):
 
     def __eq__(self, obj):
         if isinstance(obj, (Tree,)):
-            return self.ctx == obj.ctx
+            return self.ctx.value == obj.ctx.value
         return False
 
     def __ne__(self, obj): return not self.__eq__(obj)
@@ -1047,7 +1047,7 @@ class Tree(object):
         old = self.default
         if not isinstance(node, TreeNode):
             raise TypeError('default node must be a TreeNode')
-        if not node.ctx == self.ctx:
+        if not node.ctx.value == self.ctx.value:
             raise TypeError('TreeNode must be in same tree')
         _exc.checkStatus(
             _TreeShr._TreeSetDefaultNid(self.ctx,


### PR DESCRIPTION
* Compare ctx.value instead of ctx, fixes #2325

When instance of active tree is created (i.e. Tree()), comparing ctx
of node and tree result in node seeming to be from another tree