### PR TITLE
Fix: change ports on test case to avoid conflict on macOS Big Sur

### DIFF
--- a/python/MDSplus/tests/connection_case.py
+++ b/python/MDSplus/tests/connection_case.py
@@ -69,7 +69,7 @@ class Tests(_common.TreeTests, _common.MdsIp):
                 print(nci, t, l, c)
                 raise
         server, server_port = self._setup_mdsip(
-            'ACTION_SERVER', 'ACTION_PORT', 7000+self.index, True)
+            'ACTION_SERVER', 'ACTION_PORT', 7500+self.index, True)
 
         svr, svr_log = self._start_mdsip(server, server_port, 'thick')
         try:
@@ -177,7 +177,7 @@ class Tests(_common.TreeTests, _common.MdsIp):
 
     def tcp(self):
         server, server_port = self._setup_mdsip(
-            'ACTION_SERVER', 'ACTION_PORT', 7010+self.index, True)
+            'ACTION_SERVER', 'ACTION_PORT', 7510+self.index, True)
         svr, svr_log = self._start_mdsip(server, server_port, 'tcp')
         try:
             self._thread_test(server)
@@ -212,7 +212,7 @@ class Tests(_common.TreeTests, _common.MdsIp):
                   (name, i / (end-start), max_period))
 
         server, server_port = self._setup_mdsip(
-            'ACTION_SERVER', 'ACTION_PORT', 7020+self.index, True)
+            'ACTION_SERVER', 'ACTION_PORT', 7520+self.index, True)
         tempdir = tempfile.mkdtemp()
         try:
             svr, svr_log = self._start_mdsip(server, server_port, 'tcp')


### PR DESCRIPTION
On Josh's Intel macOS Big Sur, a test failed because port 7000 was already being used by ControlCenter.

Additional detail:
- It is unclear why there was a port conflict on Intel macOS Big Sur but not on Intel macOS Ventura.
- Josh requested that the test case be changed to use port 7500, so changed all three port assignments accordingly.
- It is possible (likely?) that port assignments for all test cases (including this one) will change again when the switch from Autotools to CMake occurs.
- Issue #2597 requires this PR.