### PR TITLE
Fix: can not get/set current shot over thick

### DIFF
--- a/treeshr/RemoteAccess.c
+++ b/treeshr/RemoteAccess.c
@@ -945,7 +945,7 @@ int TreeGetCurrentShotIdRemote(const char *treearg, char *path, int *shot)
 {
   int status = TreeFAILURE;
   int conid = remote_connect(path);
-  if (conid > 0)
+  if (conid >= 0)
   {
     struct descrip ans = {0};
     struct descrip tree = STR2DESCRIP(treearg);


### PR DESCRIPTION
The code to access the current shot id for thick client was checking
that the connection ID > 0.  0 is a valid (1st) connection ID>