### PR TITLE
Fix: Use _Exit() instead of exit() from forked process in tunnel_rout…

### DIFF
--- a/mdstcpip/io_routines/IoRoutinesTunnel.c
+++ b/mdstcpip/io_routines/IoRoutinesTunnel.c
@@ -59,7 +59,8 @@ static int io_disconnect(Connection *c)
         usleep(100000);
       if (!i)
         kill(p_pid, SIGTERM);
-      exit(0);
+      /* Do not call any functions registered with atexit or onexit */
+      _Exit(0);
     }
     if (pid < 0)
       kill(p->pid, SIGTERM);


### PR DESCRIPTION
…ines->io_disconnect

This commit avoids that the forked process designed to kill the connection subprocess (such as ssh) calls exit(0) which will call registered functions using `atexit` or `onexit` (especially ones not related to the MDSplus libraries) but _exit(0) instead.

In our particular use case (a MATLAB MEX-file), the exit(0) function would actually fail and the process would live forever.