### PR TITLE
Fix: use DESCRIPTOR_CSTRING not DESCRIPTOR macro

### DIFF
--- a/mdsshr/MdsSerialize.c
+++ b/mdsshr/MdsSerialize.c
@@ -1142,12 +1142,16 @@ EXPORT int MdsSerializeDscOutZ(
       out->pointer = 0;
       if ((unsigned int)compress >= NUM_COMPRESSION_METHODS)
           compress = 0;
-      DESCRIPTOR(image, compression_methods[compress].image);
-      DESCRIPTOR(method, compression_methods[compress].method);
-      status = MdsCompress((compress) ? &image : NULL, 
-                           (compress) ? &method : NULL, 
-                           tempxd.pointer, 
-                           out);
+      if (compress) 
+      {
+          DESCRIPTOR_FROM_CSTRING(image, compression_methods[compress].image);
+          DESCRIPTOR_FROM_CSTRING(method, compression_methods[compress].method);
+          status = MdsCompress(&image, &method, tempxd.pointer, out);
+      }
+      else
+      {
+          status = MdsCompress(NULL, NULL, tempxd.pointer, out);
+      }
       MdsFree1Dx(&tempxd, NULL);
       compressible = 0;
     }


### PR DESCRIPTION
    The DESCRIPTOR macro uses the size of its argument.  Since the code
    is passing a pointer to a string, instead of an array, this is wrong.