### PR TITLE
feature: jtraverser2 dynamically convert non-native floating formats

### DIFF
--- a/java/mdsplus-api/src/main/java/mds/Mds.java
+++ b/java/mdsplus-api/src/main/java/mds/Mds.java
@@ -85,7 +85,7 @@ public abstract class Mds implements AutoCloseable
 	public static final Pattern dollar = Pattern.compile("\\$[0-9]*(?=[^a-zA-Z]|$)");
 	protected static final int MAX_NUM_EVENTS = 256;
 	private static Mds active;
-	private static MdsIp shared_tunnel = null;
+	private static Mds shared_tunnel = null;
 
 	@SuppressWarnings(
 	{ "unchecked", "rawtypes" })
@@ -118,13 +118,13 @@ public abstract class Mds implements AutoCloseable
 		return Mds.active;
 	}
 
-	public final static MdsIp getLocal()
+	public final static Mds getLocal()
 	{
 		if (Mds.shared_tunnel == null)
 			Mds.shared_tunnel = new MdsIp();
 		if (Mds.shared_tunnel.isReady() == null)
 			return Mds.shared_tunnel;
-		return null;
+		return active;
 	}
 
 	protected transient HashSet<TransferEventListener> translisteners = new HashSet<>();

--- a/java/mdsplus-api/src/main/java/mds/data/DTYPE.java
+++ b/java/mdsplus-api/src/main/java/mds/data/DTYPE.java
@@ -30,7 +30,7 @@ public enum DTYPE
 	OU("Octaword_Unsigned", "OU"), // 25
 	O("Octaword", "O"), // 26
 	G("G_Float", "G"), // 27
-	H("H_Float", "H"), // 28
+	H("H_Float", "H"), // 28 /*bad*/
 	GC("G_Complex", "G"), // 29 IEEE
 	HC("H_Complex", "H"), // 30 128bit
 	CIT, // 31 COBOL Intermediate Temporary

--- a/java/mdsplus-api/src/main/java/mds/data/descriptor/Descriptor_A.java
+++ b/java/mdsplus-api/src/main/java/mds/data/descriptor/Descriptor_A.java
@@ -9,6 +9,8 @@ import mds.Mds;
 import mds.MdsException;
 import mds.data.DTYPE;
 import mds.data.descriptor_a.*;
+import mds.data.descriptor_r.function.CAST.FS_Float;
+import mds.data.descriptor_r.function.CAST.FT_Float;
 import mds.mdsip.Message;
 
 /** Array Descriptor (4) **/
@@ -96,23 +98,23 @@ public abstract class Descriptor_A<T> extends ARRAY<T[]> implements Iterable<T>
 		case O:
 			return new Int128Array(b);
 		case F:
-            return (Float32Array)Mds.getLocal().getDescriptor("FS_FLOAT($)", new Float32Array(b));
+			return Mds.getLocal().getDescriptor("$", Float32Array.class, new FS_Float(new Float32Array(b)));
 		case FS:
 			return new Float32Array(b);
 		case FC:
-            return (Complex32Array)Mds.getLocal().getDescriptor("FS_FLOAT($)", new Complex32Array(b));
+			return Mds.getLocal().getDescriptor("$", Complex32Array.class, new FS_Float(new Complex32Array(b)));
 		case FSC:
 			return new Complex32Array(b);
 		case D:
 		case G:
 		case H:
-            return (Float64Array)Mds.getLocal().getDescriptor("FT_FLOAT($)", new Float64Array(b));
+			return Mds.getLocal().getDescriptor("$", Float64Array.class, new FT_Float(new Float64Array(b)));
 		case FT:
 			return new Float64Array(b);
 		case DC:
 		case GC:
 		case HC:
-            return (Complex64Array)Mds.getLocal().getDescriptor("FT_FLOAT($)", new Complex64Array(b));
+			return Mds.getLocal().getDescriptor("$", Complex64Array.class, new FT_Float(new Complex64Array(b)));
 		case FTC:
 			return new Complex64Array(b);
 		case T:

--- a/java/mdsplus-api/src/main/java/mds/data/descriptor/Descriptor_A.java
+++ b/java/mdsplus-api/src/main/java/mds/data/descriptor/Descriptor_A.java
@@ -5,6 +5,7 @@ import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.Iterator;
 
+import mds.Mds;
 import mds.MdsException;
 import mds.data.DTYPE;
 import mds.data.descriptor_a.*;
@@ -95,17 +96,23 @@ public abstract class Descriptor_A<T> extends ARRAY<T[]> implements Iterable<T>
 		case O:
 			return new Int128Array(b);
 		case F:
+            return (Float32Array)Mds.getLocal().getDescriptor("FS_FLOAT($)", new Float32Array(b));
 		case FS:
 			return new Float32Array(b);
 		case FC:
+            return (Complex32Array)Mds.getLocal().getDescriptor("FS_FLOAT($)", new Complex32Array(b));
 		case FSC:
 			return new Complex32Array(b);
 		case D:
 		case G:
+		case H:
+            return (Float64Array)Mds.getLocal().getDescriptor("FT_FLOAT($)", new Float64Array(b));
 		case FT:
 			return new Float64Array(b);
 		case DC:
 		case GC:
+		case HC:
+            return (Complex64Array)Mds.getLocal().getDescriptor("FT_FLOAT($)", new Complex64Array(b));
 		case FTC:
 			return new Complex64Array(b);
 		case T:

--- a/java/mdsplus-api/src/main/java/mds/data/descriptor/Descriptor_S.java
+++ b/java/mdsplus-api/src/main/java/mds/data/descriptor/Descriptor_S.java
@@ -43,17 +43,17 @@ public abstract class Descriptor_S<T> extends Descriptor<T>
 			return new Int64(b);
 		case O:
 			return new Int128(b);
-		case F:
+		case F: // 1F0
             return (Float32)Mds.getLocal().getDescriptor("FS_FLOAT($)", new Float32(b));
-		case FS:
+		case FS: // 1E0
 			return new Float32(b);
 		case FC:
             return (Complex32)Mds.getLocal().getDescriptor("FS_FLOAT($)", new Complex32(b));
 		case FSC:
 			return new Complex32(b);
-		case D:
-		case G:
-		case H:
+		case D: // 1V0
+		case G: // 1G0
+		case H: // /*bad*/
             return (Float64)Mds.getLocal().getDescriptor("FT_FLOAT($)", new Float64(b));
 		case FT:
 			return new Float64(b);

--- a/java/mdsplus-api/src/main/java/mds/data/descriptor/Descriptor_S.java
+++ b/java/mdsplus-api/src/main/java/mds/data/descriptor/Descriptor_S.java
@@ -3,6 +3,7 @@ package mds.data.descriptor;
 import java.math.BigInteger;
 import java.nio.ByteBuffer;
 
+import mds.Mds;
 import mds.MdsException;
 import mds.data.DTYPE;
 import mds.data.descriptor_s.*;
@@ -43,17 +44,23 @@ public abstract class Descriptor_S<T> extends Descriptor<T>
 		case O:
 			return new Int128(b);
 		case F:
+            return (Float32)Mds.getLocal().getDescriptor("FS_FLOAT($)", new Float32(b));
 		case FS:
 			return new Float32(b);
 		case FC:
+            return (Complex32)Mds.getLocal().getDescriptor("FS_FLOAT($)", new Complex32(b));
 		case FSC:
 			return new Complex32(b);
 		case D:
 		case G:
+		case H:
+            return (Float64)Mds.getLocal().getDescriptor("FT_FLOAT($)", new Float64(b));
 		case FT:
 			return new Float64(b);
 		case DC:
 		case GC:
+		case HC:
+            return (Complex64)Mds.getLocal().getDescriptor("FT_FLOAT($)", new Complex64(b));
 		case FTC:
 			return new Complex64(b);
 		case T:

--- a/java/mdsplus-api/src/main/java/mds/data/descriptor/Descriptor_S.java
+++ b/java/mdsplus-api/src/main/java/mds/data/descriptor/Descriptor_S.java
@@ -6,6 +6,8 @@ import java.nio.ByteBuffer;
 import mds.Mds;
 import mds.MdsException;
 import mds.data.DTYPE;
+import mds.data.descriptor_r.function.CAST.FS_Float;
+import mds.data.descriptor_r.function.CAST.FT_Float;
 import mds.data.descriptor_s.*;
 
 /** Fixed-Length (static) Descriptor (1) **/
@@ -44,23 +46,23 @@ public abstract class Descriptor_S<T> extends Descriptor<T>
 		case O:
 			return new Int128(b);
 		case F: // 1F0
-            return (Float32)Mds.getLocal().getDescriptor("FS_FLOAT($)", new Float32(b));
+            return Mds.getLocal().getDescriptor("$", Float32.class, new FS_Float(new Float32(b)));
 		case FS: // 1E0
 			return new Float32(b);
 		case FC:
-            return (Complex32)Mds.getLocal().getDescriptor("FS_FLOAT($)", new Complex32(b));
+            return Mds.getLocal().getDescriptor("$", Complex32.class, new FS_Float(new Complex32(b)));
 		case FSC:
 			return new Complex32(b);
 		case D: // 1V0
 		case G: // 1G0
 		case H: // /*bad*/
-            return (Float64)Mds.getLocal().getDescriptor("FT_FLOAT($)", new Float64(b));
+            return Mds.getLocal().getDescriptor("$", Float64.class, new FT_Float(new Float64(b)));
 		case FT:
 			return new Float64(b);
 		case DC:
 		case GC:
 		case HC:
-            return (Complex64)Mds.getLocal().getDescriptor("FT_FLOAT($)", new Complex64(b));
+            return Mds.getLocal().getDescriptor("$", Complex64.class, new FT_Float(new Complex64(b)));
 		case FTC:
 			return new Complex64(b);
 		case T:

--- a/java/mdsplus-api/src/main/java/mds/data/descriptor_a/COMPLEXArray.java
+++ b/java/mdsplus-api/src/main/java/mds/data/descriptor_a/COMPLEXArray.java
@@ -91,7 +91,7 @@ public abstract class COMPLEXArray<T extends Number> extends NUMBERArray<Complex
 	@Override
 	protected final StringBuilder decompile(final StringBuilder pout, final Complex<T> t)
 	{
-		return COMPLEX.decompile(pout, t, this.dtype(), Descriptor.DECO_NRM);
+		return COMPLEX.decompile(mds, pout, t, this.dtype(), Descriptor.DECO_NRM);
 	}
 
 	public final T getImag(final int idx)

--- a/java/mdsplus-api/src/main/java/mds/data/descriptor_a/FLOATArray.java
+++ b/java/mdsplus-api/src/main/java/mds/data/descriptor_a/FLOATArray.java
@@ -46,7 +46,7 @@ public abstract class FLOATArray<T extends Number> extends NUMBERArray<T>
 	@Override
 	public final StringBuilder decompile(final StringBuilder pout, final T value)
 	{
-		return pout.append(FLOAT.decompile(value, this.dtype(), Descriptor.DECO_NRM));
+		return pout.append(FLOAT.decompile(mds, value, this.dtype(), Descriptor.DECO_NRM));
 	}
 
 	@Override
@@ -56,6 +56,6 @@ public abstract class FLOATArray<T extends Number> extends NUMBERArray<T>
 	@Override
 	public final String toString(final T value)
 	{
-		return FLOAT.decompile(value, this.dtype(), Descriptor.DECO_STR);
+		return FLOAT.decompile(mds, value, this.dtype(), Descriptor.DECO_STR);
 	}
 }

--- a/java/mdsplus-api/src/main/java/mds/data/descriptor_r/Function.java
+++ b/java/mdsplus-api/src/main/java/mds/data/descriptor_r/Function.java
@@ -111,6 +111,11 @@ public class Function extends Descriptor_R<Short>
 		return new Function(OPC.OpcAsIs, dscptrs);
 	}
 
+	public static final Function Decompile(final Descriptor<?> dscptrs)
+	{
+		return new Function(OPC.OpcDecompile, dscptrs);
+	}
+
 	private final static void deIndent(final StringBuilder pout)
 	{
 		int fin;

--- a/java/mdsplus-api/src/main/java/mds/data/descriptor_s/COMPLEX.java
+++ b/java/mdsplus-api/src/main/java/mds/data/descriptor_s/COMPLEX.java
@@ -1,6 +1,8 @@
 package mds.data.descriptor_s;
 
 import java.nio.ByteBuffer;
+
+import mds.Mds;
 import mds.MdsException;
 import mds.data.DATA;
 import mds.data.DTYPE;
@@ -46,12 +48,12 @@ public abstract class COMPLEX<T extends Number> extends NUMBER<Complex<T>>
 		}
 	}
 
-	public static final <T extends Number> StringBuilder decompile(final StringBuilder pout, final Complex<T> t,
+	public static final <T extends Number> StringBuilder decompile(Mds mds, final StringBuilder pout, final Complex<T> t,
 			final DTYPE dtype, final int mode)
 	{
 		pout.append("Cmplx(");
-		pout.append(FLOAT.decompile(t.real, dtype, mode)).append(',');
-		pout.append(FLOAT.decompile(t.imag, dtype, mode)).append(')');
+		pout.append(FLOAT.decompile(mds, t.real, dtype, mode)).append(',');
+		pout.append(FLOAT.decompile(mds, t.imag, dtype, mode)).append(')');
 		return pout;
 	}
 
@@ -112,7 +114,7 @@ public abstract class COMPLEX<T extends Number> extends NUMBER<Complex<T>>
 	@Override
 	public final StringBuilder decompile(final int prec, final StringBuilder pout, final int mode)
 	{
-		return COMPLEX.decompile(pout, this.getAtomic(), this.dtype(), mode);
+		return COMPLEX.decompile(mds, pout, this.getAtomic(), this.dtype(), mode);
 	}
 
 	@Override

--- a/java/mdsplus-api/src/test/java/mds/AllTests.java
+++ b/java/mdsplus-api/src/test/java/mds/AllTests.java
@@ -5,6 +5,7 @@ import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
 
 import mds.data.CONST_Test;
+import mds.data.FLOAT_Test;
 import mds.data.TREE_Test;
 import mds.data.descriptor.*;
 import mds.data.descriptor_r.Function;
@@ -14,12 +15,12 @@ import mds.mdsip.MdsIp.Provider;
 
 @RunWith(Suite.class)
 @SuiteClasses(
-{ TREE_Test.class, CONST_Test.class, Mds_Test.class, TreeShr_Test.class, MdsShr_Test.class, Function_Test.class,
-		Descriptor_S_Test.class, Descriptor_A_Test.class, Descriptor_CA_Test.class }) // ,
+{ TREE_Test.class, CONST_Test.class, FLOAT_Test.class, Mds_Test.class, TreeShr_Test.class, MdsShr_Test.class,
+		Function_Test.class, Descriptor_S_Test.class, Descriptor_A_Test.class, Descriptor_CA_Test.class }) // ,
 // Editors_Test.class})
 public class AllTests
 {
-	private static boolean local = true;
+	private static boolean local = false;
 	private static boolean mdsip = true;
 	private static boolean use_local = false;
 	private static final int port = 8000;
@@ -31,10 +32,10 @@ public class AllTests
 	public static Mds setUpBeforeClass() throws Exception
 	{
 		final boolean local_win = System.getProperty("os.name").startsWith("Win");
-		final String host = System.getenv("MDSIP_SERVER");
+		String host = System.getenv("MDSIP_SERVER");
 		AllTests.local = AllTests.local || (!AllTests.mdsip) || host == null || host.length() == 0;
 		final String treepath = (AllTests.local ? local_win : AllTests.remote_win) ? "C:\\Temp" : "/tmp";
-		final String prefix = AllTests.local ? "local://" : (AllTests.ssh ? "ssh://" : null);
+		final String prefix = AllTests.local ? "local://" : (AllTests.ssh ? "ssh://" : "");
 		final String command = AllTests.local ? "local" : (AllTests.ssh ? host : host + ":" + AllTests.port);
 		final Mds mdslocal = Mds.getLocal();
 		if (!AllTests.use_local && mdslocal != null)
@@ -49,9 +50,15 @@ public class AllTests
 			final MdsIp tmds = MdsIp.sharedConnection(new Provider(prefix + command));
 			if (tmds.isConnected())
 				mds = tmds;
+			else if (AllTests.local) {
+				final MdsIp lh = MdsIp.sharedConnection(new Provider("localhost"));
+				if (lh.isConnected())
+					mds = lh;
+			}
 		}
 		if (mds == null)
 			throw new Exception("Could not connect to mdsip.");
+		mds.setActive();
 		Function.setWindowsLineEnding(AllTests.local ? local_win : AllTests.remote_win);
 		mds.getAPI().setenv(AllTests.tree + "_path", treepath);
 		return mds;

--- a/java/mdsplus-api/src/test/java/mds/data/CONST_Test.java
+++ b/java/mdsplus-api/src/test/java/mds/data/CONST_Test.java
@@ -7,6 +7,7 @@ import mds.Mds;
 import mds.data.descriptor.Descriptor;
 import mds.data.descriptor_r.With_Error;
 import mds.data.descriptor_r.With_Units;
+import mds.data.descriptor_r.function.CAST;
 import mds.data.descriptor_r.function.CONST.*;
 
 @SuppressWarnings("static-method")
@@ -52,7 +53,8 @@ public class CONST_Test
 	{
 		// exact
 		Assert.assertEquals(new dMissing().evaluate(), CONST_Test.mds.getDescriptor("$Missing", Descriptor.class));
-		Assert.assertEquals(new dRoprand().evaluate(), CONST_Test.mds.getDescriptor("$Roprand", Descriptor.class));
+		Assert.assertEquals("$ROPRAND", CONST_Test.mds.getDescriptor("$Roprand", Descriptor.class).decompile());
+		Assert.assertEquals("$ROPRAND", new dRoprand().evaluate().decompile());
 		Assert.assertEquals(new dI().evaluate(), CONST_Test.mds.getDescriptor("$I", Descriptor.class));
 		Assert.assertEquals(new dTrue().evaluate(), CONST_Test.mds.getDescriptor("$True", Descriptor.class));
 		Assert.assertEquals(new dFalse().evaluate(), CONST_Test.mds.getDescriptor("$False", Descriptor.class));

--- a/java/mdsplus-api/src/test/java/mds/data/FLOAT_Test.java
+++ b/java/mdsplus-api/src/test/java/mds/data/FLOAT_Test.java
@@ -1,0 +1,78 @@
+package mds.data;
+
+import java.nio.ByteBuffer;
+
+import org.junit.*;
+
+import mds.AllTests;
+import mds.Mds;
+import mds.data.descriptor_s.*;
+
+@SuppressWarnings("static-method")
+public class FLOAT_Test
+{
+	private static Mds mds;
+	private static double expected = 1.234;
+	private static double delta = 0.0001;
+	
+	@BeforeClass
+	public static final void setUpBeforeClass() throws Exception
+	{
+		FLOAT_Test.mds = AllTests.setUpBeforeClass();
+	}
+
+	@AfterClass
+	public static final void tearDownAfterClass() throws Exception
+	{
+		AllTests.tearDownAfterClass(FLOAT_Test.mds);
+	}
+	
+	private <T extends FLOAT<?>>
+	 void check(byte[] serial, T data, DTYPE dtype_in, DTYPE dtype_out) throws Exception
+	{
+		Assert.assertEquals(data.dtype(), dtype_in);
+		double dvalue = mds.getDouble("FT_FLOAT($)", data);
+		Assert.assertEquals(dvalue, expected, delta);
+		float fvalue = mds.getFloat("FS_FLOAT($)", data);
+		Assert.assertEquals(fvalue, expected, delta);
+		DATA<?> reread = mds.getDescriptor("$", data).getDATA();
+		Assert.assertEquals(reread.dtype(), dtype_out);
+		Assert.assertEquals(reread.toDouble(), expected, delta);		
+	}
+	
+	@Test
+	public void f_float() throws Exception
+	{
+		final byte[] serial = // SIGNED(serializeout(1.234F0))
+		{ 4, 0, 10, 1, 8, 0, 0, 0, -99, 64, -74, -13 };
+		check(serial, new Float32(ByteBuffer.wrap(serial)), DTYPE.F, DTYPE.FS);
+	}
+
+	@Test
+	public void g_float() throws Exception
+	{
+		final byte[] serial = // SIGNED(serializeout(1.234V0))
+		{ 8, 0, 11, 1, 8, 0, 0, 0, -99, 64, -74, -13, -95, 69, -64, -54 };
+		check(serial, new Float64(ByteBuffer.wrap(serial)), DTYPE.G, DTYPE.FT);
+	}
+
+	@Test
+	public void d_float() throws Exception
+	{
+		final byte[] serial = // SIGNED(serializeout(1.234D0))
+		{ 8, 0, 53, 1, 8, 0, 0, 0, 88, 57, -76, -56, 118, -66, -13, 63 };
+		check(serial, new Float64(ByteBuffer.wrap(serial)), DTYPE.D, DTYPE.FT);
+	}
+
+	@Before
+	public void setUp() throws Exception
+	{
+		// stub
+	}
+
+	@After
+	public void tearDown() throws Exception
+	{
+		// stub
+	}
+}

--- a/java/mdsplus-api/src/test/java/mds/data/FLOAT_Test.java
+++ b/java/mdsplus-api/src/test/java/mds/data/FLOAT_Test.java
@@ -1,11 +1,14 @@
 package mds.data;
 
 import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 
 import org.junit.*;
 
 import mds.AllTests;
 import mds.Mds;
+import mds.data.descriptor.Descriptor;
+import mds.data.descriptor_r.function.CAST;
 import mds.data.descriptor_s.*;
 
 @SuppressWarnings("static-method")
@@ -14,7 +17,7 @@ public class FLOAT_Test
 	private static Mds mds;
 	private static double expected = 1.234;
 	private static double delta = 0.0001;
-	
+
 	@BeforeClass
 	public static final void setUpBeforeClass() throws Exception
 	{
@@ -26,42 +29,43 @@ public class FLOAT_Test
 	{
 		AllTests.tearDownAfterClass(FLOAT_Test.mds);
 	}
-	
-	private <T extends FLOAT<?>>
-	 void check(byte[] serial, T data, DTYPE dtype_in, DTYPE dtype_out) throws Exception
+
+	private void check(byte[] serial, String expr, DTYPE dtype_in, DTYPE dtype_out) throws Exception
 	{
+		ByteBuffer b = ByteBuffer.wrap(serial).order(ByteOrder.LITTLE_ENDIAN);
+		FLOAT<?> data = (dtype_out == DTYPE.FS) ? new Float32(b) : new Float64(b);
+		CAST cast = (dtype_out == DTYPE.FS) ? new CAST.FS_Float(data) : new CAST.FT_Float(data);
 		Assert.assertEquals(data.dtype(), dtype_in);
-		double dvalue = mds.getDouble("FT_FLOAT($)", data);
-		Assert.assertEquals(dvalue, expected, delta);
-		float fvalue = mds.getFloat("FS_FLOAT($)", data);
-		Assert.assertEquals(fvalue, expected, delta);
-		DATA<?> reread = mds.getDescriptor("$", data).getDATA();
-		Assert.assertEquals(reread.dtype(), dtype_out);
-		Assert.assertEquals(reread.toDouble(), expected, delta);		
+		Assert.assertEquals(expr, data.decompile());
+		Descriptor<?> casted = mds.getDescriptor("$", cast);
+		Assert.assertEquals(expected, casted.toDouble(), delta);
+		Descriptor<?> read = mds.getDescriptor(expr);
+		Assert.assertEquals(read.dtype(), dtype_out);
+		Assert.assertEquals(expected, read.toDouble(), delta);
 	}
-	
+
 	@Test
 	public void f_float() throws Exception
 	{
 		final byte[] serial = // SIGNED(serializeout(1.234F0))
 		{ 4, 0, 10, 1, 8, 0, 0, 0, -99, 64, -74, -13 };
-		check(serial, new Float32(ByteBuffer.wrap(serial)), DTYPE.F, DTYPE.FS);
-	}
-
-	@Test
-	public void g_float() throws Exception
-	{
-		final byte[] serial = // SIGNED(serializeout(1.234V0))
-		{ 8, 0, 11, 1, 8, 0, 0, 0, -99, 64, -74, -13, -95, 69, -64, -54 };
-		check(serial, new Float64(ByteBuffer.wrap(serial)), DTYPE.G, DTYPE.FT);
+		check(serial, "1.234F0", DTYPE.F, DTYPE.FS);
 	}
 
 	@Test
 	public void d_float() throws Exception
 	{
+		final byte[] serial = // SIGNED(serializeout(1.234V0))
+		{ 8, 0, 11, 1, 8, 0, 0, 0, -99, 64, -74, -13, -95, 69, -64, -54 };
+		check(serial, "1.234V0", DTYPE.D, DTYPE.FT);
+	}
+
+	@Test
+	public void g_float() throws Exception
+	{
 		final byte[] serial = // SIGNED(serializeout(1.234D0))
-		{ 8, 0, 53, 1, 8, 0, 0, 0, 88, 57, -76, -56, 118, -66, -13, 63 };
-		check(serial, new Float64(ByteBuffer.wrap(serial)), DTYPE.D, DTYPE.FT);
+		{ 8, 0, 27, 1, 8, 0, 0, 0, 19, 64, 118, -66, -76, -56, 88, 57 };
+		check(serial, "1.234G0", DTYPE.G, DTYPE.FT);
 	}
 
 	@Before

--- a/java/mdsplus-api/tests/Makefile.am
+++ b/java/mdsplus-api/tests/Makefile.am
@@ -17,6 +17,7 @@ TESTS = \
  mds.TdiShr_Test\
  mds.TreeShr_Test\
  mds.data.CONST_Test\
+ mds.data.FLOAT_Test\
  mds.data.TREE_Test\
  mds.data.descriptor.Descriptor_A_Test\
  mds.data.descriptor.Descriptor_CA_Test\


### PR DESCRIPTION
* this is an untested attempt to address issue #2576. 
* this is a cheap way to intercept unsupported dtypes converting them to native types.
* it may be more performant to convert only in getValue/setValue/getAtomic ... but requires sub-classes of each Float32/64 and Compex32/64 as well as their Array variants.
* this does not mark DTYPE_F etc. as supported but merely allows to import them from serialized sources.
* this will not preserve the original dtype (mdsip cannot do raw float_x other than FT and FS)