### PR TITLE
Add a fixed-length string specifier to the printf for buildtag()

### DIFF
--- a/_include/_mdsversion.h.in
+++ b/_include/_mdsversion.h.in
@@ -24,7 +24,7 @@ static mdsdsc_t RELEASE_D = { 0, DTYPE_T, CLASS_S, tag };
 
 static void buildtag()
 {
-	RELEASE_D.length = snprintf(tag, sizeof(tag), "%s_release_%d.%d.%d",
+	RELEASE_D.length = snprintf(tag, sizeof(tag), "%.12s_release_%d.%d.%d",
 	VERSIONCONST.BRANCH,
 	VERSIONCONST.MAJOR,
 	VERSIONCONST.MINOR,


### PR DESCRIPTION
There was an error generated if your branch was 12 or more characters. The string would be truncated by git_revision.sh, but it would throw an error about printing a "non-null-terminated string".