### PR TITLE
Add RHEL9 build, remove xinetd package dependency, bug fixes

### DIFF
--- a/deploy/os/rhel9.opts
+++ b/deploy/os/rhel9.opts
@@ -1,0 +1,1 @@
+--platform=redhat --valgrind=memcheck,helgrind --sanitize=address,undefined,thread --dockerimage=mdsplus/builder:rhel9 --distname=el9 --arch=amd64

--- a/deploy/packaging/alpine/alpine_build_apks.py
+++ b/deploy/packaging/alpine/alpine_build_apks.py
@@ -128,13 +128,13 @@ def clean_ws():
 
 def getFiles(info, package):
     includes = []
-    for inc in package.getiterator('include'):
+    for inc in package.iter('include'):
         for inctype in inc.attrib:
             include = inc.attrib[inctype]
             if inctype != "dironly":
                 includes.append(include)
     excludes = []
-    for exc in package.getiterator('exclude'):
+    for exc in package.iter('exclude'):
         for exctype in exc.attrib:
             excludes.append(exc.attrib[exctype])
     if package.find("exclude_staticlibs") is not None:
@@ -157,7 +157,7 @@ def collectFiles(info, package):
 
 def getDependencies(info, root, package):
     depends = []
-    for require in package.getiterator("requires"):
+    for require in package.iter("requires"):
         if 'external' in require.attrib:
             pkg = common.external_package(info, root, require.attrib['package'])
             if pkg:
@@ -193,7 +193,7 @@ def build():
     if info['arch'] == noarch_builder:
         os.system("rm -Rf %s" % noarchdir)
         os.system("mkdir -p %s" % noarchdir)
-    for package in root.getiterator('package'):
+    for package in root.iter('package'):
         pkg = package.attrib['name']
         if pkg in pkg_exclusions:
             continue

--- a/deploy/packaging/linux.xml
+++ b/deploy/packaging/linux.xml
@@ -138,7 +138,6 @@ ldconfig -n /etc/ld.so.conf.d/mdsplus.conf
     <include file="/usr/local/mdsplus/lib/libMit*"/>
     <include file="/usr/local/mdsplus/lib/libMIT*"/>
     <include file="/usr/local/mdsplus/lib/libdc1394_support*"/>
-    <include file="/usr/local/mdsplus/lib/libdc1394_support*.so"/>
     <include file="/usr/local/mdsplus/lib/acq_root_filesystem*"/>
     <include file="/usr/local/mdsplus/uid/A*"/>
     <include file="/usr/local/mdsplus/uid/B*"/>
@@ -385,7 +384,6 @@ fi
 
   <package name="kernel" arch="noarch" summary="MDSplus core system" description="MDSplus core system">
     <requires package="kernel_bin"/>
-    <requires package="xinetd" external=""/>
     <include dironly="/usr/local/mdsplus/idl"/>
     <include file="/usr/local/mdsplus/MDSplus-License.txt"/>
     <include dir="/usr/local/mdsplus/etc"/>
@@ -431,21 +429,27 @@ then
   mkdir -p /usr/share/applications/mdsplus
   ln -sf $RPM_INSTALL_PREFIX/mdsplus/desktop/kernel /usr/share/applications/mdsplus/
 fi
-if [ ! -r /etc/xinetd.d/mdsip ]
+if [ -d /etc/xinetd.d ]
 then
-  cp $RPM_INSTALL_PREFIX/mdsplus/rpm/mdsipd.xinetd /etc/xinetd.d/mdsip
-  if ( ! grep '^mdsip[[:space:]]' /etc/services &gt;/dev/null 2&gt;&amp;1)
+  if [ ! -r /etc/xinetd.d/mdsip ]
   then
-    echo 'mdsip 8000/tcp # MDSplus mdsip service' &gt;&gt; /etc/services
+    cp $RPM_INSTALL_PREFIX/mdsplus/rpm/mdsipd.xinetd /etc/xinetd.d/mdsip
+    if ( ! grep '^mdsip[[:space:]]' /etc/services &gt;/dev/null 2&gt;&amp;1)
+    then
+      echo 'mdsip 8000/tcp # MDSplus mdsip service' &gt;&gt; /etc/services
+    fi
   fi
 fi
-if [ ! -r /etc/systemd/system/mdsip.socket ]
+if [ -d /etc/systemd/system/ ]
 then
-  cp $RPM_INSTALL_PREFIX/mdsplus/rpm/mdsip.socket /etc/systemd/system/mdsip.socket
-fi
-if [ ! -r /etc/systemd/system/mdsip@.service ]
-then
-  cp $RPM_INSTALL_PREFIX/mdsplus/rpm/mdsip@.service /etc/systemd/system/mdsip@.service
+  if [ ! -r /etc/systemd/system/mdsip.socket ]
+  then
+    cp $RPM_INSTALL_PREFIX/mdsplus/rpm/mdsip.socket /etc/systemd/system/mdsip.socket
+  fi
+  if [ ! -r /etc/systemd/system/mdsip@.service ]
+  then
+    cp $RPM_INSTALL_PREFIX/mdsplus/rpm/mdsip@.service /etc/systemd/system/mdsip@.service
+  fi
 fi
     </post>
     <preun>
@@ -833,42 +837,42 @@ rm -f /etc/ld.so.conf.d/mdsplus.conf 2&gt;/dev/null
  <external_packages dist="Ubuntu22">
    <numpy package="python3-numpy"/>
    <java package="java-runtime"/>
-   <xinetd package="busybox"/>
    <readline package="libreadline8"/>
  </external_packages>
 
  <external_packages dist="Ubuntu20">
    <numpy package="python3-numpy"/>
    <java package="java-runtime"/>
-   <xinetd package="busybox"/>
    <readline package="libreadline8"/>
  </external_packages>
 
  <external_packages dist="DebianBullseye">
    <numpy package="python3-numpy"/>
    <java package="java-runtime"/>
-   <xinetd package="busybox"/>
    <readline package="libreadline8"/>
  </external_packages>
 
  <external_packages dist="Ubuntu18">
    <numpy package="python3-numpy"/>
    <java package="java-runtime"/>
-   <xinetd package="busybox"/>
    <readline package="libreadline7"/>
+ </external_packages>
+
+ <external_packages dist="el9">
+   <numpy package="python3-numpy"/>
+   <java/>
+   <readline/>
  </external_packages>
 
  <external_packages dist="el8">
    <numpy package="python3-numpy"/>
    <java/>
-   <xinetd/>
    <readline/>
  </external_packages>
 
  <external_packages dist="el7">
    <python-numpy package="numpy"/>
    <java/>
-   <xinetd/>
    <readline/>
  </external_packages>
 
@@ -876,7 +880,6 @@ rm -f /etc/ld.so.conf.d/mdsplus.conf 2&gt;/dev/null
  <external_packages platform="redhat">
    <numpy/>
    <java/>
-   <xinetd/>
    <readline/>
  </external_packages>
 
@@ -889,7 +892,6 @@ rm -f /etc/ld.so.conf.d/mdsplus.conf 2&gt;/dev/null
  <external_packages platform="debian">
    <numpy package="python-numpy"/>
    <java package="java-runtime"/>
-   <xinetd package="busybox"/>
  </external_packages>
 
 </deploy>

--- a/deploy/packaging/redhat/redhat_build_rpms.py
+++ b/deploy/packaging/redhat/redhat_build_rpms.py
@@ -97,7 +97,7 @@ def build():
     root = common.get_root()
     bin_packages = list()
     noarch_packages = list()
-    for package in root.getiterator('package'):
+    for package in root.iter('package'):
         attr = package.attrib
         if attr["arch"] == "noarch":
             noarch_packages.append(package)
@@ -105,7 +105,7 @@ def build():
             bin_packages.append(package)
     architectures = [{"target": "x86_64-linux",
                       "bits": 64, "arch_t": ".x86_64"}]
-    if info['dist'] != 'el8':
+    if info['dist'] != 'el8' and info['dist'] != 'el9':
         architectures.append(
             {"target": "i686-linux", "bits": 32, "arch_t": ".i686"})
 
@@ -123,17 +123,17 @@ def build():
             info['description'] = package.attrib['description']
             out, specfilename = tempfile.mkstemp()
             common.writeb(out, rpmspec % info)
-            for require in package.getiterator("requires"):
+            for require in package.iter("requires"):
                 doRequire(info, out, root, require)
             common.writeb(out, pckspec % info)
-            for inc in package.getiterator('include'):
+            for inc in package.iter('include'):
                 for inctype in inc.attrib:
                     include = fixFilename(info, inc.attrib[inctype])
                     if inctype == "dironly":
                         common.writeb(out, "%%dir %s\n" % include)
                     else:
                         common.writeb(out, "%s\n" % include)
-            for exc in package.getiterator('exclude'):
+            for exc in package.iter('exclude'):
                 for exctype in exc.attrib:
                     exclude = fixFilename(info, exc.attrib[exctype])
                     common.writeb(out, "%%exclude %s\n" % exclude)
@@ -179,18 +179,18 @@ def build():
         info['description'] = package.attrib['description']
         out, specfilename = tempfile.mkstemp()
         common.writeb(out, rpmspec % info)
-        for require in package.getiterator("requires"):
+        for require in package.iter("requires"):
             doRequire(info, out, root, require)
         common.writeb(out, "Buildarch: noarch\n")
         common.writeb(out, pckspec % info)
-        for inc in package.getiterator('include'):
+        for inc in package.iter('include'):
             for inctype in inc.attrib:
                 include = fixFilename(info, inc.attrib[inctype])
                 if inctype == "dironly":
                     common.writeb(out, "%%dir %s\n" % include)
                 else:
                     common.writeb(out, "%s\n" % include)
-        for exc in package.getiterator('exclude'):
+        for exc in package.iter('exclude'):
             for exctype in exc.attrib:
                 exclude = fixFilename(info, exc.attrib[exctype])
                 common.writeb(out, "%%exclude %s\n" % exclude)


### PR DESCRIPTION
Add rhel9.opts to use mdsplus/builder:rhel9 (which is based on Rocky Linux 9.1, as CentOS 9 does not exist)

Remove xinetd as a package requirement in linux.xml.
If `/etc/xinet.d/` is present, it will still install the config files, but the packages will no longer depend on it. This is because we now have systemd files as an alternative, and RHEL9 has officialy dropped support for it, so this seems like a good time to cut ties.

When installing the `mdsplus-*-kernel` package on a system without xinetd or systemd, the post install script will throw errors trying to copy files. Instead, we wrap them in if statements to only copy the files if those directories exist.

Replace `.getiterator()` with `.iter()` to fix error when using `xml.ElementTree` with python3 in `redhat_build_rpms.py` and `alpine_build_apks.py` This already seemed to be fixed in `debian_build_debs.py`

Removed seemingly duplicate include for `libdc1394_support*.so` in `linux.xml`