### PR TITLE
Fix: Influxdb signal with delta step

### DIFF
--- a/pydevices/HtsDevices/acq2106_423st.py
+++ b/pydevices/HtsDevices/acq2106_423st.py
@@ -222,6 +222,10 @@ class _ACQ2106_423ST(MDSplus.Device):
                 except Empty:
                     continue
 
+                if self.dev.trig_time.getDataNoRaise() is None:
+                    self.dev.trig_time.record = self.device_thread.trig_time - \
+                        ((self.device_thread.io_buffer_size / np.int16(0).nbytes) * dt)
+
                 buffer = np.frombuffer(buf, dtype='int16')
                 i = 0
                 for c in self.chans:
@@ -239,8 +243,6 @@ class _ACQ2106_423ST(MDSplus.Device):
 
                 self.empty_buffers.put(buf)
 
-            self.dev.trig_time.record = self.device_thread.trig_time - \
-                ((self.device_thread.io_buffer_size / np.int16(0).nbytes) * dt)
             self.device_thread.stop()
 
         class DeviceWorker(threading.Thread):

--- a/pydevices/HtsDevices/acq2106_435st.py
+++ b/pydevices/HtsDevices/acq2106_435st.py
@@ -301,9 +301,7 @@ class _ACQ2106_435ST(MDSplus.Device):
                 MDSplus.Event.setevent(event_name)
 
                 self.empty_buffers.put(buf)
-
-            self.dev.trig_time.record = self.device_thread.trig_time - \
-                ((self.device_thread.io_buffer_size / np.int32(0).nbytes) * dt)
+            
             self.device_thread.stop()
 
         class DeviceWorker(threading.Thread):

--- a/tdi/python/influxSignal.py
+++ b/tdi/python/influxSignal.py
@@ -131,8 +131,6 @@ def influxSignal(fieldKey, aggregation, where, series=None, database=None, confi
     if timeContext[2] is not None:
         deltaTime = float(timeContext[2])
 
-    # TODO: timeContext[2] is the interval which influx supports, therefore we should support it too.
-
     # Clamp the computed start/end time within the time bounds of the shot
     if startTime < shotStartTime:
         startTime = shotStartTime
@@ -174,6 +172,7 @@ def influxSignal(fieldKey, aggregation, where, series=None, database=None, confi
         if debug:
             print(aggregation, fieldKey)
 
+    """Instantiate a connection to the InfluxDB."""
     client = InfluxDBClient(host, port, username, password, database)
 
     query = 'SELECT %s AS value FROM "%s" %s %s;' % (fieldKey, series, where, groupBy)


### PR DESCRIPTION
Add INFLUX GROUP BY to the query:

groupBy = 'GROUP BY time(%sms)' % (deltaTimeMS,)

if the getSetTimeContext() contains the delta step. 

Includes changes to 435st and 423st so that the start of the shot, the trig_time is recorded into the node at the start of stream.