### PR TITLE
Fix: In a pydevice, move tree copy from init() to run() in the MDSWorker thread

### DIFF
--- a/pydevices/HtsDevices/acq2106_423st.py
+++ b/pydevices/HtsDevices/acq2106_423st.py
@@ -165,16 +165,9 @@ class _ACQ2106_423ST(MDSplus.Device):
         def __init__(self, dev):
             super(_ACQ2106_423ST.MDSWorker, self).__init__(name=dev.path)
 
-            self.dev = dev.copy()
+            self.dev = dev
 
-            self.chans = []
-            self.decim = []
             self.nchans = self.dev.sites*32
-
-            for i in range(self.nchans):
-                self.chans.append(getattr(self.dev, 'input_%3.3d' % (i+1)))
-                self.decim.append(
-                    getattr(self.dev, 'input_%3.3d_decimate' % (i+1)).data())
 
             self.seg_length = self.dev.seg_length.data()
             self.segment_bytes = self.seg_length*self.nchans*np.int16(0).nbytes
@@ -198,8 +191,17 @@ class _ACQ2106_423ST(MDSplus.Device):
                     ans = lcm(ans, e)
                 return int(ans)
 
+            self.dev = self.dev.copy()
+
             if self.dev.debug:
                 print("MDSWorker running")
+
+            self.chans = []
+            self.decim = []
+            for i in range(self.nchans):
+                self.chans.append(getattr(self.dev, 'input_%3.3d' % (i+1)))
+                self.decim.append(
+                    getattr(self.dev, 'input_%3.3d_decimate' % (i+1)).data())
 
             event_name = self.dev.seg_event.data()
 

--- a/pydevices/HtsDevices/acq2106_435st.py
+++ b/pydevices/HtsDevices/acq2106_435st.py
@@ -188,18 +188,11 @@ class _ACQ2106_435ST(MDSplus.Device):
         def __init__(self, dev):
             super(_ACQ2106_435ST.MDSWorker, self).__init__(name=dev.path)
 
-            self.dev = dev.copy()
+            self.dev = dev
 
-            self.chans = []
-            self.decim = []
             self.nchans     = self.dev.sites*32
             self.resampling = self.dev.resampling
-
-            for i in range(self.nchans):
-                self.chans.append(getattr(self.dev, 'input_%3.3d' % (i+1)))
-                self.decim.append(
-                    getattr(self.dev, 'input_%3.3d_decimate' % (i+1)).data())
-
+            
             self.seg_length = self.dev.seg_length.data()
             self.segment_bytes = self.seg_length*self.nchans*np.int32(0).nbytes
 
@@ -225,8 +218,17 @@ class _ACQ2106_435ST(MDSplus.Device):
                     ans = lcm(ans, e)
                 return int(ans)
 
+            self.dev = self.dev.copy()
+
             if self.dev.debug:
                 print("MDSWorker running")
+            
+            self.chans = []
+            self.decim = []
+            for i in range(self.nchans):
+                self.chans.append(getattr(self.dev, 'input_%3.3d' % (i+1)))
+                self.decim.append(
+                    getattr(self.dev, 'input_%3.3d_decimate' % (i+1)).data())
 
             event_name = self.dev.seg_event.data()
 
@@ -499,7 +501,7 @@ class _ACQ2106_435ST(MDSplus.Device):
             self.slots[card].nacc = '1'
 
         self.running.on = True
-        # If resampling == 1, then resampling is used during streaming:
+        # If resampling is True, then resampling is used during streaming:
         self.resampling = resampling
 
         thread = self.MDSWorker(self)


### PR DESCRIPTION
In order to resolve issues related to using distributed client (see #2360) when using MDSplus python devices (specifically, for acq2106_423st.py and acq2106_435st.py):
- we make a copy of the tree object in the MDSWork thread, not in the __init__() but in the run() of that thread.