### PR TITLE
Fix: Revert #2626 - start connection IDs at 1 (not zero) 

### DIFF
--- a/idl/mdsconnect.pro
+++ b/idl/mdsconnect.pro
@@ -6,8 +6,7 @@ endcase
 end
 
 function sockmin
-  ; Connection IDs start at 1 (see Issue #2625 for details).
-  if !version.os eq 'linux' then return, 1 else return, 11-(!version.os eq 'MacOS')
+  if !version.os eq 'linux' then return, 0 else return, 11-(!version.os eq 'MacOS')
 end
 
 function mds$socket,quiet=quiet,status=status,socket=socket

--- a/mdstcpip/mdsipshr/Connections.c
+++ b/mdstcpip/mdsipshr/Connections.c
@@ -465,17 +465,13 @@ static inline int authorize_client(Connection *c, char *username)
 int AddConnection(Connection *c)
 {
   MDSIPTHREADSTATIC_INIT;
-  
-  // Connection IDs are issued in sequence.
-  // Issue #2625 requires connection IDs starting at 1 to avoid IDL issues.
-  // Use of _FindConnection() is an integrity check of the data structures.
   static int id = INVALID_CONNECTION_ID;
   static pthread_mutex_t lock = PTHREAD_MUTEX_INITIALIZER;
   pthread_mutex_lock(&lock);
   do
   {
-    id++;
-  } while ((id == INVALID_CONNECTION_ID) || (id == 0) || _FindConnection(id, NULL, MDSIPTHREADSTATIC_VAR));
+    id++; // find next free id
+  } while (id == INVALID_CONNECTION_ID && _FindConnection(id, NULL, MDSIPTHREADSTATIC_VAR));
   c->id = id;
   pthread_mutex_unlock(&lock);
   c->state |= CON_INLIST;


### PR DESCRIPTION
This reverts commit 389ed8679a61c6907be9d3cf0b4ae0cb72bcd57f.