### PR TITLE
Fix: 2625 - start connection IDs at 1 (not zero) 

### DIFF
--- a/idl/mdsconnect.pro
+++ b/idl/mdsconnect.pro
@@ -6,7 +6,8 @@ endcase
 end
 
 function sockmin
-  if !version.os eq 'linux' then return, 0 else return, 11-(!version.os eq 'MacOS')
+  ; Linux connection IDs start at 1 (see Issue #2625 for details).
+  if !version.os eq 'linux' then return, 1 else return, 11-(!version.os eq 'MacOS')
 end
 
 function mds$socket,quiet=quiet,status=status,socket=socket

--- a/idl/mdsconnect.pro
+++ b/idl/mdsconnect.pro
@@ -6,7 +6,7 @@ endcase
 end
 
 function sockmin
-  ; Linux connection IDs start at 1 (see Issue #2625 for details).
+  ; Connection IDs start at 1 (see Issue #2625 for details).
   if !version.os eq 'linux' then return, 1 else return, 11-(!version.os eq 'MacOS')
 end
 

--- a/mdstcpip/mdsipshr/Connections.c
+++ b/mdstcpip/mdsipshr/Connections.c
@@ -465,13 +465,14 @@ static inline int authorize_client(Connection *c, char *username)
 int AddConnection(Connection *c)
 {
   MDSIPTHREADSTATIC_INIT;
-  static int id = INVALID_CONNECTION_ID;
+  
+  // Connection IDs are issued in sequence.
+  // Issue #2625 requires connection IDs starting at 1 to avoid IDL issues,
+  // so initialize this static ID to zero.
+  static int id = INVALID_CONNECTION_ID + 1;
   static pthread_mutex_t lock = PTHREAD_MUTEX_INITIALIZER;
   pthread_mutex_lock(&lock);
-  do
-  {
-    id++; // find next free id
-  } while (id == INVALID_CONNECTION_ID && _FindConnection(id, NULL, MDSIPTHREADSTATIC_VAR));
+  id++;
   c->id = id;
   pthread_mutex_unlock(&lock);
   c->state |= CON_INLIST;

--- a/mdstcpip/mdsipshr/Connections.c
+++ b/mdstcpip/mdsipshr/Connections.c
@@ -467,12 +467,15 @@ int AddConnection(Connection *c)
   MDSIPTHREADSTATIC_INIT;
   
   // Connection IDs are issued in sequence.
-  // Issue #2625 requires connection IDs starting at 1 to avoid IDL issues,
-  // so initialize this static ID to zero.
-  static int id = INVALID_CONNECTION_ID + 1;
+  // Issue #2625 requires connection IDs starting at 1 to avoid IDL issues.
+  // Use of _FindConnection() is an integrity check of the data structures.
+  static int id = INVALID_CONNECTION_ID;
   static pthread_mutex_t lock = PTHREAD_MUTEX_INITIALIZER;
   pthread_mutex_lock(&lock);
-  id++;
+  do
+  {
+    id++;
+  } while ((id == INVALID_CONNECTION_ID) || (id == 0) || _FindConnection(id, NULL, MDSIPTHREADSTATIC_VAR));
   c->id = id;
   pthread_mutex_unlock(&lock);
   c->state |= CON_INLIST;


### PR DESCRIPTION
This fixes the IDL keyword_set() issue that arises when socket IDs (aka connection IDs) start at zero.   The fix passes the entire MDSplus test suite.   And also passed manual testing, as shown below.

However, there are additional refinements that will likely be made in the coming days.   Such as removing obsolete code and improving comments.

**NOTE:**  Using `print` or `help` to examine the IDL system variables, !MDSDB_SOCKET and/or !MDS_SOCKET, occasionally has an odd interaction with the `dsql()` function -- causes it to fail evaluation of the query.   Will investigate the `dsql.pro` file in the coming days.

#2625 Testing
```
IDL> ; Test of proposed fix for Issue #2625
IDL> set_database, 'logbook'
% Compiled module: SET_DATABASE.
% Compiled module: MDSVALUE.
% Compiled module: MDSCHECKARG.
% Compiled module: MDSISCLIENT.
% Compiled module: DSQL.
IDL> print, !MDSDB_SOCKET
       1
IDL> n = dsql('select host_name()', val) & print, val
% Compiled module: EVALUATE.
some-server
IDL> 
IDL> 
IDL> mdsconnect, 'some-server'
% Compiled module: MDSDISCONNECT.
IDL> print, !MDS_SOCKET  
       2
IDL> n = dsql('select host_name()', val) & print, val
some-server
IDL> print, !MDSDB_SOCKET
       1
IDL> n = dsql('select host_name()', val) & print, val
some-server
IDL> 
IDL> 
IDL> set_database, 'logbook'
IDL> print, !MDSDB_SOCKET                            
       3
IDL> n = dsql('select host_name()', val) & print, val
some-server
IDL> 
```

#2580 Testing
```
IDL> ; Test to ensure Issue #2580 is still fixed
IDL> mdsconnect, 'some_server'
% Compiled module: MDSCONNECT.
% Compiled module: MDSDISCONNECT.
IDL>      
IDL> print, !MDS_SOCKET
       1
IDL> 
```
