### PR TITLE
Fix: socket returned can now be zero

### DIFF
--- a/idl/mdsconnect.pro
+++ b/idl/mdsconnect.pro
@@ -162,7 +162,6 @@ pro mdsconnect,host,status=status,quiet=quiet,port=port,socket=socket
   endif
 
   sock = call_external(MdsIPImage(),'IdlConnectToMds',host,value=[byte(!version.os ne 'windows')])
-  print, 'ConnectToMds returned', sock
   sockmin=sockmin()
   if (sock ge sockmin) then begin
     status = 1

--- a/idl/mdsconnect.pro
+++ b/idl/mdsconnect.pro
@@ -5,9 +5,13 @@ case (!version.os) of
 endcase
 end
 
+function sockmin
+  if !version.os eq 'linux' then return, 0 else return, 11-(!version.os eq 'MacOS')
+end
+
 function mds$socket,quiet=quiet,status=status,socket=socket
   status = 1
-  sockmin=1l-(!version.os eq 'MacOS')
+  sockmin=sockmin()
   sock=sockmin-1
   if (keyword_set(socket)) then $
       if (socket ge sockmin) then $
@@ -116,7 +120,7 @@ pro mds$connect,host,status=status,quiet=quiet,port=port
   endif
   if (!version.release ne '5.0.3') then !ERROR_STATE.MSG="About to connect"
   sock = call_external(MdsIPImage(),'IdlConnectToMds',host,value=[byte(!version.os ne 'windows')])
-  sockmin=1l-(!version.os eq 'MacOS')
+  sockmin=sockmin()
   if (sock ge sockmin) then begin
     status = 1
     !MDS_SOCKET = sock
@@ -158,7 +162,8 @@ pro mdsconnect,host,status=status,quiet=quiet,port=port,socket=socket
   endif
 
   sock = call_external(MdsIPImage(),'IdlConnectToMds',host,value=[byte(!version.os ne 'windows')])
-  sockmin=1l-(!version.os eq 'MacOS')
+  print, 'ConnectToMds returned', sock
+  sockmin=sockmin()
   if (sock ge sockmin) then begin
     status = 1
     if not keyword_set(socket) then $


### PR DESCRIPTION
IdlConnectToMds can now return zero as a valid answer.

This is true at least on linux.  It should be tested on other platforms, the code may need further adjustment.

There is specific conditional code for MacOS.

Please approve this PR so that a linux customer can proceed

addresses: https://github.com/MDSplus/mdsplus/issues/2580