### PR TITLE
Intel Fortran (ifort) errors because the boolean type doesn't match the prototype

### DIFF
--- a/math/csint.f
+++ b/math/csint.f
@@ -254,7 +254,7 @@
       Do j = 1,ndata
             idx(j) = j
       Enddo
-      Call SVRGP(ndata,xdata,break,1,idx)
+      Call SVRGP(ndata,xdata,break,.true.,idx)
       Do j = 1,ndata
             c(1,idx(j)) = fdata(j)
             c(2,idx(j)) = dfdata(j)

--- a/math/dcsint.f
+++ b/math/dcsint.f
@@ -248,7 +248,7 @@
       Do j = 1,ndata
             idx(j) = j
       Enddo
-      Call DSVRGP(ndata,xdata,break,1,idx)
+      Call DSVRGP(ndata,xdata,break,.true.,idx)
       Do j = 1,ndata
             c(1,idx(j)) = fdata(j)
             c(2,idx(j)) = dfdata(j)


### PR DESCRIPTION
The prototype had explicit boolean .false. in it.  Just convert to use boolean.