### PR TITLE
Fix: Replace broken lib.exe with dlltool for windows build

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -85,6 +85,7 @@ AC_PROG_RANLIB
 AC_PROG_MKDIR_P
 AC_PROG_INSTALL
 AC_PROG_SED
+AC_CHECK_TOOL([DLLTOOL], [dlltool], [:])
 AC_CHECK_TOOL([WINDRES], [windres], [:])
 
 # Always do the visibility check but don't set AM_CFLAGS on Windows.
@@ -365,12 +366,12 @@ case "$host" in
          SQL_ARCH=32
          BINDIR=bin_x86
          VS_ARCH=x86
-	 IDL_LIB="-L/mnt/scratch/mdsplus/idl-mingw-libs -lidl64"
+         IDL_LIB="-L/mnt/scratch/mdsplus/idl-mingw-libs -lidl64"
        else
          SQL_ARCH=64
          BINDIR=bin_x86_64
          VS_ARCH=x64
-	 IDL_LIB="-L/mnt/scratch/mdsplus/idl-mingw-libs -lidl32"
+         IDL_LIB="-L/mnt/scratch/mdsplus/idl-mingw-libs -lidl32"
        fi
        MAKELIBDIR="\$(top_builddir)/${BINDIR}/"
        MAKESHLIBDIR="\$(top_builddir)/${BINDIR}/"

--- a/deploy/platform/windows/visual-studio-build.bat
+++ b/deploy/platform/windows/visual-studio-build.bat
@@ -31,28 +31,6 @@ SET TEMP=\tmp
 echo %CCP%
 CD %CPP%
 
-REM Build Visual Studio compatible lib files for the C based libraries (both 64 and 32 bit versions)
-
-lib /def:%DEFS%\MdsShr.def	/out:%BUILD64%\bin_x86_64\MdsShr.lib	/machine:x64 >NUL
-lib /def:%DEFS%\TreeShr.def	/out:%BUILD64%\bin_x86_64\TreeShr.lib	/machine:x64 >NUL
-lib /def:%DEFS%\TdiShr.def	/out:%BUILD64%\bin_x86_64\TdiShr.lib	/machine:x64 >NUL
-lib /def:%DEFS%\MdsIpShr.def	/out:%BUILD64%\bin_x86_64\MdsIpShr.lib	/machine:x64 >NUL
-lib /def:%DEFS%\MdsMisc.def	/out:%BUILD64%\bin_x86_64\MdsMisc.lib	/machine:x64 >NUL
-lib /def:%DEFS%\MdsLib.def	/out:%BUILD64%\bin_x86_64\MdsLib.lib	/machine:x64 >NUL
-lib /def:%DEFS%\Mdsdcl.def	/out:%BUILD64%\bin_x86_64\Mdsdcl.lib	/machine:x64 >NUL
-lib /def:%DEFS%\MdsMath.def	/out:%BUILD64%\bin_x86_64\MdsMath.lib	/machine:x64 >NUL
-lib /def:%DEFS%\MdsServerShr.def /out:%BUILD64%\bin_x86_64\MdsServerShr.lib /machine:x64 >NUL
-
-lib /def:%DEFS%\MdsShr.def	/out:%BUILD32%\bin_x86\MdsShr.lib	/machine:x86 >NUL
-lib /def:%DEFS%\TreeShr.def	/out:%BUILD32%\bin_x86\TreeShr.lib	/machine:x86 >NUL
-lib /def:%DEFS%\TdiShr.def	/out:%BUILD32%\bin_x86\TdiShr.lib	/machine:x86 >NUL
-lib /def:%DEFS%\MdsIpShr.def	/out:%BUILD32%\bin_x86\MdsIpShr.lib	/machine:x86 >NUL
-lib /def:%DEFS%\MdsMisc.def	/out:%BUILD32%\bin_x86\MdsMisc.lib	/machine:x86 >NUL
-lib /def:%DEFS%\MdsLib.def	/out:%BUILD32%\bin_x86\MdsLib.lib	/machine:x86 >NUL
-lib /def:%DEFS%\Mdsdcl.def	/out:%BUILD32%\bin_x86\Mdsdcl.lib	/machine:x86 >NUL
-lib /def:%DEFS%\MdsMath.def	/out:%BUILD32%\bin_x86\MdsMath.lib	/machine:x86 >NUL
-lib /def:%DEFS%\MdsServerShr.def /out:%BUILD32%\bin_x86\MdsServerShr.lib /machine:x86 >NUL
-
 REM Use Visual studio compiler to compile the CPP modules
 
 REM _WINDOWS - required for zlib

--- a/deploy/platform/windows/windows_docker_build.sh
+++ b/deploy/platform/windows/windows_docker_build.sh
@@ -50,8 +50,11 @@ buildrelease() {
     fi
     popd
     if [ -z "$NOMAKE" ]; then
+      pushd /workspace/releasebld/32/mdsobjects/cpp
+      $MAKE generate-libs-from-dlls
+      popd
       pushd /workspace/releasebld/64/mdsobjects/cpp
-      $MAKE defs
+      $MAKE generate-libs-from-dlls
       HOME=/workspace/winebottle64 WINEARCH=win64\
 	wine cmd /C ${srcdir}/deploy/platform/windows/visual-studio-build.bat
       cp /workspace/releasebld/64/bin_x86_64/MdsObjectsCppShr-VS.dll ${MDSPLUS_DIR}/bin_x86_64/

--- a/mdsobjects/cpp/Makefile.in
+++ b/mdsobjects/cpp/Makefile.in
@@ -46,19 +46,19 @@ install: $(libdir)
 	$(AR) -cr $@ $(OBJECTS)
 	@RANLIB@ $@
 
-defs:
+generate-libs-from-dlls:
 	@mkdir -p $(top_builddir)/defs
 	@for i in $$(find @MAKESHLIBDIR@ -follow -name '*.dll'); do \
 	  deffile=$(top_builddir)/defs/$$(basename $${i/.dll/.def}) ;\
 	  gendef -a - $$i > $$deffile ;\
+	  @DLLTOOL@ -d $$deffile -l @MAKESHLIBDIR@/$$(basename $${i/.dll/.lib}); \
 	done
 
-.PHONY: defs
+.PHONY: generate-libs-from-dlls 
 
 ifneq "$(VSDLL)" ""
 
-$(VSDLL) : $(CXXSOURCES) $(SOURCES) $(IMPLIB) defs
-@HAVE_WINE_TRUE@	@for i in $(top_builddir)/defs/*.def; do wine cmd.exe /C "cd @MAKESHLIBDIR@ & @VS_DIR@\\@VS_ARCH@\\bin\\lib /MACHINE:@VS_ARCH@ /DEF:Z:$${deffile////\\}"; done
+$(VSDLL) : $(CXXSOURCES) $(SOURCES) $(IMPLIB) generate-libs-from-dlls
 @HAVE_WINE_TRUE@	wine cmd.exe /C vsbuild @VS_DIR@ @VS_ARCH@ @MAKESHLIBDIR@
 @HAVE_WINE_FALSE@	@echo VSDLL defined but no wine: at this point we would have built VSDLLs
 


### PR DESCRIPTION
Switch from lib.exe to dlltool
Move .lib generation from windows_docker_build.sh to Makefile
Add search for dlltool to configure.ac