### PR TITLE
Switch Ubuntu18 to use python3-numpy

### DIFF
--- a/deploy/packaging/linux.xml
+++ b/deploy/packaging/linux.xml
@@ -830,7 +830,7 @@ rm -f /etc/ld.so.conf.d/mdsplus.conf 2&gt;/dev/null
  </external_packages>
 
  <external_packages dist="Ubuntu18">
-   <numpy package="python-numpy"/>
+   <numpy package="python3-numpy"/>
    <java package="java-runtime"/>
    <xinetd package="busybox"/>
    <readline package="libreadline7"/>


### PR DESCRIPTION
Currently, Ubuntu18 installs python-numpy, which in turn installs python2
I would like to switch it to python3-numpy, which will not install python2

@zack-vii I would like your input on this one