### PR TITLE
Fix: on some systems UIDs are > 16 bits

### DIFF
--- a/tcl/tcl_directory.c
+++ b/tcl/tcl_directory.c
@@ -81,6 +81,9 @@ static char *mds_owner(                   /* Return: ptr to "user" string       
 #endif
 #ifdef HAVE_GETPWUID
   struct passwd *p = getpwuid(uid);
+  if (!p) {
+        p = getpwuid(owner);
+  }
   if (p)
   {
     username = alloca(strlen(p->pw_name) + 3);

--- a/treeshr/TreePutRecord.c
+++ b/treeshr/TreePutRecord.c
@@ -127,7 +127,11 @@ int _TreePutRecord(void *dbid, int nid, struct descriptor *descriptor_ptr,
   int compress_utility = utility_update == 2;
 #ifndef _WIN32
   if (!saved_uic)
-    saved_uic = (getgid() << 16) | getuid();
+  {
+    saved_uic = getuid();
+    if (!(saved_uic & 0xFFFF0000))
+      saved_uic = (getgid() << 16) | (saved_uic);
+  }
 #endif
   if (!(IS_OPEN(dblist)))
     return TreeNOT_OPEN;

--- a/treeshr/TreeSegments.c
+++ b/treeshr/TreeSegments.c
@@ -985,7 +985,14 @@ inline static int begin_finish(vars_t *vars)
 
 #ifndef _WIN32
 static int saved_uic = 0;
-static void init_saved_uic() { saved_uic = (getgid() << 16) | getuid(); }
+static void init_saved_uic() { 
+  if (!saved_uic)
+  {
+    saved_uic = getuid();
+    if (!(saved_uic & 0xFFFF0000))
+      saved_uic = (getgid() << 16) | (saved_uic);
+  }
+}
 #endif
 inline static void begin_local_nci(vars_t *vars,
                                    const mdsdsc_a_t *initialValue)


### PR DESCRIPTION
On systems using active directory uids can be constructed from
AD SIDs and may have bits in their high word set.  This PR
addresses https://github.com/MDSplus/mdsplus/issues/2375

If their are bits set in the high word of the UID then do not or in
the group.

When displaying in TCL, if the the low 16 bits of the owner do not
translate to a user, then try to translate all 32 bits to an owner