### PR TITLE
Fix: Add upgrades to PG devices

### DIFF
--- a/deploy/packaging/debian/htsdevices.noarch
+++ b/deploy/packaging/debian/htsdevices.noarch
@@ -5,6 +5,7 @@
 ./usr/local/mdsplus/pydevices/HtsDevices/acq2106_435st.py
 ./usr/local/mdsplus/pydevices/HtsDevices/acq2106_435tr.py
 ./usr/local/mdsplus/pydevices/HtsDevices/acq2106_WRPG.py
+./usr/local/mdsplus/pydevices/HtsDevices/acq2106_DIOPG.py
 ./usr/local/mdsplus/pydevices/HtsDevices/acq2106_WRTD.py
 ./usr/local/mdsplus/pydevices/HtsDevices/cryocon18i.py
 ./usr/local/mdsplus/pydevices/HtsDevices/cryocon24c.py

--- a/deploy/packaging/redhat/htsdevices.noarch
+++ b/deploy/packaging/redhat/htsdevices.noarch
@@ -6,6 +6,7 @@
 ./usr/local/mdsplus/pydevices/HtsDevices/acq2106_435st.py
 ./usr/local/mdsplus/pydevices/HtsDevices/acq2106_435tr.py
 ./usr/local/mdsplus/pydevices/HtsDevices/acq2106_WRPG.py
+./usr/local/mdsplus/pydevices/HtsDevices/acq2106_DIOPG.py
 ./usr/local/mdsplus/pydevices/HtsDevices/acq2106_WRTD.py
 ./usr/local/mdsplus/pydevices/HtsDevices/cryocon18i.py
 ./usr/local/mdsplus/pydevices/HtsDevices/cryocon24c.py

--- a/pydevices/HtsDevices/acq2106_DIOPG.py
+++ b/pydevices/HtsDevices/acq2106_DIOPG.py
@@ -1,0 +1,401 @@
+#
+# Copyright (c) 2020, Massachusetts Institute of Technology All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# Redistributions of source code must retain the above copyright notice, this
+# list of conditions and the following disclaimer.
+#
+# Redistributions in binary form must reproduce the above copyright notice, this
+# list of conditions and the following disclaimer in the documentation and/or
+# other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+import MDSplus
+import time
+import numpy
+
+class _ACQ2106_DIOPG(MDSplus.Device):
+    """
+    D-Tacq ACQ2106 with ACQ423 Digitizers (up to 6)  real time streaming support.
+
+    DIO with 4 channels or 32
+
+    MDSplus.Device.debug - Controlled by environment variable DEBUG_DEVICES
+        MDSplus.Device.dprint(debuglevel, fmt, args)
+         - print if debuglevel >= MDSplus.Device.debug
+
+    """
+    base_parts=[
+        {
+            'path':':COMMENT',
+            'type':'text',     
+            'options':('no_write_shot',)
+        },
+        {
+            'path':':NODE',        
+            'type':'text',
+            'value': '192.168.0.254',   
+            'options':('no_write_shot',)
+        },
+        {
+            'path':':DIO_SITE',    
+            'type':'numeric',  
+            'value': int(5), 
+            'options':('no_write_shot',)
+        },
+        {
+            'path':':TRIG_TIME',   
+            'type':'numeric',  
+            'options':('write_shot',)
+        },
+        {
+            'path':':RUNNING',     
+            'type':'numeric',  
+            'options':('no_write_model',)
+        },
+        {
+            'path':':LOG_OUTPUT',  
+            'type':'text',     
+            'options':('no_write_model', 'write_once', 'write_shot',)
+        },
+        {
+            'path':':INIT_ACTION', 
+            'type':'action',   
+            'valueExpr':"Action(Dispatch('CAMAC_SERVER','INIT',50,None),Method(None,'INIT',head))",
+            'options':('no_write_shot',)
+        },
+        {
+            'path':':TRIG_ACTION', 
+            'type':'action',   
+            'valueExpr':"Action(Dispatch('CAMAC_SERVER','TRIG',50,None),Method(None,'TRIG',head))",
+            'options':('no_write_shot',)    
+        },
+        {
+            'path':':STOP_ACTION', 
+            'type':'action',   
+            'valueExpr':"Action(Dispatch('CAMAC_SERVER','STORE',50,None),Method(None,'STOP',head))",
+            'options':('no_write_shot',)
+        },
+        {
+            'path':':STL',         
+            'type':'text',     
+            'options':('write_shot',)
+        },
+        {
+            'path':':GPG_TRG_DX',  
+            'type':'text',     
+            'value': 'dx', 
+            'options':('write_shot',)
+        },
+    ]
+
+
+    def init(self):
+        slot = self.getSlot()
+
+        # Setting the trigger in the PG/GPG module. These settings depends very much on what is the
+        # configuration of the experiment. For example, when using one WRTT timing highway, then we can use d0, which will be
+        # the same used by the digitazer module. Otherwise, we can choose a different one, to be in an independent highway from
+        # the digitazer, like d1.
+
+        slot.GPG_ENABLE = 1
+        slot.GPG_MODE   = 'LOOP'
+
+        if self.isPG():
+            slot.TRG        = 'enable'
+            slot.TRG_DX     = str(self.gpg_trg_dx.data())
+            slot.TRG_SENSE  = 'rising'
+        else:
+            slot.GPG_TRG        = 'enable'
+            slot.GPG_TRG_DX     = str(self.gpg_trg_dx.data())
+            slot.GPG_TRG_SENSE  = 'rising'
+
+
+        self.dprint(2, "Building STL: start")
+
+        # Create the STL table from a series of transition times and states given in the OUTPUT node in the tree.
+        # TIGA: PG nchans = 4, or non-TIGA PG nchans = 32
+        tiga    = '7B'
+        nontiga = '6B'
+
+        site = self.dio_site.data()
+        if site == 0 or slot.MTYPE in nontiga:
+            nchans = 32
+            if self.debug >= 2:
+                self.dprint(2, 'DIO site and Number of Channels: {} {}'.format(self.dio_site.data(), nchans))
+        elif slot.MTYPE in tiga:
+            nchans = 4            
+            if self.debug >= 2:
+                self.dprint(2, 'DIO site and Number of Channels: {} {}'.format(self.dio_site.data(), nchans))
+
+        # Create the STL table:
+        self.set_stl(nchans)
+
+        #Load the STL into the DIO or GPG module.
+        self.load_stl_data()
+        
+        self.dprint(1, 'WRPG has loaded the STL')
+      
+    INIT=init
+
+    def stop(self):
+        slot = self.getSlot()
+        slot.GPG_ENABLE = 0
+        self.running.on = False
+    STOP=stop
+
+    def getUUT(self):
+        import acq400_hapi
+        uut = acq400_hapi.factory(self.node.data())
+        return uut
+
+    def getSlot(self):
+        uut = self.getUUT()
+        site_number  = int(self.dio_site.data())
+
+        # Verify site_number is a valid int between 1 and 6
+        # if site_number in range(1, 7):
+        #     self.slot = uut.__getattr__('s' + self.dio_site.data())
+
+        try:
+            if site_number   == 0: 
+                slot = uut.s0    # Only for a GPG system.
+            elif site_number == 1:
+                slot = uut.s1
+            elif site_number == 2:
+                slot = uut.s2
+            elif site_number == 3:
+                slot = uut.s3
+            elif site_number == 4:
+                slot = uut.s4
+            elif site_number == 5:
+                slot = uut.s5
+            elif site_number == 6:
+                slot = uut.s6
+        except:
+            pass
+        
+        return slot
+
+    def isPG(self):
+        uut  = self.getUUT()
+        slot = self.getSlot()
+
+        site = self.dio_site.data()
+        
+        try:
+            if site == 0:
+                is_pg = False
+            else:
+                is_pg = slot.GPG_ENABLE is not None
+        except:
+            is_pg = False
+
+        return is_pg
+    
+
+    def load_stl_data(self):
+        uut = self.getUUT()
+        # Pair of (transition time, 32 bit channel states):
+        stl = str(self.stl.data())
+        
+        is_debug = (self.debug > 0)
+        
+        #What follows checks if the system is a GPG module (site 0) or a PG module (site 1..6)
+        if self.isPG():
+            uut.load_dio482pg(self.dio_site.data(), stl, is_debug)
+        else:
+            uut.load_wrpg(stl, is_debug)
+
+
+    def set_stl(self, nchan):
+
+        data_by_chan = []
+        all_times = []
+
+        for i in range(nchan):
+            c = self.__getattr__('OUTPUT_%3.3d' % (i + 1))
+
+            times = c.dim_of().data()
+            data = c.data()
+
+            # Build dictionary of times -> states
+            data_dict = { k: v for k, v in zip(times, data) }
+
+            data_by_chan.append(data_dict)
+            all_times.extend(times)
+
+        all_times = sorted(list(set(all_times)))
+
+        # all_t_times   = []
+        # all_t_times_states = []
+
+        # for i in range(nchan):
+        #     chan_signal = self.__getattr__('OUTPUT_%3.3d' % (i+1))
+
+        #     # Pair of (transition time, state) for each channel:
+        #     chan_states = chan_signal.data()
+        #     chan_times = chan_signal.dim_of().data()
+            
+        #     # Python zip it
+        #     chan_t_states = zip(chan_times, chan_states)
+            
+        #     print(chan_t_states)
+
+        #     # # Creation of an array that contains, as EVERY OTHER element, all the transition times in it, appending them
+        #     # # for each channel:
+        #     # for x in numpy.nditer(chan_t_states):
+        #     #     all_t_times_states.append(x) #Appends arrays made of one element,
+            
+        #     all_t_times_states.extend(chan_t_states)
+
+        # # Choosing only the transition times:
+        # all_t_times = all_t_times_states[0::2]
+
+        # # Removing duplicates and then sorting in ascending manner:
+        # t_times = []
+        # for i in all_t_times:
+        #     if i not in t_times:
+        #         t_times.append(i)
+
+        # t_times contains the unique set of transitions times used in the experiment:
+        # t_times = sorted(numpy.float64(t_times))
+
+        # initialize the state matrix
+        # state_matrix = [ [ 0 ] * nchan ] * len(all_times)
+        state_matrix = numpy.zeros((len(all_times), nchan), dtype='int')
+        # state_matrix = [ [ 0 for i in range(cols) ] for j in range(rows) ]
+        
+        # print(state_matrix)
+        
+        for c, data in enumerate(data_by_chan):
+            # print(c, data)
+            for t, time in enumerate(all_times):
+                # print(t, time)
+                if time in data:
+                    state_matrix[t][c] = data[time]
+                    #print('matrix[{}] = {}'.format(t, state_matrix[t]))
+                else:
+                    state_matrix[t][c] = state_matrix[t - 1][c]
+                    #print('matrix[{}][{}] = last row'.format(t, c))
+
+        # print('1717', state_matrix[1717])
+        # print('1718', state_matrix[1718])
+        # print('1719', state_matrix[1719])
+
+        # print(state_matrix)
+        
+        # Building the state matrix. For each channel, we traverse all the transition times to find those who are 
+        # in the particular channel. 
+        # If the transition time is in the channel, we copied its state into the state[i][j] element. 
+        # If a transition time does not appear in that channel, we keep the previous state for, i.e. the state doesn't change.
+        # for j in range(nchan):
+        #     chan_t_states = self.__getattr__('OUTPUT_%3.3d' % (j+1))
+
+        #     for i in range(len(t_times)):
+
+        #         if i == 0:
+        #             state[i][j] = 0
+        #         else:
+        #             state[i][j] = state[i-1][j]
+                    
+        #             # chan_t_states its elements are pairs of [ttimes, state]. e.g [[0.0, 0],[1.0, 1],...]
+        #             # chan_t_states[0] are all the first elements of those pairs, i.e the trans. times: 
+        #             # e.g [[1D0], [2D0], [3D0], [4D0] ... ]
+        #             # chan_t_states[1] are all the second elements of those pairs, i.e. the states: 
+        #             # e.g [[0],[1],...]
+        #             for t in range(len(chan_t_states[0])):
+        #                 #Check if the transition time is one of the times that belongs to this channel:
+        #                 if t_times[i] == chan_t_states[0][t][0]:
+        #                     state[i][j] = int(chan_t_states[1][t][0])
+
+
+        # Building the string of 1s and 0s for each transition time:
+        binary_rows = []
+        times_usecs = []
+        last_row = None
+        for time, row in zip(all_times, state_matrix):
+            if not numpy.array_equal(row, last_row):
+                rowstr = [ str(i) for i in numpy.flip(row) ]  # flipping the bits so that chan 1 is in the far right position
+                binary_rows.append(''.join(rowstr))
+                times_usecs.append(int(time * 1E7))
+                last_row = row
+
+        #print(binary_rows)
+        #print(times_usecs)
+
+        # Converting the original units of the transtion times in seconds, to 1/10th micro-seconds:
+
+        # for time in all_times:
+        #     #The documentation and STL examples says time is in micro-seconds, but it's actually in 1/10th of micro-seconds.
+
+        binary_rows = binary_rows[0:96]
+        times_usecs = times_usecs[0:96]
+        
+        # Write to a list with states in HEX form.
+        stl  = ''
+        for time, state in zip(times_usecs, binary_rows):
+            stl += '%d,%08X\n' % (time, int(state, 2))
+        
+        print(stl)
+        # MDSplus wants a numpy array
+        self.stl.record = stl
+
+
+    def set_output_signal(self, num):
+        chan = self.__getattr__('OUTPUT_%3.3d' % num)
+        
+        output_signal = "2 * BUILD_SIGNAL([0, REPLICATE([1,0], 0, ESIZE(SIGNALS.YAG.HARDWARE:J221_50HZ:OUTPUT_01:GATES) / 2), MOD(ESIZE(SIGNALS.YAG.HARDWARE:J221_50HZ:OUTPUT_01:GATES), 2) ? [1,1] : 0], *, [MINVAL(SIGNALS.YAG.HARDWARE:J221_50HZ:OUTPUT_01:GATES) - .1 * (MAXVAL(SIGNALS.YAG.HARDWARE:J221_50HZ:OUTPUT_01:GATES) - MINVAL(SIGNALS.YAG.HARDWARE:J221_50HZ:OUTPUT_01:GATES)), SIGNALS.YAG.HARDWARE:J221_50HZ:OUTPUT_01:GATES, MAXVAL(SIGNALS.YAG.HARDWARE:J221_50HZ:OUTPUT_01:GATES) + .1 * (MAXVAL(SIGNALS.YAG.HARDWARE:J221_50HZ:OUTPUT_01:GATES) - MINVAL(SIGNALS.YAG.HARDWARE:J221_50HZ:OUTPUT_01:GATES))])"
+        
+        chan.putData(output_signal)
+
+
+OUTFMT3 = ':OUTPUT_%3.3d'
+ACQ2106_CHANNEL_CHOICES = [4, 32]
+
+def create_classes(base_class, root_name, parts, channel_choices):
+    my_classes = {}
+    for nchan in channel_choices:
+        class_name = "%s_%sCH" % (root_name, nchan)
+        my_parts = list(parts)
+        my_classes[class_name] = assemble(type(class_name, (base_class,), {"nchan": nchan, "parts": my_parts}))
+        my_classes[class_name].__module__ = base_class.__module__
+    return my_classes
+
+def assemble(cls):
+    outfmt = OUTFMT3
+    for ch in range(1, cls.nchan+1):
+        cls.parts.append(
+            {'path':outfmt % (ch,), 
+             'type':'SIGNAL', 
+             #'valueExpr': 'head.set_output_signal(%d)' % (ch,),
+             #'valueExpr': '2 * BUILD_SIGNAL([0, REPLICATE([1,0], 0, ESIZE(SIGNALS.YAG.HARDWARE:J221_50HZ:OUTPUT_01:GATES) / 2), MOD(ESIZE(SIGNALS.YAG.HARDWARE:J221_50HZ:OUTPUT_01:GATES), 2) ? [1,1] : 0], *, [MINVAL(SIGNALS.YAG.HARDWARE:J221_50HZ:OUTPUT_01:GATES) - .1 * (MAXVAL(SIGNALS.YAG.HARDWARE:J221_50HZ:OUTPUT_01:GATES) - MINVAL(SIGNALS.YAG.HARDWARE:J221_50HZ:OUTPUT_01:GATES)), SIGNALS.YAG.HARDWARE:J221_50HZ:OUTPUT_01:GATES, MAXVAL(SIGNALS.YAG.HARDWARE:J221_50HZ:OUTPUT_01:GATES) + .1 * (MAXVAL(SIGNALS.YAG.HARDWARE:J221_50HZ:OUTPUT_01:GATES) - MINVAL(SIGNALS.YAG.HARDWARE:J221_50HZ:OUTPUT_01:GATES))])'
+             'options':('no_write_shot',)}
+            )
+    return cls
+
+class_ch_dict = create_classes(
+    _ACQ2106_DIOPG, "ACQ2106_DIOPG",
+    list(_ACQ2106_DIOPG.base_parts),
+    ACQ2106_CHANNEL_CHOICES
+)
+
+globals().update(class_ch_dict)
+
+del(class_ch_dict)
+
+# public classes created in this module
+# ACQ2106_DIOPG_4CH
+# ACQ2106_DIOPG_32CH

--- a/pydevices/HtsDevices/acq2106_DIOPG.py
+++ b/pydevices/HtsDevices/acq2106_DIOPG.py
@@ -239,47 +239,11 @@ class _ACQ2106_DIOPG(MDSplus.Device):
 
         all_times = sorted(list(set(all_times)))
 
-        # all_t_times   = []
-        # all_t_times_states = []
-
-        # for i in range(nchan):
-        #     chan_signal = self.__getattr__('OUTPUT_%3.3d' % (i+1))
-
-        #     # Pair of (transition time, state) for each channel:
-        #     chan_states = chan_signal.data()
-        #     chan_times = chan_signal.dim_of().data()
-            
-        #     # Python zip it
-        #     chan_t_states = zip(chan_times, chan_states)
-            
-        #     print(chan_t_states)
-
-        #     # # Creation of an array that contains, as EVERY OTHER element, all the transition times in it, appending them
-        #     # # for each channel:
-        #     # for x in numpy.nditer(chan_t_states):
-        #     #     all_t_times_states.append(x) #Appends arrays made of one element,
-            
-        #     all_t_times_states.extend(chan_t_states)
-
-        # # Choosing only the transition times:
-        # all_t_times = all_t_times_states[0::2]
-
-        # # Removing duplicates and then sorting in ascending manner:
-        # t_times = []
-        # for i in all_t_times:
-        #     if i not in t_times:
-        #         t_times.append(i)
-
-        # t_times contains the unique set of transitions times used in the experiment:
-        # t_times = sorted(numpy.float64(t_times))
-
         # initialize the state matrix
         # state_matrix = [ [ 0 ] * nchan ] * len(all_times)
         state_matrix = numpy.zeros((len(all_times), nchan), dtype='int')
         # state_matrix = [ [ 0 for i in range(cols) ] for j in range(rows) ]
-        
-        # print(state_matrix)
-        
+                
         for c, data in enumerate(data_by_chan):
             # print(c, data)
             for t, time in enumerate(all_times):
@@ -291,37 +255,6 @@ class _ACQ2106_DIOPG(MDSplus.Device):
                     state_matrix[t][c] = state_matrix[t - 1][c]
                     #print('matrix[{}][{}] = last row'.format(t, c))
 
-        # print('1717', state_matrix[1717])
-        # print('1718', state_matrix[1718])
-        # print('1719', state_matrix[1719])
-
-        # print(state_matrix)
-        
-        # Building the state matrix. For each channel, we traverse all the transition times to find those who are 
-        # in the particular channel. 
-        # If the transition time is in the channel, we copied its state into the state[i][j] element. 
-        # If a transition time does not appear in that channel, we keep the previous state for, i.e. the state doesn't change.
-        # for j in range(nchan):
-        #     chan_t_states = self.__getattr__('OUTPUT_%3.3d' % (j+1))
-
-        #     for i in range(len(t_times)):
-
-        #         if i == 0:
-        #             state[i][j] = 0
-        #         else:
-        #             state[i][j] = state[i-1][j]
-                    
-        #             # chan_t_states its elements are pairs of [ttimes, state]. e.g [[0.0, 0],[1.0, 1],...]
-        #             # chan_t_states[0] are all the first elements of those pairs, i.e the trans. times: 
-        #             # e.g [[1D0], [2D0], [3D0], [4D0] ... ]
-        #             # chan_t_states[1] are all the second elements of those pairs, i.e. the states: 
-        #             # e.g [[0],[1],...]
-        #             for t in range(len(chan_t_states[0])):
-        #                 #Check if the transition time is one of the times that belongs to this channel:
-        #                 if t_times[i] == chan_t_states[0][t][0]:
-        #                     state[i][j] = int(chan_t_states[1][t][0])
-
-
         # Building the string of 1s and 0s for each transition time:
         binary_rows = []
         times_usecs = []
@@ -330,16 +263,9 @@ class _ACQ2106_DIOPG(MDSplus.Device):
             if not numpy.array_equal(row, last_row):
                 rowstr = [ str(i) for i in numpy.flip(row) ]  # flipping the bits so that chan 1 is in the far right position
                 binary_rows.append(''.join(rowstr))
-                times_usecs.append(int(time * 1E7))
+                times_usecs.append(int(time * 1E7)) # Converting the original units of the transtion times in seconds, to 1/10th micro-seconds
                 last_row = row
 
-        #print(binary_rows)
-        #print(times_usecs)
-
-        # Converting the original units of the transtion times in seconds, to 1/10th micro-seconds:
-
-        # for time in all_times:
-        #     #The documentation and STL examples says time is in micro-seconds, but it's actually in 1/10th of micro-seconds.
 
         binary_rows = binary_rows[0:96]
         times_usecs = times_usecs[0:96]

--- a/pydevices/HtsDevices/acq2106_DIOPG.py
+++ b/pydevices/HtsDevices/acq2106_DIOPG.py
@@ -269,8 +269,6 @@ class _ACQ2106_DIOPG(MDSplus.Device):
         for time, state in zip(times_usecs, binary_rows):
             stl += '%d,%08X\n' % (time, int(state, 2))
         
-        print(stl)
-        # MDSplus wants a numpy array
         self.stl.record = stl
 
 

--- a/pydevices/HtsDevices/acq2106_DIOPG.py
+++ b/pydevices/HtsDevices/acq2106_DIOPG.py
@@ -274,6 +274,7 @@ class _ACQ2106_DIOPG(MDSplus.Device):
         self.stl.record = stl
 
 
+
 OUTFMT3 = ':OUTPUT_%3.3d'
 ACQ2106_CHANNEL_CHOICES = [4, 32]
 

--- a/pydevices/HtsDevices/acq2106_WRPG.py
+++ b/pydevices/HtsDevices/acq2106_WRPG.py
@@ -38,17 +38,67 @@ class _ACQ2106_WRPG(MDSplus.Device):
 
     """
     base_parts=[
-        {'path':':COMMENT',     'type':'text',     'options':('no_write_shot',)},
-        {'path':':NODE',        'type':'text',     'options':('no_write_shot',)},
-        {'path':':DIO_SITE',    'type':'numeric',  'value': int(4), 'options':('no_write_shot',)},
-        {'path':':TRIG_TIME',   'type':'numeric',  'options':('write_shot',)},
-        {'path':':RUNNING',     'type':'numeric',  'options':('no_write_model',)},
-        {'path':':LOG_OUTPUT',  'type':'text',     'options':('no_write_model', 'write_once', 'write_shot',)},
-        {'path':':INIT_ACTION', 'type':'action',   'valueExpr':"Action(Dispatch('CAMAC_SERVER','INIT',50,None),Method(None,'INIT',head))",'options':('no_write_shot',)},
-        {'path':':TRIG_ACTION', 'type':'action',   'valueExpr':"Action(Dispatch('CAMAC_SERVER','TRIG',50,None),Method(None,'TRIG',head))",'options':('no_write_shot',)},
-        {'path':':STOP_ACTION', 'type':'action',   'valueExpr':"Action(Dispatch('CAMAC_SERVER','STORE',50,None),Method(None,'STOP',head))",'options':('no_write_shot',)},
-        {'path':':STL',         'type':'text',     'options':('write_shot',)},
-        {'path':':GPG_TRG_DX',  'type':'text',     'value': 'dx', 'options':('write_shot',)},
+        {
+            'path':':COMMENT',
+            'type':'text',     
+            'options':('no_write_shot',)
+        },
+        {
+            'path':':NODE',        
+            'type':'text',
+            'value': '192.168.0.254',   
+            'options':('no_write_shot',)
+        },
+        {
+            'path':':DIO_SITE',    
+            'type':'numeric',  
+            'value': int(5), 
+            'options':('no_write_shot',)
+        },
+        {
+            'path':':TRIG_TIME',   
+            'type':'numeric',  
+            'options':('write_shot',)
+        },
+        {
+            'path':':RUNNING',     
+            'type':'numeric',  
+            'options':('no_write_model',)
+        },
+        {
+            'path':':LOG_OUTPUT',  
+            'type':'text',     
+            'options':('no_write_model', 'write_once', 'write_shot',)
+        },
+        {
+            'path':':INIT_ACTION', 
+            'type':'action',   
+            'valueExpr':"Action(Dispatch('CAMAC_SERVER','INIT',50,None),Method(None,'INIT',head))",
+            'options':('no_write_shot',)
+        },
+        {
+            'path':':TRIG_ACTION', 
+            'type':'action',   
+            'valueExpr':"Action(Dispatch('CAMAC_SERVER','TRIG',50,None),Method(None,'TRIG',head))",
+            'options':('no_write_shot',)    
+        },
+        {
+            'path':':STOP_ACTION', 
+            'type':'action',   
+            'valueExpr':"Action(Dispatch('CAMAC_SERVER','STORE',50,None),Method(None,'STOP',head))",
+            'options':('no_write_shot',)
+        },
+        {
+            'path':':STL',         
+            'type':'text',     
+            'options':('write_shot',)
+        },
+        {
+            'path':':GPG_TRG_DX',  
+            'type':'text',     
+            'value': 'dx', 
+            'options':('write_shot',)
+        },
     ]
 
 
@@ -75,8 +125,8 @@ class _ACQ2106_WRPG(MDSplus.Device):
 
         self.dprint(2, "Building STL: start")
 
-        #Create the STL table from a series of transition times and states given in OUTPUT.
-        #TIGA: PG nchans = 4, or non-TIGA PG nchans = 32
+        # Create the STL table from a series of transition times and states given in the OUTPUT node in the tree.
+        # TIGA: PG nchans = 4, or non-TIGA PG nchans = 32
         tiga    = '7B'
         nontiga = '6B'
 
@@ -93,7 +143,7 @@ class _ACQ2106_WRPG(MDSplus.Device):
         # Create the STL table:
         self.set_stl(nchans)
 
-        #Load the STL into the WRPG hardware: GPG
+        #Load the STL into the DIO or GPG module.
         self.load_stl_data()
         
         self.dprint(1, 'WRPG has loaded the STL')
@@ -232,10 +282,11 @@ class _ACQ2106_WRPG(MDSplus.Device):
             rowstr = [str(i) for i in numpy.flip(row)]  # flipping the bits so that chan 1 is in the far right position
             binrows.append(''.join(rowstr))
 
-        # Converting the original units of the transtion times in seconds, to micro-seconts:
+        # Converting the original units of the transtion times in seconds, to 1/10th micro-seconds:
         times_usecs = []
         for elements in t_times:
-            times_usecs.append(int(elements * 1E7)) #The documention says this is in micro-seconds, but it's actually in 1/10 micro-seconds.
+            #The documentation and STL examples says time is in micro-seconds, but it's actually in 1/10th of micro-seconds.
+            times_usecs.append(int(elements * 1E7)) 
          
         # Write to a list with states in HEX form.
         stl  = ''

--- a/pydevices/HtsDevices/acq2106_WRPG.py
+++ b/pydevices/HtsDevices/acq2106_WRPG.py
@@ -293,7 +293,6 @@ class _ACQ2106_WRPG(MDSplus.Device):
         for time, state in zip(times_usecs, binrows):
             stl += '%d,%08X\n' % (time, int(state, 2))
 
-        # MDSplus wants a numpy array
         self.stl.record = stl
 
 OUTFMT3 = ':OUTPUT_%3.3d'

--- a/pydevices/HtsDevices/acq2106_WRPG.py
+++ b/pydevices/HtsDevices/acq2106_WRPG.py
@@ -235,7 +235,7 @@ class _ACQ2106_WRPG(MDSplus.Device):
         # Converting the original units of the transtion times in seconds, to micro-seconts:
         times_usecs = []
         for elements in t_times:
-            times_usecs.append(int(elements * 1E6)) #in micro-seconds
+            times_usecs.append(int(elements * 1E7)) #The documention says this is in micro-seconds, but it's actually in 1/10 micro-seconds.
          
         # Write to a list with states in HEX form.
         stl  = ''

--- a/pydevices/HtsDevices/acq2106_WRPG.py
+++ b/pydevices/HtsDevices/acq2106_WRPG.py
@@ -108,7 +108,7 @@ class _ACQ2106_WRPG(MDSplus.Device):
 
     def getUUT(self):
         import acq400_hapi
-        uut = acq400_hapi.Acq2106_TIGA(self.node.data())
+        uut = acq400_hapi.factory(self.node.data())
         return uut
 
     def getSlot(self):


### PR DESCRIPTION
Some clean up of the code.
Add debugging when using D-Tacq API that loads the STL.
Remove the usage of putData and instead directly add STL as text to the output nodes.

Note:
Passed tests.