### PR TITLE
Fix - on macOS disable iPhone check for LabVIEW

### DIFF
--- a/include/mdsobjects.h
+++ b/include/mdsobjects.h
@@ -1,5 +1,13 @@
 #ifndef MDSOBJECTS_H
 #define MDSOBJECTS_H
+
+// Prevents errors when using Clang on macOS with LabVIEW
+#ifdef __APPLE__
+#ifndef TARGET_OS_IPHONE
+#define TARGET_OS_IPHONE 0
+#endif
+#endif
+
 #include <mdsplus/mdsconfig.h>
 
 #include <algorithm>

--- a/mdsobjects/labview/lv.c
+++ b/mdsobjects/labview/lv.c
@@ -33,6 +33,14 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *
  *   Josh Stillerman 10/19/12
  */
+
+// Prevents errors when using Clang on macOS with LabVIEW
+#ifdef __APPLE__
+#ifndef TARGET_OS_IPHONE
+#define TARGET_OS_IPHONE 0
+#endif
+#endif
+
 #include <extcode.h>
 #include <fundtypes.h>
 #include <libroutines.h>


### PR DESCRIPTION
The third-party code for LabVIEW (on macOS) references defines that are set by Apple's compiler, AppleClang.   However, when using the stock Clang, the defines aren't present which causes compile errors.