### PR TITLE
Fix: eliminate segfaults caused by erroneous unmap (#2523)

### DIFF
--- a/treeshr/TreeOpen.c
+++ b/treeshr/TreeOpen.c
@@ -1122,6 +1122,7 @@ static int MapFile(int fd, TREE_INFO *info, int nomap)
 //    TreeEstablishRundownEvent(info);
     if (nomap)
     {
+      info->mapped = FALSE;
       if (header.version < 2)
       {
         int idx;


### PR DESCRIPTION
The root cause of the crash is that close_top_tree() assumes it is dealing with a memory mapped file, thus calls munmap() to free up memory.  However when mdsplus8 reads a Format-1 treefile, it does not map the file into memory.   Because of the in-memory expansion of the node names, mdsplus8 has to instead use calloc() to allocate memory and then read in the file.   Applying munmap() to an address generated by calloc(), trashes the memory pages and marks them as inaccessible.   Thus causing a variety of segfaults and crashes.

The bug appears to be intermittent simply because it all depends on where data and variables are allocated in the heap.

The fix is simple, namely to set the TREE_INFO "mapped" bit to FALSE when mdsplus8 is dealing with Format-1 treefiles.

Note that with mdsplus8 there are two ways to read a file: memory mapped for Format-2 files and the slower calloc() / read process for Format-1 files.   This fix assumes that the entire MDSplus codebase only uses TREE_INFO's "mapped" bit to indicate how a file has been loaded.

However, if portions of MDSplus use the "mapped" bit to merely indicate that a file has been loaded (regardless of method and file format), then this fix will have to be revisited.   In that case, an alternative is to add logic to close_top_tree() to prevent applying the munmap() call when dealing with Format-1 treefiles.   The munmap() call is in TreeOpen.c around line 422.

Because this fix potentially breaks other features of MDSplus (i.e., any code that checks the "mapped" bit), it must be thoroughly tested.   Stated another way, this fix should be considered tentative until the mdsplus8 branch passes the standard regression tests used on all production releases of MDSplus.