### PR TITLE
Allow APD data be accessed via thin client via Connection.get()

### DIFF
--- a/include/mdsobjects.h
+++ b/include/mdsobjects.h
@@ -4459,6 +4459,20 @@ namespace MDSplus
     virtual void dataReceived(Data *samples, Data *times, int shot = 0) = 0;
   };
 
+  
+  struct ConnectionThreadContextInfo
+  {
+    public: 
+#ifdef _MSC_VER
+      DWORD tid;
+#else
+      pthread_t tid;
+#endif
+      int sockId;
+  };
+  
+  
+  
   class EXPORT Connection
   {
   public:
@@ -4497,7 +4511,13 @@ namespace MDSplus
 
     std::string mdsipAddrStr;
     int clevel;
-    int sockId;
+    
+
+    std::vector<ConnectionThreadContextInfo> threadContextV;
+    
+    std::string ipAddrStr;
+    int getSockId();
+
     Mutex mutex;
     static Mutex globalMutex;
     std::vector<DataStreamListener *> listenerV;

--- a/java/mdsobjects/src/main/java/MDSplus/Connection.java
+++ b/java/mdsobjects/src/main/java/MDSplus/Connection.java
@@ -96,13 +96,18 @@ public class Connection
 	{
 		if (!checkArgs(args))
 			throw new MdsException(
-					"Invalid arguments: only scalars and arrays arguments can be passed to COnnection.get()");
-		return get(sockId, expr, args);
+					"Invalid arguments: only scalars and arrays arguments can be passed to Connection.get()");
+                java.lang.String expandedExpr = "serializeout(`("+expr+"))";
+                Data serData = get(sockId, expandedExpr, args);
+                return Data.deserialize(serData.getByteArray());
+
 	}
 
 	public Data get(java.lang.String expr) throws MdsException
 	{
-		return get(expr, new Data[0]);
+                java.lang.String expandedExpr = "serializeout(`("+expr+"))";
+                Data serData = get(sockId, expandedExpr, new Data[0]);
+                return Data.deserialize(serData.getByteArray());
 	}
 
 	public void put(java.lang.String path, java.lang.String expr, Data args[]) throws MdsException
@@ -145,7 +150,19 @@ public class Connection
 	{
 		return new PutManyInConnection();
 	}
-
+       public static void main(java.lang.String args[])
+        {
+            try {
+            
+                MDSplus.Connection c = new MDSplus.Connection("localhost:8001");
+                c.openTree("test", -1);
+                System.out.println(c.get("anyapd"));
+            }catch(Exception exc)
+            {
+                System.out.println(exc);
+            }
+        }
+ 
 	////////// GetMany
 	class GetManyInConnection extends List implements GetMany
 	{
@@ -288,5 +305,7 @@ public class Connection
 				throw new MdsException(retMsg.getString());
 		}
 	}
+        
+        
 
 }

--- a/mdsobjects/cpp/mdsipobjects.cpp
+++ b/mdsobjects/cpp/mdsipobjects.cpp
@@ -395,8 +395,12 @@ Data *Connection::get(const char *expr, Data **args, int nArgs)
   }
 
   lockLocal();
+  std::string expExpr("serializeout(`(");
+  expExpr +=expr;
+  expExpr += "))";
   status = SendArg(sockId, 0, DTYPE_CSTRING_IP, nArgs + 1,
-                   std::string(expr).size(), 0, 0, (char *)expr);
+                   expExpr.size(), 0, 0, (char *)expExpr.c_str());
+//                   std::string(expr).size(), 0, 0, (char *)expr);
   if (STATUS_NOT_OK)
   {
     unlockLocal();
@@ -519,7 +523,11 @@ Data *Connection::get(const char *expr, Data **args, int nArgs)
 
   if (mem)
     FreeMessage(mem);
-  return resData;
+  
+  Data *deserData = deserialize(resData);
+  deleteData(resData);
+  
+  return deserData;
 }
 
 void Connection::put(const char *inPath, char *expr, Data **args, int nArgs)

--- a/mdsobjects/cpp/mdsipobjects.cpp
+++ b/mdsobjects/cpp/mdsipobjects.cpp
@@ -30,6 +30,16 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <iostream>
 #include <string>
 
+
+#ifdef _WIN32
+#define GET_THREAD_ID GetCurrentThreadId()
+#define THREAD_ID DWORD
+#else
+#define GET_THREAD_ID pthread_self()
+#define THREAD_ID pthread_t
+#endif
+
+
 #ifdef _WIN32
 #include <windows.h>
 #else
@@ -294,28 +304,51 @@ void *putManyObj(char *serializedIn)
 Mutex Connection::globalMutex;
 
 Connection::Connection(char *mdsipAddr,
-                       int clevel) // mdsipAddr of the form <IP addr>[:<port>]
+                       int clevel):ipAddrStr(mdsipAddr) // mdsipAddr of the form <IP addr>[:<port>]
 {
   mdsipAddrStr.assign((const char *)mdsipAddr);
   this->clevel = clevel;
   lockGlobal();
   SetCompressionLevel(clevel);
-  sockId = ConnectToMds(mdsipAddr);
+  int sockId = ConnectToMds(mdsipAddr);
   unlockGlobal();
+  
   if (sockId < 0)
   {
     std::string msg("Cannot connect to ");
     msg += mdsipAddr;
     throw MdsException(msg);
   }
+  struct ConnectionThreadContextInfo ttci = {GET_THREAD_ID, sockId};
+  threadContextV.push_back(ttci);
 }
 
 Connection::~Connection()
 {
   lockGlobal();
-  DisconnectFromMds(sockId);
+  DisconnectFromMds(getSockId());
   unlockGlobal();
 }
+
+int Connection::getSockId()
+{
+  
+    AutoLock lock(mutex);
+    THREAD_ID thisTid = GET_THREAD_ID;
+    for(size_t i = 0; i < threadContextV.size(); i++)
+    {
+        if(threadContextV[i].tid == thisTid)
+        {
+            return threadContextV[i].sockId;
+        }
+    }
+    //If we arrive here this is the first Connection operation in a new thread and the tree must be opened again
+    int sockId = ConnectToMds((char *)mdsipAddrStr.c_str());
+    struct ConnectionThreadContextInfo ttci = {thisTid, sockId};
+    threadContextV.push_back(ttci);
+    return sockId;
+}
+
 
 void Connection::lockLocal() { mutex.lock(); }
 
@@ -327,15 +360,14 @@ void Connection::unlockGlobal() { globalMutex.unlock(); }
 
 void Connection::openTree(char *tree, int shot)
 {
-  int status = MdsOpen(sockId, tree, shot);
-  //	std::cout << "SOCK ID: " << sockId << std::endl;
+  int status = MdsOpen(getSockId(), tree, shot);
   if (STATUS_NOT_OK)
     throw MdsException(status);
 }
 
 void Connection::closeAllTrees()
 {
-  int status = MdsClose(sockId);
+  int status = MdsClose(getSockId());
   if (STATUS_NOT_OK)
     throw MdsException(status);
 }
@@ -350,6 +382,8 @@ Data *Connection::get(const char *expr, Data **args, int nArgs)
   int retDims[MAX_DIMS];
   Data *resData;
 
+  int sockId = getSockId();
+  
   // Check whether arguments are compatible (Scalars or Arrays)
   for (std::size_t argIdx = 0; argIdx < (std::size_t)nArgs; ++argIdx)
   {
@@ -497,6 +531,8 @@ void Connection::put(const char *inPath, char *expr, Data **args, int nArgs)
   int *dims;
   int status;
   void *ptr, *mem = 0;
+  
+  int sockId = getSockId();
 
   // Check whether arguments are compatible (Scalars or Arrays)
   for (std::size_t argIdx = 0; argIdx < (std::size_t)nArgs; ++argIdx)
@@ -560,7 +596,7 @@ void Connection::put(const char *inPath, char *expr, Data **args, int nArgs)
 
 void Connection::setDefault(char *path)
 {
-  int status = MdsSetDefault(sockId, path);
+  int status = MdsSetDefault(getSockId(), path);
   if (STATUS_NOT_OK)
     throw MdsException(status);
 }
@@ -665,10 +701,17 @@ void Connection::startStreaming()
 void Connection::resetConnection()
 {
   lockGlobal();
-  DisconnectFromMds(sockId);
+  DisconnectFromMds(getSockId());
   SetCompressionLevel(clevel);
   char *mdsipAddr = (char *)mdsipAddrStr.c_str();
-  sockId = ConnectToMds(mdsipAddr);
+  int sockId = ConnectToMds(mdsipAddr);
+  if(sockId >= 0)
+  {
+      threadContextV.clear();
+      THREAD_ID thisTid = GET_THREAD_ID;
+      struct ConnectionThreadContextInfo ttci = {thisTid, sockId};
+      threadContextV.push_back(ttci);
+  }
   unlockGlobal();
   if (sockId < 0)
   {
@@ -676,6 +719,7 @@ void Connection::resetConnection()
     msg += mdsipAddr;
     throw MdsException(msg.c_str());
   }
+
 }
 
 void GetMany::insert(int idx, char *name, char *expr, Data **args, int nArgs)

--- a/mdsobjects/cpp/mdsipobjects.cpp
+++ b/mdsobjects/cpp/mdsipobjects.cpp
@@ -304,7 +304,7 @@ void *putManyObj(char *serializedIn)
 Mutex Connection::globalMutex;
 
 Connection::Connection(char *mdsipAddr,
-                       int clevel):ipAddrStr(mdsipAddr) // mdsipAddr of the form <IP addr>[:<port>]
+                       int clevel)// mdsipAddr of the form <IP addr>[:<port>]
 {
   mdsipAddrStr.assign((const char *)mdsipAddr);
   this->clevel = clevel;

--- a/mdsobjects/cpp/mdsipobjects.cpp
+++ b/mdsobjects/cpp/mdsipobjects.cpp
@@ -395,7 +395,6 @@ Data *Connection::get(const char *expr, Data **args, int nArgs)
   }
 
   lockLocal();
-  //	lockGlobal();
   status = SendArg(sockId, 0, DTYPE_CSTRING_IP, nArgs + 1,
                    std::string(expr).size(), 0, 0, (char *)expr);
   if (STATUS_NOT_OK)
@@ -416,7 +415,6 @@ Data *Connection::get(const char *expr, Data **args, int nArgs)
       throw MdsException(status);
     }
   }
-  //	unlockGlobal();
   status = GetAnswerInfoTS(sockId, &dtype, &length, &nDims, retDims, &numBytes,
                            &ptr, &mem);
   unlockLocal();

--- a/python/MDSplus/connection.py
+++ b/python/MDSplus/connection.py
@@ -205,12 +205,16 @@ class _Connection:
             args = kwargs['arglist']
         timeout = kwargs.get('timeout', -1)
         num = len(args)+1
+        
+        exp = 'serializeout(`('+exp+'))'
+        
         exp = _ver.tobytes(exp)
         _exc.checkStatus(_SendArg(self.conid, 0, 14, num,
                                   len(exp), 0, 0, ctypes.c_char_p(exp)))
         for i, arg in enumerate(args):
             self._send_arg(arg, i+1, num)
-        return self._get_answer(timeout)
+        retSerialized = self._get_answer(timeout)
+        return retSerialized.deserialize()
 
 
 class Connection(object):


### PR DESCRIPTION
Implemented by explicitly sending over mdsip the serialized version of the expression evaluation result and deserializing it locally