### PR TITLE
Fixed check for returned socket

### DIFF
--- a/mdsobjects/cpp/mdsipobjects.cpp
+++ b/mdsobjects/cpp/mdsipobjects.cpp
@@ -661,7 +661,7 @@ void Connection::resetConnection()
   char *mdsipAddr = (char *)mdsipAddrStr.c_str();
   sockId = ConnectToMds(mdsipAddr);
   unlockGlobal();
-  if (sockId <= 0)
+  if (sockId < 0)
   {
     std::string msg("Cannot connect to ");
     msg += mdsipAddr;


### PR DESCRIPTION
ConnectToMds now can return sockId = 0