### PR TITLE
Fix: remove numpy.str usage in MDSplus

### DIFF
--- a/python/MDSplus/mdsscalar.py
+++ b/python/MDSplus/mdsscalar.py
@@ -419,7 +419,7 @@ class String(Scalar):
 
     def __init__(self, value):
         super(String, self).__init__(value)
-        if not isinstance(self._value, _N.str):
+        if not isinstance(self._value, str):
             self._value = _ver.npstr(_ver.tostr(self._value))
 
     @property


### PR DESCRIPTION
In MDSplus python/mdsscalar.py, in the String class, resides the only usage of the numpy.str method. This method has been deprecated in numpy versions >= 1.24.

The fix consists in using Python's own str method instead.