### PR TITLE
Fix XNCI writes corrupting node data

### DIFF
--- a/treeshr/TreeSegments.c
+++ b/treeshr/TreeSegments.c
@@ -311,12 +311,6 @@ inline static void begin_extended_nci(vars_t *vars)
   {
     vars->attr_offset =
         RfaToSeek(vars->local_nci.DATA_INFO.DATA_LOCATION.rfa);
-    if (vars->attr.facility_offset[STANDARD_RECORD_FACILITY] != -1)
-    {
-      vars->attr.facility_offset[STANDARD_RECORD_FACILITY] = -1;
-      vars->attr.facility_length[STANDARD_RECORD_FACILITY] = 0;
-      vars->attr_update = 1;
-    }
   }
   else
   {
@@ -565,11 +559,13 @@ static int set_xnci(vars_t *vars, mdsdsc_t *value, int is_offset)
   {
     value_offset = vars->xnci_header_offset;
     value_length = -1;
+    printf("is_offset value_offset=%ld\n", value_offset);
   }
   else
   {
     if (value)
     { // NULL means delete
+      printf("calling tree_put_dsc()\n");
       RETURN_IF_NOT_OK(tree_put_dsc(
           vars->dblist, vars->tinfo, *(int *)vars->nid_ptr, (mdsdsc_t *)value,
           &value_offset, &value_length, vars->compress));
@@ -581,13 +577,16 @@ static int set_xnci(vars_t *vars, mdsdsc_t *value, int is_offset)
    */
   if (vars->attr_offset == -1)
   {
+    printf("vars->attr_offset == -1\n");
     if (value_length == 0)
       return status; // has not xnci; nothing to delete
     if (((vars->local_nci.flags2 & NciM_EXTENDED_NCI) == 0) &&
         vars->local_nci.length > 0)
     {
+      printf("((vars->local_nci.flags2 & NciM_EXTENDED_NCI) == 0) && vars->local_nci.length > 0\n");
       if (vars->local_nci.flags2 & NciM_DATA_IN_ATT_BLOCK)
       {
+        printf("vars->local_nci.flags2 & NciM_DATA_IN_ATT_BLOCK\n");
         EMPTYXD(dsc);
         mdsdsc_t *dptr;
         dtype_t dsc_dtype = DTYPE_DSC;

--- a/treeshr/TreeSegments.c
+++ b/treeshr/TreeSegments.c
@@ -559,13 +559,11 @@ static int set_xnci(vars_t *vars, mdsdsc_t *value, int is_offset)
   {
     value_offset = vars->xnci_header_offset;
     value_length = -1;
-    printf("is_offset value_offset=%ld\n", value_offset);
   }
   else
   {
     if (value)
     { // NULL means delete
-      printf("calling tree_put_dsc()\n");
       RETURN_IF_NOT_OK(tree_put_dsc(
           vars->dblist, vars->tinfo, *(int *)vars->nid_ptr, (mdsdsc_t *)value,
           &value_offset, &value_length, vars->compress));
@@ -577,16 +575,13 @@ static int set_xnci(vars_t *vars, mdsdsc_t *value, int is_offset)
    */
   if (vars->attr_offset == -1)
   {
-    printf("vars->attr_offset == -1\n");
     if (value_length == 0)
       return status; // has not xnci; nothing to delete
     if (((vars->local_nci.flags2 & NciM_EXTENDED_NCI) == 0) &&
         vars->local_nci.length > 0)
     {
-      printf("((vars->local_nci.flags2 & NciM_EXTENDED_NCI) == 0) && vars->local_nci.length > 0\n");
       if (vars->local_nci.flags2 & NciM_DATA_IN_ATT_BLOCK)
       {
-        printf("vars->local_nci.flags2 & NciM_DATA_IN_ATT_BLOCK\n");
         EMPTYXD(dsc);
         mdsdsc_t *dptr;
         dtype_t dsc_dtype = DTYPE_DSC;


### PR DESCRIPTION
The following code is likely supposed to do something useful, but currently it clobbers the data in a node when you write data into an XNCI.

Steps to reproduce with current alpha:
```py
import MDSplus
tree = MDSplus.Tree('tree', 0)
tree.NODE_NAME.record = 1234
tree.setExtendedAttribute('hello', 'world')
tree.NODE_NAME.record # throws data corrupted exception
```

@zack-vii This code was part of one of your original commits to add / restructure XNCIs, I would love for you to look at this before I remove these lines.