### PR TITLE
MacOS now has working OFD locks

### DIFF
--- a/treeshr/RemoteAccess.c
+++ b/treeshr/RemoteAccess.c
@@ -24,6 +24,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
 #include <mdsplus/mdsconfig.h>
+#include <mdsplus/mdsplus.h>
 #ifdef _WIN32
 #include <winsock2.h>
 #include <windows.h>
@@ -39,11 +40,23 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 // # define flock lx_flock
 // # include <linux/fcntl.h>
 // # undef flock
+
 #ifndef F_OFD_SETLK
+#ifdef _MACOSX
+// Open File Descriptor (OFD) locks have existed as a private / undocumented
+// feature in MacOS releases since 2015.  For more details, refer to the
+// comments at the end of Issue #2599 and the earlier PRs #2163 and #2198.
+#define F_OFD_GETLK 92
+#define F_OFD_SETLK 90
+#define F_OFD_SETLKW 91
+#else
+// The usual defines for Linux
 #define F_OFD_GETLK 36
 #define F_OFD_SETLK 37
 #define F_OFD_SETLKW 38
 #endif
+#endif
+
 #endif
 #include <ctype.h>
 #include <errno.h>


### PR DESCRIPTION
The "Open File Descriptor" locks (OFD) were defined incorrectly for MacOS.   Consequently, MacOS Ventura was throwing errors (on both Intel and Apple Silicon CPUs).   And in particular, the TreeSegmentTest was failing.

Darren found the correct definitions for OFD locks in Apple's published open source.   Although OFD locks are an undocumented feature of MacOS, they have been present since 2015.

Prior to creating this PR, testing was done to ensure that TreeSegmentTest passes on the following platforms.
- Ubuntu20 (x86_64)
- RHEL9 (x86_64)
- Windows (x86_64)
- Intel MacOS Ventura
- Apple Silicon MacOS Ventura
- Ubuntu22 (aarch64, aka arm64)