### PR TITLE
Fix: issue 2589 -- tostring() deprecated since numpy 1.19.0, replaced with tobytes()

### DIFF
--- a/python/MDSplus/mdsscalar.py
+++ b/python/MDSplus/mdsscalar.py
@@ -434,7 +434,7 @@ class String(Scalar):
     def fromDescriptor(cls, d):
         if d.length == 0:
             return cls('')
-        return cls(_N.array(_C.cast(d.pointer, _C.POINTER((_C.c_byte*d.length))).contents[:], dtype=_N.uint8).tostring())
+        return cls(_N.array(_C.cast(d.pointer, _C.POINTER((_C.c_byte*d.length))).contents[:], dtype=_N.uint8).tobytes())
 
     def __radd__(self, y):
         """radd: x.__radd__(y) <==> y+x

--- a/python/MDSplus/mdsscalar.py
+++ b/python/MDSplus/mdsscalar.py
@@ -33,6 +33,7 @@ def _mimport(name, level=1):
 
 import numpy as _N
 import ctypes as _C
+import sys
 
 _dat = _mimport('mdsdata')
 _arr = _mimport('mdsarray')
@@ -434,7 +435,10 @@ class String(Scalar):
     def fromDescriptor(cls, d):
         if d.length == 0:
             return cls('')
-        return cls(_N.array(_C.cast(d.pointer, _C.POINTER((_C.c_byte*d.length))).contents[:], dtype=_N.uint8).tobytes())
+        if sys.version_info.major == 2: # needed for rhel7 and ubuntu14
+            return cls(_N.array(_C.cast(d.pointer, _C.POINTER((_C.c_byte*d.length))).contents[:], dtype=_N.uint8).tostring())
+        else:
+            return cls(_N.array(_C.cast(d.pointer, _C.POINTER((_C.c_byte*d.length))).contents[:], dtype=_N.uint8).tobytes())
 
     def __radd__(self, y):
         """radd: x.__radd__(y) <==> y+x


### PR DESCRIPTION
Should also be cherry-picked into the stable branch.