### PR TITLE
Fix: mdsmisc GetXYSignalXd() invalid free xd on error

### DIFF
--- a/mdsmisc/ScopeUtilities.c
+++ b/mdsmisc/ScopeUtilities.c
@@ -886,6 +886,9 @@ EXPORT int GetXYSignalXd(mdsdsc_t *const inY, mdsdsc_t *const inX,
     return TdiNULL_PTR;
   EMPTYXD(yXd);
   EMPTYXD(xXd);
+  EMPTYXD(title);
+  EMPTYXD(xLabel);
+  EMPTYXD(yLabel);
   int estimatedSegmentSamples = 0;
   int isLong = FALSE;
   double xmin = -INFINITY, xmax = INFINITY; // requested
@@ -936,9 +939,6 @@ EXPORT int GetXYSignalXd(mdsdsc_t *const inY, mdsdsc_t *const inX,
   if (STATUS_NOT_OK)
     goto return_err;
   // Get Y, title, and yLabel, if any
-  EMPTYXD(title);
-  EMPTYXD(xLabel);
-  EMPTYXD(yLabel);
   recGetHelp(yXd.pointer, &title);
   recGetUnits(yXd.pointer, &yLabel);
   // Get X


### PR DESCRIPTION
should fix #2372 :  uninitialized title, xlabel, ylabel on error. 