### PR TITLE
Build: Add support for nix packaging (flake)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ The MDSplus developers want to know who you are. If you or your site is using MD
 [MDSplus User Survey](https://docs.google.com/forms/d/e/1FAIpQLScSsA-fY2yTsW076bBreJmNbBqY9jsd-m4vmAdPvfCxXidiOQ/viewform?usp=sf_link).
 
 ## Building MDSplus
+
+### Building from source manually
 To build and install MDSplus on unix systems, you will need to obtain the
 MDSplus distribution from github either as a git repository or as a 
 compressed tar file.
@@ -35,6 +37,7 @@ When MDSplus is built to generate releases for public distribution a deploy
 script is used which uses Docker to pull specially configured Docker images
 from https://hub.docker.com/r/mdsplus/docker/
 
+### Building using Dockerized build environment
 You can build MDSplus for any of the linux and windows operatings systems
 without needing to install any special compilers or libraries. If you have
 the mdsplus source code and Docker installed on your linux system and your
@@ -60,6 +63,20 @@ You can find the available operating systems that you could specify for the
     # ls <mdsplus-src-dir>/deploy/os/*.opts
 
     
+### Building with nix package manager
+The mdsplus repo is a nix flake, meaning that it specifies a build recipe
+for mdsplus and all of its dependencies.  You can automatically download,
+build, and install mdsplus using the following nix command (after enabling the 
+currently experimental flakes feature):
+
+    nix shell github:mdsplus/mdsplus/<branch or tag name>
+    
+Upon first invocation, the above command will build and install mdsplus into
+the nix store, and then put the user into a subshell in which the mdsplus
+programs are available on the PATH.  The commands will be accessible until
+the subshell is exited.  In subsequent invocations, the user will go directly
+into the subshell without rebuilding or reinstalling.
+
 ---------------------------------------------------------------------------
 Who Uses MDSplus
 This map shows world fusion sites using MDSplus.  

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1622516815,
+        "narHash": "sha256-ZjBd81a6J3TwtlBr3rHsZspYUwT9OdhDk+a/SgSEf7I=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "7e9b0dff974c89e070da1ad85713ff3c20b0ca97",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "21.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,58 @@
+{
+	description = "mdsplus scientific database";
+	inputs.nixpkgs.url = "github:nixos/nixpkgs/21.05";
+
+	outputs = { self, nixpkgs }:
+		with import nixpkgs {
+			system = "x86_64-linux";
+		};
+	
+	let
+		mdsplus = stdenv.mkDerivation rec {
+			name = "mdsplus";
+			src = self;
+			# https://github.com/MDSplus/mdsplus/blob/alpha/README.INSTALL
+			buildInputs = [ 
+				gperf
+				jdk8
+				jre8
+				libxml2
+				readline
+				motif
+				perl
+				xorg.libXt
+			];
+			patchPhase = ''
+				patchShebangs --build .
+			'';
+			preConfigure = ''
+				./bootstrap
+			'';
+			nativeBuildInputs = [
+				which
+				automake
+				autoconf
+				autoconf-archive
+				python
+				git
+				flex
+				bison
+				gfortran
+				rsync
+			];
+		};
+
+		mdsplus_wrapped = runCommand "mdsplus" { 
+			buildInputs = [ mdsplus ]; 
+			nativeBuildInputs = [ makeWrapper ];
+			} ''
+				for b in $(ls ${mdsplus}/bin); do
+					makeWrapper ${mdsplus}/bin/$b $out/bin/$b --set MDSPLUS_DIR "${mdsplus}"
+				done
+			'';
+
+	in {
+		packages.x86_64-linux = { mdsplus = mdsplus_wrapped; };
+		defaultPackage.x86_64-linux = self.packages.x86_64-linux.mdsplus;
+	};
+}

--- a/flake.nix
+++ b/flake.nix
@@ -49,6 +49,7 @@
 				for b in $(ls ${mdsplus}/bin); do
 					makeWrapper ${mdsplus}/bin/$b $out/bin/$b --set MDSPLUS_DIR "${mdsplus}"
 				done
+				ln -s ${mdsplus} $out/mdsplus-install-location
 			'';
 
 	in {


### PR DESCRIPTION
This PR makes the mdsplus repo a nix flake by adding `flake.nix` and `flake.lock` files.

I am new to mdsplus and started going through [this tutorial](https://www.mdsplus.org/index.php?title=Documentation:Tutorial&open=76203664636339686323781681&page=Documentation%252FThe+MDSplus+tutorial) to get acquainted.  I saw in the mdsplus repo and [MDSplus/Docker ](https://github.com/MDSplus/Docker) repos that Docker is used for heavily for both building mdsplus from source as well as running mdsplus programs without building.  This approach is reasonable and is one I have tried before myself many times but have been frustrated by all the hoops to jump through with `docker-compose`, environment variables, mapping X11 permissions, mapping external files into the container, inscrutable command line options, and more.  My opinion is that Docker is a good fit for deploying web services to the cloud, but a poor fit for a CLI or GUI interactive ecosystem.

Nix flakes from the nix package manager are an alternative build and installation solution that some, like myself, might find more approachable or more robust in this case.  An overview of flakes is provided [here](https://www.tweag.io/blog/2020-05-25-flakes/).  In short, the flake provides a fully specified build and install recipe for a package and all its dependencies, and installs in a way that is isolated from the rest of the user's system.  Here is an example.

```
dan@dan-desktop:~$ mdstcl
mdstcl: command not found
dan@dan-desktop:~$ jTraverser
jTraverser: command not found
dan@dan-desktop:~$ export my_tree_path=$(realpath Desktop/my_tree_tutorial)
dan@dan-desktop:~$ nix shell github:fluffynukeit/mdsplus/stable
dan@dan-desktop:~$ mdstcl
TCL> set tree my_tree
TCL> dir

\MY_TREE::TOP

 :NUM1         :NUM2         :NUM3         :TXT         

  MY_SUBTREE    SUB1        

Total of 6 nodes.
TCL> exit
dan@dan-desktop:~$ jTraverser
dan@dan-desktop:~$ exit
exit
dan@dan-desktop:~$ mdstcl
mdstcl: command not found
```

The `nix shell` command will build and/or install the package and all its dependencies the first time it's called.  Most of the dependencies are cached in binary form and don't need to be built from scratch.

I don't think that the PR is ready to be taken as-is because I don't have enough experience with mdsplus to test everything or anticipate every problem.  I'm hoping this PR starts a discussion on whether this path is a viable alternative to the docker route.  I'm hoping being able to more easily build from source helps to encourage more contributions from the community.

## Anticipated Issues Collected from Discussion

1. Mdsplus gets installed in the nix store, which is read-only.  I've only skimmed the surface of the tutorial so far, but I have seen that new TCL functions and python functions are added by putting new files into the MDSPLUS_DIR path (read only in this case).  Is there any method of adding access to the files using environment variables instead of modifying the contents of MDSPLUS_DIR?



