### PR TITLE
Fix: changed tditest/test-mdsip test case so works on macOS

### DIFF
--- a/mdstcpip/mdsipshr/CheckClient.c
+++ b/mdstcpip/mdsipshr/CheckClient.c
@@ -94,6 +94,13 @@ static int become_user(const char *remote_user,
   else
     user = local_user;
   struct passwd *pwd = user ? getpwnam(user) : 0;
+  // On macOS Ventura, searching for "unknown" in password list 
+  // returns default "_unknown" user, which should be ignored.
+#ifdef __APPLE__
+  if (pwd && (strcmp("_unknown", pwd->pw_name) == 0)) {
+    pwd = 0;
+  }
+#endif
   if (!pwd && user == remote_user)
   {
     int i;
@@ -102,6 +109,11 @@ static int become_user(const char *remote_user,
       lowuser[i] = tolower(remote_user[i]);
     pwd = getpwnam(lowuser);
     free(lowuser);
+#ifdef __APPLE__
+    if (pwd && (strcmp("_unknown", pwd->pw_name) == 0)) {
+      pwd = 0;
+    }
+#endif
   }
   int access;
   if (pwd)

--- a/tditest/testing/do_tditests.sh
+++ b/tditest/testing/do_tditests.sh
@@ -60,12 +60,12 @@ if [ ! -z $1 ]; then
   if [[ $test == *"dev"* ]]; then
     found=0
     for path in ${LD_LIBRARY_PATH//:/ }; do
-      if [ -e $path/libMitDevices.so ]; then
+      if [ -e $path/libMitDevices.so ] || [ -e $path/libMitDevices.dylib ]; then
         found=1
       fi
     done
     if [ $found == 0 ]; then
-      echo no libMitDevices.so
+      echo "no libMitDevices.so or no libMitDevices.dylib (macOS)"
       exit 77
     fi
   fi


### PR DESCRIPTION
The mdsip.hosts file was not being processed correctly because MDSplus user authentication failed on macOS.

Additional detail:

- Regarding `do_tditests.sh`, this PR only includes the macOS related changes.  The CMake related changes to the same file will be submitted in a future PR.
- Issue #2597 requires this PR.