### PR TITLE
Fix: remove #pragma once from the code

### DIFF
--- a/_include/P2WMutex.hpp
+++ b/_include/P2WMutex.hpp
@@ -1,4 +1,6 @@
-#pragma once
+#ifndef _P2WMUTEX_HPP
+#define _P2WMUTEX_HPP
+
 #ifndef _GNU_SOURCE
 #define _GNU_SOURCE
 #endif
@@ -280,3 +282,4 @@ public:
 };
 static_assert(sizeof(pthread_cond_t) == sizeof(P2WCond), "Size is not correct");
 #endif
+#endif // ifndef _P2WMUTEX_HPP

--- a/_include/P2WSem.hpp
+++ b/_include/P2WSem.hpp
@@ -1,4 +1,6 @@
-#pragma once
+#ifndef _P2WSEM_HPP
+#define _P2WSEM_HPP
+
 #ifndef _GNU_SOURCE
 #define _GNU_SOURCE
 #endif
@@ -70,3 +72,4 @@ public:
   }
 };
 static_assert(sizeof(sem_t) == sizeof(P2WSem), "Size is not correct");
+#endif // ifndef _P2WSEM_HPP

--- a/_include/P2WThread.hpp
+++ b/_include/P2WThread.hpp
@@ -1,4 +1,6 @@
-#pragma once
+#ifndef _P2WTHREAD_HPP
+#define _P2WTHREAD_HPP
+
 #ifndef _GNU_SOURCE
 #define _GNU_SOURCE
 #endif
@@ -348,3 +350,4 @@ private:
   }
 #endif // PTHREAD
 };
+#endif // ifndef _P2WTHREAD_HPP

--- a/_include/_mdsshr.h
+++ b/_include/_mdsshr.h
@@ -1,4 +1,5 @@
-#pragma once
+#ifndef __MDSSHR_H
+#define __MDSSHR_H
 #include <mdsshr.h>
 #include <status.h>
 #include <mdsmsg.h>
@@ -20,3 +21,4 @@ struct sockaddr;
   MDSSHR_LOAD_LIBROUTINE(method, lib, method, on_error)
 
 extern int _LibGetHostAddr(const char *hostname, const char *service, struct sockaddr *sin);
+#endif // ifndef __MDSSHR_H

--- a/_include/int128.h
+++ b/_include/int128.h
@@ -1,4 +1,5 @@
-#pragma once
+#ifndef _INT128_H
+#define _INT128_H
 #include <inttypes.h>
 #include <math.h>
 #include <stdio.h>
@@ -379,3 +380,4 @@ static inline int int128_div(const int128_t *x, const int128_t *d,
     int128_minus(ans, ans);
   return 1;
 }
+#endif // ifndef _INT128_H

--- a/configure.ac
+++ b/configure.ac
@@ -1206,7 +1206,8 @@ dnl Here we define all custom autoheader adds to mdsconfig.h.in
 
 dnl add here what goes on tom of mdsconfig.h
 AH_TOP(
-#pragma once
+#ifndef _MDSCONFIG_H
+#define _MDSCONFIG_H
 #ifdef _MSC_VER
 #define __attribute__(...)
 #define EXPORT __declspec(dllexport)
@@ -1248,6 +1249,7 @@ AH_VERBATIM([_WIN32], [
 dnl add here what goes on bottom of mdsconfig.h
 AH_BOTTOM(
 #endif // _MSC_VER else
+#endif // ifndef _MDSCONFIG_H
 )
 
 

--- a/deploy/gen_messages.py
+++ b/deploy/gen_messages.py
@@ -135,7 +135,8 @@ MDSplusException.statusDict[%(msgnum)d] = %(fac)s%(msgnam)s
 """
 
 inc_head = """
-#pragma once
+#ifndef _{base}_{ext}
+#define _{base}_{ext}
 #include <status.h>
 
 """
@@ -296,7 +297,8 @@ def gen_include(root, filename, faclist, msglistm, f_test):
     print(filename)
     with open("%s/include/%sh" % (sourcedir, filename[0:-3]), 'w') as f_inc:
         add_c_header(f_inc, filename)
-        f_inc.write(inc_head)
+        parts = filename.upper().split('.')
+        f_inc.write(inc_head.format(base=parts[0],ext=parts[1]))
         for f in root.iter('facility'):
             facnam = f.get('name')
             facnum = int(f.get('value'))
@@ -352,6 +354,7 @@ def gen_include(root, filename, faclist, msglistm, f_test):
                 if not facnam in pfaclist:
                     pfaclist.append(facnam)
                 msglist.append(msg)
+        f_inc.write("#endif")
 
 
 # gen_msglist():

--- a/include/Xmds/XmdsWaveform.h
+++ b/include/Xmds/XmdsWaveform.h
@@ -41,7 +41,8 @@
    Management.
 ----------------------------------------------------------------------------*/
 
-#pragma once
+#ifndef _XMDSWAVEFORM_H
+#define _XMDSWAVEFORM_H
 #include <stdio.h>
 #ifndef _Xm_h
 #include <Xm/Xm.h>
@@ -210,3 +211,4 @@ extern void XmdsWaveformUpdate(Widget w, XmdsWaveformValStruct *x,
 extern void XmdsWaveformSetWave(Widget w, int count, float *x, float *y,
                                 Boolean *select, Boolean *pendown,
                                 Boolean autoscale, Boolean defer_update);
+#endif //ifndef _XMDSWAVEFORM_H

--- a/include/camshr.h
+++ b/include/camshr.h
@@ -1,4 +1,5 @@
-#pragma once
+#ifndef _CAMSHR_H
+#define _CAMSHR_H
 
 extern int CamBytcnt(unsigned short *iosb);
 extern int CamError(int *xexp, int *qexp, unsigned short *iosb_in);
@@ -35,3 +36,4 @@ typedef struct
 } CamKey;
 
 extern int CamXlateLogicalname(char *Name, CamKey *key);
+#endif

--- a/include/dbidef.h
+++ b/include/dbidef.h
@@ -1,4 +1,5 @@
-#pragma once
+#ifndef _DBIDEF_H
+#define _DBIDEF_H
 /*  VAX/DEC CMS REPLACEMENT HISTORY, Element DBIDEF.H */
 /*  *3     1-APR-1991 17:29:45 TWF "Add readonly open" */
 /*  *2    16-FEB-1990 10:28:18 TWF "Add itmlst struct" */
@@ -33,3 +34,4 @@ typedef struct dbi_itm
   void *pointer;
   int *return_length_address;
 } DBI_ITM;
+#endif

--- a/include/dcl.h
+++ b/include/dcl.h
@@ -1,4 +1,5 @@
-#pragma once
+#ifndef _DCL_H
+#define _DCL_H
 
 #include <mdsdescrip.h>
 extern int mdsdclAddCommands(const char *name_in, char **error);
@@ -20,3 +21,4 @@ extern int mdsdcl_do_command_extra_args(char const *command, char **prompt,
                                         char *(*getline)(), void *getlineinfo);
 extern int cli_get_value(void *ctx, const char *name, char **value);
 extern int cli_present(void *ctx, const char *name);
+#endif

--- a/include/mdsshr.h
+++ b/include/mdsshr.h
@@ -1,5 +1,5 @@
-#pragma once
-
+#ifndef _MDSSHR_H
+#define _MDSSHR_H
 #define MdsCOMPRESSIBLE 3
 #include <mdsdescrip.h>
 #include <mdstypes.h>
@@ -158,4 +158,5 @@ extern "C"
 
 #ifdef __cplusplus
 }
+#endif
 #endif

--- a/include/ncidef.h
+++ b/include/ncidef.h
@@ -1,4 +1,5 @@
-#pragma once
+#ifndef _NCIDEF_H
+#define _NCIDEF_H
 /**************************************
   NCIDEF.H - definitions of constants
   used in  item list arguments to the
@@ -93,3 +94,4 @@ typedef struct nci_itm
   void *pointer;
   int *return_length_address;
 } NCI_ITM;
+#endif

--- a/include/status.h
+++ b/include/status.h
@@ -1,4 +1,5 @@
-#pragma once
+#ifndef _STATUS_H
+#define _STATUS_H
 #include <mdsshr_messages.h>
 #define STATUS_H(x) x
 #define FALSE 0
@@ -34,3 +35,4 @@
 #define GOTO_IF_NOT_OK(MARK, CHECK)  \
   if (IS_NOT_OK((status = (CHECK)))) \
     goto MARK;
+#endif

--- a/include/strroutines.h
+++ b/include/strroutines.h
@@ -1,4 +1,5 @@
-#pragma once
+#ifndef _STRROUTINES_H
+#define _STRROUTINES_H
 
 #include <mdsdescrip.h>
 
@@ -50,4 +51,5 @@ static void __attribute__((unused)) free_d(void *ptr)
   FREED_ON_EXIT(&var)
 #define INIT_AND_FREED_ON_EXIT(var, dtype) \
   INIT_AS_AND_FREED_ON_EXIT(var, ((mdsdsc_d_t){0, dtype, CLASS_D, NULL}))
+#endif
 #endif

--- a/include/tdishr.h
+++ b/include/tdishr.h
@@ -1,4 +1,5 @@
-#pragma once
+#ifndef _TDISHR_H
+#define _TDISHR_H
 #include <mdsdescrip.h>
 #include <mdstypes.h>
 #include <status.h>
@@ -31,3 +32,4 @@ extern int _TdiIntrinsic(void **ctx, opcode_t opcode, int narg,
                          struct descriptor_xd *out_ptr);
 extern int CvtConvertFloat(void *invalue, uint32_t indtype, void *outvalue,
                            uint32_t outdtype, uint32_t options);
+#endif

--- a/include/treeshr.h
+++ b/include/treeshr.h
@@ -1,4 +1,5 @@
-#pragma once
+#ifndef _TREESHR_H
+#define _TREESHR_H
 
 /********** define this in case user code is checking it ************/
 
@@ -377,4 +378,5 @@ extern "C"
 
 #ifdef __cplusplus
 }
+#endif
 #endif

--- a/include/usagedef.h
+++ b/include/usagedef.h
@@ -1,4 +1,5 @@
-#pragma once
+#ifndef _USAGEDEF_H
+#define _USAGEDEF_H
 /*  USAGEDEF.H ************************************
 
 Node Usage definitions
@@ -28,3 +29,4 @@ TYPEDEF(1){TreeUSAGE_ANY = 0, TreeUSAGE_STRUCTURE = 1, TreeUSAGE_ACTION = 2,
 #undef TYPEDEF
 #undef ENDDEF
 #define TreeUSAGE_NONE TreeUSAGE_STRUCTURE
+#endif

--- a/include/xmdsshr.h
+++ b/include/xmdsshr.h
@@ -1,4 +1,5 @@
-#pragma once
+#ifndef _XMDSSHR_H
+#define _XMDSSHR_H
 #include <Mrm/MrmPublic.h>
 #include <X11/Intrinsic.h>
 #include <Xmds/ListTreeP.h>
@@ -74,3 +75,4 @@ extern EXPORT Pixmap *XmdsUsageGrayIcons();
 
 extern EXPORT WidgetClass xmdsWaveformWidgetClass;
 extern EXPORT XmdsWaveformClassRec xmdsWaveformClassRec;
+#endif

--- a/mdsdcl/mdsdclthreadstatic.h
+++ b/mdsdcl/mdsdclthreadstatic.h
@@ -1,4 +1,5 @@
-#pragma once
+#ifndef _MDSDCLTHREADSTATIC_H
+#define _MDSDCLTHREADSTATIC_H
 #include "../mdsshr/mdsthreadstatic.h"
 #include "dcl_p.h"
 
@@ -18,3 +19,4 @@ typedef struct
 #define DCL_DOCS DCLTHREADSTATIC_VAR->docs
 
 extern DEFINE_GETTHREADSTATIC(DCLTHREADSTATIC_TYPE, DclGetThreadStatic);
+#endif // ifndef _MDSDCLTHREADSTATIC_H

--- a/mdsshr/mdsshrp.h
+++ b/mdsshr/mdsshrp.h
@@ -1,4 +1,5 @@
-#pragma once
+#ifndef _MDSSHRP_H
+#define _MDSSHRP_H
 
 #include <mdsdescrip.h>
 
@@ -22,3 +23,4 @@ extern int MDSUdpEventAstMask(char const *eventName,
 extern int MDSUdpEventCan(int eventid);
 extern int MDSUdpEvent(char const *eventName, int bufLen, char const *buf);
 extern int LibSFree1Dd(struct descriptor *out);
+#endif  //indef _MDSSHRP_H

--- a/mdsshr/mdsthreadstatic.h
+++ b/mdsshr/mdsthreadstatic.h
@@ -1,4 +1,5 @@
-#pragma once
+#ifndef _MDSTHREADSTATIC_H
+#define _MDSTHREADSTATIC_H
 #include <mdsdescrip.h>
 #include <mdstypes.h>
 #include <pthread_port.h>
@@ -59,3 +60,4 @@ typedef struct
 #define MDS_FIS_ERROR MDSTHREADSTATIC_VAR->librtl_fis_error
 
 extern DEFINE_GETTHREADSTATIC(MDSTHREADSTATIC_TYPE, MdsGetThreadStatic);
+#endif // ifndef _MDSTHREADSTATIC_H

--- a/mdstcpip/mdsIo.h
+++ b/mdstcpip/mdsIo.h
@@ -1,5 +1,6 @@
 
-#pragma once
+#ifndef _MDSIO_H
+#define _MDSIO_H
 #ifndef DOXYGEN // hide this part from documentation
 
 typedef enum
@@ -128,3 +129,4 @@ typedef union {
   }
 #endif
 #endif // DOXYGEN end of hidden code
+#endif // ifndef _MDSIO_H

--- a/mdstcpip/mdsipshr/mdsipthreadstatic.h
+++ b/mdstcpip/mdsipshr/mdsipthreadstatic.h
@@ -1,4 +1,5 @@
-#pragma once
+#ifndef _MDSIPTHREADSTATIC_H
+#define _MDSIPTHREADSTATIC_H
 #include "../mdsshr/mdsthreadstatic.h"
 #include "../mdsip_connections.h"
 
@@ -16,3 +17,4 @@ typedef struct
 #define MDSIP_CONNECTIONS MDSIPTHREADSTATIC_VAR->connections
 
 extern DEFINE_GETTHREADSTATIC(MDSIPTHREADSTATIC_TYPE, MdsIpGetThreadStatic);
+#endif // ifndef _MDSIPTHREADSTATIC_H

--- a/servershr/Job.h
+++ b/servershr/Job.h
@@ -1,4 +1,5 @@
-#pragma once
+#ifndef _JOB_H
+#define _JOB_H
 #include <pthread_port.h>
 
 #include <mdsmsg.h>
@@ -262,3 +263,4 @@ static void Job_cleanup(int status, int jobid)
     j = Job_pop_by_conid(conid);
   } while (j);
 }
+#endif // ifndef _JOB_H

--- a/tdishr/tdithreadstatic.h
+++ b/tdishr/tdithreadstatic.h
@@ -1,4 +1,6 @@
-#pragma once
+#ifndef _TDITHREADSTATIC_H
+#define _TDITHREADSTATIC_H
+
 #include "../mdsshr/mdsthreadstatic.h"
 #include "tdirefzone.h"
 
@@ -72,3 +74,4 @@ typedef struct
 #define TDI_BALANCE (TDI_STACK.balance.all)
 
 extern DEFINE_GETTHREADSTATIC(TDITHREADSTATIC_TYPE, TdiGetThreadStatic);
+#endif // ifndef _TDITHREADSTATIC_H

--- a/testing/testing.h
+++ b/testing/testing.h
@@ -1,4 +1,5 @@
-#pragma once
+#ifndef _TESTING_H
+#define _TESTING_H
 
 #include <assert.h>
 #include <string.h>
@@ -211,3 +212,4 @@ _Pragma("GCC diagnostic ignored \"-Wcatch-value\"")
     TEST1(correct_exception_caught);        \
   }
 #endif
+#endif // ifndef _TESTING_H

--- a/treeshr/treeshr_xnci.h
+++ b/treeshr/treeshr_xnci.h
@@ -1,5 +1,7 @@
 
-#pragma once
+#ifndef _TREESHR_XNCI_H
+#define _TREESHR_XNCI_H
+
 #include <treeshr.h>
 #ifdef __cplusplus
 extern "C"
@@ -72,3 +74,4 @@ extern "C"
 #ifdef __cplusplus
 }
 #endif
+#endif // ifndef _TREESHR_XNCI_H

--- a/treeshr/treethreadstatic.h
+++ b/treeshr/treethreadstatic.h
@@ -1,4 +1,6 @@
-#pragma once
+#ifndef _TREETHREADSTATIC_H
+#define _TREETHREADSTATIC_H
+
 #include "../mdsshr/mdsthreadstatic.h"
 #include "treeshrp.h"
 
@@ -41,3 +43,4 @@ extern DEFINE_GETTHREADSTATIC(TREETHREADSTATIC_TYPE, TreeGetThreadStatic);
 
 extern void **TreeCtx();
 extern EXPORT int TreeUsePrivateCtx(int onoff);
+#endif // ifndef _TREETHREADSTATIC_H


### PR DESCRIPTION
User reported that #pragma once, which is a nonstandard feature
is not supported by their compiler.  As it is 'nonstandard' it
seemed sensible to revert to #ifndef _FILENAME_EXT  instead.

Should resolve:
https://github.com/MDSplus/mdsplus/issues/2347