### PR TITLE
Fix: TreeShr cleanup connections only at key locations of the code

### DIFF
--- a/treeshr/RemoteAccess.c
+++ b/treeshr/RemoteAccess.c
@@ -85,7 +85,7 @@ static int remote_connect(char *server)
   MDSSHR_LOAD_LIBROUTINE_LOCAL(MdsIpShr, ReuseCheck, return conid, int, (char *, char *, int));
   MDSSHR_LOAD_LIBROUTINE_LOCAL(MdsIpShr, ConnectToMds, return conid, int, (char *));
   char unique[HOST_UNIQUE_SIZE] = "";
-  if (ReuseCheck(server, unique, 128) < 0)
+  if (ReuseCheck(server, unique, HOST_UNIQUE_SIZE) < 0)
   {
     conid = ConnectToMds(server);
     if (conid == -1)

--- a/treeshr/RemoteAccess.c
+++ b/treeshr/RemoteAccess.c
@@ -84,7 +84,7 @@ static int remote_connect(char *server)
   int conid = -1;
   MDSSHR_LOAD_LIBROUTINE_LOCAL(MdsIpShr, ReuseCheck, return conid, int, (char *, char *, int));
   MDSSHR_LOAD_LIBROUTINE_LOCAL(MdsIpShr, ConnectToMds, return conid, int, (char *));
-  char unique[sizeof(((Host*)NULL)->unique)] = "";
+  char unique[HOST_UNIQUE_SIZE] = "";
   if (ReuseCheck(server, unique, 128) < 0)
   {
     conid = ConnectToMds(server);
@@ -103,7 +103,7 @@ static int remote_connect(char *server)
     TREETHREADSTATIC_INIT;
     for (host = TREE_HOSTLIST; host; host = host->next)
     {
-      if (!strncmp(host->unique, unique, sizeof(unique)))
+      if (!strncmp(host->unique, unique, HOST_UNIQUE_SIZE))
       {
         conid = host->conid;
         host->links++;
@@ -121,7 +121,7 @@ static int remote_connect(char *server)
       host = malloc(sizeof(Host));
       host->conid = conid;
       host->links = 1;
-      strncpy(host->unique, unique, sizeof(unique));
+      strncpy(host->unique, unique, HOST_UNIQUE_SIZE);
       host->next = TREE_HOSTLIST;
       TREE_HOSTLIST = host;
       MDSDBG(HOST_PRI ", server='%s': new", HOST_VAR(host), server);

--- a/treeshr/TreeOpen.c
+++ b/treeshr/TreeOpen.c
@@ -83,7 +83,7 @@ static int GetVmForTree(TREE_INFO *info, int nomap);
 static int MapTree(TREE_INFO *info, TREE_INFO *root, int edit_flag);
 static void SubtreeNodeConnect(PINO_DATABASE *dblist, NODE *parent,
                                NODE *subtreetop);
-
+extern void TreeCleanupConnections();
 extern void **TreeCtx();
 
 int TreeClose(char const *tree, int shot)
@@ -325,6 +325,7 @@ int _TreeClose(void **dbid, char const *tree, int shot)
         status = TreeNOT_OPEN;
     }
   }
+  TreeCleanupConnections();
   return status;
 }
 
@@ -1351,6 +1352,7 @@ int _TreeOpenEdit(void **dbid, char const *tree_in, int shot_in)
         free_top_db(dblist);
     }
   }
+  TreeCleanupConnections();
   return status;
 }
 
@@ -1465,6 +1467,7 @@ int _TreeOpenNew(void **dbid, char const *tree_in, int shot_in)
     _TreeWriteTree(dbid, 0, 0);
     MDS_IO_CLOSE(fd_keepalive);
   }
+  TreeCleanupConnections();
   return status;
 }
 

--- a/treeshr/TreeThreadStatic.c
+++ b/treeshr/TreeThreadStatic.c
@@ -49,7 +49,6 @@ void destroy_host(Host *host)
   MDSSHR_LOAD_LIBROUTINE_LOCAL(MdsIpShr, DisconnectFromMds, abort(), void, (int));
   MDSDBG(HOST_PRI, HOST_VAR(host));
   DisconnectFromMds(host->conid);
-  free(host->unique);
   free(host);
 }
 

--- a/treeshr/treethreadstatic.h
+++ b/treeshr/treethreadstatic.h
@@ -2,12 +2,13 @@
 #include "../mdsshr/mdsthreadstatic.h"
 #include "treeshrp.h"
 
+#define HOST_UNIQUE_SIZE 64
 typedef struct host
 {
   struct host *next;
   int conid;
   int links;
-  char unique[64];
+  char unique[HOST_UNIQUE_SIZE];
 } Host;
 #define HOST_PRI "Host(conid=%d, links=%d, unique='%s')"
 #define HOST_VAR(h) (h)->conid, (h)->links, (h)->unique

--- a/treeshr/treethreadstatic.h
+++ b/treeshr/treethreadstatic.h
@@ -7,7 +7,7 @@ typedef struct host
   struct host *next;
   int conid;
   int links;
-  char *unique;
+  char unique[64];
 } Host;
 #define HOST_PRI "Host(conid=%d, links=%d, unique='%s')"
 #define HOST_VAR(h) (h)->conid, (h)->links, (h)->unique


### PR DESCRIPTION
This should fix issue #2352 by keeping connections in the treeshr connection list until the TreeOpen is complete.

* convert unique into fixed length char for performance, was limited already and 64 bytes is plenty, even for ip6 addresses.