### PR TITLE
fix np.float

### DIFF
--- a/pydevices/RfxDevices/SPIDER_FFT.py
+++ b/pydevices/RfxDevices/SPIDER_FFT.py
@@ -125,7 +125,7 @@ class SPIDER_FFT(Device):
                             if currMax > maxIdx:
                                 origOffset = origOffset + 1  #keep trak of the shift that may occur removing the index
                         maxIdxs.append(maxIdx)
-                        outFreqSegs[hIdx].append(acqFreq * np.float(maxIdx + origOffset) / burstSize)
+                        outFreqSegs[hIdx].append(acqFreq * float(maxIdx + origOffset) / burstSize)
                         outAmplSegs[hIdx].append(fftAmp[maxIdx])
                         outPhaseSegs[hIdx].append(fftPhs[maxIdx])
                         np.delete(fftAmp, maxIdx)


### PR DESCRIPTION
Before this change, we get the following error on modern NumPy versions:
```
Error importing from MARTE2_PYTHON_PID.py: module 'numpy' has no attribute 'float'.
`np.float` was a deprecated alias for the builtin `float`. To avoid this error in existing code, use `float` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.float64` here.
The aliases was originally deprecated in NumPy 1.20; for more details and guidance see the original release note at:
    https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
Traceback (most recent call last):
  File "/usr/local/mdsplus/pydevices/RfxDevices/__init__.py", line 40, in _mimport
    module = __import__(name, globals())
```

This commit resolves that error.