### PR TITLE
Fix: Setting of Ac2106 435 Signal Conditioning Gains and Offsets in a more efficient way, i.e using PyEpics.

### DIFF
--- a/pydevices/HtsDevices/acq2106_435sc.py
+++ b/pydevices/HtsDevices/acq2106_435sc.py
@@ -64,8 +64,8 @@ class _ACQ2106_435SC(acq2106_435st._ACQ2106_435ST):
             self.setGainsOffsets(card)
             self.slots[card].SC32_GAIN_COMMIT = 1
             
-            if self.debug:
-                print("GAINs Committed for site %s" % (card,))
+            #if self.debug:
+            print("GAINs Committed for site %s" % (card,))
                 
         # Here, the argument to the init of the superclass:
         # - init(True) => use resampling function:
@@ -80,19 +80,55 @@ class _ACQ2106_435SC(acq2106_435st._ACQ2106_435ST):
         return uut
 
     def setGainsOffsets(self, card):
+
         for ic in range(1,32+1):
             if card == 1:
-                setattr(self.slots[card], 'SC32_OFFSET_%2.2d' % (ic,), getattr(self, 'INPUT_%3.3d:SC_OFFSET' % (ic,)).data())
-                setattr(self.slots[card], 'SC32_G1_%2.2d' % (ic,), getattr(self, 'INPUT_%3.3d:SC_GAIN1' % (ic,)).data())
-                setattr(self.slots[card], 'SC32_G2_%2.2d' % (ic,), getattr(self, 'INPUT_%3.3d:SC_GAIN2' % (ic,)).data())
+                offset = getattr(self.slots[card], 'SC32_OFFSET_%2.2d' % (ic,))
+                g1 = getattr(self.slots[card], 'SC32_G1_%2.2d' % (ic,))
+                g2 = getattr(self.slots[card], 'SC32_G2_%2.2d' % (ic,))
+
+                offsetNode = getattr(self, 'INPUT_%3.3d:SC_OFFSET' % (ic,)).data()
+                g1Node = getattr(self, 'INPUT_%3.3d:SC_GAIN1' % (ic,)).data()
+                g2Node = getattr(self, 'INPUT_%3.3d:SC_GAIN2' % (ic,)).data()
+
+                if offsetNode != offset:
+                    setattr(self.slots[card], 'SC32_OFFSET_%2.2d' % (ic,), getattr(self, 'INPUT_%3.3d:SC_OFFSET' % (ic,)).data())
+                if g1Node != g1:
+                    setattr(self.slots[card], 'SC32_G1_%2.2d' % (ic,), getattr(self, 'INPUT_%3.3d:SC_GAIN1' % (ic,)).data())
+                if g2Node != g2:
+                    setattr(self.slots[card], 'SC32_G2_%2.2d' % (ic,), getattr(self, 'INPUT_%3.3d:SC_GAIN2' % (ic,)).data())
+
             elif card == 3:
-                setattr(self.slots[card], 'SC32_OFFSET_%2.2d' % (ic,), getattr(self, 'INPUT_%3.3d:SC_OFFSET' % (ic+32,)).data())
-                setattr(self.slots[card], 'SC32_G1_%2.2d' % (ic,), getattr(self, 'INPUT_%3.3d:SC_GAIN1' % (ic+32,)).data())
-                setattr(self.slots[card], 'SC32_G2_%2.2d' % (ic,), getattr(self, 'INPUT_%3.3d:SC_GAIN2' % (ic+32,)).data())
+                offset = getattr(self.slots[card], 'SC32_OFFSET_%2.2d' % (ic,))
+                g1 = getattr(self.slots[card], 'SC32_G1_%2.2d' % (ic,))
+                g2 = getattr(self.slots[card], 'SC32_G2_%2.2d' % (ic,))
+
+                offsetNode = getattr(self, 'INPUT_%3.3d:SC_OFFSET' % (ic+32,)).data()
+                g1Node = getattr(self, 'INPUT_%3.3d:SC_GAIN1' % (ic+32,)).data()
+                g2Node = getattr(self, 'INPUT_%3.3d:SC_GAIN2' % (ic+32,)).data()
+
+                if offsetNode != offset:
+                    setattr(self.slots[card], 'SC32_OFFSET_%2.2d' % (ic,), getattr(self, 'INPUT_%3.3d:SC_OFFSET' % (ic+32,)).data())
+                if g1Node != g1:
+                    setattr(self.slots[card], 'SC32_G1_%2.2d' % (ic,), getattr(self, 'INPUT_%3.3d:SC_GAIN1' % (ic+32,)).data())
+                if g2Node != g2:
+                    setattr(self.slots[card], 'SC32_G2_%2.2d' % (ic,), getattr(self, 'INPUT_%3.3d:SC_GAIN2' % (ic+32,)).data())
+
             elif card == 5:
-                setattr(self.slots[card], 'SC32_OFFSET_%2.2d' % (ic,), getattr(self, 'INPUT_%3.3d:SC_OFFSET' % (ic+64,)).data())
-                setattr(self.slots[card], 'SC32_G1_%2.2d' % (ic,), getattr(self, 'INPUT_%3.3d:SC_GAIN1' % (ic+64,)).data())
-                setattr(self.slots[card], 'SC32_G2_%2.2d' % (ic,), getattr(self, 'INPUT_%3.3d:SC_GAIN2' % (ic+64,)).data())
+                offset = getattr(self.slots[card], 'SC32_OFFSET_%2.2d' % (ic,))
+                g1 = getattr(self.slots[card], 'SC32_G1_%2.2d' % (ic,))
+                g2 = getattr(self.slots[card], 'SC32_G2_%2.2d' % (ic,))
+
+                offsetNode = getattr(self, 'INPUT_%3.3d:SC_OFFSET' % (ic+64,)).data()
+                g1Node = getattr(self, 'INPUT_%3.3d:SC_GAIN1' % (ic+64,)).data()
+                g2Node = getattr(self, 'INPUT_%3.3d:SC_GAIN2' % (ic+64,)).data()
+
+                if offsetNode != offset:
+                    setattr(self.slots[card], 'SC32_OFFSET_%2.2d' % (ic,), getattr(self, 'INPUT_%3.3d:SC_OFFSET' % (ic+64,)).data())
+                if g1Node != g1:
+                    setattr(self.slots[card], 'SC32_G1_%2.2d' % (ic,), getattr(self, 'INPUT_%3.3d:SC_GAIN1' % (ic+64,)).data())
+                if g2Node != g2:
+                    setattr(self.slots[card], 'SC32_G2_%2.2d' % (ic,), getattr(self, 'INPUT_%3.3d:SC_GAIN2' % (ic+64,)).data())
 
     def setChanScale(self, node, num):
         #Raw input channel, where the conditioning has been applied:

--- a/pydevices/HtsDevices/acq2106_435sc.py
+++ b/pydevices/HtsDevices/acq2106_435sc.py
@@ -25,6 +25,7 @@
 
 import MDSplus
 import importlib
+import threading
 
 acq2106_435st = importlib.import_module('acq2106_435st')
 
@@ -60,12 +61,19 @@ class _ACQ2106_435SC(acq2106_435st._ACQ2106_435ST):
             raise MDSplus.DevBAD_PARAMETER(
                 "FREQ must be 10000, 20000, 40000, 80000 or 128000; not %d" % (freq,))
 
+        thread_list = []
         for card in self.slots:
-            self.setGainsOffsets(card)
+            thread = threading.Thread(target=self.setGainsOffsets, args=(card,))
+            thread_list.append(thread)
+            thread.start()
+        
+        for thread in thread_list:
+            thread.join()
+
+        for card in self.slots:
             self.slots[card].SC32_GAIN_COMMIT = 1
-            
-            #if self.debug:
-            print("GAINs Committed for site %s" % (card,))
+            if self.debug:
+                print("GAINs Committed for site %s" % (card,))
                 
         # Here, the argument to the init of the superclass:
         # - init(True) => use resampling function:
@@ -92,15 +100,18 @@ class _ACQ2106_435SC(acq2106_435st._ACQ2106_435ST):
                 g2Node = int(getattr(self, 'INPUT_%3.3d:SC_GAIN2' % (ic,)).data())
 
                 if offsetNode != offset:
-                    print('OFFSET will change from %3.3d to %3.3d in card %3.3d' % (offset, offsetNode, card,))
+                    if self.debug:
+                        print('OFFSET will change from %3.3d --> %3.3d in card %3.3d and channel %3.3d' % (offset, offsetNode, card, ic, ))
                     setattr(self.slots[card], 'SC32_OFFSET_%2.2d' % (ic,), getattr(self, 'INPUT_%3.3d:SC_OFFSET' % (ic,)).data())
 
                 if g1Node != g1:
-                    print('GAIN1 will change from %3.3d  to %3.3d in card %3.3d' % (g1, g1Node, card,))
+                    if self.debug:
+                        print('GAIN1 will change from %3.3d --> %3.3d in card %3.3d and channel %3.3d' % (g1, g1Node, card, ic, ))
                     setattr(self.slots[card], 'SC32_G1_%2.2d' % (ic,), getattr(self, 'INPUT_%3.3d:SC_GAIN1' % (ic,)).data())
 
                 if g2Node != g2:
-                    print('GAIN2 will change from %3.3d  to %3.3d in card %3.3d' % (g2, g2Node, card,))
+                    if self.debug:
+                        print('GAIN2 will change from %3.3d --> %3.3d in card %3.3d and channel %3.3d' % (g2, g2Node, card, ic, ))
                     setattr(self.slots[card], 'SC32_G2_%2.2d' % (ic,), getattr(self, 'INPUT_%3.3d:SC_GAIN2' % (ic,)).data())
 
             elif card == 3:
@@ -113,12 +124,18 @@ class _ACQ2106_435SC(acq2106_435st._ACQ2106_435ST):
                 g2Node = int(getattr(self, 'INPUT_%3.3d:SC_GAIN2' % (ic+32,)).data())
 
                 if offsetNode != offset:
+                    if self.debug:
+                        print('OFFSET will change from %3.3d --> %3.3d in card %3.3d and channel %3.3d' % (offset, offsetNode, card, ic+32, ))
                     setattr(self.slots[card], 'SC32_OFFSET_%2.2d' % (ic,), getattr(self, 'INPUT_%3.3d:SC_OFFSET' % (ic+32,)).data())
                     
                 if g1Node != g1:
+                    if self.debug:
+                        print('GAIN1 will change from %3.3d --> %3.3d in card %3.3d and channel %3.3d' % (g1, g1Node, card, ic+32, ))
                     setattr(self.slots[card], 'SC32_G1_%2.2d' % (ic,), getattr(self, 'INPUT_%3.3d:SC_GAIN1' % (ic+32,)).data())
 
                 if g2Node != g2:
+                    if self.debug:
+                        print('GAIN2 will change from %3.3d --> %3.3d in card %3.3d and channel %3.3d' % (g1, g1Node, card, ic+32, ))
                     setattr(self.slots[card], 'SC32_G2_%2.2d' % (ic,), getattr(self, 'INPUT_%3.3d:SC_GAIN2' % (ic+32,)).data())
 
             elif card == 5:
@@ -131,12 +148,18 @@ class _ACQ2106_435SC(acq2106_435st._ACQ2106_435ST):
                 g2Node = int(getattr(self, 'INPUT_%3.3d:SC_GAIN2' % (ic+64,)).data())
 
                 if offsetNode != offset:
+                    if self.debug:
+                        print('OFFSET will change from %3.3d --> %3.3d in card %3.3d and channel %3.3d' % (offset, offsetNode, card, ic+64, ))
                     setattr(self.slots[card], 'SC32_OFFSET_%2.2d' % (ic,), getattr(self, 'INPUT_%3.3d:SC_OFFSET' % (ic+64,)).data())
 
                 if g1Node != g1:
+                    if self.debug:
+                        print('GAIN1 will change from %3.3d --> %3.3d in card %3.3d and channel %3.3d' % (g1, g1Node, card, ic+64, ))
                     setattr(self.slots[card], 'SC32_G1_%2.2d' % (ic,), getattr(self, 'INPUT_%3.3d:SC_GAIN1' % (ic+64,)).data())
 
                 if g2Node != g2:
+                    if self.debug:
+                        print('GAIN2 will change from %3.3d --> %3.3d in card %3.3d and channel %3.3d' % (g1, g1Node, card, ic+64, ))
                     setattr(self.slots[card], 'SC32_G2_%2.2d' % (ic,), getattr(self, 'INPUT_%3.3d:SC_GAIN2' % (ic+64,)).data())
 
     def setChanScale(self, node, num):

--- a/pydevices/HtsDevices/acq2106_435sc.py
+++ b/pydevices/HtsDevices/acq2106_435sc.py
@@ -90,6 +90,21 @@ class _ACQ2106_435SC(acq2106_435st._ACQ2106_435ST):
 
         for card in self.slots:
             if self.is_global.data() == 1:
+
+                for ic in range(1,32+1):
+                    if card == 1:
+                        setattr(getattr(self, 'INPUT_%3.3d' % (ic,)), 
+                            'head.setChanScaleGlobal("INPUT_%3.3d", %d, %d, %d, %d)' 
+                            % (ic, ic, self.def_gain1.data(), self.def_gain2.data(), self.def_offset.data()))
+                    elif card == 3:
+                        setattr(getattr(self, 'INPUT_%3.3d' % (ic+32,)), 
+                            'head.setChanScaleGlobal("INPUT_%3.3d", %d, %d, %d, %d)' 
+                            % (ic+32, ic+32, self.def_gain1.data(), self.def_gain2.data(), self.def_offset.data()))
+                    elif card == 5:
+                        setattr(getattr(self, 'INPUT_%3.3d' % (ic+64,)), 
+                            'head.setChanScaleGlobal("INPUT_%3.3d", %d, %d, %d, %d)' 
+                            % (ic+64, ic+64, self.def_gain1.data(), self.def_gain2.data(), self.def_offset.data()))
+
                 # Global controls for GAINS and OFFSETS
                 self.slots[card].SC32_OFFSET_ALL = self.def_offset.data()
 
@@ -150,6 +165,18 @@ class _ACQ2106_435SC(acq2106_435st._ACQ2106_435ST):
                                        MDSplus.MULTIPLY(input_chan.SC_GAIN1, input_chan.SC_GAIN2)), 
                                        MDSplus.SUBTRACT(input_chan.OFFSET, input_chan.SC_OFFSET))
             )
+
+    def setChanScaleGlobal(self, node, num, def_gain1, def_gain2, def_offset):
+        #Raw input channel, where the conditioning has been applied:
+        input_chan = self.__getattr__('INPUT_%3.3d' % num)
+        chan       = self.__getattr__(node)
+        #Un-conditioning the signal:
+        chan.setSegmentScale(
+            MDSplus.ADD(MDSplus.DIVIDE(MDSplus.MULTIPLY(input_chan.COEFFICIENT, MDSplus.dVALUE()), 
+                                        MDSplus.MULTIPLY(def_gain1, def_gain2)), 
+                                        MDSplus.SUBTRACT(input_chan.OFFSET, def_offset))
+            )
+
 
 def assemble(cls):
     cls.parts = list(_ACQ2106_435SC.carrier_parts + _ACQ2106_435SC.sc_parts)

--- a/pydevices/HtsDevices/acq2106_435sc.py
+++ b/pydevices/HtsDevices/acq2106_435sc.py
@@ -65,7 +65,7 @@ class _ACQ2106_435SC(acq2106_435st._ACQ2106_435ST):
 
         thread_list = []
         for card in self.slots:
-            thread = threading.Thread(target=self.setGains, args=(card,))
+            thread = threading.Thread(target=self.setGainsOffsets, args=(card,))
             thread_list.append(thread)
             thread.start()
         
@@ -91,19 +91,19 @@ class _ACQ2106_435SC(acq2106_435st._ACQ2106_435ST):
         return uut
 
 
-    def setGains(self, card):
+    def setGainsOffsets(self, card):
         import epics
         import socket
         domainName = socket.gethostbyaddr(self.node.data())[0]
         splitDomainName = domainName.split(".")
 
-        #For EPICS, the ACQs hostnames should be of the format <chassis>_<three digists serial number>
+        #For EPICS PV definitions hardcoded in D-Tacq "/tmp/records.dbl", 
+        # the ACQs DNS hostnames should be of the format <chassis name> _ <three digits serial number>
         if "-" in splitDomainName[0]:
             epicsDomainName = splitDomainName[0].replace("-", "_")
         else:
             epicsDomainName = splitDomainName[0]
 
-        
         for ic in range(1,32+1):
             if card == 1:
                 pvg1 = "{}:{}:SC32:G1:{:02d}".format(epicsDomainName, card, ic)
@@ -116,6 +116,11 @@ class _ACQ2106_435SC(acq2106_435st._ACQ2106_435ST):
                 valueg2 = str(getattr(self, 'INPUT_%3.3d:SC_GAIN2' % (ic,)).data())
                 pv.put(valueg2, wait=True)
 
+                pvg3 = "{}:{}:SC32:OFFSET:{:02d}".format(epicsDomainName, card, ic)
+                pv = epics.PV(pvg3)
+                valueg3 = str(getattr(self, 'INPUT_%3.3d:SC_OFFSET' % (ic,)).data())
+                pv.put(valueg3, wait=True)
+
             elif card == 3:
                 pvg1 = "{}:{}:SC32:G1:{:02d}".format(epicsDomainName, card, ic)
                 pv = epics.PV(pvg1)
@@ -126,6 +131,11 @@ class _ACQ2106_435SC(acq2106_435st._ACQ2106_435ST):
                 pv = epics.PV(pvg2)
                 valueg2 = str(getattr(self, 'INPUT_%3.3d:SC_GAIN2' % (ic+32,)).data())
                 pv.put(valueg2, wait=True)
+
+                pvg3 = "{}:{}:SC32:OFFSET:{:02d}".format(epicsDomainName, card, ic)
+                pv = epics.PV(pvg3)
+                valueg3 = str(getattr(self, 'INPUT_%3.3d:SC_OFFSET' % (ic+32,)).data())
+                pv.put(valueg3, wait=True)
 
             elif card == 5:
                 pvg1 = "{}:{}:SC32:G1:{:02d}".format(epicsDomainName, card, ic)
@@ -138,6 +148,10 @@ class _ACQ2106_435SC(acq2106_435st._ACQ2106_435ST):
                 valueg2 = str(getattr(self, 'INPUT_%3.3d:SC_GAIN2' % (ic+64,)).data())
                 pv.put(valueg2, wait=True)
 
+                pvg3 = "{}:{}:SC32:OFFSET:{:02d}".format(epicsDomainName, card, ic)
+                pv = epics.PV(pvg3)
+                valueg3 = str(getattr(self, 'INPUT_%3.3d:SC_OFFSET' % (ic+64,)).data())
+                pv.put(valueg3, wait=True)
 
     def setChanScale(self, node, num):
         #Raw input channel, where the conditioning has been applied:

--- a/pydevices/HtsDevices/acq2106_435sc.py
+++ b/pydevices/HtsDevices/acq2106_435sc.py
@@ -35,34 +35,6 @@ class _ACQ2106_435SC(acq2106_435st._ACQ2106_435ST):
     
     sc_parts = [
         {
-            # IS_GLOBAL controls if the GAINS and OFFSETS are set globally or per channel
-            'path': ':IS_GLOBAL',
-            'type': 'numeric', 
-            'value': 1, # mean, global settings are used in the D-Tacq SC device.
-            'options': ('no_write_shot',)
-        },
-        { 
-            # Global D-Tacq SC GAIN1
-            'path': ':DEF_GAIN1',
-            'type': 'numeric',
-            'value': 1,
-            'options': ('no_write_shot',)
-        },
-        {
-            # Global D-Tacq SC GAIN2
-            'path': ':DEF_GAIN2',
-            'type': 'numeric',
-            'value': 1,
-            'options': ('no_write_shot',)
-        },
-        {
-            # Global D-Tacq SC OFFSET
-            'path': ':DEF_OFFSET',
-            'type': 'numeric',
-            'value': 0,
-            'options': ('no_write_shot',)
-        },
-        {
             # Resampling factor. This is used during streaming by makeSegmentResampled()
             'path': ':RES_FACTOR',
             'type': 'numeric',
@@ -89,40 +61,7 @@ class _ACQ2106_435SC(acq2106_435st._ACQ2106_435ST):
                 "FREQ must be 10000, 20000, 40000, 80000 or 128000; not %d" % (freq,))
 
         for card in self.slots:
-            if self.is_global.data() == 1:
-
-                for ic in range(1,32+1):
-                    if card == 1:
-                        setattr(getattr(self, 'INPUT_%3.3d' % (ic,)), 
-                            'head.setChanScaleGlobal("INPUT_%3.3d", %d, %d, %d, %d)' 
-                            % (ic, ic, self.def_gain1.data(), self.def_gain2.data(), self.def_offset.data()))
-                    elif card == 3:
-                        setattr(getattr(self, 'INPUT_%3.3d' % (ic+32,)), 
-                            'head.setChanScaleGlobal("INPUT_%3.3d", %d, %d, %d, %d)' 
-                            % (ic+32, ic+32, self.def_gain1.data(), self.def_gain2.data(), self.def_offset.data()))
-                    elif card == 5:
-                        setattr(getattr(self, 'INPUT_%3.3d' % (ic+64,)), 
-                            'head.setChanScaleGlobal("INPUT_%3.3d", %d, %d, %d, %d)' 
-                            % (ic+64, ic+64, self.def_gain1.data(), self.def_gain2.data(), self.def_offset.data()))
-
-                # Global controls for GAINS and OFFSETS
-                self.slots[card].SC32_OFFSET_ALL = self.def_offset.data()
-
-                if self.debug:
-                    print("Site %s OFFSET ALL %d" % (card, int(self.def_offset.data())))
-
-                self.slots[card].SC32_G1_ALL     = self.def_gain1.data()
-                
-                if self.debug:
-                    print("Site %s GAIN 1 ALL %d" % (card, int(self.def_gain1.data())))
-
-                self.slots[card].SC32_G2_ALL     = self.def_gain2.data()
-                
-                if self.debug:
-                    print("Site %s GAIN 2 ALL %d" % (card, int(self.def_gain2.data())))
-            else:
-                self.setGainsOffsets(card)
-
+            self.setGainsOffsets(card)
             self.slots[card].SC32_GAIN_COMMIT = 1
             
             if self.debug:
@@ -164,17 +103,6 @@ class _ACQ2106_435SC(acq2106_435st._ACQ2106_435ST):
             MDSplus.ADD(MDSplus.DIVIDE(MDSplus.MULTIPLY(input_chan.COEFFICIENT, MDSplus.dVALUE()), 
                                        MDSplus.MULTIPLY(input_chan.SC_GAIN1, input_chan.SC_GAIN2)), 
                                        MDSplus.SUBTRACT(input_chan.OFFSET, input_chan.SC_OFFSET))
-            )
-
-    def setChanScaleGlobal(self, node, num, def_gain1, def_gain2, def_offset):
-        #Raw input channel, where the conditioning has been applied:
-        input_chan = self.__getattr__('INPUT_%3.3d' % num)
-        chan       = self.__getattr__(node)
-        #Un-conditioning the signal:
-        chan.setSegmentScale(
-            MDSplus.ADD(MDSplus.DIVIDE(MDSplus.MULTIPLY(input_chan.COEFFICIENT, MDSplus.dVALUE()), 
-                                        MDSplus.MULTIPLY(def_gain1, def_gain2)), 
-                                        MDSplus.SUBTRACT(input_chan.OFFSET, def_offset))
             )
 
 

--- a/pydevices/HtsDevices/acq2106_435sc.py
+++ b/pydevices/HtsDevices/acq2106_435sc.py
@@ -83,50 +83,59 @@ class _ACQ2106_435SC(acq2106_435st._ACQ2106_435ST):
 
         for ic in range(1,32+1):
             if card == 1:
-                offset = getattr(self.slots[card], 'SC32_OFFSET_%2.2d' % (ic,))
-                g1 = getattr(self.slots[card], 'SC32_G1_%2.2d' % (ic,))
-                g2 = getattr(self.slots[card], 'SC32_G2_%2.2d' % (ic,))
+                offset = int((getattr(self.slots[card], 'SC32_OFFSET_%2.2d' % (ic,))).split(' ')[1])
+                g1 = int((getattr(self.slots[card], 'SC32_G1_%2.2d' % (ic,))).split(' ')[1])
+                g2 = int((getattr(self.slots[card], 'SC32_G2_%2.2d' % (ic,))).split(' ')[1])
 
-                offsetNode = getattr(self, 'INPUT_%3.3d:SC_OFFSET' % (ic,)).data()
-                g1Node = getattr(self, 'INPUT_%3.3d:SC_GAIN1' % (ic,)).data()
-                g2Node = getattr(self, 'INPUT_%3.3d:SC_GAIN2' % (ic,)).data()
+                offsetNode = int(getattr(self, 'INPUT_%3.3d:SC_OFFSET' % (ic,)).data())
+                g1Node = int(getattr(self, 'INPUT_%3.3d:SC_GAIN1' % (ic,)).data())
+                g2Node = int(getattr(self, 'INPUT_%3.3d:SC_GAIN2' % (ic,)).data())
 
                 if offsetNode != offset:
+                    print('OFFSET will change from %3.3d to %3.3d in card %3.3d' % (offset, offsetNode, card,))
                     setattr(self.slots[card], 'SC32_OFFSET_%2.2d' % (ic,), getattr(self, 'INPUT_%3.3d:SC_OFFSET' % (ic,)).data())
+
                 if g1Node != g1:
+                    print('GAIN1 will change from %3.3d  to %3.3d in card %3.3d' % (g1, g1Node, card,))
                     setattr(self.slots[card], 'SC32_G1_%2.2d' % (ic,), getattr(self, 'INPUT_%3.3d:SC_GAIN1' % (ic,)).data())
+
                 if g2Node != g2:
+                    print('GAIN2 will change from %3.3d  to %3.3d in card %3.3d' % (g2, g2Node, card,))
                     setattr(self.slots[card], 'SC32_G2_%2.2d' % (ic,), getattr(self, 'INPUT_%3.3d:SC_GAIN2' % (ic,)).data())
 
             elif card == 3:
-                offset = getattr(self.slots[card], 'SC32_OFFSET_%2.2d' % (ic,))
-                g1 = getattr(self.slots[card], 'SC32_G1_%2.2d' % (ic,))
-                g2 = getattr(self.slots[card], 'SC32_G2_%2.2d' % (ic,))
+                offset = int((getattr(self.slots[card], 'SC32_OFFSET_%2.2d' % (ic,))).split(' ')[1])
+                g1 = int((getattr(self.slots[card], 'SC32_G1_%2.2d' % (ic,))).split(' ')[1])
+                g2 = int((getattr(self.slots[card], 'SC32_G2_%2.2d' % (ic,))).split(' ')[1])
 
-                offsetNode = getattr(self, 'INPUT_%3.3d:SC_OFFSET' % (ic+32,)).data()
-                g1Node = getattr(self, 'INPUT_%3.3d:SC_GAIN1' % (ic+32,)).data()
-                g2Node = getattr(self, 'INPUT_%3.3d:SC_GAIN2' % (ic+32,)).data()
+                offsetNode = int(getattr(self, 'INPUT_%3.3d:SC_OFFSET' % (ic+32,)).data())
+                g1Node = int(getattr(self, 'INPUT_%3.3d:SC_GAIN1' % (ic+32,)).data())
+                g2Node = int(getattr(self, 'INPUT_%3.3d:SC_GAIN2' % (ic+32,)).data())
 
                 if offsetNode != offset:
                     setattr(self.slots[card], 'SC32_OFFSET_%2.2d' % (ic,), getattr(self, 'INPUT_%3.3d:SC_OFFSET' % (ic+32,)).data())
+                    
                 if g1Node != g1:
                     setattr(self.slots[card], 'SC32_G1_%2.2d' % (ic,), getattr(self, 'INPUT_%3.3d:SC_GAIN1' % (ic+32,)).data())
+
                 if g2Node != g2:
                     setattr(self.slots[card], 'SC32_G2_%2.2d' % (ic,), getattr(self, 'INPUT_%3.3d:SC_GAIN2' % (ic+32,)).data())
 
             elif card == 5:
-                offset = getattr(self.slots[card], 'SC32_OFFSET_%2.2d' % (ic,))
-                g1 = getattr(self.slots[card], 'SC32_G1_%2.2d' % (ic,))
-                g2 = getattr(self.slots[card], 'SC32_G2_%2.2d' % (ic,))
+                offset = int((getattr(self.slots[card], 'SC32_OFFSET_%2.2d' % (ic,))).split(' ')[1])
+                g1 = int((getattr(self.slots[card], 'SC32_G1_%2.2d' % (ic,))).split(' ')[1])
+                g2 = int((getattr(self.slots[card], 'SC32_G2_%2.2d' % (ic,))).split(' ')[1])
 
-                offsetNode = getattr(self, 'INPUT_%3.3d:SC_OFFSET' % (ic+64,)).data()
-                g1Node = getattr(self, 'INPUT_%3.3d:SC_GAIN1' % (ic+64,)).data()
-                g2Node = getattr(self, 'INPUT_%3.3d:SC_GAIN2' % (ic+64,)).data()
+                offsetNode = int(getattr(self, 'INPUT_%3.3d:SC_OFFSET' % (ic+64,)).data())
+                g1Node = int(getattr(self, 'INPUT_%3.3d:SC_GAIN1' % (ic+64,)).data())
+                g2Node = int(getattr(self, 'INPUT_%3.3d:SC_GAIN2' % (ic+64,)).data())
 
                 if offsetNode != offset:
                     setattr(self.slots[card], 'SC32_OFFSET_%2.2d' % (ic,), getattr(self, 'INPUT_%3.3d:SC_OFFSET' % (ic+64,)).data())
+
                 if g1Node != g1:
                     setattr(self.slots[card], 'SC32_G1_%2.2d' % (ic,), getattr(self, 'INPUT_%3.3d:SC_GAIN1' % (ic+64,)).data())
+
                 if g2Node != g2:
                     setattr(self.slots[card], 'SC32_G2_%2.2d' % (ic,), getattr(self, 'INPUT_%3.3d:SC_GAIN2' % (ic+64,)).data())
 

--- a/pydevices/HtsDevices/acq2106_435sc.py
+++ b/pydevices/HtsDevices/acq2106_435sc.py
@@ -26,7 +26,6 @@
 
 import MDSplus
 import importlib
-import threading
 
 
 acq2106_435st = importlib.import_module('acq2106_435st')
@@ -63,16 +62,8 @@ class _ACQ2106_435SC(acq2106_435st._ACQ2106_435ST):
             raise MDSplus.DevBAD_PARAMETER(
                 "FREQ must be 10000, 20000, 40000, 80000 or 128000; not %d" % (freq,))
 
-        thread_list = []
         for card in self.slots:
-            thread = threading.Thread(target=self.setGainsOffsets, args=(card,))
-            thread_list.append(thread)
-            thread.start()
-        
-        for thread in thread_list:
-            thread.join()
-
-        for card in self.slots:
+            self.setGainsOffsets(card)
             self.slots[card].SC32_GAIN_COMMIT = 1
             if self.debug:
                 print("GAINs Committed for site %s" % (card,))

--- a/pydevices/HtsDevices/acq2106_435sc.py
+++ b/pydevices/HtsDevices/acq2106_435sc.py
@@ -137,21 +137,21 @@ def assemble(cls):
                 # Local (per channel) SC gains
                 'path': ':INPUT_%3.3d:SC_GAIN1' % (i+1,),
                 'type':'NUMERIC', 
-                'valueExpr':'head.def_gain1',
+                'value':1,
                 'options':('no_write_shot',)
             },
             {
                 # Local (per channel) SC gains
                 'path': ':INPUT_%3.3d:SC_GAIN2' % (i+1,),
                 'type':'NUMERIC', 
-                'valueExpr':'head.def_gain2',
+                'value':1,
                 'options':('no_write_shot',)
             },
             {
                 # Local (per channel) SC offsets
                 'path': ':INPUT_%3.3d:SC_OFFSET' % (i+1,),
                 'type':'NUMERIC', 
-                'valueExpr':'head.def_offset',
+                'value':0,
                 'options':('no_write_shot',)
             },   
             {

--- a/pydevices/HtsDevices/acq2106_435sc.py
+++ b/pydevices/HtsDevices/acq2106_435sc.py
@@ -94,11 +94,12 @@ class _ACQ2106_435SC(acq2106_435st._ACQ2106_435ST):
     def setGainsOffsets(self, card):
         import epics
         import socket
-        domainName = socket.gethostbyaddr(self.node.data())[0]
+
+        domainName = socket.gethostbyaddr(str(self.node.data()))[0]
         splitDomainName = domainName.split(".")
 
-        #For EPICS PV definitions hardcoded in D-Tacq "/tmp/records.dbl", 
-        # the ACQs DNS hostnames should be of the format <chassis name> _ <three digits serial number>
+        #For EPICS PV definitions hardcoded in D-Tacq's "/tmp/records.dbl", 
+        # the ACQs DNS hostnames/domain names should be of the format <chassis name> _ <three digits serial number>
         if "-" in splitDomainName[0]:
             epicsDomainName = splitDomainName[0].replace("-", "_")
         else:

--- a/pydevices/HtsDevices/acq2106_435st.py
+++ b/pydevices/HtsDevices/acq2106_435st.py
@@ -544,8 +544,7 @@ class _ACQ2106_435ST(MDSplus.Device):
 
     def setChanScale(self, num):
         chan = self.__getattr__('INPUT_%3.3d' % num)
-        chan.setSegmentScale(MDSplus.ADD(MDSplus.MULTIPLY(
-            chan.COEFFICIENT, MDSplus.dVALUE()), chan.OFFSET))
+        chan.setSegmentScale(MDSplus.ADD(MDSplus.MULTIPLY(chan.COEFFICIENT, MDSplus.dVALUE()), chan.OFFSET))
 
 
 def assemble(cls):

--- a/pydevices/HtsDevices/acq2106_435st.py
+++ b/pydevices/HtsDevices/acq2106_435st.py
@@ -100,7 +100,7 @@ class _ACQ2106_435ST(MDSplus.Device):
         {
             'path': ':HW_FILTER',
             'type': 'numeric',
-            'value': 0,
+            'value': 1,
             'options': ('no_write_shot',)
         },
         {
@@ -495,7 +495,7 @@ class _ACQ2106_435ST(MDSplus.Device):
             for card in self.slots:
                 self.slots[card].nacc = ('%d' % nacc_samp).strip()
         else:
-            print("WARNING: Hardware Filter samples must be in the range [0,32]. 0 => Disabled == 1")
+            print("WARNING: Hardware Filter samples must be in the range [1,32]. A value of 0 => Disabled == 1")
             for card in self.slots:
                 self.slots[card].nacc = '1'
 

--- a/pydevices/HtsDevices/acq2106_435st.py
+++ b/pydevices/HtsDevices/acq2106_435st.py
@@ -496,7 +496,8 @@ class _ACQ2106_435ST(MDSplus.Device):
                 self.slots[card].nacc = ('%d' % nacc_samp).strip()
         else:
             print("WARNING: Hardware Filter samples must be in the range [0,32]. 0 => Disabled == 1")
-            self.slots[card].nacc = '1'
+            for card in self.slots:
+                self.slots[card].nacc = '1'
 
         self.running.on = True
         # If resampling == 1, then resampling is used during streaming:


### PR DESCRIPTION
The ACQ2106 SC device gains and offsets are now set for each channel every time the device is execute:

1- Global values nodes for gains and offsets were removed. In total 4 nodes were removed from the tree.
2- Setting of the gains and offsets is done directly using PyEpics. This implies a great improvement on time and performance of the device.
