### PR TITLE
Add DbiTREE_VERSION, add version to `show db`

### DIFF
--- a/include/dbidef.h
+++ b/include/dbidef.h
@@ -26,6 +26,7 @@
 #define DbiVERSIONS_IN_PULSE 11 /* True if using versioning in pulse files */
 #define DbiREADONLY 12          /* True if making tree readonly */
 #define DbiDISPATCH_TABLE 13    /* Tree dispatch table */
+#define DbiTREE_VERSION 14      /* Tree format version number */
 
 typedef struct dbi_itm
 {

--- a/include/mdsobjects.h
+++ b/include/mdsobjects.h
@@ -4133,6 +4133,11 @@ namespace MDSplus
     /// for segmented data.
     ///
     void setVersionsInPulse(bool enable);
+    
+    /// This function returns the tree file format version number. See treeshr
+    /// function \ref TreeGetDbi() called with code DbiTREE_VERSION.
+    ///
+    int getTreeVersion();
 
     /// View data stored in tree from given start date when version control is
     /// enabled.

--- a/java/mdsobjects/src/main/java/MDSplus/Tree.java
+++ b/java/mdsobjects/src/main/java/MDSplus/Tree.java
@@ -24,7 +24,7 @@ public class Tree
     
 	static final int DbiNAME = 1, DbiSHOTID = 2, DbiMODIFIED = 3, DbiOPEN_FOR_EDIT = 4, DbiINDEX = 5,
 			DbiNUMBER_OPENED = 6, DbiMAX_OPEN = 7, DbiDEFAULT = 8, DbiOPEN_READONLY = 9, DbiVERSIONS_IN_MODEL = 10,
-			DbiVERSIONS_IN_PULSE = 11;
+			DbiVERSIONS_IN_PULSE = 11, DbiTREE_VERSION = 14;
 	static public final int TreeUSAGE_ANY = 0, TreeUSAGE_NONE = 1, TreeUSAGE_STRUCTURE = 1, TreeUSAGE_ACTION = 2,
 			TreeUSAGE_DEVICE = 3, TreeUSAGE_DISPATCH = 4, TreeUSAGE_NUMERIC = 5, TreeUSAGE_SIGNAL = 6,
 			TreeUSAGE_TASK = 7, TreeUSAGE_TEXT = 8, TreeUSAGE_WINDOW = 9, TreeUSAGE_AXIS = 10, TreeUSAGE_SUBTREE = 11,
@@ -172,6 +172,8 @@ public class Tree
 
 	private static native void setDbiFlag(long ctx, boolean flag, int dbiType) throws MdsException;
 
+	private static native int getDbiInt(long ctx, int dbiType) throws MdsException;
+
 	private static native void setTreeViewDate(java.lang.String date) throws MdsException;
 
 	private static native void setTreeTimeContext(long ctx, Data start, Data end, Data delta);
@@ -313,6 +315,9 @@ public class Tree
 
 	public boolean isReadOnly() throws MdsException
 	{ return getDbiFlag(getCtx(), DbiOPEN_READONLY); }
+	
+	public int getTreeVersion() throws MdsException
+	{ return getDbiInt(getCtx(), DbiTREE_VERSION); }
 
 	/**
 	 * Set the version date: all read data will refer to the version active to that

--- a/javamds/MDSplus_Tree.h
+++ b/javamds/MDSplus_Tree.h
@@ -30,6 +30,8 @@ extern "C"
 #define MDSplus_Tree_DbiVERSIONS_IN_MODEL 10L
 #undef MDSplus_Tree_DbiVERSIONS_IN_PULSE
 #define MDSplus_Tree_DbiVERSIONS_IN_PULSE 11L
+#undef MDSplus_Tree_DbiTREE_VERSION
+#define MDSplus_Tree_DbiTREE_VERSION 14L
 #undef MDSplus_Tree_TreeUSAGE_ANY
 #define MDSplus_Tree_TreeUSAGE_ANY 0L
 #undef MDSplus_Tree_TreeUSAGE_NONE
@@ -144,6 +146,14 @@ extern "C"
  */
   JNIEXPORT void JNICALL Java_MDSplus_Tree_setDbiFlag(JNIEnv *, jclass, jlong,
                                                       jboolean, jint);
+
+  /*
+ * Class:     MDSplus_Tree
+ * Method:    getDbiInt
+ * Signature: (JI)Z
+ */
+  JNIEXPORT jint JNICALL Java_MDSplus_Tree_getDbiInt(JNIEnv *, jclass, jlong,
+                                                     jint);
 
   /*
  * Class:     MDSplus_Tree

--- a/javamds/mdsobjects.c
+++ b/javamds/mdsobjects.c
@@ -1922,6 +1922,29 @@ JNIEXPORT void JNICALL Java_MDSplus_Tree_setDbiFlag(JNIEnv *env,
 
 /*
  * Class:     MDSplus_Tree
+ * Method:    getDbiInt
+ * Signature: (JI)I
+ */
+JNIEXPORT jint JNICALL Java_MDSplus_Tree_getDbiInt(JNIEnv *env,
+                                                   jclass cls
+                                                   __attribute__((unused)),
+                                                   jlong jctx, jint code)
+{
+  int value, len = sizeof(jint), status;
+  void * ctx = JLONG2PTR(jctx);
+  struct dbi_itm dbiList[] = {
+    {sizeof(int), 0, &value, &len},
+    {0, DbiEND_OF_LIST, 0, 0}
+  };
+  dbiList[0].code = (short)code;
+  status = CTXCALLN(TreeGetDbi, dbiList);
+  if (STATUS_NOT_OK)
+    throwMdsException(env, status);
+  return value;
+}
+
+/*
+ * Class:     MDSplus_Tree
  * Method:    setTreeViewDate
  * Signature: (Ljava/lang/String;)V
  */

--- a/mdsobjects/cpp/mdstreeobjects.cpp
+++ b/mdsobjects/cpp/mdstreeobjects.cpp
@@ -576,6 +576,23 @@ bool Tree::isOpenForEdit() { return dbiTest(getCtx(), DbiOPEN_FOR_EDIT); }
 
 bool Tree::isReadOnly() { return dbiTest(getCtx(), DbiOPEN_READONLY); }
 
+int Tree::getTreeVersion()
+{
+  int treeVersion;
+  
+  int len;
+  struct dbi_itm dbiList[] = {
+    {sizeof(int), DbiTREE_VERSION, &treeVersion, &len},
+    {0, DbiEND_OF_LIST, 0, 0}
+  };
+
+  int status = _TreeGetDbi(getCtx(), dbiList);
+  if (STATUS_NOT_OK)
+    throw MdsException(status);
+
+  return treeVersion;  
+}
+
 static void dbiSet(void *ctx, short int code, bool value)
 {
   int len;

--- a/python/MDSplus/tree.py
+++ b/python/MDSplus/tree.py
@@ -144,6 +144,7 @@ class Dbi(object):
     VERSIONS_IN_MODEL = (10, bool, 4)  # settable
     VERSIONS_IN_PULSE = (11, bool, 4)  # settable
     DISPATCH_TABLE = (13, bool, 4)
+    TREE_VERSION = (14, int, 4)
 
     class _dbi_item(_C.Structure):
         """ Ctype structure class for making calls into _TreeGetDbi() """
@@ -652,6 +653,8 @@ class Tree(object):
         Dbi.VERSIONS_IN_PULSE, "Support versioning of data in pulse.", True)
     dispatch_table = Dbi._dbiProp(
         Dbi.DISPATCH_TABLE,   "True if dispatch table is built")
+    tree_version = Dbi._dbiProp(
+        Dbi.TREE_VERSION,     "Tree format version number")
 
     @property
     def default(self):

--- a/tcl/tcl_show_db.c
+++ b/tcl/tcl_show_db.c
@@ -80,7 +80,7 @@ EXPORT int TclShowDB(void *ctx __attribute__((unused)),
       };
       sts = TreeGetDbi(itm2);
       dbi_name = itm2[1].pointer;
-      dbi_default = itm2[5].pointer;
+      dbi_default = itm2[3].pointer;
       outstr_length = strlen(dbi_name) + strlen(dbi_default) + 100;
       outstr = (char *)malloc(outstr_length);
       snprintf(outstr, outstr_length,

--- a/tcl/tcl_show_db.c
+++ b/tcl/tcl_show_db.c
@@ -50,7 +50,9 @@ EXPORT int TclShowDB(void *ctx __attribute__((unused)),
 {
   int sts;
   int open;
-  DBI_ITM itm1[] = {{sizeof(open), DbiNUMBER_OPENED, &open, 0}, {0}};
+  DBI_ITM itm1[] = {
+    {sizeof(open), DbiNUMBER_OPENED, &open, 0}, {0}
+  };
   sts = TreeGetDbi(itm1);
   if (sts & 1)
   {
@@ -59,23 +61,40 @@ EXPORT int TclShowDB(void *ctx __attribute__((unused)),
     for (idx = 0; idx < open; idx++)
     {
       int shotid;
+      int tree_version;
       char modified;
       char edit;
       char *outstr = 0;
-      DBI_ITM itm2[] = {{sizeof(idx), DbiINDEX, &idx, 0},
-                        {0, DbiNAME, 0, 0},
-                        {sizeof(shotid), DbiSHOTID, &shotid, 0},
-                        {sizeof(modified), DbiMODIFIED, &modified, 0},
-                        {sizeof(edit), DbiOPEN_FOR_EDIT, &edit, 0},
-                        {0, DbiDEFAULT, 0, 0},
-                        {0}};
+      char * dbi_name = 0;
+      char * dbi_default = 0;
+      size_t outstr_length = 0;
+      DBI_ITM itm2[] = {
+        {sizeof(idx), DbiINDEX, &idx, 0},
+        {0, DbiNAME, 0, 0},
+        {sizeof(shotid), DbiSHOTID, &shotid, 0},
+        {0, DbiDEFAULT, 0, 0},
+        {sizeof(edit), DbiOPEN_FOR_EDIT, &edit, 0},
+        {sizeof(modified), DbiMODIFIED, &modified, 0},
+        {sizeof(tree_version), DbiTREE_VERSION, &tree_version, 0},
+        {0}
+      };
       sts = TreeGetDbi(itm2);
-      outstr = malloc(strlen(itm2[1].pointer) + strlen(itm2[5].pointer) + 100);
-      sprintf(outstr, "%03d  %-12s  shot: %d [%s] %s%s\n", idx,
-              (char *)itm2[1].pointer, shotid, (char *)itm2[5].pointer,
-              edit ? "open for edit" : " ", modified ? ",modified" : " ");
-      free(itm2[1].pointer);
-      free(itm2[5].pointer);
+      dbi_name = itm2[1].pointer;
+      dbi_default = itm2[5].pointer;
+      outstr_length = strlen(dbi_name) + strlen(dbi_default) + 100;
+      outstr = (char *)malloc(outstr_length);
+      snprintf(outstr, outstr_length,
+        "%03d  %-12s  shot: %d [%s] %s%s version: %d\n",
+        idx,
+        dbi_name,
+        shotid,
+        dbi_default,
+        edit ? "open for edit" : " ",
+        modified ? ",modified" : " ",
+        tree_version
+      );
+      free(dbi_name);
+      free(dbi_default);
       tclAppend(output, outstr);
       free(outstr);
     }

--- a/tdishr/TdiGetDbi.c
+++ b/tdishr/TdiGetDbi.c
@@ -61,6 +61,7 @@ static const struct item
     {"OPEN_FOR_EDIT", DbiOPEN_FOR_EDIT, DTYPE_BU, 1},
     {"OPEN_READONLY", DbiOPEN_READONLY, DTYPE_BU, 1},
     {"SHOTID", DbiSHOTID, DTYPE_L, 4},
+    {"TREE_VERSION", DbiTREE_VERSION, DTYPE_L, 4}
 };
 
 #define siztab sizeof(struct item)

--- a/treeshr/TreeGetDbi.c
+++ b/treeshr/TreeGetDbi.c
@@ -66,76 +66,67 @@ int _TreeGetDbi(void *dbid, struct dbi_itm *itmlst)
     switch (lst->code)
     {
     case DbiNAME:
-
       CheckOpen(db);
       string = strdup(db->main_treenam);
       break;
 
     case DbiSHOTID:
-
       CheckOpen(db);
       set_retlen(sizeof(db->shotid));
       *(int *)lst->pointer = db->shotid;
       break;
 
     case DbiMODIFIED:
-
       CheckOpen(db);
       set_ret_char(db->modified);
       break;
 
     case DbiOPEN_FOR_EDIT:
-
       CheckOpen(db);
       set_ret_char(db->open_for_edit);
       break;
 
     case DbiOPEN_READONLY:
-
       CheckOpen(db);
       set_ret_char(db->open_readonly);
       break;
 
     case DbiINDEX:
-
-    {
-      int idx;
-      for (idx = 0, db = (PINO_DATABASE *)dbid;
-           db && (idx < (*(int *)(lst->pointer) & 0xff)); idx++, db = db->next)
-        ;
+      {
+        int idx;
+        for (idx = 0, db = (PINO_DATABASE *)dbid;
+            db && (idx < (*(int *)(lst->pointer) & 0xff)); idx++, db = db->next)
+          ;
+      }
       break;
-    }
 
     case DbiNUMBER_OPENED:
-
-    {
-      int count;
-      PINO_DATABASE *db_tmp;
-      for (count = 0, db_tmp = (PINO_DATABASE *)dbid; db_tmp ? db_tmp->open : 0;
-           count++, db_tmp = db_tmp->next)
-        ;
-      memset(lst->pointer, 0, (size_t)lst->buffer_length);
-      int length = minInt(lst->buffer_length, sizeof(int));
-      memcpy(lst->pointer, &count, (size_t)length);
-      if (lst->return_length_address)
-        *lst->return_length_address = length;
+      {
+        int count;
+        PINO_DATABASE *db_tmp;
+        for (count = 0, db_tmp = (PINO_DATABASE *)dbid; db_tmp ? db_tmp->open : 0;
+            count++, db_tmp = db_tmp->next)
+          ;
+        memset(lst->pointer, 0, (size_t)lst->buffer_length);
+        int length = minInt(lst->buffer_length, sizeof(int));
+        memcpy(lst->pointer, &count, (size_t)length);
+        if (lst->return_length_address)
+          *lst->return_length_address = length;
+      }
       break;
-    }
 
     case DbiMAX_OPEN:
-
-    {
-      int count = db->stack_size;
-      memset(lst->pointer, 0, (size_t)lst->buffer_length);
-      int length = minInt(lst->buffer_length, sizeof(int));
-      memcpy(lst->pointer, &count, (size_t)length);
-      if (lst->return_length_address)
-        *lst->return_length_address = length;
+      {
+        int count = db->stack_size;
+        memset(lst->pointer, 0, (size_t)lst->buffer_length);
+        int length = minInt(lst->buffer_length, sizeof(int));
+        memcpy(lst->pointer, &count, (size_t)length);
+        if (lst->return_length_address)
+          *lst->return_length_address = length;
+      }
       break;
-    }
 
     case DbiDEFAULT:
-
       CheckOpen(db);
       {
         int nid;
@@ -153,8 +144,8 @@ int _TreeGetDbi(void *dbid, struct dbi_itm *itmlst)
         memcpy(lst->pointer, &value, (size_t)length);
         if (lst->return_length_address)
           *lst->return_length_address = length;
-        break;
       }
+      break;
 
     case DbiVERSIONS_IN_PULSE:
       CheckOpen(db);
@@ -165,8 +156,8 @@ int _TreeGetDbi(void *dbid, struct dbi_itm *itmlst)
         memcpy(lst->pointer, &value, (size_t)length);
         if (lst->return_length_address)
           *lst->return_length_address = length;
-        break;
       }
+      break;
 
     case DbiDISPATCH_TABLE:
       CheckOpen(db);
@@ -177,8 +168,17 @@ int _TreeGetDbi(void *dbid, struct dbi_itm *itmlst)
         memcpy(lst->pointer, &value, (size_t)length);
         if (lst->return_length_address)
           *lst->return_length_address = length;
-        break;
       }
+      break;
+      
+    case DbiTREE_VERSION:
+      CheckOpen(db);
+      {
+        // TREE_HEADER::version is a char, but upcast it to an int for ease of use
+        set_retlen(sizeof(int));
+        *(int *)lst->pointer = (int)db->tree_info->header->version;
+      }
+      break;
 
     default:
       status = TreeILLEGAL_ITEM;


### PR DESCRIPTION
Add DbiTREE_VERSION, which returns `db->info->header->version`
Add the tree file format version number to the output of `mdstcl show db`

Example:
```
TCL> set tree oldtree
TCL> set tree newtree
TCL> show db
000  NEWTREE       shot: -1 [\NEWTREE::TOP]    version: 2
001  OLDTREE       shot: -1 [\OLDTREE::TOP]    version: 1
```