### PR TITLE
Fix: use size of packed NCI instead of 42

### DIFF
--- a/mdsobjects/cpp/mdsipobjects.cpp
+++ b/mdsobjects/cpp/mdsipobjects.cpp
@@ -45,8 +45,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 using namespace MDSplus;
 using namespace std;
 
-extern "C" void *getManyObj(char *serializedIn) throw(MdsException);
-extern "C" void *putManyObj(char *serializedIn) throw(MdsException);
+extern "C" void *getManyObj(char *serializedIn);
+extern "C" void *putManyObj(char *serializedIn);
 extern "C" void *compileFromExprWithArgs(char *expr, int nArgs, void *args,
                                          void *tree);
 extern "C" int SendArg(int sock, unsigned char idx, char dtype,
@@ -108,7 +108,7 @@ static int convertType(int mdsType)
   }
 }
 
-void *getManyObj(char *serializedIn) throw(MdsException)
+void *getManyObj(char *serializedIn) 
 {
   AutoData<List> inArgs((List *)deserialize((const char *)serializedIn));
   if (inArgs->clazz != CLASS_APD) // || inArgs->dtype != DTYPE_LIST)
@@ -241,7 +241,7 @@ void *getManyObj(char *serializedIn) throw(MdsException)
   return result->convertToDsc();
 }
 
-void *putManyObj(char *serializedIn) throw(MdsException)
+void *putManyObj(char *serializedIn) 
 {
   AutoData<List> inArgs((List *)deserialize((const char *)serializedIn));
   if (inArgs->clazz != CLASS_APD) // || inArgs->dtype != DTYPE_LIST)

--- a/treeshr/TreeAddNode.c
+++ b/treeshr/TreeAddNode.c
@@ -1022,7 +1022,7 @@ static int TreeWriteNci(TREE_INFO *info)
     int numnodes = info->header->nodes - info->edit->first_in_mem;
     int i;
     NCI nci;
-    char nci_bytes[42];
+    char nci_bytes[sizeof(PACKED_NCI)];
     int nbytes = (int)sizeof(nci_bytes);
     int offset;
     for (i = 0, offset = info->edit->first_in_mem * nbytes;

--- a/treeshr/TreeGetNci.c
+++ b/treeshr/TreeGetNci.c
@@ -935,7 +935,7 @@ int tree_get_nci(TREE_INFO *info, int node_num, NCI *nci, unsigned int version,
   if ((info->edit == 0) || (node_num < info->edit->first_in_mem))
   {
     int deleted = TRUE;
-    char nci_bytes[42];
+    char nci_bytes[sizeof(PACKED_NCI)];
     unsigned int n_version = 0;
     int64_t viewDate;
     RETURN_IF_NOT_OK(TreeOpenNciR(info));

--- a/treeshr/TreeGetRecord.c
+++ b/treeshr/TreeGetRecord.c
@@ -522,7 +522,7 @@ int TreeGetViewDate(int64_t *date)
 
 int TreeGetVersionNci(TREE_INFO *info, NCI *nci, NCI *v_nci)
 {
-  char nci_bytes[42];
+  char nci_bytes[sizeof(PACKED_NCI)];
   int status = TreeOpenDatafileR(info);
   if (STATUS_OK)
   {
@@ -538,7 +538,7 @@ int TreeGetVersionNci(TREE_INFO *info, NCI *nci, NCI *v_nci)
     do
     {
       status = (MDS_IO_READ_X(info->data_file->get, rfa_l, (void *)nci_bytes,
-                              42, &deleted) == 42)
+                              sizeof(PACKED_NCI), &deleted) == sizeof(PACKED_NCI))
                    ? TreeSUCCESS
                    : TreeDFREAD;
       if (STATUS_OK && deleted)

--- a/treeshr/TreePutRecord.c
+++ b/treeshr/TreePutRecord.c
@@ -591,7 +591,7 @@ static int put_datafile(TREE_INFO *info, int nodenum, NCI *nci_ptr,
       }
       if (nci_ptr->flags & NciM_VERSIONS)
       {
-        char nci_bytes[42];
+        char nci_bytes[sizeof(PACKED_NCI)];
         int64_t seek_end;
         TreeSerializeNciOut(old_nci_ptr, nci_bytes);
         seek_end = MDS_IO_LSEEK(info->data_file->put, 0, SEEK_END);

--- a/treeshr/TreeSerializeNci.c
+++ b/treeshr/TreeSerializeNci.c
@@ -29,65 +29,65 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 void TreeSerializeNciOut(const NCI *in, char *out)
 {
-  char *ptr = out;
-  memset(out, 0, 42);
-  putint32(&ptr, &in->flags);
-  putint8(&ptr, &in->flags2);
-  putint8(&ptr, &in->spare);
-  putint64(&ptr, &in->time_inserted);
-  putint32(&ptr, &in->owner_identifier);
-  putint8(&ptr, &in->class);
-  putint8(&ptr, &in->dtype);
-  putint32(&ptr, &in->length);
-  putint8(&ptr, &in->compression_method);
-  putint32(&ptr, &in->status);
+  PACKED_NCI *ptr = (PACKED_NCI *)out;
+  memset(out, 0, sizeof(PACKED_NCI));
+  ptr->flags = in->flags;
+  ptr->flags2 = in->flags2;
+  ptr->spare = in->spare;
+  ptr->time_inserted = in->time_inserted;
+  ptr->owner_identifier = in->owner_identifier;
+  ptr->class = in->class;
+  ptr->dtype = in->dtype;
+  ptr->length = in->length;
+  ptr->compression_method = in->compression_method;
+
   if (in->flags2 & NciM_DATA_IN_ATT_BLOCK)
   {
-    putint8(&ptr, &in->DATA_INFO.DATA_IN_RECORD.element_length);
-    putchars(&ptr, &in->DATA_INFO.DATA_IN_RECORD.data, 11);
+    ptr->DATA_INFO.DATA_IN_RECORD.element_length = in->DATA_INFO.DATA_IN_RECORD.element_length;
+    memcpy(ptr->DATA_INFO.DATA_IN_RECORD.data, in->DATA_INFO.DATA_IN_RECORD.data, sizeof(in->DATA_INFO.DATA_IN_RECORD.data));
   }
   else if (in->flags2 & NciM_ERROR_ON_PUT)
   {
-    putint32(&ptr, &in->DATA_INFO.ERROR_INFO.error_status);
-    putint32(&ptr, &in->DATA_INFO.ERROR_INFO.stv);
+    ptr->DATA_INFO.ERROR_INFO.error_status = in->DATA_INFO.ERROR_INFO.error_status;
+    ptr->DATA_INFO.ERROR_INFO.stv = in->DATA_INFO.ERROR_INFO.stv;
   }
   else
   {
-    putint8(&ptr, &in->DATA_INFO.DATA_LOCATION.file_level);
-    putint8(&ptr, &in->DATA_INFO.DATA_LOCATION.file_version);
-    putchars(&ptr, &in->DATA_INFO.DATA_LOCATION.rfa, 6);
-    putint32(&ptr, &in->DATA_INFO.DATA_LOCATION.record_length);
+    ptr->DATA_INFO.DATA_LOCATION.file_level = in->DATA_INFO.DATA_LOCATION.file_level ;
+    ptr->DATA_INFO.DATA_LOCATION.file_version = in->DATA_INFO.DATA_LOCATION.file_version ;
+    memcpy(ptr->DATA_INFO.DATA_LOCATION.rfa, in->DATA_INFO.DATA_LOCATION.rfa, sizeof(in->DATA_INFO.DATA_LOCATION.rfa));
+    ptr->DATA_INFO.DATA_LOCATION.record_length = in->DATA_INFO.DATA_LOCATION.record_length ;
   }
 }
 
 void TreeSerializeNciIn(const char *in, NCI *out)
 {
-  char *ptr = (char *)in;
-  getint32(&ptr, &out->flags);
-  getint8(&ptr, &out->flags2);
-  getint8(&ptr, &out->spare);
-  getint64(&ptr, &out->time_inserted);
-  getint32(&ptr, &out->owner_identifier);
-  getint8(&ptr, &out->class);
-  getint8(&ptr, &out->dtype);
-  getint32(&ptr, &out->length);
-  getint8(&ptr, &out->compression_method);
-  getint32(&ptr, &out->status);
+  PACKED_NCI *ptr = (PACKED_NCI *)in; 
+  out->flags = ptr->flags;
+  out->flags2 = ptr->flags2;
+  out->spare = ptr->spare;
+  out->time_inserted = ptr->time_inserted;
+  out->owner_identifier = ptr->owner_identifier;
+  out->class = ptr->class;
+  out->dtype = ptr->dtype;
+  out->length = ptr->length;
+  out->compression_method = ptr->compression_method;
+  out->status = ptr->status;
   if (out->flags2 & NciM_DATA_IN_ATT_BLOCK)
   {
-    getint8(&ptr, &out->DATA_INFO.DATA_IN_RECORD.element_length);
-    getchars(&ptr, &out->DATA_INFO.DATA_IN_RECORD.data, 11);
+    out->DATA_INFO.DATA_IN_RECORD.element_length = ptr->DATA_INFO.DATA_IN_RECORD.element_length;
+    memcpy(out->DATA_INFO.DATA_IN_RECORD.data, ptr->DATA_INFO.DATA_IN_RECORD.data, sizeof(ptr->DATA_INFO.DATA_IN_RECORD.data));
   }
   else if (out->flags2 & NciM_ERROR_ON_PUT)
   {
-    getint32(&ptr, &out->DATA_INFO.ERROR_INFO.error_status);
-    getint32(&ptr, &out->DATA_INFO.ERROR_INFO.stv);
+    out->DATA_INFO.ERROR_INFO.error_status = ptr->DATA_INFO.ERROR_INFO.error_status;
+    out->DATA_INFO.ERROR_INFO.stv = ptr->DATA_INFO.ERROR_INFO.stv;
   }
   else
   {
-    getint8(&ptr, &out->DATA_INFO.DATA_LOCATION.file_level);
-    getint8(&ptr, &out->DATA_INFO.DATA_LOCATION.file_version);
-    getchars(&ptr, &out->DATA_INFO.DATA_LOCATION.rfa, 6);
-    getint32(&ptr, &out->DATA_INFO.DATA_LOCATION.record_length);
+    out->DATA_INFO.DATA_LOCATION.file_level = ptr->DATA_INFO.DATA_LOCATION.file_level;
+    out->DATA_INFO.DATA_LOCATION.file_version = ptr->DATA_INFO.DATA_LOCATION.file_version;
+    memcpy(out->DATA_INFO.DATA_LOCATION.rfa, ptr->DATA_INFO.DATA_LOCATION.rfa, sizeof(ptr->DATA_INFO.DATA_LOCATION.rfa));
+    out->DATA_INFO.DATA_LOCATION.record_length = ptr->DATA_INFO.DATA_LOCATION.record_length;
   }
 }

--- a/treeshr/TreeSetNci.c
+++ b/treeshr/TreeSetNci.c
@@ -105,8 +105,8 @@ int tree_lock_nci(TREE_INFO *info, int readonly, int nodenum, int *deleted,
     if (*locked == 0)
     { // acquire lock
       status = MDS_IO_LOCK(
-          readonly ? info->nci_file->get : info->nci_file->put, nodenum * 42,
-          42, readonly ? MDS_IO_LOCK_RD : MDS_IO_LOCK_WRT, deleted_ptr);
+          readonly ? info->nci_file->get : info->nci_file->put, nodenum * sizeof(PACKED_NCI),
+          sizeof(PACKED_NCI), readonly ? MDS_IO_LOCK_RD : MDS_IO_LOCK_WRT, deleted_ptr);
       if (STATUS_OK)
       {
         if (!*deleted_ptr)
@@ -138,7 +138,7 @@ void tree_unlock_nci(TREE_INFO *info, int readonly, int nodenum, int *locked)
     if (*locked == 1)
     { // last lock and lock acquired -> release lock
       MDS_IO_LOCK(readonly ? info->nci_file->get : info->nci_file->put,
-                  nodenum * 42, 42, MDS_IO_LOCK_NONE, 0);
+                  nodenum * sizeof(PACKED_NCI), sizeof(PACKED_NCI), MDS_IO_LOCK_NONE, 0);
       *locked = 0;
     }
   }
@@ -335,7 +335,7 @@ int tree_get_and_lock_nci(TREE_INFO *info, int node_num, NCI *nci,
   if ((info->edit == 0) || (node_num < info->edit->first_in_mem))
   {
     int deleted = TRUE;
-    char nci_bytes[42];
+    char nci_bytes[sizeof(PACKED_NCI)];
     if ((info->nci_file == 0) || (info->nci_file->put == 0))
       RETURN_IF_NOT_OK(TreeOpenNciW(info, 0));
     while (STATUS_OK)
@@ -474,7 +474,7 @@ int _TreeOpenNciW(TREE_INFO *info, int tmpfile)
     if (info->edit)
     {
       info->edit->first_in_mem =
-          (int)MDS_IO_LSEEK(info->nci_file->put, 0, SEEK_END) / 42;
+          (int)MDS_IO_LSEEK(info->nci_file->put, 0, SEEK_END) / sizeof(PACKED_NCI);
     }
   }
   if (STATUS_OK)
@@ -521,7 +521,7 @@ int tree_put_nci(TREE_INFO *info, int node_num, NCI *nci, int *locked)
     ***********************/
     if (!*locked)
       RETURN_IF_NOT_OK(tree_lock_nci(info, 0, node_num, NULL, locked));
-    char nci_bytes[42] = {0};
+    char nci_bytes[sizeof(PACKED_NCI)] = {0};
     TreeSerializeNciOut(nci, nci_bytes);
     MDS_IO_LSEEK(info->nci_file->put, sizeof(nci_bytes) * node_num, SEEK_SET);
     status = (MDS_IO_WRITE(info->nci_file->put, nci_bytes, sizeof(nci_bytes)) ==

--- a/treeshr/treeshrp.h
+++ b/treeshr/treeshrp.h
@@ -76,6 +76,41 @@ typedef struct nci
   } DATA_INFO;
   unsigned char nci_fill;
 } NCI;
+#pragma pack(push, 1)
+typedef struct packed_nci
+{
+  unsigned int flags;
+  unsigned char flags2;
+  unsigned char spare;
+  int64_t time_inserted;
+  unsigned int owner_identifier;
+  class_t class;
+  dtype_t dtype;
+  l_length_t length;
+  unsigned char compression_method;
+  unsigned int status;
+  union {
+    struct
+    {
+      unsigned char file_level;
+      unsigned char file_version;
+      unsigned char rfa[6];
+      unsigned int record_length;
+    } DATA_LOCATION;
+    struct
+    {
+      unsigned char element_length;
+      unsigned char data[11];
+    } DATA_IN_RECORD;
+    struct
+    {
+      unsigned int error_status;
+      unsigned int stv;
+    } ERROR_INFO;
+  } DATA_INFO;
+  unsigned char nci_fill;
+} PACKED_NCI;
+#pragma pack(pop)
 
 #define FACILITIES_PER_EA 8
 typedef struct extended_attributes


### PR DESCRIPTION
The code was using the known size of the packed NCI structure (42)
instead of asking the compiler to fill this in for us.

Replace the explicit byte offset memory copies in SerializeNCI with
structure references.