### PR TITLE
In the 423/435 stream devices, dev.copy() was moved back to the main process.

### DIFF
--- a/pydevices/HtsDevices/acq2106_423st.py
+++ b/pydevices/HtsDevices/acq2106_423st.py
@@ -167,7 +167,10 @@ class _ACQ2106_423ST(MDSplus.Device):
         def __init__(self, dev):
             super(_ACQ2106_423ST.MDSWorker, self).__init__(name=dev.path)
 
-            self.dev = dev.copy()
+            # Tuple designed to bring a copy of the tree to the MDSWorker thread
+            self.info = (dev.tree.name, dev.tree.shot, dev.path)
+
+            self.dev = dev
 
             self.nchans = self.dev.sites * self.dev.NUM_CHANS_PER_SITE
 
@@ -192,6 +195,9 @@ class _ACQ2106_423ST(MDSplus.Device):
                 for e in arr:
                     ans = lcm(ans, e)
                 return int(ans)
+
+            tree = MDSplus.Tree(self.info[0], self.info[1])
+            self.dev = tree.getNode(self.info[2])
 
             if self.dev.debug:
                 print("MDSWorker running")

--- a/pydevices/HtsDevices/acq2106_423st.py
+++ b/pydevices/HtsDevices/acq2106_423st.py
@@ -167,8 +167,10 @@ class _ACQ2106_423ST(MDSplus.Device):
         def __init__(self, dev):
             super(_ACQ2106_423ST.MDSWorker, self).__init__(name=dev.path)
 
-            # Tuple designed to bring a copy of the tree to the MDSWorker thread
-            self.info = (dev.tree.name, dev.tree.shot, dev.path)
+            # Variables designed to bring a copy of the tree to the MDSWorker thread
+            self.tree = dev.tree.name
+            self.shot = dev.tree.shot
+            self.path = dev.path
 
             self.dev = dev
 
@@ -196,8 +198,8 @@ class _ACQ2106_423ST(MDSplus.Device):
                     ans = lcm(ans, e)
                 return int(ans)
 
-            tree = MDSplus.Tree(self.info[0], self.info[1])
-            self.dev = tree.getNode(self.info[2])
+            tree = MDSplus.Tree(self.tree, self.shot)
+            self.dev = tree.getNode(self.path)
 
             if self.dev.debug:
                 print("MDSWorker running")

--- a/pydevices/HtsDevices/acq2106_423st.py
+++ b/pydevices/HtsDevices/acq2106_423st.py
@@ -169,7 +169,7 @@ class _ACQ2106_423ST(MDSplus.Device):
 
             self.dev = dev.copy()
 
-            self.nchans = self.dev.sites * NUM_CHANS_PER_SITE
+            self.nchans = self.dev.sites * self.dev.NUM_CHANS_PER_SITE
 
             self.seg_length = self.dev.seg_length.data()
             self.segment_bytes = self.seg_length*self.nchans*np.int16(0).nbytes
@@ -409,7 +409,7 @@ class _ACQ2106_423ST(MDSplus.Device):
         eoff = uut.cal_eoff[1:]
 
         chans = []
-        nchans = self.sites * NUM_CHANS_PER_SITE
+        nchans = self.sites * self.NUM_CHANS_PER_SITE
         for ii in range(nchans):
             chans.append(getattr(self, 'INPUT_%3.3d' % (ii+1)))
 

--- a/pydevices/HtsDevices/acq2106_423st.py
+++ b/pydevices/HtsDevices/acq2106_423st.py
@@ -165,7 +165,7 @@ class _ACQ2106_423ST(MDSplus.Device):
         def __init__(self, dev):
             super(_ACQ2106_423ST.MDSWorker, self).__init__(name=dev.path)
 
-            self.dev = dev
+            self.dev = dev.copy()
 
             self.nchans = self.dev.sites*32
 
@@ -190,8 +190,6 @@ class _ACQ2106_423ST(MDSplus.Device):
                 for e in arr:
                     ans = lcm(ans, e)
                 return int(ans)
-
-            self.dev = self.dev.copy()
 
             if self.dev.debug:
                 print("MDSWorker running")
@@ -409,7 +407,7 @@ class _ACQ2106_423ST(MDSplus.Device):
         eoff = uut.cal_eoff[1:]
 
         self.chans = []
-        nchans = uut.nchan()
+        nchans = self.sites*32
         for ii in range(nchans):
             self.chans.append(getattr(self, 'INPUT_%3.3d' % (ii+1)))
 

--- a/pydevices/HtsDevices/acq2106_423st.py
+++ b/pydevices/HtsDevices/acq2106_423st.py
@@ -159,6 +159,8 @@ class _ACQ2106_423ST(MDSplus.Device):
 
     trig_types = ['hard', 'soft', 'automatic']
 
+    NUM_CHANS_PER_SITE = 32
+
     class MDSWorker(threading.Thread):
         NUM_BUFFERS = 20
 
@@ -167,7 +169,7 @@ class _ACQ2106_423ST(MDSplus.Device):
 
             self.dev = dev.copy()
 
-            self.nchans = self.dev.sites*32
+            self.nchans = self.dev.sites * NUM_CHANS_PER_SITE
 
             self.seg_length = self.dev.seg_length.data()
             self.segment_bytes = self.seg_length*self.nchans*np.int16(0).nbytes
@@ -407,7 +409,7 @@ class _ACQ2106_423ST(MDSplus.Device):
         eoff = uut.cal_eoff[1:]
 
         chans = []
-        nchans = self.sites*32
+        nchans = self.sites * NUM_CHANS_PER_SITE
         for ii in range(nchans):
             chans.append(getattr(self, 'INPUT_%3.3d' % (ii+1)))
 
@@ -448,7 +450,7 @@ class _ACQ2106_423ST(MDSplus.Device):
 
 def assemble(cls):
     cls.parts = list(_ACQ2106_423ST.carrier_parts)
-    for i in range(cls.sites*32):
+    for i in range(cls.sites * cls.NUM_CHANS_PER_SITE):
         cls.parts += [
             {
                 'path': ':INPUT_%3.3d' % (i+1,),            

--- a/pydevices/HtsDevices/acq2106_423st.py
+++ b/pydevices/HtsDevices/acq2106_423st.py
@@ -194,18 +194,18 @@ class _ACQ2106_423ST(MDSplus.Device):
             if self.dev.debug:
                 print("MDSWorker running")
 
-            self.chans = []
-            self.decim = []
+            chans = []
+            decim = []
             for i in range(self.nchans):
-                self.chans.append(getattr(self.dev, 'input_%3.3d' % (i+1)))
-                self.decim.append(
+                chans.append(getattr(self.dev, 'input_%3.3d' % (i+1)))
+                decim.append(
                     getattr(self.dev, 'input_%3.3d_decimate' % (i+1)).data())
 
             event_name = self.dev.seg_event.data()
 
             dt = 1./self.dev.freq.data()
 
-            decimator = lcma(self.decim)
+            decimator = lcma(decim)
 
             if self.seg_length % decimator:
                 self.seg_length = (self.seg_length //
@@ -228,11 +228,11 @@ class _ACQ2106_423ST(MDSplus.Device):
 
                 buffer = np.frombuffer(buf, dtype='int16')
                 i = 0
-                for c in self.chans:
-                    slength = self.seg_length/self.decim[i]
-                    deltat = dt * self.decim[i]
+                for c in chans:
+                    slength = self.seg_length/decim[i]
+                    deltat = dt * decim[i]
                     if c.on:
-                        b = buffer[i::self.nchans*self.decim[i]]
+                        b = buffer[i::self.nchans*decim[i]]
                         begin = segment * slength * deltat
                         end = begin + (slength - 1) * deltat
                         dim = MDSplus.Range(begin, end, deltat)
@@ -406,12 +406,12 @@ class _ACQ2106_423ST(MDSplus.Device):
         coeffs = uut.cal_eslo[1:]
         eoff = uut.cal_eoff[1:]
 
-        self.chans = []
+        chans = []
         nchans = self.sites*32
         for ii in range(nchans):
-            self.chans.append(getattr(self, 'INPUT_%3.3d' % (ii+1)))
+            chans.append(getattr(self, 'INPUT_%3.3d' % (ii+1)))
 
-        for ic, ch in enumerate(self.chans):
+        for ic, ch in enumerate(chans):
             if ch.on:
                 ch.OFFSET.putData(float(eoff[ic]))
                 ch.COEFFICIENT.putData(float(coeffs[ic]))

--- a/pydevices/HtsDevices/acq2106_435st.py
+++ b/pydevices/HtsDevices/acq2106_435st.py
@@ -190,7 +190,7 @@ class _ACQ2106_435ST(MDSplus.Device):
 
             self.dev = dev.copy()
 
-            self.nchans     = self.dev.sites*32
+            self.nchans     = self.dev.sites * 32
             self.resampling = self.dev.resampling
             
             self.seg_length = self.dev.seg_length.data()
@@ -467,7 +467,7 @@ class _ACQ2106_435ST(MDSplus.Device):
         eoff = uut.cal_eoff[1:]
 
         chans = []
-        nchans = uut.nchan()
+        nchans = self.sites * 32
         for ii in range(nchans):
             chans.append(getattr(self, 'INPUT_%3.3d' % (ii+1)))
 

--- a/pydevices/HtsDevices/acq2106_435st.py
+++ b/pydevices/HtsDevices/acq2106_435st.py
@@ -190,8 +190,10 @@ class _ACQ2106_435ST(MDSplus.Device):
         def __init__(self, dev):
             super(_ACQ2106_435ST.MDSWorker, self).__init__(name=dev.path)
 
-            # Tuple designed to bring a copy of the tree to the MDSWorker thread
-            self.info = (dev.tree.name, dev.tree.shot, dev.path)
+            # Variables designed to bring a copy of the tree to the MDSWorker thread
+            self.tree = dev.tree.name
+            self.shot = dev.tree.shot
+            self.path = dev.path
 
             self.dev = dev
 
@@ -223,8 +225,8 @@ class _ACQ2106_435ST(MDSplus.Device):
                     ans = lcm(ans, e)
                 return int(ans)
 
-            tree = MDSplus.Tree(self.info[0], self.info[1])
-            self.dev = tree.getNode(self.info[2])
+            tree = MDSplus.Tree(self.tree, self.shot)
+            self.dev = tree.getNode(self.path)
 
             if self.dev.debug:
                 print("MDSWorker running")

--- a/pydevices/HtsDevices/acq2106_435st.py
+++ b/pydevices/HtsDevices/acq2106_435st.py
@@ -182,6 +182,8 @@ class _ACQ2106_435ST(MDSplus.Device):
 
     data_socket = -1
 
+    NUM_CHANS_PER_SITE = 32
+
     class MDSWorker(threading.Thread):
         NUM_BUFFERS = 20
 
@@ -190,7 +192,7 @@ class _ACQ2106_435ST(MDSplus.Device):
 
             self.dev = dev.copy()
 
-            self.nchans     = self.dev.sites * 32
+            self.nchans     = self.dev.sites * NUM_CHANS_PER_SITE
             self.resampling = self.dev.resampling
             
             self.seg_length = self.dev.seg_length.data()
@@ -467,7 +469,7 @@ class _ACQ2106_435ST(MDSplus.Device):
         eoff = uut.cal_eoff[1:]
 
         chans = []
-        nchans = self.sites * 32
+        nchans = self.sites * NUM_CHANS_PER_SITE
         for ii in range(nchans):
             chans.append(getattr(self, 'INPUT_%3.3d' % (ii+1)))
 
@@ -553,7 +555,7 @@ class _ACQ2106_435ST(MDSplus.Device):
 
 def assemble(cls):
     cls.parts = list(_ACQ2106_435ST.carrier_parts)
-    for i in range(cls.sites*32):
+    for i in range(cls.sites * cls.NUM_CHANS_PER_SITE):
         cls.parts += [
             {
                 'path': ':INPUT_%3.3d' % (i+1,),

--- a/pydevices/HtsDevices/acq2106_435st.py
+++ b/pydevices/HtsDevices/acq2106_435st.py
@@ -192,7 +192,7 @@ class _ACQ2106_435ST(MDSplus.Device):
 
             self.dev = dev.copy()
 
-            self.nchans     = self.dev.sites * NUM_CHANS_PER_SITE
+            self.nchans     = self.dev.sites * self.dev.NUM_CHANS_PER_SITE
             self.resampling = self.dev.resampling
             
             self.seg_length = self.dev.seg_length.data()
@@ -469,7 +469,7 @@ class _ACQ2106_435ST(MDSplus.Device):
         eoff = uut.cal_eoff[1:]
 
         chans = []
-        nchans = self.sites * NUM_CHANS_PER_SITE
+        nchans = self.sites * self.NUM_CHANS_PER_SITE
         for ii in range(nchans):
             chans.append(getattr(self, 'INPUT_%3.3d' % (ii+1)))
 

--- a/pydevices/HtsDevices/acq2106_435st.py
+++ b/pydevices/HtsDevices/acq2106_435st.py
@@ -190,7 +190,10 @@ class _ACQ2106_435ST(MDSplus.Device):
         def __init__(self, dev):
             super(_ACQ2106_435ST.MDSWorker, self).__init__(name=dev.path)
 
-            self.dev = dev.copy()
+            # Tuple designed to bring a copy of the tree to the MDSWorker thread
+            self.info = (dev.tree.name, dev.tree.shot, dev.path)
+
+            self.dev = dev
 
             self.nchans     = self.dev.sites * self.dev.NUM_CHANS_PER_SITE
             self.resampling = self.dev.resampling
@@ -219,6 +222,9 @@ class _ACQ2106_435ST(MDSplus.Device):
                 for e in arr:
                     ans = lcm(ans, e)
                 return int(ans)
+
+            tree = MDSplus.Tree(self.info[0], self.info[1])
+            self.dev = tree.getNode(self.info[2])
 
             if self.dev.debug:
                 print("MDSWorker running")

--- a/pydevices/HtsDevices/acq2106_435st.py
+++ b/pydevices/HtsDevices/acq2106_435st.py
@@ -188,10 +188,17 @@ class _ACQ2106_435ST(MDSplus.Device):
         def __init__(self, dev):
             super(_ACQ2106_435ST.MDSWorker, self).__init__(name=dev.path)
 
-            self.dev = dev
+            self.dev = dev.copy()
 
-            self.nchans     = self.dev.sites * 32
+            self.chans = []
+            self.decim = []
+            self.nchans     = self.dev.sites*32
             self.resampling = self.dev.resampling
+
+            for i in range(self.nchans):
+                self.chans.append(getattr(self.dev, 'input_%3.3d' % (i+1)))
+                self.decim.append(
+                    getattr(self.dev, 'input_%3.3d_decimate' % (i+1)).data())
             
             self.seg_length = self.dev.seg_length.data()
             self.segment_bytes = self.seg_length*self.nchans*np.int32(0).nbytes
@@ -218,17 +225,8 @@ class _ACQ2106_435ST(MDSplus.Device):
                     ans = lcm(ans, e)
                 return int(ans)
 
-            self.dev = self.dev.copy()
-
             if self.dev.debug:
                 print("MDSWorker running")
-            
-            self.chans = []
-            self.decim = []
-            for i in range(self.nchans):
-                self.chans.append(getattr(self.dev, 'input_%3.3d' % (i+1)))
-                self.decim.append(
-                    getattr(self.dev, 'input_%3.3d_decimate' % (i+1)).data())
 
             event_name = self.dev.seg_event.data()
 


### PR DESCRIPTION
The 423/435 streaming devices contain a call to copy the tree (`dev.copy()`) inside the MDSWorker's new thread. 
This breaks the code when executing it from an mdsip service (i.e. when dispatching the INIT action).
Moving that statement back to the main process thread fixes the issue.
