### PR TITLE
Fix: Update the regex in influxSignal

### DIFF
--- a/tdi/python/influxSignal.py
+++ b/tdi/python/influxSignal.py
@@ -168,7 +168,7 @@ def influxSignal(fieldKey, aggregation, where, series=None, database=None, confi
         # any equations stored in it
         # For example:
         #   10*fVal will become 10*MEAN(fVal)
-        fieldKey = re.sub(r'([a-zA-Z]*)', '%s(\\1)' % (aggregation,), fieldKey)
+        fieldKey = re.sub(r'([a-zA-Z]+)', '%s(\\1)' % (aggregation,), fieldKey)
         if debug:
             print(aggregation, fieldKey)
 


### PR DESCRIPTION
Change the * to a + in the regex replace triggered by deltaTime being set. This was leading to a strange bug (possibly caused by going from python2 to python3) where it would match the entire fieldKey, and then match the empty space at the end of the line. 

So instead of:
`MEAN(fVal)`
it would become:
`MEAN(fVal)MEAN()`

.. which would then make InfluxDB reject our query.