### PR TITLE
Fix: Inconsistent behavior for empty records #2401

### DIFF
--- a/mdstcpip/mdsipshr/GetAnswerInfo.c
+++ b/mdstcpip/mdsipshr/GetAnswerInfo.c
@@ -95,7 +95,7 @@ int GetAnswerInfoTO(int id, char *dtype, short *length, char *ndims, int *dims,
       dims[i] =
           i % 2 ? m->h.dims[i / 2] & 0xffffffff : (*m)->h.dims[i / 2] >> 32;
 #else
-      if (m->h.dims[i])
+      if (m->h.dims[i] || !datalen)
         dims[i] = m->h.dims[i];
       else
       {

--- a/tdishr/TdiGetNci.c
+++ b/tdishr/TdiGetNci.c
@@ -656,7 +656,16 @@ int Tdi1GetNci(opcode_t opcode __attribute__((unused)), int narg,
     out_ptr->pointer->dtype = DTYPE_NID;
   if (STATUS_OK && out_ptr->pointer && out_ptr->pointer->class == CLASS_A &&
       ((struct descriptor_a *)(out_ptr->pointer))->arsize == 0)
-    status = TreeNNF;
+  {
+    if (key_ptr->item_code != RECORDIDX) {
+      status = TreeNNF; // Keep previous behaviour when not asking for RECORD
+    }
+    else if (out_ptr->pointer->length == 0)
+    {
+      status = TreeNODATA; // If RECORD is truly empty, return TreeNODATA error
+    }
+    // If RECORD is not empty but has zero size, no action is needed
+  }
 
   return status;
 }


### PR DESCRIPTION
* For mdsip, accept 0 as dimension when data length is also 0
* For Tdi1GetNci, do not throw error for empty arrays

A more detailed description of the changes is in one of the issue comments.