### PR TITLE
Fix: standardizing on pass by reference for exception handling

### DIFF
--- a/device_support/basler/BASLERACA.cpp
+++ b/device_support/basler/BASLERACA.cpp
@@ -877,7 +877,7 @@ int BASLER_ACA::startFramesAcquisition()
     Data *nodeData = t0Node->getData();
     timeStamp0 = (int64_t)nodeData->getLong();
   }
-  catch (MdsException *exc)
+  catch (const MdsException & exc)
   {
     sprintf(error, "%s: Error getting frame0 time\n", this->ipAddress);
   }
@@ -892,7 +892,7 @@ int BASLER_ACA::startFramesAcquisition()
       Data *nodeData = tStartOffset->getData();
       timeOffset = (float)nodeData->getFloatArray()[0];
     }
-    catch (MdsException *exc)
+    catch (const MdsException & exc)
     {
       sprintf(error,
               "%s: Error getting timebaseNid (offset time set to 0.0s)\n",

--- a/device_support/basler/BASLERACA.cpp
+++ b/device_support/basler/BASLERACA.cpp
@@ -877,7 +877,7 @@ int BASLER_ACA::startFramesAcquisition()
     Data *nodeData = t0Node->getData();
     timeStamp0 = (int64_t)nodeData->getLong();
   }
-  catch (const MdsException & exc)
+  catch (const MdsException &exc)
   {
     sprintf(error, "%s: Error getting frame0 time\n", this->ipAddress);
   }
@@ -892,7 +892,7 @@ int BASLER_ACA::startFramesAcquisition()
       Data *nodeData = tStartOffset->getData();
       timeOffset = (float)nodeData->getFloatArray()[0];
     }
-    catch (const MdsException & exc)
+    catch (const MdsException &exc)
     {
       sprintf(error,
               "%s: Error getting timebaseNid (offset time set to 0.0s)\n",

--- a/device_support/basler/main.cpp
+++ b/device_support/basler/main.cpp
@@ -48,9 +48,9 @@ int main(int argc, char **argv)
     node = tree->getNode((char *)"\\BASLER::TOP:BASLER:FRAME0_TIME");
     frame0TimeNid = node->getNid();
   }
-  catch (const MdsException & exc)
+  catch (const MdsException &exc)
   {
-    std::cout << "ERROR reading data" << exc << "\n";
+    std::cout << "ERROR reading data" << exc.what() << "\n";
   }
 
   // printf("frame node path: %s\n", node->getPath());

--- a/device_support/basler/main.cpp
+++ b/device_support/basler/main.cpp
@@ -48,9 +48,9 @@ int main(int argc, char **argv)
     node = tree->getNode((char *)"\\BASLER::TOP:BASLER:FRAME0_TIME");
     frame0TimeNid = node->getNid();
   }
-  catch (MdsException *exc)
+  catch (const MdsException & exc)
   {
-    std::cout << "ERROR reading data" << exc->what() << "\n";
+    std::cout << "ERROR reading data" << exc << "\n";
   }
 
   // printf("frame node path: %s\n", node->getPath());

--- a/device_support/caen/caenInterface.cpp
+++ b/device_support/caen/caenInterface.cpp
@@ -200,9 +200,9 @@ public:
       deleteData(endTime);
       deleteData(segCount);
     }
-    catch (const MdsException & exc)
+    catch (const MdsException &exc)
     {
-      printf("Cannot put segment: %s\n", exc);
+      printf("Cannot put segment: %s\n", exc.what());
     }
     delete dataNode;
     delete clockNode;
@@ -366,9 +366,9 @@ extern "C" void openTree(char *name, int shot, void **treePtr)
     Tree *tree = new Tree(name, shot);
     *treePtr = (void *)tree;
   }
-  catch (const MdsException & exc)
+  catch (const MdsException &exc)
   {
-    printf("Cannot open tree %s %d: %s\n", name, shot, exc);
+    printf("Cannot open tree %s %d: %s\n", name, shot, exc.what());
   }
 }
 

--- a/device_support/caen/caenInterface.cpp
+++ b/device_support/caen/caenInterface.cpp
@@ -200,9 +200,9 @@ public:
       deleteData(endTime);
       deleteData(segCount);
     }
-    catch (MdsException *exc)
+    catch (const MdsException & exc)
     {
-      printf("Cannot put segment: %s\n", exc->what());
+      printf("Cannot put segment: %s\n", exc);
     }
     delete dataNode;
     delete clockNode;
@@ -366,9 +366,9 @@ extern "C" void openTree(char *name, int shot, void **treePtr)
     Tree *tree = new Tree(name, shot);
     *treePtr = (void *)tree;
   }
-  catch (MdsException *exc)
+  catch (const MdsException & exc)
   {
-    printf("Cannot open tree %s %d: %s\n", name, shot, exc->what());
+    printf("Cannot open tree %s %d: %s\n", name, shot, exc);
   }
 }
 

--- a/device_support/camera_utils/cammdsutils.cpp
+++ b/device_support/camera_utils/cammdsutils.cpp
@@ -168,9 +168,9 @@ public:
           metaNode->makeSegment(time, time, dim, (Array *)metaData);
         }
       }
-      catch (MdsException *exc)
+      catch (const MdsException & exc)
       {
-        cout << "ERROR WRITING SEGMENT: " << exc->what() << "\n";
+        cout << "ERROR WRITING SEGMENT: " << exc << "\n";
       }
       deleteData(data);
       deleteData(time);
@@ -196,9 +196,9 @@ public:
       {
         dim = compileWithArgs("[$1]", (Tree *)treePtr, 1, time);
       }
-      catch (MdsException *exc)
+      catch (const MdsException & exc)
       {
-        cout << "ERROR CompileWithArgs: " << exc->what() << "\n";
+        cout << "ERROR CompileWithArgs: " << exc << "\n";
       }
 
       try
@@ -212,9 +212,9 @@ public:
           metaNode->makeSegment(time, time, dim, (Array *)metaData);
         }
       }
-      catch (MdsException *exc)
+      catch (const MdsException & exc)
       {
-        cout << "ERROR WRITING SEGMENT " << exc->what() << "\n";
+        cout << "ERROR WRITING SEGMENT " << exc << "\n";
       }
 
       try
@@ -233,9 +233,9 @@ public:
         else if (pixelSize <= 32)
           delete (int *)frame;
       }
-      catch (MdsException *exc)
+      catch (const MdsException & exc)
       {
-        cout << "ERROR deleting data" << exc->what() << "\n";
+        cout << "ERROR deleting data" << exc << "\n";
       }
     }
   }
@@ -426,9 +426,9 @@ int camOpenTree(char *treeName, int shot, void **treePtr)
     *treePtr = (void *)tree;
     return 0;
   }
-  catch (MdsException *exc)
+  catch (const MdsException & exc)
   {
-    cout << "Error opening Tree " << treeName << ": " << exc->what() << "\n";
+    cout << "Error opening Tree " << treeName << ": " << exc << "\n";
     return -1;
   }
 }

--- a/device_support/camera_utils/cammdsutils.cpp
+++ b/device_support/camera_utils/cammdsutils.cpp
@@ -168,9 +168,9 @@ public:
           metaNode->makeSegment(time, time, dim, (Array *)metaData);
         }
       }
-      catch (const MdsException & exc)
+      catch (const MdsException &exc)
       {
-        cout << "ERROR WRITING SEGMENT: " << exc << "\n";
+        cout << "ERROR WRITING SEGMENT: " << exc.what() << "\n";
       }
       deleteData(data);
       deleteData(time);
@@ -196,9 +196,9 @@ public:
       {
         dim = compileWithArgs("[$1]", (Tree *)treePtr, 1, time);
       }
-      catch (const MdsException & exc)
+      catch (const MdsException &exc)
       {
-        cout << "ERROR CompileWithArgs: " << exc << "\n";
+        cout << "ERROR CompileWithArgs: " << exc.what() << "\n";
       }
 
       try
@@ -212,9 +212,9 @@ public:
           metaNode->makeSegment(time, time, dim, (Array *)metaData);
         }
       }
-      catch (const MdsException & exc)
+      catch (const MdsException &exc)
       {
-        cout << "ERROR WRITING SEGMENT " << exc << "\n";
+        cout << "ERROR WRITING SEGMENT " << exc.what() << "\n";
       }
 
       try
@@ -233,9 +233,9 @@ public:
         else if (pixelSize <= 32)
           delete (int *)frame;
       }
-      catch (const MdsException & exc)
+      catch (const MdsException &exc)
       {
-        cout << "ERROR deleting data" << exc << "\n";
+        cout << "ERROR deleting data" << exc.what() << "\n";
       }
     }
   }
@@ -426,9 +426,9 @@ int camOpenTree(char *treeName, int shot, void **treePtr)
     *treePtr = (void *)tree;
     return 0;
   }
-  catch (const MdsException & exc)
+  catch (const MdsException &exc)
   {
-    cout << "Error opening Tree " << treeName << ": " << exc << "\n";
+    cout << "Error opening Tree " << treeName << ": " << exc.what() << "\n";
     return -1;
   }
 }

--- a/device_support/flir/FLIRSC65X.cpp
+++ b/device_support/flir/FLIRSC65X.cpp
@@ -1972,7 +1972,7 @@ int FLIR_SC65X::startFramesAcquisition()
     Data *nodeData = t0Node->getData();
     timeStamp0 = (int64_t)nodeData->getLong();
   }
-  catch (const MdsException & exc)
+  catch (const MdsException &exc)
   {
     printf("Error getting frame0 time\n");
   }

--- a/device_support/flir/FLIRSC65X.cpp
+++ b/device_support/flir/FLIRSC65X.cpp
@@ -1972,7 +1972,7 @@ int FLIR_SC65X::startFramesAcquisition()
     Data *nodeData = t0Node->getData();
     timeStamp0 = (int64_t)nodeData->getLong();
   }
-  catch (MdsException *exc)
+  catch (const MdsException & exc)
   {
     printf("Error getting frame0 time\n");
   }

--- a/device_support/flir/main.cpp
+++ b/device_support/flir/main.cpp
@@ -69,9 +69,9 @@ int main(int argc, char **argv)
         tree->getNode((char *)"\\CAMERATEST::TOP:POINTGRAY:FRAMES_METAD");
     dataNid = node->getNid(); // Node id to save the acquired frames
   }
-  catch (const MdsException & exc)
+  catch (const MdsException &exc)
   {
-    std::cout << "ERROR reading data" << exc << "\n";
+    std::cout << "ERROR reading data" << exc.what() << "\n";
   }
 
   printf("frame node path: %s\n", node->getPath());
@@ -113,9 +113,9 @@ int main(int argc, char **argv)
     framePtr = (frameData)->getShortArray(dataDims);
     framePtrMeta = (frameDataMeta)->getByteArray(dataDimsMeta);
   }
-  catch (const MdsException & exc)
+  catch (const MdsException &exc)
   {
-    std::cout << "ERROR reading data" << exc << "\n";
+    std::cout << "ERROR reading data" << exc.what() << "\n";
   }
 
   FLIR_SC65X *FlirCam;

--- a/device_support/flir/main.cpp
+++ b/device_support/flir/main.cpp
@@ -69,9 +69,9 @@ int main(int argc, char **argv)
         tree->getNode((char *)"\\CAMERATEST::TOP:POINTGRAY:FRAMES_METAD");
     dataNid = node->getNid(); // Node id to save the acquired frames
   }
-  catch (MdsException *exc)
+  catch (const MdsException & exc)
   {
-    std::cout << "ERROR reading data" << exc->what() << "\n";
+    std::cout << "ERROR reading data" << exc << "\n";
   }
 
   printf("frame node path: %s\n", node->getPath());
@@ -113,9 +113,9 @@ int main(int argc, char **argv)
     framePtr = (frameData)->getShortArray(dataDims);
     framePtrMeta = (frameDataMeta)->getByteArray(dataDimsMeta);
   }
-  catch (MdsException *exc)
+  catch (const MdsException & exc)
   {
-    std::cout << "ERROR reading data" << exc->what() << "\n";
+    std::cout << "ERROR reading data" << exc << "\n";
   }
 
   FLIR_SC65X *FlirCam;

--- a/device_support/national/AsyncStoreManager.cpp
+++ b/device_support/national/AsyncStoreManager.cpp
@@ -317,9 +317,9 @@ std::cout << "CHIAMO LA FUN.." << std::endl;
       /* Send Event on Segment update <TreeName>_<DeviceNodeName>_CH<numchannel>*/
       // sendChannelSegmentPutEvent(dataNode);
     }
-    catch (MdsException *exc)
+    catch (const MdsException & exc)
     {
-      printf("Cannot put segment: %s\n", exc->what());
+      printf("Cannot put segment: %s\n", exc);
     }
     delete clockNode;
   }

--- a/device_support/national/AsyncStoreManager.cpp
+++ b/device_support/national/AsyncStoreManager.cpp
@@ -126,7 +126,7 @@ void SaveItem::save()
         delete[] samples;
         delete[] times;
       }
-      catch (MdsException &exc)
+      catch (const MdsException &exc)
       {
         printf("Cannot convert stream sample: %s\n", exc.what());
       }
@@ -221,7 +221,7 @@ std::cout << "CHIAMO LA FUN.." << std::endl;
           else
             dataNode->beginSegment(startTime, endTime, dim, fData);
         }
-        catch (MdsException &exc)
+        catch (const MdsException &exc)
         {
           printf("BEGIN SEGMENT FAILED FOR NODE %s: %s\n",
                  dataNode->getFullPath(), exc.what());
@@ -245,7 +245,7 @@ std::cout << "CHIAMO LA FUN.." << std::endl;
           else
             dataNode->beginSegment(startTime, endTime, dim, fData);
         }
-        catch (MdsException &exc)
+        catch (const MdsException &exc)
         {
           printf("BEGIN SEGMENT FAILED FOR NODE %s: %s\n",
                  dataNode->getFullPath(), exc.what());
@@ -280,7 +280,7 @@ std::cout << "CHIAMO LA FUN.." << std::endl;
           else
             dataNode->putSegment(data, -1);
         }
-        catch (MdsException &exc)
+        catch (const MdsException &exc)
         {
           printf("PUT SEGMENT FAILED FOR NODE: %s: %s\n", dataNode->getFullPath(),
                  exc.what());
@@ -302,7 +302,7 @@ std::cout << "CHIAMO LA FUN.." << std::endl;
           else
             dataNode->putSegment(data, -1);
         }
-        catch (MdsException &exc)
+        catch (const MdsException &exc)
         {
           printf("PUT SEGMENT FAILED FOR NODE: %s: %s\n", dataNode->getFullPath(),
                  exc.what());
@@ -317,9 +317,9 @@ std::cout << "CHIAMO LA FUN.." << std::endl;
       /* Send Event on Segment update <TreeName>_<DeviceNodeName>_CH<numchannel>*/
       // sendChannelSegmentPutEvent(dataNode);
     }
-    catch (const MdsException & exc)
+    catch (const MdsException &exc)
     {
-      printf("Cannot put segment: %s\n", exc);
+      printf("Cannot put segment: %s\n", exc.what());
     }
     delete clockNode;
   }

--- a/device_support/national/AsyncStoreManager.h
+++ b/device_support/national/AsyncStoreManager.h
@@ -87,9 +87,9 @@ private:
               (tokens[1].substr(8)).data());
       Event::setevent(event);
     }
-    catch (const MdsException & exc)
+    catch (const MdsException &exc)
     {
-      printf("Send Event Error: %s\n", exc);
+      printf("Send Event Error: %s\n", exc.what());
     }
   }
 

--- a/device_support/national/AsyncStoreManager.h
+++ b/device_support/national/AsyncStoreManager.h
@@ -87,9 +87,9 @@ private:
               (tokens[1].substr(8)).data());
       Event::setevent(event);
     }
-    catch (MdsException *exc)
+    catch (const MdsException & exc)
     {
-      printf("Send Event Error: %s\n", exc->what());
+      printf("Send Event Error: %s\n", exc);
     }
   }
 

--- a/device_support/national/NiInterface.cpp
+++ b/device_support/national/NiInterface.cpp
@@ -267,9 +267,9 @@ void openTree(char *name, int shot, void **treePtr)
     *treePtr = (void *)tree;
     TreeNode *n = tree->getNode("\\TOP");
   }
-  catch (MdsException *exc)
+  catch (const MdsException & exc)
   {
-    printf("Cannot open tree %s %d: %s\n", name, shot, exc->what());
+    printf("Cannot open tree %s %d: %s\n", name, shot, exc);
   }
 }
 
@@ -279,7 +279,7 @@ void closeTree(void *treePtr)
   {
     delete ((Tree *)treePtr);
   }
-  catch (MdsException *exc)
+  catch (const MdsException & exc)
   {
     printf("Cannot close tree %s %d: %s\n", exc->what());
   }
@@ -577,7 +577,7 @@ int xseriesReadAndSaveAllChannels(int aiFd, int nChan, void *chanFdPtr,
         Data *streamGainData = dataNode->getExtendedAttribute("STREAM_GAIN");
         streamGains[chan] = streamGainData->getFloat();
       }
-      catch (MdsException &exc)
+      catch (const MdsException & exc)
       {
         streamGains[chan] = 1;
       }
@@ -587,12 +587,12 @@ int xseriesReadAndSaveAllChannels(int aiFd, int nChan, void *chanFdPtr,
             dataNode->getExtendedAttribute("STREAM_OFFSET");
         streamOffsets[chan] = streamOffsetData->getFloat();
       }
-      catch (MdsException &exc)
+      catch (const MdsException & exc)
       {
         streamOffsets[chan] = 0;
       }
     }
-    catch (MdsException &exc)
+    catch (const MdsException & exc)
     {
       streamNames[chan] = NULL;
       streamGains[chan] = 0;
@@ -616,7 +616,7 @@ int xseriesReadAndSaveAllChannels(int aiFd, int nChan, void *chanFdPtr,
       coeffs[chanIdx] = rangeData->getFloatArray(&numCoeffs[chanIdx]);
       deleteData(rangeData);
     }
-    catch (MdsException &exc)
+    catch (const MdsException & exc)
     {
       printf("%s\n", exc.what());
     }
@@ -927,7 +927,7 @@ int pxi6259_readAndSaveAllChannels(
           Data *streamGainData = currNode->getExtendedAttribute("STREAM_GAIN");
           streamGains[i] = streamGainData->getFloat();
         }
-        catch (MdsException &exc)
+        catch (const MdsException & exc)
         {
           streamGains[i] = 1;
         }
@@ -937,12 +937,12 @@ int pxi6259_readAndSaveAllChannels(
               currNode->getExtendedAttribute("STREAM_OFFSET");
           streamOffsets[i] = streamOffsetData->getFloat();
         }
-        catch (MdsException &exc)
+        catch (const MdsException & exc)
         {
           streamOffsets[i] = 0;
         }
       }
-      catch (MdsException &exc)
+      catch (const MdsException & exc)
       {
         streamNames[i] = NULL;
         streamGains[i] = 0;
@@ -956,7 +956,7 @@ int pxi6259_readAndSaveAllChannels(
         delete currNode;
       }
     }
-    catch (MdsException &exc)
+    catch (const MdsException & exc)
     {
       printf("Error deleting data nodes\n");
     }
@@ -1719,7 +1719,7 @@ int temperatureProbeControl(uint32_t boardID, uint32_t *inChan, int numChan,
     errorNode = t->getNode((char *)"\\IPP_TC_TREND::ERROR");
     vRefNode = t->getNode((char *)"\\IPP_TC_TREND::VREF");
   }
-  catch (MdsException *exc)
+  catch (const MdsException & exc)
   {
     printf("%s\n", exc->what());
     return -1;
@@ -1866,9 +1866,9 @@ int temperatureProbeControl(uint32_t boardID, uint32_t *inChan, int numChan,
         currData = new Float32(vRef);
         vRefNode->putRow(currData, &currTime);
       }
-      catch (MdsException *exc)
+      catch (const MdsException & exc)
       {
-        printf("%s\n", exc->what());
+        printf("%s\n", exc);
         error = 1;
         goto out;
       }
@@ -2723,9 +2723,9 @@ public:
         MDSplus::deleteData(endData);
         MDSplus::deleteData(dimData);
       }
-      catch (MDSplus::MdsException &exc)
+      catch (const MDSplus::MdsException & exc)
       {
-        std::cout << "Error in BeginSegment: " << exc.what() << std::endl;
+        std::cout << "Error in BeginSegment: " << exc << std::endl;
       }
       break;
     case SEGMENT_OP_MAKE:
@@ -2738,9 +2738,9 @@ public:
         MDSplus::deleteData(dimData);
         MDSplus::deleteData(segData);
       }
-      catch (MDSplus::MdsException &exc)
+      catch (const MDSplus::MdsException & exc)
       {
-        std::cout << "Error in MakeSegment: " << exc.what() << std::endl;
+        std::cout << "Error in MakeSegment: " << exc << std::endl;
       }
       break;
     case SEGMENT_OP_UPDATE:
@@ -2752,9 +2752,9 @@ public:
         MDSplus::deleteData(endData);
         MDSplus::deleteData(dimData);
       }
-      catch (MDSplus::MdsException &exc)
+      catch (const MDSplus::MdsException & exc)
       {
-        std::cout << "Error in UpdateSegment: " << exc.what() << std::endl;
+        std::cout << "Error in UpdateSegment: " << exc << std::endl;
       }
       break;
     case SEGMENT_OP_PUT:
@@ -2764,9 +2764,9 @@ public:
         node->putSegment(segData, -1);
         MDSplus::deleteData(segData);
       }
-      catch (MDSplus::MdsException &exc)
+      catch (const MDSplus::MdsException & exc)
       {
-        std::cout << "Error in PutSegment: " << exc.what() << std::endl;
+        std::cout << "Error in PutSegment: " << exc << std::endl;
       }
       break;
     }
@@ -3525,7 +3525,7 @@ int pxi6259EV_readAndSaveAllChannels(
       treeNodes[i] = new TreeNode(dataNid[i], (Tree *)treePtr);
       treeNodes[i]->deleteData();
     }
-    catch (MdsException &exc)
+    catch (const MdsException & exc)
     {
       printf("Error deleting data nodes\n");
     }
@@ -3669,7 +3669,7 @@ int pxi6368EV_readAndSaveAllChannels(
       treeNodes[i] = new TreeNode(dataNid[i], (Tree *)treePtr);
       treeNodes[i]->deleteData();
     }
-    catch (MdsException &exc)
+    catch (const MdsException & exc)
     {
       printf("Error deleting data nodes\n");
     }
@@ -3696,9 +3696,9 @@ int pxi6368EV_readAndSaveAllChannels(
       coeffs[chan] = rangeData->getFloatArray(&numCoeffs[chan]);
       deleteData(rangeData);
     }
-    catch (MdsException &exc)
+    catch (const MdsException & exc)
     {
-      printf("%s\n", exc.what());
+      printf("%s\n", exc);
     }
     if (isBurst[chan])
     {

--- a/device_support/national/NiInterface.cpp
+++ b/device_support/national/NiInterface.cpp
@@ -267,9 +267,9 @@ void openTree(char *name, int shot, void **treePtr)
     *treePtr = (void *)tree;
     TreeNode *n = tree->getNode("\\TOP");
   }
-  catch (const MdsException & exc)
+  catch (const MdsException &exc)
   {
-    printf("Cannot open tree %s %d: %s\n", name, shot, exc);
+    printf("Cannot open tree %s %d: %s\n", name, shot, exc.what());
   }
 }
 
@@ -279,9 +279,9 @@ void closeTree(void *treePtr)
   {
     delete ((Tree *)treePtr);
   }
-  catch (const MdsException & exc)
+  catch (const MdsException &exc)
   {
-    printf("Cannot close tree %s %d: %s\n", exc->what());
+    printf("Cannot close tree %s %d: %s\n", exc.what());
   }
 }
 
@@ -577,7 +577,7 @@ int xseriesReadAndSaveAllChannels(int aiFd, int nChan, void *chanFdPtr,
         Data *streamGainData = dataNode->getExtendedAttribute("STREAM_GAIN");
         streamGains[chan] = streamGainData->getFloat();
       }
-      catch (const MdsException & exc)
+      catch (const MdsException &exc)
       {
         streamGains[chan] = 1;
       }
@@ -587,12 +587,12 @@ int xseriesReadAndSaveAllChannels(int aiFd, int nChan, void *chanFdPtr,
             dataNode->getExtendedAttribute("STREAM_OFFSET");
         streamOffsets[chan] = streamOffsetData->getFloat();
       }
-      catch (const MdsException & exc)
+      catch (const MdsException &exc)
       {
         streamOffsets[chan] = 0;
       }
     }
-    catch (const MdsException & exc)
+    catch (const MdsException &exc)
     {
       streamNames[chan] = NULL;
       streamGains[chan] = 0;
@@ -616,7 +616,7 @@ int xseriesReadAndSaveAllChannels(int aiFd, int nChan, void *chanFdPtr,
       coeffs[chanIdx] = rangeData->getFloatArray(&numCoeffs[chanIdx]);
       deleteData(rangeData);
     }
-    catch (const MdsException & exc)
+    catch (const MdsException &exc)
     {
       printf("%s\n", exc.what());
     }
@@ -927,7 +927,7 @@ int pxi6259_readAndSaveAllChannels(
           Data *streamGainData = currNode->getExtendedAttribute("STREAM_GAIN");
           streamGains[i] = streamGainData->getFloat();
         }
-        catch (const MdsException & exc)
+        catch (const MdsException &exc)
         {
           streamGains[i] = 1;
         }
@@ -937,12 +937,12 @@ int pxi6259_readAndSaveAllChannels(
               currNode->getExtendedAttribute("STREAM_OFFSET");
           streamOffsets[i] = streamOffsetData->getFloat();
         }
-        catch (const MdsException & exc)
+        catch (const MdsException &exc)
         {
           streamOffsets[i] = 0;
         }
       }
-      catch (const MdsException & exc)
+      catch (const MdsException &exc)
       {
         streamNames[i] = NULL;
         streamGains[i] = 0;
@@ -956,7 +956,7 @@ int pxi6259_readAndSaveAllChannels(
         delete currNode;
       }
     }
-    catch (const MdsException & exc)
+    catch (const MdsException &exc)
     {
       printf("Error deleting data nodes\n");
     }
@@ -1719,9 +1719,9 @@ int temperatureProbeControl(uint32_t boardID, uint32_t *inChan, int numChan,
     errorNode = t->getNode((char *)"\\IPP_TC_TREND::ERROR");
     vRefNode = t->getNode((char *)"\\IPP_TC_TREND::VREF");
   }
-  catch (const MdsException & exc)
+  catch (const MdsException &exc)
   {
-    printf("%s\n", exc->what());
+    printf("%s\n", exc.what());
     return -1;
   }
 
@@ -1866,9 +1866,9 @@ int temperatureProbeControl(uint32_t boardID, uint32_t *inChan, int numChan,
         currData = new Float32(vRef);
         vRefNode->putRow(currData, &currTime);
       }
-      catch (const MdsException & exc)
+      catch (const MdsException &exc)
       {
-        printf("%s\n", exc);
+        printf("%s\n", exc.what());
         error = 1;
         goto out;
       }
@@ -2723,9 +2723,9 @@ public:
         MDSplus::deleteData(endData);
         MDSplus::deleteData(dimData);
       }
-      catch (const MDSplus::MdsException & exc)
+      catch (const MDSplus::MdsException &exc)
       {
-        std::cout << "Error in BeginSegment: " << exc << std::endl;
+        std::cout << "Error in BeginSegment: " << exc.what() << std::endl;
       }
       break;
     case SEGMENT_OP_MAKE:
@@ -2738,9 +2738,9 @@ public:
         MDSplus::deleteData(dimData);
         MDSplus::deleteData(segData);
       }
-      catch (const MDSplus::MdsException & exc)
+      catch (const MDSplus::MdsException &exc)
       {
-        std::cout << "Error in MakeSegment: " << exc << std::endl;
+        std::cout << "Error in MakeSegment: " << exc.what() << std::endl;
       }
       break;
     case SEGMENT_OP_UPDATE:
@@ -2752,9 +2752,9 @@ public:
         MDSplus::deleteData(endData);
         MDSplus::deleteData(dimData);
       }
-      catch (const MDSplus::MdsException & exc)
+      catch (const MDSplus::MdsException &exc)
       {
-        std::cout << "Error in UpdateSegment: " << exc << std::endl;
+        std::cout << "Error in UpdateSegment: " << exc.what() << std::endl;
       }
       break;
     case SEGMENT_OP_PUT:
@@ -2764,9 +2764,9 @@ public:
         node->putSegment(segData, -1);
         MDSplus::deleteData(segData);
       }
-      catch (const MDSplus::MdsException & exc)
+      catch (const MDSplus::MdsException &exc)
       {
-        std::cout << "Error in PutSegment: " << exc << std::endl;
+        std::cout << "Error in PutSegment: " << exc.what() << std::endl;
       }
       break;
     }
@@ -3525,7 +3525,7 @@ int pxi6259EV_readAndSaveAllChannels(
       treeNodes[i] = new TreeNode(dataNid[i], (Tree *)treePtr);
       treeNodes[i]->deleteData();
     }
-    catch (const MdsException & exc)
+    catch (const MdsException &exc)
     {
       printf("Error deleting data nodes\n");
     }
@@ -3669,7 +3669,7 @@ int pxi6368EV_readAndSaveAllChannels(
       treeNodes[i] = new TreeNode(dataNid[i], (Tree *)treePtr);
       treeNodes[i]->deleteData();
     }
-    catch (const MdsException & exc)
+    catch (const MdsException &exc)
     {
       printf("Error deleting data nodes\n");
     }
@@ -3696,9 +3696,9 @@ int pxi6368EV_readAndSaveAllChannels(
       coeffs[chan] = rangeData->getFloatArray(&numCoeffs[chan]);
       deleteData(rangeData);
     }
-    catch (const MdsException & exc)
+    catch (const MdsException &exc)
     {
-      printf("%s\n", exc);
+      printf("%s\n", exc.what());
     }
     if (isBurst[chan])
     {

--- a/device_support/national/cRioFAUfunction.cpp
+++ b/device_support/national/cRioFAUfunction.cpp
@@ -100,9 +100,9 @@ public:
       currSize);
       */
     }
-    catch (MdsException *exc)
+    catch (const MdsException & exc)
     {
-      printf("Class FAUSaveItem: Error saving data  %s\n", exc->what());
+      printf("Class FAUSaveItem: Error saving data  %s\n", exc);
     }
   }
 };
@@ -597,9 +597,9 @@ int fauSaveAcqData(NiFpga_Session session, double tickPeriod, double trigTime,
       {
         currNode[i] = new TreeNode(dataNids[i], (Tree *)treePtr);
       }
-      catch (MdsException *exc)
+      catch (const MdsException & exc)
       {
-        printf("Error collecting data nodes %s\n", exc->what());
+        printf("Error collecting data nodes %s\n", exc);
       }
     }
 

--- a/device_support/national/cRioFAUfunction.cpp
+++ b/device_support/national/cRioFAUfunction.cpp
@@ -100,9 +100,9 @@ public:
       currSize);
       */
     }
-    catch (const MdsException & exc)
+    catch (const MdsException &exc)
     {
-      printf("Class FAUSaveItem: Error saving data  %s\n", exc);
+      printf("Class FAUSaveItem: Error saving data  %s\n", exc.what());
     }
   }
 };
@@ -597,9 +597,9 @@ int fauSaveAcqData(NiFpga_Session session, double tickPeriod, double trigTime,
       {
         currNode[i] = new TreeNode(dataNids[i], (Tree *)treePtr);
       }
-      catch (const MdsException & exc)
+      catch (const MdsException &exc)
       {
-        printf("Error collecting data nodes %s\n", exc);
+        printf("Error collecting data nodes %s\n", exc.what());
       }
     }
 

--- a/device_support/national/cRioMPAGfunction.cpp
+++ b/device_support/national/cRioMPAGfunction.cpp
@@ -668,7 +668,7 @@ int mpag_readAndSaveAllChannels(NiFpga_Session session, int nChan, int *chanStat
           Data *streamGainData = currNode->getExtendedAttribute("STREAM_GAIN");
           streamGains[i] = streamGainData->getFloat();
         }
-        catch (MdsException &exc)
+        catch (const MdsException &exc)
         {
           streamGains[i] = 1;
         }
@@ -677,12 +677,12 @@ int mpag_readAndSaveAllChannels(NiFpga_Session session, int nChan, int *chanStat
           Data *streamOffsetData = currNode->getExtendedAttribute("STREAM_OFFSET");
           streamOffsets[i] = streamOffsetData->getFloat();
         }
-        catch (MdsException &exc)
+        catch (const MdsException &exc)
         {
           streamOffsets[i] = 0;
         }
       }
-      catch (MdsException &exc)
+      catch (const MdsException &exc)
       {
         streamNames[i] = NULL;
         streamGains[i] = 0;
@@ -696,7 +696,7 @@ int mpag_readAndSaveAllChannels(NiFpga_Session session, int nChan, int *chanStat
         delete currNode;
       }
     }
-    catch (MdsException &exc)
+    catch (const MdsException &exc)
     {
       printf("Error deleting data nodes %s : %s\n", currNode->getPath(), exc.what());
     }

--- a/device_support/national/probeTermControl.cpp
+++ b/device_support/national/probeTermControl.cpp
@@ -325,9 +325,9 @@ int main(int argc, char **argv)
       node[i] = t->getNode(path);
     }
   }
-  catch (MdsException *exc)
+  catch (const MdsException & exc)
   {
-    printf("%s\n", exc->what());
+    printf("%s\n", exc);
     exit(1);
   }
 
@@ -430,9 +430,9 @@ int main(int argc, char **argv)
           node[i]->putRow(currData, &currTime);
         }
       }
-      catch (MdsException *exc)
+      catch (const MdsException & exc)
       {
-        printf("%s\n", exc->what());
+        printf("%s\n", exc);
         error = 1;
         goto out;
       }

--- a/device_support/national/probeTermControl.cpp
+++ b/device_support/national/probeTermControl.cpp
@@ -325,9 +325,9 @@ int main(int argc, char **argv)
       node[i] = t->getNode(path);
     }
   }
-  catch (const MdsException & exc)
+  catch (const MdsException &exc)
   {
-    printf("%s\n", exc);
+    printf("%s\n", exc.what());
     exit(1);
   }
 
@@ -430,9 +430,9 @@ int main(int argc, char **argv)
           node[i]->putRow(currData, &currTime);
         }
       }
-      catch (const MdsException & exc)
+      catch (const MdsException &exc)
       {
-        printf("%s\n", exc);
+        printf("%s\n", exc.what());
         error = 1;
         goto out;
       }

--- a/device_support/ptgrey/PTGREY.cpp
+++ b/device_support/ptgrey/PTGREY.cpp
@@ -1289,7 +1289,7 @@ int PTGREY::startFramesAcquisition()
     Data *nodeData = t0Node->getData();
     timeStamp0 = (int64_t)nodeData->getLong();
   }
-  catch (const MdsException & exc)
+  catch (const MdsException &exc)
   {
     printf("Error getting frame0 time\n");
   }
@@ -1303,7 +1303,7 @@ int PTGREY::startFramesAcquisition()
       Data *nodeData = tStartOffset->getData();
       timeOffset = (float)nodeData->getFloatArray()[0];
     }
-    catch (const MdsException & exc)
+    catch (const MdsException &exc)
     {
       printf("Error getting timebaseNid (offset time set to 0.0s)\n");
       timeOffset = 0.0;

--- a/device_support/ptgrey/PTGREY.cpp
+++ b/device_support/ptgrey/PTGREY.cpp
@@ -1289,7 +1289,7 @@ int PTGREY::startFramesAcquisition()
     Data *nodeData = t0Node->getData();
     timeStamp0 = (int64_t)nodeData->getLong();
   }
-  catch (MdsException *exc)
+  catch (const MdsException & exc)
   {
     printf("Error getting frame0 time\n");
   }
@@ -1303,7 +1303,7 @@ int PTGREY::startFramesAcquisition()
       Data *nodeData = tStartOffset->getData();
       timeOffset = (float)nodeData->getFloatArray()[0];
     }
-    catch (MdsException *exc)
+    catch (const MdsException & exc)
     {
       printf("Error getting timebaseNid (offset time set to 0.0s)\n");
       timeOffset = 0.0;

--- a/device_support/ptgrey/main.cpp
+++ b/device_support/ptgrey/main.cpp
@@ -66,9 +66,9 @@ int main(int argc, char **argv)
     nodeMeta = tree->getNode((char *)"\\CAMERATEST::TOP:POINTGREY:FRAMES_METAD");
     dataNid = node->getNid(); //Node id to save the acquired frames
   }
-  catch (const MDSplus::MdsException & exc)
+  catch (const MDSplus::MdsException &exc)
   {
-    std::cout << "ERROR reading data" << exc << "\n";
+    std::cout << "ERROR reading data" << exc.what() << "\n";
   }
 
   printf("frame node path: %s\n", node->getPath());
@@ -107,9 +107,9 @@ int main(int argc, char **argv)
     framePtr = (frameData)->getShortArray(dataDims);
     framePtrMeta = (frameDataMeta)->getByteArray(dataDimsMeta);
   }
-  catch (const MdsException & exc)
+  catch (const MDSplus::MdsException &exc)
   {
-    std::cout << "ERROR reading data" << exc << "\n";
+    std::cout << "ERROR reading data" << exc.what() << "\n";
   }
 
   PTGREY *PtgreyCam;

--- a/device_support/ptgrey/main.cpp
+++ b/device_support/ptgrey/main.cpp
@@ -66,9 +66,9 @@ int main(int argc, char **argv)
     nodeMeta = tree->getNode((char *)"\\CAMERATEST::TOP:POINTGREY:FRAMES_METAD");
     dataNid = node->getNid(); //Node id to save the acquired frames
   }
-  catch (MDSplus::MdsException *exc)
+  catch (const MDSplus::MdsException & exc)
   {
-    std::cout << "ERROR reading data" << exc->what() << "\n";
+    std::cout << "ERROR reading data" << exc << "\n";
   }
 
   printf("frame node path: %s\n", node->getPath());
@@ -107,9 +107,9 @@ int main(int argc, char **argv)
     framePtr = (frameData)->getShortArray(dataDims);
     framePtrMeta = (frameDataMeta)->getByteArray(dataDimsMeta);
   }
-  catch (MdsException *exc)
+  catch (const MdsException & exc)
   {
-    std::cout << "ERROR reading data" << exc->what() << "\n";
+    std::cout << "ERROR reading data" << exc << "\n";
   }
 
   PTGREY *PtgreyCam;

--- a/device_support/redpitaya/AsyncStoreManager.cpp
+++ b/device_support/redpitaya/AsyncStoreManager.cpp
@@ -63,9 +63,9 @@ void SaveItem::save()
     std::cout << "MAKE SEGMENT  SAMPLES:" << segmentSamples << std::endl;
     dataNode->makeSegment(startSegData, endSegData, timebase, chanData);
   }
-  catch (MDSplus::MdsException &exc)
+  catch (const MDSplus::MdsException & exc)
   {
-    std::cout << "Error writing segment: " << exc.what() << std::endl;
+    std::cout << "Error writing segment: " << exc << std::endl;
   }
   MDSplus::deleteData(chanData);
   MDSplus::deleteData(timebase);

--- a/device_support/redpitaya/AsyncStoreManager.cpp
+++ b/device_support/redpitaya/AsyncStoreManager.cpp
@@ -63,9 +63,9 @@ void SaveItem::save()
     std::cout << "MAKE SEGMENT  SAMPLES:" << segmentSamples << std::endl;
     dataNode->makeSegment(startSegData, endSegData, timebase, chanData);
   }
-  catch (const MDSplus::MdsException & exc)
+  catch (const MDSplus::MdsException &exc)
   {
-    std::cout << "Error writing segment: " << exc << std::endl;
+    std::cout << "Error writing segment: " << exc.what() << std::endl;
   }
   MDSplus::deleteData(chanData);
   MDSplus::deleteData(timebase);

--- a/device_support/redpitaya/redpitaya.cpp
+++ b/device_support/redpitaya/redpitaya.cpp
@@ -730,7 +730,7 @@ void openTree(char *name, int shot, MDSplus::Tree **treePtr)
   {
     *treePtr = new MDSplus::Tree(name, shot);
   }
-  catch (MDSplus::MdsException &exc)
+  catch (const MDSplus::MdsException & exc)
   {
     *treePtr = 0;
   }

--- a/device_support/redpitaya/redpitaya.cpp
+++ b/device_support/redpitaya/redpitaya.cpp
@@ -730,7 +730,7 @@ void openTree(char *name, int shot, MDSplus::Tree **treePtr)
   {
     *treePtr = new MDSplus::Tree(name, shot);
   }
-  catch (const MDSplus::MdsException & exc)
+  catch (const MDSplus::MdsException &exc)
   {
     *treePtr = 0;
   }

--- a/epics/cas/main.cc
+++ b/epics/cas/main.cc
@@ -26,9 +26,9 @@ extern int main(int argc, const char **argv)
 	    append = true;
 	else
 	    append = false; 
-    }catch(MdsException *exc)
+    }catch(const MdsException &exc)
     {
-	std::cout << "Cannot open experiment " << argv[1] << ": " << exc-> what() << "\n";
+	std::cout << "Cannot open experiment " << argv[1] << ": " << exc.what() << "\n";
 	return -1;
     }
     try {

--- a/epics/cas/mdsPV.cc
+++ b/epics/cas/mdsPV.cc
@@ -250,9 +250,9 @@ mdsPV::mdsPV(mdsServer & casIn, char *name, Tree *treeIn, TreeNode *topNode, boo
 //		arr->getInfo(&clazz, &dtype, &length, &currDims, &dims, &ptr);
 //		nDims = currDims - 1;
 		deleteData(arr);
-	    }catch(MdsException *exc)
+	    }catch(const MdsException & exc)
 	    {
-		std::cout << "Error prevDef reading value for " << name << ": " << exc->what() << "\n";
+		std::cout << "Error prevDef reading value for " << name << ": " << exc << "\n";
 		delete exc;
 	    }
 	}
@@ -263,9 +263,9 @@ mdsPV::mdsPV(mdsServer & casIn, char *name, Tree *treeIn, TreeNode *topNode, boo
 //		data->getInfo(&clazz, &dtype, &length, &currDims, &dims, &ptr);
 //		nDims = currDims;
 		deleteData(data);
-	    }catch(MdsException *exc)
+	    }catch(const MdsException & exc)
 	    {
-		std::cout << "Error reading value for " << name << ": " << exc->what() << "\n";
+		std::cout << "Error reading value for " << name << ": " << exc << "\n";
 		delete exc;
 	    }
 	}
@@ -290,7 +290,7 @@ std::cout << "mdsPV  Data "<< currNode << "\n";
 //	    delete currNode;
 	    return;
 	}
-	catch(MdsException *exc)
+	catch(const MdsException & exc)
 	{
 	    nDims = 0;
 std::cout << "mdsPV  nDims exc"<< nDims <<"\n";
@@ -306,7 +306,7 @@ std::cout << "mdsPV  nDims "<< nDims <<"\n";
 	    hopr = currNode->getDouble();
 	    delete currNode;
 	    hasOpr = true;
-	} catch(MdsException *exc)
+	} catch(const MdsException & exc)
 	{
 	    std::cout << "Cannot get LOPR or HOPR for " << name << "\n";
 	    hasOpr = false;
@@ -316,7 +316,7 @@ std::cout << "mdsPV  nDims "<< nDims <<"\n";
 	    currNode = tree->getNode(":UNITS");
 	    units = currNode->getString();
 	    delete currNode;
-	} catch(MdsException *exc)
+	} catch(const MdsException & exc)
 	{
 	    std::cout << "Cannot get UNITS for " << name << "\n";
 	    units = NULL;
@@ -330,7 +330,7 @@ std::cout << "mdsPV  nDims "<< nDims <<"\n";
 	    lowAlarm = currNode->getDouble();
 	    delete currNode;
 	    hasAlarm = true;
-	} catch(MdsException *exc)
+	} catch(const MdsException & exc)
 	{
 //	    std::cout << "Cannot get HIGH_ALARM or LOW_ALARM for " << name << "\n";
 	    hasAlarm = false;
@@ -344,7 +344,7 @@ std::cout << "mdsPV  nDims "<< nDims <<"\n";
 	    lowWarning = currNode->getDouble();
 	    delete currNode;
 	    hasWarning = true;
-	} catch(MdsException *exc)
+	} catch(const MdsException & exc)
 	{
 //	    std::cout << "Cannot get HIGH_WARN or LOW_WARN for " << name << "\n";
 	    hasWarning = false;
@@ -358,7 +358,7 @@ std::cout << "mdsPV  nDims "<< nDims <<"\n";
 	    lowCtrl = currNode->getDouble();
 	    delete currNode;
 	    hasCtrl = true;
-	} catch(MdsException *exc)
+	} catch(const MdsException & exc)
 	{
 //	    std::cout << "Cannot get HIGH_CTRL or LOW_CTRL for " << name << "\n";
 	    hasCtrl = false;
@@ -372,7 +372,7 @@ std::cout << "mdsPV  nDims "<< nDims <<"\n";
 	    lowGraphic = currNode->getDouble();
 	    delete currNode;
 	    hasGraphic = true;
-	} catch(MdsException *exc)
+	} catch(const MdsException & exc)
 	{
 //	    std::cout << "Cannot get HIGH_GRAPH or LOW_GRAPH for " << name << "\n";
 	    hasGraphic = false;
@@ -382,7 +382,7 @@ std::cout << "mdsPV  nDims "<< nDims <<"\n";
 	    currNode = tree->getNode(":PREC");
 	    precision = currNode->getInt();
 	    delete currNode;
-	} catch(MdsException *exc)
+	} catch(const MdsException & exc)
 	{
 //	    std::cout << "Cannot get PREC for " << name << "\n";
 	    precision = 0;
@@ -394,7 +394,7 @@ std::cout << "mdsPV  nDims "<< nDims <<"\n";
 	    enums = enumData->getStringArray(&numEnums);
 	    deleteData(enumData);
 	    delete currNode;
-	} catch(MdsException *exc)
+	} catch(const MdsException & exc)
 	{
 	    enums = NULL;
 	    numEnums = 0;
@@ -403,9 +403,9 @@ std::cout << "mdsPV  nDims "<< nDims <<"\n";
 	tree->setDefault(prevDef);
 	delete prevDef;
         valid = true;
-   }catch(MdsException *exc)
+   }catch(const MdsException & exc)
     {
-	std::cout << "Error initilizing MDSplus nodes: " << exc->what() << "\n";
+	std::cout << "Error initilizing MDSplus nodes: " << exc << "\n";
 	valid = false;
 	tree->setDefault(prevDef);
 	delete prevDef;
@@ -568,9 +568,9 @@ caStatus mdsPV::updateValue(const gdd & valueIn)
 	}
 	else
 	    valNode->putData(dataIn);
-    }catch(MdsException *exc)
+    }catch(const MdsException & exc)
     {
-	std::cout << "Error writing data: " << exc->what() << "\n";
+	std::cout << "Error writing data: " << exc << "\n";
 	deleteData(dataIn);
 	return S_casApp_undefined;
     } 
@@ -910,7 +910,7 @@ Data *mdsPV::getData()
 	    deleteData(arr);
 	    delete [] dims;
 	    return retData;
-	}catch(MdsException *exc)
+	}catch(const MdsException & exc)
 	{
 	    return NULL;
 	    delete exc;
@@ -920,7 +920,7 @@ Data *mdsPV::getData()
     {
 	try {
 	    return valNode->getData();
-        }catch(MdsException *exc)
+        }catch(const MdsException & exc)
 	{
 	    return NULL;
 	    delete exc;

--- a/epics/cas/mdsPV.cc
+++ b/epics/cas/mdsPV.cc
@@ -250,9 +250,9 @@ mdsPV::mdsPV(mdsServer & casIn, char *name, Tree *treeIn, TreeNode *topNode, boo
 //		arr->getInfo(&clazz, &dtype, &length, &currDims, &dims, &ptr);
 //		nDims = currDims - 1;
 		deleteData(arr);
-	    }catch(const MdsException & exc)
+	    }catch(const MdsException &exc)
 	    {
-		std::cout << "Error prevDef reading value for " << name << ": " << exc << "\n";
+		std::cout << "Error prevDef reading value for " << name << ": " << exc.what() << "\n";
 		delete exc;
 	    }
 	}
@@ -263,9 +263,9 @@ mdsPV::mdsPV(mdsServer & casIn, char *name, Tree *treeIn, TreeNode *topNode, boo
 //		data->getInfo(&clazz, &dtype, &length, &currDims, &dims, &ptr);
 //		nDims = currDims;
 		deleteData(data);
-	    }catch(const MdsException & exc)
+	    }catch(const MdsException &exc)
 	    {
-		std::cout << "Error reading value for " << name << ": " << exc << "\n";
+		std::cout << "Error reading value for " << name << ": " << exc.what() << "\n";
 		delete exc;
 	    }
 	}
@@ -290,7 +290,7 @@ std::cout << "mdsPV  Data "<< currNode << "\n";
 //	    delete currNode;
 	    return;
 	}
-	catch(const MdsException & exc)
+	catch(const MdsException &exc)
 	{
 	    nDims = 0;
 std::cout << "mdsPV  nDims exc"<< nDims <<"\n";
@@ -306,7 +306,7 @@ std::cout << "mdsPV  nDims "<< nDims <<"\n";
 	    hopr = currNode->getDouble();
 	    delete currNode;
 	    hasOpr = true;
-	} catch(const MdsException & exc)
+	} catch(const MdsException &exc)
 	{
 	    std::cout << "Cannot get LOPR or HOPR for " << name << "\n";
 	    hasOpr = false;
@@ -316,7 +316,7 @@ std::cout << "mdsPV  nDims "<< nDims <<"\n";
 	    currNode = tree->getNode(":UNITS");
 	    units = currNode->getString();
 	    delete currNode;
-	} catch(const MdsException & exc)
+	} catch(const MdsException &exc)
 	{
 	    std::cout << "Cannot get UNITS for " << name << "\n";
 	    units = NULL;
@@ -330,7 +330,7 @@ std::cout << "mdsPV  nDims "<< nDims <<"\n";
 	    lowAlarm = currNode->getDouble();
 	    delete currNode;
 	    hasAlarm = true;
-	} catch(const MdsException & exc)
+	} catch(const MdsException &exc)
 	{
 //	    std::cout << "Cannot get HIGH_ALARM or LOW_ALARM for " << name << "\n";
 	    hasAlarm = false;
@@ -344,7 +344,7 @@ std::cout << "mdsPV  nDims "<< nDims <<"\n";
 	    lowWarning = currNode->getDouble();
 	    delete currNode;
 	    hasWarning = true;
-	} catch(const MdsException & exc)
+	} catch(const MdsException &exc)
 	{
 //	    std::cout << "Cannot get HIGH_WARN or LOW_WARN for " << name << "\n";
 	    hasWarning = false;
@@ -358,7 +358,7 @@ std::cout << "mdsPV  nDims "<< nDims <<"\n";
 	    lowCtrl = currNode->getDouble();
 	    delete currNode;
 	    hasCtrl = true;
-	} catch(const MdsException & exc)
+	} catch(const MdsException &exc)
 	{
 //	    std::cout << "Cannot get HIGH_CTRL or LOW_CTRL for " << name << "\n";
 	    hasCtrl = false;
@@ -372,7 +372,7 @@ std::cout << "mdsPV  nDims "<< nDims <<"\n";
 	    lowGraphic = currNode->getDouble();
 	    delete currNode;
 	    hasGraphic = true;
-	} catch(const MdsException & exc)
+	} catch(const MdsException &exc)
 	{
 //	    std::cout << "Cannot get HIGH_GRAPH or LOW_GRAPH for " << name << "\n";
 	    hasGraphic = false;
@@ -382,7 +382,7 @@ std::cout << "mdsPV  nDims "<< nDims <<"\n";
 	    currNode = tree->getNode(":PREC");
 	    precision = currNode->getInt();
 	    delete currNode;
-	} catch(const MdsException & exc)
+	} catch(const MdsException &exc)
 	{
 //	    std::cout << "Cannot get PREC for " << name << "\n";
 	    precision = 0;
@@ -394,7 +394,7 @@ std::cout << "mdsPV  nDims "<< nDims <<"\n";
 	    enums = enumData->getStringArray(&numEnums);
 	    deleteData(enumData);
 	    delete currNode;
-	} catch(const MdsException & exc)
+	} catch(const MdsException &exc)
 	{
 	    enums = NULL;
 	    numEnums = 0;
@@ -403,9 +403,9 @@ std::cout << "mdsPV  nDims "<< nDims <<"\n";
 	tree->setDefault(prevDef);
 	delete prevDef;
         valid = true;
-   }catch(const MdsException & exc)
+   }catch(const MdsException &exc)
     {
-	std::cout << "Error initilizing MDSplus nodes: " << exc << "\n";
+	std::cout << "Error initilizing MDSplus nodes: " << exc.what() << "\n";
 	valid = false;
 	tree->setDefault(prevDef);
 	delete prevDef;
@@ -568,9 +568,9 @@ caStatus mdsPV::updateValue(const gdd & valueIn)
 	}
 	else
 	    valNode->putData(dataIn);
-    }catch(const MdsException & exc)
+    }catch(const MdsException &exc)
     {
-	std::cout << "Error writing data: " << exc << "\n";
+	std::cout << "Error writing data: " << exc.what() << "\n";
 	deleteData(dataIn);
 	return S_casApp_undefined;
     } 
@@ -910,7 +910,7 @@ Data *mdsPV::getData()
 	    deleteData(arr);
 	    delete [] dims;
 	    return retData;
-	}catch(const MdsException & exc)
+	}catch(const MdsException &exc)
 	{
 	    return NULL;
 	    delete exc;
@@ -920,7 +920,7 @@ Data *mdsPV::getData()
     {
 	try {
 	    return valNode->getData();
-        }catch(const MdsException & exc)
+        }catch(const MdsException &exc)
 	{
 	    return NULL;
 	    delete exc;

--- a/epics/cas/mdsServer.cc
+++ b/epics/cas/mdsServer.cc
@@ -93,9 +93,9 @@ printf("TAG1: %s\n", pvName);
 	    delete [] tags[i];
 	}
 	delete [] tags;
-    }catch(MdsException *exc)
+    }catch(const MdsException & exc)
     {
-	std::cout << "Error reading tags: "<< exc->what() << "\n";
+	std::cout << "Error reading tags: "<< exc << "\n";
     }
 }
 
@@ -137,10 +137,10 @@ mdsServer::mdsServer (Tree *tree, bool appendIn)
 		    deleteData(pvNameData);
 		    delete parentNode;
 		    delete valNode;
-		}catch(MdsException *exc)
+		}catch(const MdsException & exc)
 		{
 	
-		    std::cout << "Inconsistent node set found: " << fullPath << " " << exc->what() << "\n";
+		    std::cout << "Inconsistent node set found: " << fullPath << " " << exc << "\n";
 		    //std::cout << "Inconsistent node set found: " << fullPath << " " <<  "\n";
 		}
 		delete [] fullPath;
@@ -148,9 +148,9 @@ mdsServer::mdsServer (Tree *tree, bool appendIn)
 	    delete [] currName;
 	}
 	delete stringNodes;
-     }catch(MdsException *exc)
+     }catch(const MdsException & exc)
     {
-	std::cout << "Error Scanning tree: "<< exc->what() << "\n";
+	std::cout << "Error Scanning tree: "<< exc << "\n";
     }
  }
 

--- a/epics/cas/mdsServer.cc
+++ b/epics/cas/mdsServer.cc
@@ -93,9 +93,9 @@ printf("TAG1: %s\n", pvName);
 	    delete [] tags[i];
 	}
 	delete [] tags;
-    }catch(const MdsException & exc)
+    }catch(const MdsException &exc)
     {
-	std::cout << "Error reading tags: "<< exc << "\n";
+	std::cout << "Error reading tags: "<< exc.what() << "\n";
     }
 }
 
@@ -137,10 +137,10 @@ mdsServer::mdsServer (Tree *tree, bool appendIn)
 		    deleteData(pvNameData);
 		    delete parentNode;
 		    delete valNode;
-		}catch(const MdsException & exc)
+		}catch(const MdsException &exc)
 		{
 	
-		    std::cout << "Inconsistent node set found: " << fullPath << " " << exc << "\n";
+		    std::cout << "Inconsistent node set found: " << fullPath << " " << exc.what() << "\n";
 		    //std::cout << "Inconsistent node set found: " << fullPath << " " <<  "\n";
 		}
 		delete [] fullPath;
@@ -148,9 +148,9 @@ mdsServer::mdsServer (Tree *tree, bool appendIn)
 	    delete [] currName;
 	}
 	delete stringNodes;
-     }catch(const MdsException & exc)
+     }catch(const MdsException &exc)
     {
-	std::cout << "Error Scanning tree: "<< exc << "\n";
+	std::cout << "Error Scanning tree: "<< exc.what() << "\n";
     }
  }
 

--- a/epics/mdsrecords/mdsplusSupUtilities.cpp
+++ b/epics/mdsrecords/mdsplusSupUtilities.cpp
@@ -207,7 +207,7 @@ static int getConnectionId(char *ipAddr, char *exp, int shot)
                        // required
         connectionTable[i].connection->openTree(exp, shot);
     }
-    catch (MdsException &exc)
+    catch (const MdsException &exc)
     {
       printf("Cannot establish mdsip connection: %s\n", exc.what());
       connectionTable[i].connection = 0;
@@ -258,7 +258,7 @@ int openMds(char *expName, int shot, int isLocal, char *ipAddr, char *path,
       else
         node = 0;
     }
-    catch (MdsException &exc)
+    catch (const MdsException &exc)
     {
       printf("Cannot Open tree or find node: %s\n", exc.what());
       strncpy(errMsg, exc.what(), 40);
@@ -431,7 +431,7 @@ int writeMds(int nodeId, double *vals, int dtype, int preTriggerSamples,
         node->putRow(data, (int64_t *)&epicsTime);
         deleteData(data);
       }
-      catch (MdsException &exc)
+      catch (const MdsException &exc)
       {
         strncpy(errMsg, exc.what(), 40);
         return 0;
@@ -453,7 +453,7 @@ int writeMds(int nodeId, double *vals, int dtype, int preTriggerSamples,
         deleteData(data);
         deleteData(timeData);
       }
-      catch (MdsException &exc)
+      catch (const MdsException &exc)
       {
         if (debug)
           printf("ERROR WRITING REMOTE TREE: %s\n", exc.what());
@@ -525,7 +525,7 @@ int writeMds(int nodeId, double *vals, int dtype, int preTriggerSamples,
         deleteData(times);
         deleteData(end);
       }
-      catch (MdsException &exc)
+      catch (const MdsException &exc)
       {
         strncpy(errMsg, exc.what(), 40);
         return 0;
@@ -556,7 +556,7 @@ int writeMds(int nodeId, double *vals, int dtype, int preTriggerSamples,
         deleteData(args[4]);
         deleteData(end);
       }
-      catch (MdsException &exc)
+      catch (const MdsException &exc)
       {
         if (debug)
           printf("ERROR WRITING REMOTE TREE: %s\n", exc.what());
@@ -844,7 +844,7 @@ int evaluateExpr(char *expr, int treeIdx, int nBuffers, void **buffers,
     for (i = 0; i < nBuffers; i++)
       deleteData(args[i]);
   }
-  catch (MdsException &exc)
+  catch (const MdsException &exc)
   {
     printf("ERROR WRITING REMOTE TREE: %s\n", exc.what());
     strncpy(errMsg, exc.what(), 40);
@@ -923,7 +923,7 @@ int doMdsAction(char *path, int nodeId, char *errMsg)
       // printf("Returned Data: %s\n", (resData)?resData->decompile():"");
       // if(resData) deleteData(resData);
     }
-    catch (MdsException &exc)
+    catch (const MdsException &exc)
     {
       printf("ERROR EXECUTING ACTION: %s\n", exc.what());
       strncpy(errMsg, exc.what(), 40);
@@ -939,7 +939,7 @@ int doMdsAction(char *path, int nodeId, char *errMsg)
       if (resData)
         deleteData(resData);
     }
-    catch (MdsException &exc)
+    catch (const MdsException &exc)
     {
       printf("ERROR EXECUTING REMOTE ACTION: %s\n", exc.what());
       strncpy(errMsg, exc.what(), 40);

--- a/include/mdsobjects.h
+++ b/include/mdsobjects.h
@@ -104,7 +104,7 @@ namespace MDSplus
   {
 
     friend EXPORT std::ostream &operator<<(std::ostream &outStream,
-                                           MdsException &exc)
+                                           const MdsException &exc)
     {
       return outStream << exc.what();
     }

--- a/mdsobjects/cpp/testing/MdsExceptionTest.cpp
+++ b/mdsobjects/cpp/testing/MdsExceptionTest.cpp
@@ -40,7 +40,7 @@ int main()
   {
     throw_exception_msg();
   }
-  catch (mds::MdsException e)
+  catch (const mds::MdsException & e)
   {
     TEST1(std::string(e.what()) == "test message");
   }
@@ -49,7 +49,7 @@ int main()
   {
     throw_exception_status();
   }
-  catch (mds::MdsException e)
+  catch (const mds::MdsException & e)
   {
     TEST1(std::string(e.what()) == std::string(MdsGetMsg(5552368)));
   }

--- a/mdsobjects/cpp/testing/MdsExceptionTest.cpp
+++ b/mdsobjects/cpp/testing/MdsExceptionTest.cpp
@@ -40,7 +40,7 @@ int main()
   {
     throw_exception_msg();
   }
-  catch (const mds::MdsException & e)
+  catch (const mds::MdsException &e)
   {
     TEST1(std::string(e.what()) == "test message");
   }
@@ -49,7 +49,7 @@ int main()
   {
     throw_exception_status();
   }
-  catch (const mds::MdsException & e)
+  catch (const mds::MdsException &e)
   {
     TEST1(std::string(e.what()) == std::string(MdsGetMsg(5552368)));
   }

--- a/mdsobjects/cpp/testing/MdsTdiTest.cpp
+++ b/mdsobjects/cpp/testing/MdsTdiTest.cpp
@@ -94,7 +94,7 @@ int SingleThreadTest(int idx, int repeats)
         else if (STATUS_NOT_OK)
           throw MDSplus::MdsException(status);
       }
-      catch (const MDSplus::MdsException & e)
+      catch (const MDSplus::MdsException &e)
       {
         std::cerr << "ERROR in cycle " << ii << ":=" << status << " >> "
                   << cmds[ic] << "\n";

--- a/mdsobjects/cpp/testing/MdsTdiTest.cpp
+++ b/mdsobjects/cpp/testing/MdsTdiTest.cpp
@@ -94,7 +94,7 @@ int SingleThreadTest(int idx, int repeats)
         else if (STATUS_NOT_OK)
           throw MDSplus::MdsException(status);
       }
-      catch (MDSplus::MdsException e)
+      catch (const MDSplus::MdsException & e)
       {
         std::cerr << "ERROR in cycle " << ii << ":=" << status << " >> "
                   << cmds[ic] << "\n";

--- a/mdsobjects/labview/mdsdataobjectswrp.cpp
+++ b/mdsobjects/labview/mdsdataobjectswrp.cpp
@@ -101,7 +101,7 @@ namespace MDSplus
       f();
       fillErrorCluster(errorCode, src, errorMessage, error);
     }
-    catch (MdsException const &e)
+    catch (const MdsException &e)
     {
       errorCode = bogusError;
       errorMessage = e.what();
@@ -6510,7 +6510,7 @@ namespace MDSplus
       {
         MDSplus::Tree *tree = new Tree("CACCA", -1);
       }
-      catch (MdsException &exc)
+      catch (const MdsException &exc)
       {
         std::cout << exc.what() << std::endl;
       }
@@ -6756,7 +6756,7 @@ namespace MDSplus
         Data *arrD = new Float32Array(floatArr, 10);
         n->makeSegment(start, end, dim, (Array *)arrD);
       }
-      catch (MdsException &exc)
+      catch (const MdsException &exc)
       {
         std::cout << "ERRORE: " << exc.what() << std::endl;
       }

--- a/mdsobjects/labview/mdseventobjectswrp.cpp
+++ b/mdsobjects/labview/mdseventobjectswrp.cpp
@@ -74,7 +74,7 @@ EXPORT void mdsplus_event_abort(const void *lvEventPtr, ErrorCluster *error)
                 eventPtr = reinterpret_cast<Event *>(const_cast<void
 *>(lvEventPtr)); eventPtr->abort();
         }
-        catch (const MdsException & e)
+        catch (const MdsException &e)
         {
                 errorCode = bogusError;
                 errorMessage = e.what();

--- a/mdsobjects/labview/mdsipobjectswrp.cpp
+++ b/mdsobjects/labview/mdsipobjectswrp.cpp
@@ -41,7 +41,7 @@ EXPORT void mdsplus_connection_constructor(void **lvConnectionPtrOut,
   catch (const MDSplus::MdsException &e)
   {
     errorCode = bogusError;
-    errorMessage = e.what();
+    errorMessage = e;
     fillErrorCluster(errorCode, errorSource, errorMessage, error);
     return;
   }
@@ -75,7 +75,7 @@ EXPORT void mdsplus_connection_getData(const void *lvConnectionPtr,
   catch (const MDSplus::MdsException &e)
   {
     errorCode = bogusError;
-    errorMessage = e.what();
+    errorMessage = e;
   }
   fillErrorCluster(errorCode, errorSource, errorMessage, error);
 }
@@ -102,7 +102,7 @@ EXPORT void mdsplus_connection_putData(const void *lvConnectionPtr,
   catch (const MDSplus::MdsException &e)
   {
     errorCode = bogusError;
-    errorMessage = e.what();
+    errorMessage = e;
     fillErrorCluster(errorCode, errorSource, errorMessage, error);
     return;
   }
@@ -126,7 +126,7 @@ EXPORT void mdsplus_connection_openTree(const void *lvConnectionPtr,
   catch (const MDSplus::MdsException &e)
   {
     errorCode = bogusError;
-    errorMessage = e.what();
+    errorMessage = e;
   }
   fillErrorCluster(errorCode, errorSource, errorMessage, error);
 }
@@ -147,7 +147,7 @@ EXPORT void mdsplus_connection_closeTree(const void *lvConnectionPtr,
   catch (const MDSplus::MdsException &e)
   {
     errorCode = bogusError;
-    errorMessage = e.what();
+    errorMessage = e;
   }
   fillErrorCluster(errorCode, errorSource, errorMessage, error);
 }
@@ -174,7 +174,7 @@ EXPORT void mdsplus_connection_getNode(const void *lvConnectionPtr,
   {
     errorCode = bogusError;
     *lvTreeNodePtrOut = 0;
-    fillErrorCluster(errorCode, errorSource, const_cast<char *>(mdsE.what()),
+    fillErrorCluster(errorCode, errorSource, const_cast<char *>(mdsE),
                      error);
   }
 }

--- a/mdsobjects/labview/mdsipobjectswrp.cpp
+++ b/mdsobjects/labview/mdsipobjectswrp.cpp
@@ -41,7 +41,7 @@ EXPORT void mdsplus_connection_constructor(void **lvConnectionPtrOut,
   catch (const MDSplus::MdsException &e)
   {
     errorCode = bogusError;
-    errorMessage = e;
+    errorMessage = e.what();
     fillErrorCluster(errorCode, errorSource, errorMessage, error);
     return;
   }
@@ -75,7 +75,7 @@ EXPORT void mdsplus_connection_getData(const void *lvConnectionPtr,
   catch (const MDSplus::MdsException &e)
   {
     errorCode = bogusError;
-    errorMessage = e;
+    errorMessage = e.what();
   }
   fillErrorCluster(errorCode, errorSource, errorMessage, error);
 }
@@ -102,7 +102,7 @@ EXPORT void mdsplus_connection_putData(const void *lvConnectionPtr,
   catch (const MDSplus::MdsException &e)
   {
     errorCode = bogusError;
-    errorMessage = e;
+    errorMessage = e.what();
     fillErrorCluster(errorCode, errorSource, errorMessage, error);
     return;
   }
@@ -126,7 +126,7 @@ EXPORT void mdsplus_connection_openTree(const void *lvConnectionPtr,
   catch (const MDSplus::MdsException &e)
   {
     errorCode = bogusError;
-    errorMessage = e;
+    errorMessage = e.what();
   }
   fillErrorCluster(errorCode, errorSource, errorMessage, error);
 }
@@ -147,7 +147,7 @@ EXPORT void mdsplus_connection_closeTree(const void *lvConnectionPtr,
   catch (const MDSplus::MdsException &e)
   {
     errorCode = bogusError;
-    errorMessage = e;
+    errorMessage = e.what();
   }
   fillErrorCluster(errorCode, errorSource, errorMessage, error);
 }
@@ -174,7 +174,7 @@ EXPORT void mdsplus_connection_getNode(const void *lvConnectionPtr,
   {
     errorCode = bogusError;
     *lvTreeNodePtrOut = 0;
-    fillErrorCluster(errorCode, errorSource, const_cast<char *>(mdsE),
+    fillErrorCluster(errorCode, errorSource, const_cast<char *>(mdsE.what()),
                      error);
   }
 }


### PR DESCRIPTION
Exception handling in several C++ codes has been updated/standardized to pass by reference, for example:
```
catch (const MdsException & exc)
```

instead of pointers, i.e:

```
catch (MdsException *exc)
```
