### PR TITLE
Info: add comments explaining MDSplus status codes

### DIFF
--- a/deploy/gen_messages.py
+++ b/deploy/gen_messages.py
@@ -278,6 +278,29 @@ jma_tail = """\t\t\tdefault:
 \t}
 }"""
 
+# Severity scheme is modeled after VAX VMS.
+#
+# The status code is 32 bits, with these three fields:
+#    16 bit facility code in high order bits,
+#    13 bit message number, 
+#     3 bit severity (low order bits).
+#
+# Every odd severity is a flavor of success ("status & 0x1" is easy check).
+# Every even severity is a flavor of error.
+#   W = warning = 0   -- bad
+#   S = success = 1   -- OK
+#   E = error = 2     -- bad
+#   I = info = 3      -- OK
+#   F = fatal = 4     -- bad
+#   ? = unused = 5    -- OK
+#   ? = unused = 6    -- bad
+#   ? = internal = 7  -- OK (see usage in mdsshr/mdsshr_messages.xml)
+#
+# SsINTERNAL is all bits set in all fields (= -1), and is unusual because it
+# is both informational (when trapped by calling code) and an error (when
+# it is an unhandled exception that the user sees).  It is also unusual
+# because it has a different facility code (-1) than used by the rest
+# of the Ss exceptions (which are facility code 0).
 
 import xml.etree.ElementTree as ET
 import sys

--- a/deploy/gen_messages.py
+++ b/deploy/gen_messages.py
@@ -278,13 +278,12 @@ jma_tail = """\t\t\tdefault:
 \t}
 }"""
 
-# Severity scheme is modeled after VAX VMS.
-#
 # The status code is 32 bits, with these three fields:
 #    16 bit facility code in high order bits,
 #    13 bit message number, 
 #     3 bit severity (low order bits).
 #
+# The severity scheme is similar to that used by VAX VMS.
 # Every odd severity is a flavor of success ("status & 0x1" is easy check).
 # Every even severity is a flavor of error.
 #   W = warning = 0   -- bad
@@ -296,11 +295,10 @@ jma_tail = """\t\t\tdefault:
 #   ? = unused = 6    -- bad
 #   ? = internal = 7  -- OK (see usage in mdsshr/mdsshr_messages.xml)
 #
-# SsINTERNAL is all bits set in all fields (= -1), and is unusual because it
-# is both informational (when trapped by calling code) and an error (when
-# it is an unhandled exception that the user sees).  It is also unusual
-# because it has a different facility code (-1) than used by the rest
-# of the Ss exceptions (which are facility code 0).
+# SsINTERNAL is merely a synonym for -1; it is not a status code.
+# If the status variable is ever erroneously set to SsINTERNAL, note
+# that the STATUS_OK macro will treat it as success (because the low-order
+# bit is set).  See PR #2617 for details.
 
 import xml.etree.ElementTree as ET
 import sys

--- a/mdsshr/mdsshr_messages.xml
+++ b/mdsshr/mdsshr_messages.xml
@@ -50,6 +50,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
   <facility name="Ss" value="0">
     <status name="SUCCESS"  value="0"  severity="Success" text="Success"/>
     <status name="INTOVF" value="143" severity="Fatal" text="Integer overflow"/>
+    <!-- SsINTERNAL is merely a synonym for -1 (i.e., 0xFFFFFFFF).  It is not a status code and should not be used with STATUS_OK, etc. -->
     <status name="INTERNAL" value="-1" severity="Internal" text="This status is meant for internal use only, you should never have seen this message."/>
   </facility>
 </messages>


### PR DESCRIPTION
As a maintenance developer, it was a surprise to learn the following:
- the 3-bit severity field interacts with the `STATUS_OK` macro to create 4 flavors of failure and 4 flavors of success,
- the SsINTERNAL code is not treated as a failure but is instead a flavor of success (because low-order bit is set),
- the Ss facility code is zero, yet SsINTERNAL has a facility code of minus one,
- that status codes consist of facility code, message number and severity

Status codes are an important concept in the MDSplus source code, thus deserve a few comments of explanation.

Work on Issue #2597 resulted in many exceptions and segfaults.  The above information was useful in debugging / fixing the issues.