### PR TITLE
Add socket/service files for running per-connection mdsip servers with systemd

### DIFF
--- a/deploy/packaging/debian/kernel.noarch
+++ b/deploy/packaging/debian/kernel.noarch
@@ -33,6 +33,8 @@
 ./usr/local/mdsplus/pixmaps/tdi.png
 ./usr/local/mdsplus/rpm/mdsipd.xinetd
 ./usr/local/mdsplus/rpm/mdsipsd.xinetd
+./usr/local/mdsplus/rpm/mdsip.socket
+./usr/local/mdsplus/rpm/mdsip@.service
 ./usr/local/mdsplus/rpm/post_install_script
 ./usr/local/mdsplus/rpm/post_uninstall_script
 ./usr/local/mdsplus/rpm/python_module_install.sh

--- a/deploy/packaging/linux.xml
+++ b/deploy/packaging/linux.xml
@@ -439,6 +439,14 @@ then
     echo 'mdsip 8000/tcp # MDSplus mdsip service' &gt;&gt; /etc/services
   fi
 fi
+if [ ! -r /etc/systemd/system/mdsip.socket ]
+then
+  cp $RPM_INSTALL_PREFIX/mdsplus/rpm/mdsip.socket /etc/systemd/system/mdsip.socket
+fi
+if [ ! -r /etc/systemd/system/mdsip@.service ]
+then
+  cp $RPM_INSTALL_PREFIX/mdsplus/rpm/mdsip@.service /etc/systemd/system/mdsip@.service
+fi
     </post>
     <preun>
 if [ "$1" == "0" ]

--- a/deploy/packaging/redhat/kernel.noarch
+++ b/deploy/packaging/redhat/kernel.noarch
@@ -41,6 +41,8 @@
 ./usr/local/mdsplus/rpm
 ./usr/local/mdsplus/rpm/mdsipd.xinetd
 ./usr/local/mdsplus/rpm/mdsipsd.xinetd
+./usr/local/mdsplus/rpm/mdsip.socket
+./usr/local/mdsplus/rpm/mdsip@.service
 ./usr/local/mdsplus/rpm/post_install_script
 ./usr/local/mdsplus/rpm/post_uninstall_script
 ./usr/local/mdsplus/rpm/python_module_install.sh

--- a/rpm/Makefile.am
+++ b/rpm/Makefile.am
@@ -9,5 +9,5 @@ dist_rpm_SCRIPTS = post_install_script python_module_install.sh python_module_re
 if GLOBUSLICENSE
 dist_rpm_DATA = fusiongrid-mdsip.xinetd fusiongrid-mdsips.xinetd globus-gatekeeper.xinetd globus-gridftp.xinetd
 else
-dist_rpm_DATA = mdsipd.xinetd mdsipsd.xinetd
+dist_rpm_DATA = mdsipd.xinetd mdsipsd.xinetd mdsip.socket mdsip@.service
 endif

--- a/rpm/mdsip.socket
+++ b/rpm/mdsip.socket
@@ -1,0 +1,13 @@
+[Unit]
+Description=MDSplus Socket for Per-Connection Servers
+
+[Socket]
+Accept=yes
+KeepAlive=true
+NoDelay=true
+# If we don't force IPv4, the addresses come in from 0.0.0.0 and the host mapping breaks
+# Service names don't work here, so we have to use 8000 instead of mdsip
+ListenStream=0.0.0.0:8000
+
+[Install]
+WantedBy=sockets.target

--- a/rpm/mdsip@.service
+++ b/rpm/mdsip@.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=MDSplus Per-Connection Server
+
+[Service]
+User=root
+Type=forking
+# NOTE: If you installed MDSplus to a different location, make sure you change the following line
+ExecStart=/usr/local/mdsplus/bin/mdsipd mdsip /var/log/mdsplus/mdsipd
+# This spawns the process inetd-style with the incoming socket bound to stdin
+StandardInput=socket


### PR DESCRIPTION
These will be placed in /etc/systemd/system/ but not enabled by default.

I'll need to add instructions somewhere to run the following:
```
sudo systemctl enable mdsip.socket
```