### PR TITLE
Fix: solve socket binding problems causing test cases to fail

### DIFF
--- a/mdsshr/UdpEvents.c
+++ b/mdsshr/UdpEvents.c
@@ -31,6 +31,10 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#ifndef _WIN32
+#include <sys/socket.h>
+#include <netinet/in.h>
+#endif
 #include <sys/types.h>
 #include <unistd.h>
 


### PR DESCRIPTION
On Josh's Intel macOS Big Sur, this change was needed to fix some failing test cases (Java's MDSplus.MdsTreeNodeTest?).

Additional detail:
- Josh added these includes when debugging test cases that failed on macOS Big Sur.   (Apparently, there was an issue with socket binding.)
- Initial testing of this fix revealed that the two include files do not exist on Windows, so caused compile errors.
- Adding the `#ifndef` allowed this fix to pass on Linux, Windows and macOS.
- It is unclear why this fix was needed on Josh's Intel macOS Big Sur but not on Mark's Intel macOS Ventura.
- This fix was communicated verbally, thus might be missing a few lines of changed code.
- Issue #2597 requires this PR