### PR TITLE
Fix: Tdi SPREAD function does not work on scalars

### DIFF
--- a/tdishr/TdiTrans.c
+++ b/tdishr/TdiTrans.c
@@ -327,8 +327,15 @@ int Tdi1Trans(int opcode, int narg, mdsdsc_t *list[], mdsdsc_xd_t *out_ptr)
     }
     pmask = (mdsdsc_t *)&ncopies;
     /** scalar to simple vector **/
-    if (rank == 0)
-      memcpy((char *)&arr, (char *)pa, head);
+    if (rank == 0) {
+      memcpy((char *)&arr, (char *)pa, sizeof(struct descriptor));
+      arr.dimct = 1;
+      arr.aflags.coeff = 0;
+      arr.a0 = arr.pointer;
+      arr.arsize = arr.length;
+      arr.m[1] = arr.m[0] = 1;
+      arr.m[dim] = ncopies;
+    }
     else if (rank >= MAX_DIMS)
       status = TdiNDIM_OVER;
     /** coefficient vector **/

--- a/tdishr/TdiTrans.c
+++ b/tdishr/TdiTrans.c
@@ -291,8 +291,15 @@ int Tdi1Trans(int opcode, int narg, mdsdsc_t *list[], mdsdsc_xd_t *out_ptr)
       psig->dimensions[dim] = 0;
     pmask = (mdsdsc_t *)&ncopies;
     /** scalar to simple vector **/
-    if (rank == 0)
-      memcpy((char *)&arr, (char *)pa, head);
+    if (rank == 0) {
+      memcpy((char *)&arr, (char *)pa, sizeof(struct descriptor));
+      arr.dimct = 1;
+      arr.aflags.coeff = 0;
+      arr.a0 = arr.pointer;
+      arr.arsize = arr.length;
+      arr.m[1] = arr.m[0] = 1;
+      arr.m[dim] = ncopies;
+    }
     /** simple and coefficient vector **/
     else
     {

--- a/tdishr/TdiTrans.c
+++ b/tdishr/TdiTrans.c
@@ -297,7 +297,8 @@ int Tdi1Trans(int opcode, int narg, mdsdsc_t *list[], mdsdsc_xd_t *out_ptr)
       arr.aflags.coeff = 0;
       arr.a0 = arr.pointer;
       arr.arsize = arr.length;
-      arr.m[1] = arr.m[0] = 1;
+      arr.m[0] = 1;
+      arr.m[1] = 1;
       arr.m[dim] = ncopies;
     }
     /** simple and coefficient vector **/
@@ -340,7 +341,8 @@ int Tdi1Trans(int opcode, int narg, mdsdsc_t *list[], mdsdsc_xd_t *out_ptr)
       arr.aflags.coeff = 0;
       arr.a0 = arr.pointer;
       arr.arsize = arr.length;
-      arr.m[1] = arr.m[0] = 1;
+      arr.m[0] = 1;
+      arr.m[1] = 1;
       arr.m[dim] = ncopies;
     }
     else if (rank >= MAX_DIMS)
@@ -366,7 +368,8 @@ int Tdi1Trans(int opcode, int narg, mdsdsc_t *list[], mdsdsc_xd_t *out_ptr)
       arr.dimct = 2;
       arr.aflags.coeff = 1;
       arr.a0 = arr.pointer;
-      arr.m[1] = arr.m[0] = (int)pa->arsize / (int)pa->length;
+      arr.m[0] = (int)pa->arsize / (int)pa->length;
+      arr.m[1] = arr.m[0];
       arr.m[dim] = ncopies;
     }
     arr.arsize *= ncopies;


### PR DESCRIPTION

The TDI SPREAD and REPLICATE functions were treating the pointer 'pa'
as an array descriptor, while it was copied from a scalar descriptor.

Instead just copy the first sizeof(struct descriptor) bytes, and at
the bottom of Tdi1Trans Build the array descriptor that we want.

Closes: https://github.com/MDSplus/mdsplus/issues/2503