### PR TITLE
Fix: minor change to UDT4 protocol for CMake and macOS

### DIFF
--- a/mdstcpip/udt4/src/channel.cpp
+++ b/mdstcpip/udt4/src/channel.cpp
@@ -124,7 +124,7 @@ void CChannel::open(UDPSOCKET udpsock) {
 }
 
 void CChannel::setUDPSockOpt() {
-#if defined(BSD) || defined(OSX)
+#if defined(BSD) || defined(__APPLE__)
   // BSD system will fail setsockopt if the requested buffer size exceeds system
   // maximum value
   int maxsize = 64000;
@@ -148,7 +148,7 @@ void CChannel::setUDPSockOpt() {
 
   timeval tv;
   tv.tv_sec = 0;
-#if defined(BSD) || defined(OSX)
+#if defined(BSD) || defined(__APPLE__)
   // Known BSD bug as the day I wrote this code.
   // A small time out value will cause the socket to block forever.
   tv.tv_usec = 10000;

--- a/mdstcpip/udt4/src/common.cpp
+++ b/mdstcpip/udt4/src/common.cpp
@@ -42,7 +42,7 @@ written by
 #include <cstring>
 #include <cerrno>
 #include <unistd.h>
-#ifdef OSX
+#ifdef __APPLE__
 #include <mach/mach_time.h>
 #endif
 #else
@@ -115,7 +115,7 @@ void CTimer::rdtsc(uint64_t &x) {
   // SetThreadAffinityMask(hCurThread, dwOldMask);
   if (!ret)
     x = getTime() * s_ullCPUFrequency;
-#elif defined(OSX)
+#elif defined(__APPLE__)
   x = mach_absolute_time();
 #else
   // use system call to read time clock for other archs
@@ -142,7 +142,7 @@ uint64_t CTimer::readCPUFrequency() {
   int64_t ccf;
   if (QueryPerformanceFrequency((LARGE_INTEGER *)&ccf))
     frequency = ccf / 1000000;
-#elif defined(OSX)
+#elif defined(__APPLE__)
   mach_timebase_info_data_t info;
   mach_timebase_info(&info);
   frequency = info.denom * 1000ULL / info.numer;


### PR DESCRIPTION
The UDT4 protocol was failing on macOS Ventura because the CMake build does not define the OSX environment variable.

Additional detail:
- With the Autotools build system, the OSX environment variable was defined in the Makefile.   In the new CMake based build system, OSX is not defined and thus the UDT4 test cases fail. 
- Issue #2597 requires this PR.