### PR TITLE
Fix: Get clock plan and calculate the correct nanosec per ticks for the ACQ2106 WRTD TICKNS.

### DIFF
--- a/pydevices/HtsDevices/acq2106_WRTD.py
+++ b/pydevices/HtsDevices/acq2106_WRTD.py
@@ -45,11 +45,6 @@ class ACQ2106_WRTD(MDSplus.Device):
             'options': ('no_write_shot',)
         },
         {
-            'path': ':HOSTNAME',
-            'type': 'text',
-            'options': ('no_write_shot',)
-        },
-        {
             'path': ':COMMENT',
             'type': 'text',
             'options': ('no_write_shot',)
@@ -67,12 +62,6 @@ class ACQ2106_WRTD(MDSplus.Device):
         },
         {
             'path': ':TRIG_TIME',
-            'type': 'numeric',
-            'value': 0.,
-            'options': ('write_shot',)
-        },
-        {
-            'path': ':T0',
             'type': 'numeric',
             'value': 0.,
             'options': ('write_shot',)
@@ -101,7 +90,7 @@ class ACQ2106_WRTD(MDSplus.Device):
             'path': ':WR_INIT:WRTD_TICKNS',
             'type': 'numeric',
             'value': 50.0,
-            'options': ('no_write_shot',)
+            'options': ('write_shot',)
         },
         # 50msec - our "safe time for broadcast". From uut.cC.WRTD_DELTA_NS
         {

--- a/pydevices/HtsDevices/acq2106_WRTD.py
+++ b/pydevices/HtsDevices/acq2106_WRTD.py
@@ -199,18 +199,19 @@ class ACQ2106_WRTD(MDSplus.Device):
         # Sets WRTD TICKNS in nsecs: defined by 1/MBCLK
         # We can take MBCLK from the name of the clock plan that is going to be used when 
         # the desired sample rate is set by the acq2106 device's INIT function.
-        # Quering sync_role() will give us the clock plan name (FIN):
+        #
+        # 1- Quering sync_role() will give us the clock plan name (FIN):
         # sync_role_query = uut.s0.sync_role
         # clk_plan        = sync_role_query.split('\n')[4]
         # MBCLK           = clk_plan.split(' ')[1]
 
-        # Or, it can be query by:
+        # 2- Quering SYS:CLK:CONFIG will also give us the clock plan's name:
         sys_clk_plan = uut.s0.SYS_CLK_CONFIG
         MBCLK        = sys_clk_plan.split(' ')[1]
 
-        tonano = 1E9
-        allowed_plans = {'31M25-5M12':(1./5120000)*tonano, '31M25-10M24':(1./10240000)*tonano, '31M25-20M48':(1./20480000)*tonano, 
-                        '31M25-32M768':(1./32768000)*tonano, '31M25-40M':25.0000, '31M25-20M':50.0000}
+        to_nano = 1E9
+        allowed_plans = {'31M25-5M12':(1./5120000)*to_nano, '31M25-10M24':(1./10240000)*to_nano, '31M25-20M48':(1./20480000)*to_nano, 
+                        '31M25-32M768':(1./32768000)*to_nano, '31M25-40M':25.0000, '31M25-20M':50.0000}
         
         # In TIGA systems the clock plan is 31M25-40M, but MBCLK = 10 MHz, and is set to WRTD_TICKNS = 100.
 
@@ -220,7 +221,7 @@ class ACQ2106_WRTD(MDSplus.Device):
                 self.wr_init_wrtd_tickns.record = allowed_plans.get(MBCLK)
             else:
                 raise MDSplus.DevBAD_PARAMETER(
-                    "MBCLK must be 5M12, 10M24, 20M48, 32M768, 31M25-40M or 31M25-20M; not %d" % (MBCLK,))
+                    "MBCLK must be 31M25-5M12, 31M25-10M24, 31M25-20M48, 31M25-32M768, 31M25-40M or 31M25-20M; not %d" % (MBCLK,))
 
         # Sets WR "safe time for broadcasts" the message, i.e. WRTT_TAI = TAI_TIME_NOW + WRTD_DELTA_NS
         uut.cC.WRTD_DELTA_NS = self.wr_init_wrtd_dns.data()

--- a/pydevices/HtsDevices/acq2106_WRTD.py
+++ b/pydevices/HtsDevices/acq2106_WRTD.py
@@ -100,7 +100,7 @@ class ACQ2106_WRTD(MDSplus.Device):
         {
             'path': ':WR_INIT:WRTD_TICKNS',
             'type': 'numeric',
-            'value': 50,
+            'value': 50.0,
             'options': ('no_write_shot',)
         },
         # 50msec - our "safe time for broadcast". From uut.cC.WRTD_DELTA_NS
@@ -204,11 +204,12 @@ class ACQ2106_WRTD(MDSplus.Device):
         # clk_plan        = sync_role_query.split('\n')[4]
         # MBCLK           = clk_plan.split(' ')[1]
 
+        # Or, it can be query by:
         sys_clk_plan = uut.s0.SYS_CLK_CONFIG
         MBCLK        = sys_clk_plan.split(' ')[1]
 
         tonano = 1E9
-        allowed_plans = {'31M25-5M12':(1./51200000)*tonano, '31M25-10M24':(1./10240000)*tonano, '31M25-20M48':(1./20480000)*tonano, 
+        allowed_plans = {'31M25-5M12':(1./5120000)*tonano, '31M25-10M24':(1./10240000)*tonano, '31M25-20M48':(1./20480000)*tonano, 
                         '31M25-32M768':(1./32768000)*tonano, '31M25-40M':25.0000, '31M25-20M':50.0000}
         
         # In TIGA systems the clock plan is 31M25-40M, but MBCLK = 10 MHz, and is set to WRTD_TICKNS = 100.

--- a/pydevices/HtsDevices/acq2106_WRTD.py
+++ b/pydevices/HtsDevices/acq2106_WRTD.py
@@ -192,7 +192,7 @@ class ACQ2106_WRTD(MDSplus.Device):
         # 1- Quering sync_role() will give us the clock plan name (FIN):
         sync_role_query = uut.s0.sync_role
         if 'FIN_DEF=' in sync_role_query:
-            mbclk_plan = sync_role_query.split('FIN_DEF=')[1]
+            mbclk_plan = '31M25-' + sync_role_query.split('FIN_DEF=')[1]
         else:
             mbclk_plan = ''
 


### PR DESCRIPTION
The changes are in the acq2106_WRTD device.

1- Now the clock plan name is checked directly from the ACQ.
2- The name is used to to calculate the correct nanosec per tick value for the ACQ's uut.cC.WRTD_TICKNS