### PR TITLE
Fix: camshr, for case when scsi host is > 9 and scsi linux device > 7

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -221,7 +221,7 @@ tests-env:
 
 # Interdependent directories:
 actions: mdsshr tdishr treeshr xmdsshr mdstcpip servershr
-camshr: mdsdcl
+camshr: mdsdcl mdstcpip
 ccl: camshr  mdsshr mdsdcl
 tcl: mdsshr treeshr tdishr mdstcpip servershr mdsdcl
 dwscope: xmdsshr
@@ -234,7 +234,7 @@ java/jdispatcher: java/mdsobjects
 java/jtraverser: java/mdsobjects java/jscope
 java/jtraverser2: java/mdsplus-api
 math: mdsshr
-mdsdcl: mdsshr
+mdsdcl: mdsshr treeshr
 mdslib: mdstcpip
 mdslibidl: tdishr
 mdsmisc: tdishr xtreeshr

--- a/camshr/QueryHighwayType.c
+++ b/camshr/QueryHighwayType.c
@@ -115,7 +115,7 @@ int QueryHighwayType(char *serial_hwy_driver)
     {
       if (strstr(line, "Host:"))
       {
-        sscanf(line, "Host: scsi%1d Channel: %*2d Id: %2d", &tmpHost, &tmpId);
+        sscanf(line, "Host: scsi%d Channel: %*2d Id: %2d", &tmpHost, &tmpId);
 
         if (tmpHost == host_adapter && tmpId == scsi_id)
         {

--- a/camshr/parse_crate_db.c
+++ b/camshr/parse_crate_db.c
@@ -83,7 +83,7 @@ void parse_crate_db(struct CRATE *in, struct Crate_ *out)
   );
 
   out->device = (in->DSFname[0] != '.')
-                    ? strtol(in->DSFname, NULL, 0) // valid /dev/sg#
+                    ? strtol(in->DSFname, NULL, 10) // valid /dev/sg#
                     : -1;                          // in-valid
 
   out->type = in->HwyType; // highway type


### PR DESCRIPTION
Recently got a new dataserver connected to a CAMAC system.  The disk system on this dataserver uses the first 8 SCSI hosts/devices, these changes allow for higher-valued SCSI host numbers to work.

3 small changes:
1 - updated Makefile.in dependencies related to building camshr.
2 - In camshr/QueryHighwayType.c, allowed it to recognize SCSI host IDs with more than 1 digit (in my case, SCSI host for the controller is 14)
3 - In camshr/parse_crate_db.c, switched the strtol base to 10.  Base 0 incorrectly reads the device number (/dev/sgN) when N is greater than 7. (in crate.db it is written as a 3-digit number, the leading 0 becomes a problem).

Thanks,

Kyle Morgan (University of Washington)