### PR TITLE
Feature: New TDI python function that query Influxdb data from an MDSplus node

### DIFF
--- a/deploy/packaging/debian/kernel.noarch
+++ b/deploy/packaging/debian/kernel.noarch
@@ -156,6 +156,7 @@
 ./usr/local/mdsplus/tdi/python/intersect1d.py
 ./usr/local/mdsplus/tdi/python/pyfun.py
 ./usr/local/mdsplus/tdi/python/setdiff1d.py
+./usr/local/mdsplus/tdi/python/influxSignal.py
 ./usr/local/mdsplus/tdi/remote/GetManyExecute.fun
 ./usr/local/mdsplus/tdi/remote/ListConnections.fun
 ./usr/local/mdsplus/tdi/remote/MdsConnect.fun

--- a/deploy/packaging/redhat/kernel.noarch
+++ b/deploy/packaging/redhat/kernel.noarch
@@ -182,6 +182,7 @@
 ./usr/local/mdsplus/tdi/python/intersect1d.py
 ./usr/local/mdsplus/tdi/python/pyfun.py
 ./usr/local/mdsplus/tdi/python/setdiff1d.py
+./usr/local/mdsplus/tdi/python/influxSignal.py
 ./usr/local/mdsplus/tdi/remote
 ./usr/local/mdsplus/tdi/remote/GetManyExecute.fun
 ./usr/local/mdsplus/tdi/remote/ListConnections.fun

--- a/pydevices/HtsDevices/acq2106_435st.py
+++ b/pydevices/HtsDevices/acq2106_435st.py
@@ -273,6 +273,10 @@ class _ACQ2106_435ST(MDSplus.Device):
                 except Empty:
                     continue
 
+                if self.dev.trig_time.getDataNoRaise() is None:
+                    self.dev.trig_time.record = self.device_thread.trig_time - \
+                        ((self.device_thread.io_buffer_size / np.int32(0).nbytes) * dt)
+
                 buffer = np.right_shift(np.frombuffer(buf, dtype='int32'), 8)
                 i = 0
                 for c in self.chans:

--- a/tdi/python/influxSignal.py
+++ b/tdi/python/influxSignal.py
@@ -1,0 +1,52 @@
+import MDSplus
+
+try:
+    from influxdb import InfluxDBClient
+except:
+    print(
+        "You must install the `influxdb` python package.")
+    exit(1)
+
+def influxSignal(dbname, measurement, field_value):
+    """Instantiate a connection to the InfluxDB."""
+    host     = 'localhost'
+    port     = 8086
+    user     = 'admin'
+    password = 'password'
+
+    dbname      = dbname.data()
+    measurement = measurement.data()
+    field_value = field_value.data()
+
+    MDSplus.Data.execute('TreeOpen("influx", 0)')
+    start_end_times = MDSplus.Tree.getTimeContext()
+    print('Getting time context from the tree: {} '.format(start_end_times))
+    start_time = str(int(start_end_times[0]))
+    end_time   = str(int(start_end_times[1]))
+    
+    client = InfluxDBClient(host, port, user, password, dbname)
+    # example influxDB query:
+    # dbname      = 'NOAA_water_database' 
+    # measurement = h2o_feet
+    # field_value = water_level
+    # 'SELECT "water_level" FROM "h2o_feet" WHERE time >= 1568745000000000000 AND time <= 1568750760000000000;'
+    query = 'SELECT "%s" FROM "%s" WHERE time >= %s AND time <= %s;' % (field_value, measurement, start_time, end_time)
+    print('Query: %s' % query)
+
+    result = client.query(query, params={'epoch': 'ms'})
+
+    data = list(result.get_points())
+
+    valueData = [None] * len(data)
+    timeData  = [None] * len(data)
+
+    i = 0
+    for row in data:
+        valueData[i] = float(row['water_level'])
+        timeData[i] = row['time']
+        i += 1
+
+    values = MDSplus.Float32Array(valueData)
+    times  = MDSplus.Uint64Array(timeData)
+
+    return MDSplus.Signal(values, None, times)

--- a/tdi/python/influxSignal.py
+++ b/tdi/python/influxSignal.py
@@ -77,7 +77,7 @@ def influxSignal(fieldKey, where, series=None, database=None, config=None, shotS
     series = series.data()
     fieldKey = fieldKey.data()
     shotStartTime = shotStartTime.data()
-    shotEndTime = shotEndTime.data()
+    shotEndTime = shotEndTime.getDataNoRaise()
 
     if where == '':
         return
@@ -102,15 +102,14 @@ def influxSignal(fieldKey, where, series=None, database=None, config=None, shotS
     # Clamp the computed start/end time within the time bounds of the shot
     if startTime < shotStartTime:
         startTime = shotStartTime
-    if endTime > shotEndTime:
+    if endTime is not None and endTime > shotEndTime:
         endTime = shotEndTime
 
     startTimeQuery = ''
     endTimeQuery = ''
 
     # Convert to nanosecond UNIX timestamp
-    if startTime is not None:
-        startTimeQuery = 'time > %d' % (startTime * 1000000,)
+    startTimeQuery = 'time > %d' % (startTime * 1000000,)
 
     # Convert to nanosecond UNIX timestamp
     if endTime is not None:

--- a/tdi/python/influxSignal.py
+++ b/tdi/python/influxSignal.py
@@ -27,7 +27,7 @@ def influxSignal(dbname, measurement, field_value):
     client = InfluxDBClient(host, port, user, password, dbname)
     # example influxDB query:
     # dbname      = 'NOAA_water_database' 
-    # measurement = h2o_feet
+    # measurement = h2o_feet == Table
     # field_value = water_level
     # 'SELECT "water_level" FROM "h2o_feet" WHERE time >= 1568745000000000000 AND time <= 1568750760000000000;'
     query = 'SELECT "%s" AS value FROM "%s" WHERE time >= %s AND time <= %s;' % (field_value, measurement, start_time, end_time)

--- a/tdi/python/influxSignal.py
+++ b/tdi/python/influxSignal.py
@@ -18,8 +18,8 @@ def influxSignal(dbname, measurement, field_value):
     measurement = measurement.data()
     field_value = field_value.data()
 
-    MDSplus.Data.execute('TreeOpen("influx", 0)')
     start_end_times = MDSplus.Tree.getTimeContext()
+
     print('Getting time context from the tree: {} '.format(start_end_times))
     start_time = str(int(start_end_times[0]))
     end_time   = str(int(start_end_times[1]))
@@ -30,7 +30,7 @@ def influxSignal(dbname, measurement, field_value):
     # measurement = h2o_feet
     # field_value = water_level
     # 'SELECT "water_level" FROM "h2o_feet" WHERE time >= 1568745000000000000 AND time <= 1568750760000000000;'
-    query = 'SELECT "%s" FROM "%s" WHERE time >= %s AND time <= %s;' % (field_value, measurement, start_time, end_time)
+    query = 'SELECT "%s" AS value FROM "%s" WHERE time >= %s AND time <= %s;' % (field_value, measurement, start_time, end_time)
     print('Query: %s' % query)
 
     result = client.query(query, params={'epoch': 'ms'})
@@ -42,7 +42,7 @@ def influxSignal(dbname, measurement, field_value):
 
     i = 0
     for row in data:
-        valueData[i] = float(row['water_level'])
+        valueData[i] = float(row['value'])
         timeData[i] = row['time']
         i += 1
 

--- a/tdi/python/influxSignal.py
+++ b/tdi/python/influxSignal.py
@@ -1,3 +1,28 @@
+#
+# Copyright (c) 2021, Massachusetts Institute of Technology All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# Redistributions of source code must retain the above copyright notice, this
+# list of conditions and the following disclaimer.
+#
+# Redistributions in binary form must reproduce the above copyright notice, this
+# list of conditions and the following disclaimer in the documentation and/or
+# other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
 import MDSplus
 
 try:
@@ -31,6 +56,7 @@ def influxSignal(dbname, measurement, field_value, address, credentials):
     measurement = measurement.data()
     field_value = field_value.data()
 
+    # We get the start_time and the end_time of the query from the defined MDSplus tree time context
     start_end_times = MDSplus.Tree.getTimeContext()
 
     print('Getting time context from the tree: {} '.format(start_end_times))

--- a/tdi/python/influxSignal.py
+++ b/tdi/python/influxSignal.py
@@ -7,16 +7,29 @@ except:
         "You must install the `influxdb` python package.")
     exit(1)
 
-def influxSignal(dbname, measurement, field_value):
+def influxSignal(dbname, measurement, field_value, address, credentials):
     """Instantiate a connection to the InfluxDB."""
-    host     = 'localhost'
+    host     = address.data()
     port     = 8086
-    user     = 'admin'
-    password = 'password'
+
+    username = ''
+    password = ''
+    try:
+        with open(credentials.data()) as cred_file:
+            lines = cred_file.readlines()
+
+            if len(lines) < 2:
+                print("Failed to read credentials from file %s" %(credentials,))
+
+            username = lines[0].strip('\n')
+            password = lines[1].strip('\n')
+
+    except IOError as e:
+        print("Failed to open credentials file %s" %(credentials,))
 
     dbname      = dbname.data()
-    measurement = measurement.data()
-    field_value = field_value.data()
+    #measurement = measurement.data()
+    #field_value = field_value.data()
 
     start_end_times = MDSplus.Tree.getTimeContext()
 
@@ -24,7 +37,8 @@ def influxSignal(dbname, measurement, field_value):
     start_time = str(int(start_end_times[0]))
     end_time   = str(int(start_end_times[1]))
     
-    client = InfluxDBClient(host, port, user, password, dbname)
+    client = InfluxDBClient(host, port, username, password, dbname)
+
     # example influxDB query:
     # dbname      = 'NOAA_water_database' 
     # measurement = h2o_feet == Table
@@ -50,3 +64,4 @@ def influxSignal(dbname, measurement, field_value):
     times  = MDSplus.Uint64Array(timeData)
 
     return MDSplus.Signal(values, None, times)
+

--- a/tdi/python/influxSignal.py
+++ b/tdi/python/influxSignal.py
@@ -19,13 +19,13 @@ def influxSignal(dbname, measurement, field_value, address, credentials):
             lines = cred_file.readlines()
 
             if len(lines) < 2:
-                print("Failed to read credentials from file %s" %(credentials,))
+                print("Failed to read credentials from file %s" %(credentials.data(),))
 
             username = lines[0].strip('\n')
             password = lines[1].strip('\n')
 
     except IOError as e:
-        print("Failed to open credentials file %s" %(credentials,))
+        print("Failed to open credentials file %s" %(credentials.data(),))
 
     dbname      = dbname.data()
     #measurement = measurement.data()

--- a/tdi/python/influxSignal.py
+++ b/tdi/python/influxSignal.py
@@ -28,8 +28,8 @@ def influxSignal(dbname, measurement, field_value, address, credentials):
         print("Failed to open credentials file %s" %(credentials.data(),))
 
     dbname      = dbname.data()
-    #measurement = measurement.data()
-    #field_value = field_value.data()
+    measurement = measurement.data()
+    field_value = field_value.data()
 
     start_end_times = MDSplus.Tree.getTimeContext()
 


### PR DESCRIPTION
A new python TDI function that allows for query data from InfluxDB from an MDSplus node.

The MDsplus node will contain a following function call:

influxSignal(
	"fVal",
	"tagPath = 'ic/dc bus/i_focs_bus'",
	\TFMC::TOP.INFLUXDB:SERIES,
	\TFMC::TOP.INFLUXDB:DATABASE,
	\TFMC::TOP.INFLUXDB:CONFIG,
	\TFMC::TOP.INFLUXDB:START_TIME,
	\TFMC::TOP.INFLUXDB:END_TIME
)

where:

fVal = it's the field key
tagPAth =  this is the "where" part of the query
\TFMC::TOP.INFLUXDB:CONFIG is there the credential file is located. This file contains the IP address and port of the server.

This PR also contain a change to the acq2106_435st class, to correctly set the TRIG_TIME, i.e. the START_TIME for the beginning of the shot.
