### PR TITLE
Fix: can not get cli_get_value a qualifier twice

### DIFF
--- a/tcl/tcl_set_node.c
+++ b/tcl/tcl_set_node.c
@@ -79,7 +79,7 @@ EXPORT int TclSetNode(void *ctx, char **error, char **output)
     if(cli_get_value(ctx, "COMPRESSION_METHOD", &compression_method_str) & 1)
     {
       char *p = compression_method_str;
-      int i;
+      unsigned int i;
       for ( ; *p; ++p) *p = tolower(*p);
       for (i=0; i < NUM_COMPRESSION_METHODS; i++)
       {


### PR DESCRIPTION
Can not and should not anyway ask for the value of the same
qualifier more than one time.

This change gets the compression method, if specified, outside of
the node loop.