### PR TITLE
Fix: Error in Python's Tree::__del__

### DIFF
--- a/python/MDSplus/tree.py
+++ b/python/MDSplus/tree.py
@@ -574,7 +574,7 @@ class Tree(object):
         return self
 
     def __del__(self):
-        if not self.public:
+        if not self.public and _TreeShr is not None:
             self.__exit__()
             _TreeShr.TreeFreeDbid(self._ctx)
 


### PR DESCRIPTION
Add an extra check for _TreeShr to prevent a useless error when a python script is exiting

```
Exception ignored in: <function Tree.__del__ at 0x7fd04848d160>
Traceback (most recent call last):
 File "/usr/local/mdsplus/python/MDSplus/tree.py", line 579, in __del__
AttributeError: 'NoneType' object has no attribute 'TreeFreeDbid'
```