### PR TITLE
Fix: mdsconnect incorrectly aborts on the first connection

### DIFF
--- a/tdi/remote/MdsConnect.fun
+++ b/tdi/remote/MdsConnect.fun
@@ -13,6 +13,6 @@ call:	_host  = Host name eg elpp1.epfl.ch or elpp1.epfl.ch:9000
       write(*,"Host taken from MDS_HOST ["//_host//"]");
    }
    _status = TdiShrExt->rMdsConnect(ref(_host//char(0)));
-   if (present(_abort) && _status == 0) abort();
+   if (present(_abort) && _status == -1) abort();
    return(_status);
 }


### PR DESCRIPTION
Somewhere along the line TdiShrExt->rMdsConnect started returning the connection number (starting at 0) instead of a status code.
So on an error, it actually returns -1, not 0.
If mdsconnect is called with _abort set, then it will abort() on the first connection (_status == 0).