### PR TITLE
Fix: 2625 v2 - only change IDL for socket 0 issue

### DIFF
--- a/idl/dsql.pro
+++ b/idl/dsql.pro
@@ -230,7 +230,8 @@ if (debug) then $
 ; now execute the query
 ; !!!  if it is a string it is a database error
 ;
-count = mdsvalue(expr, socket=!MDSDB_SOCKET)
+socket_var = !MDSDB_SOCKET
+count = mdsvalue(expr, socket=socket_var)
 
 sz = size(count)
 if (sz(n_elements(sz)-2) eq 7) then begin
@@ -254,7 +255,8 @@ endif else begin
         if (debug) then $
           print, 'Working on arg ', i
         arg = 'a'+string(i, format="(I3.3)")
-        val = MDSVALUE("_"+arg,socket=!MDSDB_SOCKET,/QUIET)
+        socket_var = !MDSDB_SOCKET
+        val = MDSVALUE("_"+arg,socket=socket_var,/QUIET)
         ok = evaluate(arg + ' = val')
         if (ok eq "OK") then status = 1L else status = 0L
         if (debug) then $
@@ -275,8 +277,10 @@ endif else begin
 ;
 ; free all the tdi variables returned by DSQL
 ;
-    if (not debug) then $
-      dummy = MdsValue("DeAllocate('_A%%%')",socket=!MDSDB_SOCKET,/QUIET)
+    if (not debug) then begin
+      socket_var = !MDSDB_SOCKET
+      dummy = MdsValue("DeAllocate('_A%%%')",socket=socket_var,/QUIET)
+    endif
 ;
 ; return the number of row
 ;

--- a/idl/mdsconnect.pro
+++ b/idl/mdsconnect.pro
@@ -13,7 +13,9 @@ function mds$socket,quiet=quiet,status=status,socket=socket
   status = 1
   sockmin=sockmin()
   sock=sockmin-1
-  if (keyword_set(socket)) then $
+  ; The arg_present() only works if the optional keyword argument 
+  ; is bound to a regular variable in the calling code.
+  if (arg_present(socket)) then $
       if (socket ge sockmin) then $
           return, socket
   defsysv,'!MDS_SOCKET',exists=old_sock
@@ -137,7 +139,7 @@ pro mds$disconnect,status=status,quiet=quiet
   if status then begin
     status = call_external(MdsIPImage(),'IdlDisconnectFromMds',sock,value=[1b])
     if (status eq 0) then status = 1 else status = 0
-    !MDS_SOCKET = 0l
+    !MDS_SOCKET = 0l  ; Is this correct?  Should it be -1?
   endif
   return
 end
@@ -153,7 +155,9 @@ end
 
 pro mdsconnect,host,status=status,quiet=quiet,port=port,socket=socket
   on_error,2
-  if (not keyword_set(socket)) then $
+  ; The arg_present() only works if the optional keyword argument 
+  ; is bound to a regular variable in the calling code.
+  if (not arg_present(socket)) then $
     mdsdisconnect,/quiet
   if n_elements(port) ne 0 then begin
     setenv_,'mdsip='+strtrim(port,2)
@@ -165,7 +169,7 @@ pro mdsconnect,host,status=status,quiet=quiet,port=port,socket=socket
   sockmin=sockmin()
   if (sock ge sockmin) then begin
     status = 1
-    if not keyword_set(socket) then $
+    if not arg_present(socket) then $
       !MDS_SOCKET = sock $
     else $
       socket = sock

--- a/idl/mdsdisconnect.pro
+++ b/idl/mdsdisconnect.pro
@@ -2,14 +2,16 @@ pro mdsdisconnect,status=status,quiet=quiet, socket=socket
   forward_function mds$socket, MdsIPImage
   image = MdsIPImage()
   status = 1
-  if keyword_set(socket) then $
+  ; The arg_present() only works if the optional keyword argument 
+  ; is bound to a regular variable in the calling code.
+  if arg_present(socket) then $
     sock = socket $
   else $
     sock = mds$socket(status=status,quiet=quiet)
   if status then begin
     status = call_external(image,'DisconnectFromMds',sock,value=[1b])
     if (status eq 0) then status = 1 else status = 0
-    if not keyword_set(socket) then $
+    if not arg_present(socket) then $
       !MDS_SOCKET = -1l
   endif
   return

--- a/idl/mdsisclient.pro
+++ b/idl/mdsisclient.pro
@@ -1,13 +1,22 @@
-function mdsisclient,socket=socket
-if (keyword_set(socket)) then $
-  if (socket ge 0) then $
+; This function is used to confirm a valid connection has been established.
+function mdsisclient,socket=socket_var
+
+; For arg_present() to work, the optional keyword argument must be bound
+; to a regular variable.  It will not work if bound to a system variable
+; such as !MDS_SOCKET.  Refer to issue #2625 for more details.
+if (arg_present(socket_var)) then $
+  if (socket_var ge 0) then $
     return, 1 $
   else $
     return, 0
+
+  ; If no connection specified, then assume using the most recent one.
   defsysv,'!MDS_SOCKET',exists=mdsClient
   if (mdsClient) then begin
     value= (!MDS_SOCKET ge 0)
     return,value
+
+  ; If things have gone awry, indicate an INVALID_CONNECTION_ID
   endif else begin
     defsysv,'!MDS_SOCKET',-1
     return,0

--- a/idl/mdssql.pro
+++ b/idl/mdssql.pro
@@ -54,7 +54,8 @@ pro MDSDbDisconnect
        defsysv, '!MDSDB_SOCKET', -1
        defsysv, '!MDSDB_HOST', ''
    endif
-   MdsDisconnect, socket=!MDSDB_SOCKET
+   socket_var = !MDSDB_SOCKET
+   MdsDisconnect, socket=socket_var
    !MDSDB_SOCKET = -1
    !MDSDB_HOST = ""
 end
@@ -79,7 +80,8 @@ end
 pro set_database, dbname, status=status, quiet=quiet,debug=debug
   status = dbinfo(dbname, host, name, user, pass, mdshost)
   MDSDbconnect, mdshost
-  status = mdsvalue("DBLogin($, $, $)", host, user, pass, socket=!MDSDB_SOCKET)
+  socket_var = !MDSDB_SOCKET
+  status = mdsvalue("DBLogin($, $, $)", host, user, pass, socket=socket_var)
   if (not status) then begin
       if not (keyword_set(quiet)) then begin
           Message, "Error logging on to DbHost "+host, /continue
@@ -88,7 +90,8 @@ pro set_database, dbname, status=status, quiet=quiet,debug=debug
       endelse
       return
   endif
-;  status = mdsvalue("SetDatabase('"+ name+"')", socket=!MDSDB_SOCKET)
+;  socket_var = !MDSDB_SOCKET
+;  status = mdsvalue("SetDatabase('"+ name+"')", socket=socket_var)
   status = dsql('USE ?', name)
   if (status ne 0) then begin
       if not (keyword_set(quiet)) then begin
@@ -242,7 +245,8 @@ if (debug) then $
 ; now execute the query
 ; !!!  if it is a string it is a database error
 ;
-count = mdsvalue(expr, socket=!MDSDB_SOCKET)
+socket_var = !MDSDB_SOCKET
+count = mdsvalue(expr, socket=socket_var)
 sz = size(count)
 if (sz(n_elements(sz)-2) eq 7) then begin
 
@@ -269,7 +273,8 @@ endif else begin
         if (debug) then $
           print, 'Working on arg ', i
         arg = 'a'+string(i, format="(I3.3)")
-        cmd = arg+' = MDSVALUE("_'+arg+'",socket=!MDSDB_SOCKET)'
+        socket_var = !MDSDB_SOCKET
+        cmd = arg+' = MDSVALUE("_'+arg+'",socket=socket_var)'
         status = execute(cmd)
         if (debug) then $
           print, "got back "+arg
@@ -287,8 +292,10 @@ endif else begin
 ;
 ; free all the tdi variables returned by DSQL
 ;
-    if (not debug) then $
-      dummy = MdsValue("DeAllocate('_A%%%')",socket=!MDSDB_SOCKET)
+    if (not debug) then begin
+      socket_var = !MDSDB_SOCKET
+      dummy = MdsValue("DeAllocate('_A%%%')",socket=socket_var)
+    endif
 ;
 ; return the number of row
 ;

--- a/idl/mdsvalue.pro
+++ b/idl/mdsvalue.pro
@@ -46,6 +46,8 @@
 
 
 function MdsValue,expression,arg1,arg2,arg3,arg4,arg5,arg6,arg7,arg8,arg9,arg10,arg11,arg12,arg13,arg14,arg15,arg16,quiet=quiet,status=status,socket=socket
+  ; Note that Issue #2625 requires the optional "socket" keyword argument 
+  ; to be bound to a regular variable in the calling code.
 
   forward_function mdsIsClient,mdsIdlImage,mds$socket,MdsIPImage,evaluate
   MdsCheckArg,expression,type="STRING",name="expression"

--- a/idl/set_database.pro
+++ b/idl/set_database.pro
@@ -408,8 +408,10 @@ pro MDSDbDisconnect
        defsysv, '!MDSDB_SOCKET', -1
        defsysv, '!MDSDB_HOST', ''
    endif
-   if !MDSDB_SOCKET ne -1 then $
-     MdsDisconnect, socket=!MDSDB_SOCKET
+   if !MDSDB_SOCKET ne -1 then begin
+     socket_var = !MDSDB_SOCKET
+     MdsDisconnect, socket=socket_var
+   endif
    !MDSDB_SOCKET = -1
    !MDSDB_HOST = ""
 end
@@ -439,7 +441,8 @@ pro set_database, dbname, status=status, quiet=quiet,debug=debug, reset=reset, f
   if (status eq 0) then $
     return
   MDSDbconnect, mdshost
-  status = mdsvalue("dblogin($, $, $)", host, user, pass, socket=!MDSDB_SOCKET)
+  socket_var = !MDSDB_SOCKET
+  status = mdsvalue("dblogin($, $, $)", host, user, pass, socket=socket_var)
   if (not status) then begin
       if not (keyword_set(quiet)) then begin
           Message, mdsvalue('dsc:MdsSql->GetDBMsgText_dsc()'), /continue

--- a/mdstcpip/mdsipshr/Connections.c
+++ b/mdstcpip/mdsipshr/Connections.c
@@ -471,7 +471,7 @@ int AddConnection(Connection *c)
   do
   {
     id++; // find next free id
-  } while (id == INVALID_CONNECTION_ID && _FindConnection(id, NULL, MDSIPTHREADSTATIC_VAR));
+  } while ((id == INVALID_CONNECTION_ID) || _FindConnection(id, NULL, MDSIPTHREADSTATIC_VAR));
   c->id = id;
   pthread_mutex_unlock(&lock);
   c->state |= CON_INLIST;


### PR DESCRIPTION
Replaces PR #2626 which did not work at sites that have a mixture of old and new software on their servers.

This version changes the IDL code so that zero is accepted as a valid connection ID.