### PR TITLE
Fix: null terminate truncated node names (2472)

### DIFF
--- a/treeshr/TreeAddNode.c
+++ b/treeshr/TreeAddNode.c
@@ -159,8 +159,8 @@ int _TreeAddNode(void *dbid, char const *name, int *nid_out, char usage)
               strncpy(new_ptr->name, node_name, sizeof(new_ptr->name));
 #pragma GCC diagnostic pop
           for (i = strlen(node_name); i < sizeof(new_ptr->name); i++)
-            new_ptr->name[i] = 0;
-          new_ptr->name[MAX_NAME_LEN] = 0;  // null terminate truncated names
+            new_ptr->name[i] = '\0';
+          new_ptr->name[MAX_NAME_LEN] = '\0';
           new_ptr->child = 0;
           loadint16(&new_ptr->conglomerate_elt, &idx);
           if ((is_child && (usage == TreeUSAGE_ANY)) ||

--- a/treeshr/TreeAddNode.c
+++ b/treeshr/TreeAddNode.c
@@ -160,6 +160,7 @@ int _TreeAddNode(void *dbid, char const *name, int *nid_out, char usage)
 #pragma GCC diagnostic pop
           for (i = strlen(node_name); i < sizeof(new_ptr->name); i++)
             new_ptr->name[i] = 0;
+          new_ptr->name[MAX_NAME_LEN] = 0;  // null terminate truncated names
           new_ptr->child = 0;
           loadint16(&new_ptr->conglomerate_elt, &idx);
           if ((is_child && (usage == TreeUSAGE_ANY)) ||

--- a/treeshr/TreeRenameNode.c
+++ b/treeshr/TreeRenameNode.c
@@ -218,8 +218,8 @@ int _TreeRenameNode(void *dbid, int nid, char const *newname)
   strncpy(oldnode_ptr->name, newnode_name, sizeof(oldnode_ptr->name));
 #pragma GCC diagnostic pop
   for (i = strlen(newnode_name); i < (int) sizeof(oldnode_ptr->name); i++)
-    oldnode_ptr->name[i] = 0;
-  oldnode_ptr->name[MAX_NAME_LEN] = 0;  // null terminate truncated names
+    oldnode_ptr->name[i] = '\0';
+  oldnode_ptr->name[MAX_NAME_LEN] = '\0';
   if (is_child)
     status = TreeInsertChild(newnode, oldnode_ptr,
                              dblist->tree_info->header->sort_children);

--- a/treeshr/TreeRenameNode.c
+++ b/treeshr/TreeRenameNode.c
@@ -210,10 +210,16 @@ int _TreeRenameNode(void *dbid, int nid, char const *newname)
    Next we must connect this node up to its new
    destination.
   ***********************************************/
-  memcpy(oldnode_ptr->name, newnode_name, strlen(newnode_name));
-  if (strlen(newnode_name) < sizeof(oldnode_ptr->name))
-    memset(oldnode_ptr->name + strlen(newnode_name), 32,
-           sizeof(oldnode_ptr->name) - strlen(newnode_name));
+  // Set name with logic similar to _TreeAddNode()
+#pragma GCC diagnostic push
+#if defined __GNUC__ && 800 <= __GNUC__ * 100 + __GNUC_MINOR__
+  _Pragma("GCC diagnostic ignored \"-Wstringop-truncation\"")
+#endif
+  strncpy(oldnode_ptr->name, newnode_name, sizeof(oldnode_ptr->name));
+#pragma GCC diagnostic pop
+  for (i = strlen(newnode_name); i < (int) sizeof(oldnode_ptr->name); i++)
+    oldnode_ptr->name[i] = 0;
+  oldnode_ptr->name[MAX_NAME_LEN] = 0;  // null terminate truncated names
   if (is_child)
     status = TreeInsertChild(newnode, oldnode_ptr,
                              dblist->tree_info->header->sort_children);


### PR DESCRIPTION
Fixes issue with mdsplus8 not properly truncating node names longer than 63 visible characters.