### PR TITLE
Stephen fixed jTraverser2 so long node names now display correctly

### DIFF
--- a/java/jtraverser2/src/main/java/mds/jtraverser/TreeView.java
+++ b/java/jtraverser2/src/main/java/mds/jtraverser/TreeView.java
@@ -94,10 +94,10 @@ public final class TreeView extends JTree implements TreeSelectionListener, Data
 	{
 		Node new_node;
 		DefaultMutableTreeNode new_tree_node;
-		if (name == null || name.length() == 0 || name.length() > 12)
+		if (name == null || name.length() == 0 || name.length() > 63)
 		{
 			JOptionPane.showMessageDialog(JOptionPane.getRootFrame(),
-					"Name length must range between 1 and 12 characters", "Error adding Node",
+					"Name length must range between 1 and 63 characters", "Error adding Node",
 					JOptionPane.WARNING_MESSAGE);
 			return null;
 		}

--- a/tdishr/TdiGetNci.c
+++ b/tdishr/TdiGetNci.c
@@ -127,7 +127,7 @@ static const struct item
     {"NID_NUMBER", 0, 0, NID_NUMBER, DTYPE_L, 4},
     {"NID_REFERENCE", NciM_NID_REFERENCE, NciM_NID_REFERENCE, NciGET_FLAGS,
      DTYPE_BU, 1},
-    {"NODE_NAME", 0, 0, NciNODE_NAME, DTYPE_T, 12},
+    {"NODE_NAME", 0, 0, NciNODE_NAME, DTYPE_T, 64},
     {"NO_WRITE_MODEL", NciM_NO_WRITE_MODEL, NciM_NO_WRITE_MODEL, NciGET_FLAGS,
      DTYPE_BU, 1},
     {"NO_WRITE_SHOT", NciM_NO_WRITE_SHOT, NciM_NO_WRITE_SHOT, NciGET_FLAGS,
@@ -590,6 +590,7 @@ int Tdi1GetNci(opcode_t opcode __attribute__((unused)), int narg,
       status = TreeGetNci(nid, fixed);
       if (retlen == 0)
         goto skip;
+      holda_ptr->length = retlen;
     }
     ++outcount;
     hold_ptr += step;

--- a/treeshr/TreeGetNci.c
+++ b/treeshr/TreeGetNci.c
@@ -503,7 +503,6 @@ int TreeGetNci(int nid_in, struct nci_itm *nci_itm)
         string = strncpy(malloc(sizeof(NODE_NAME) + 1), node->name,
                          sizeof(NODE_NAME));
         int length = minInt(strlen(node->name), sizeof(NODE_NAME));
-        string[length] = '\0';
         memset(string + length, '\0', sizeof(NODE_NAME) - length + 1);
       }
       else

--- a/treeshr/TreeGetNci.c
+++ b/treeshr/TreeGetNci.c
@@ -502,7 +502,9 @@ int TreeGetNci(int nid_in, struct nci_itm *nci_itm)
       {
         string = strncpy(malloc(sizeof(NODE_NAME) + 1), node->name,
                          sizeof(NODE_NAME));
-        string[sizeof(NODE_NAME)] = '\0';
+        int length = minInt(strlen(node->name), sizeof(NODE_NAME));
+        string[length] = '\0';
+        memset(string + length, '\0', sizeof(NODE_NAME) - length + 1);
       }
       else
         string = strdup(NODE_NOT_FOUND_NAME);


### PR DESCRIPTION
Stephen fixed a TDI bug so it properly handles long node names.   That in turn fixed display of long node names in jTraverser2 (i.e., eliminated trailing garbage characters).   Mark ran Stephen's changes on an Ubuntu 22 VM running the old-trees branch, namely the same system where the bug was found.   After the debugging session, Mark removed debug printf() statements and confirmed that jTraverser2 still works fine (as do mdstcl, jTraverser and jScope).  Mark also tested jTraverser2 with edge cases that used the longest possible node name, and all worked A-OK.  Thus this fix is now ready for inclusion on the old-trees branch.