### PR TITLE
Fix: 2625 v4 -- IDL socket 0 issue and partial revert of PR #2620

### DIFF
--- a/deploy/packaging/debian/idl.noarch
+++ b/deploy/packaging/debian/idl.noarch
@@ -36,6 +36,7 @@
 ./usr/local/mdsplus/idl/mdsevent.pro
 ./usr/local/mdsplus/idl/mdsgetmsg.pro
 ./usr/local/mdsplus/idl/mdsidlimage.pro
+./usr/local/mdsplus/idl/mds_keyword_set.pro
 ./usr/local/mdsplus/idl/mdsisclient.pro
 ./usr/local/mdsplus/idl/mdslogin.pro
 ./usr/local/mdsplus/idl/mdsopen.pro

--- a/deploy/packaging/redhat/idl.noarch
+++ b/deploy/packaging/redhat/idl.noarch
@@ -40,6 +40,7 @@
 ./usr/local/mdsplus/idl/mdsgetmsg.pro
 ./usr/local/mdsplus/idl/mdsidlimage.pro
 ./usr/local/mdsplus/idl/mdsisclient.pro
+./usr/local/mdsplus/idl/mds_keyword_set.pro
 ./usr/local/mdsplus/idl/mdslogin.pro
 ./usr/local/mdsplus/idl/mdsopen.pro
 ./usr/local/mdsplus/idl/mdsput.pro

--- a/idl/mds_keyword_set.pro
+++ b/idl/mds_keyword_set.pro
@@ -1,0 +1,9 @@
+; IDL's keyword_set() only detects non-zero optional keywords (see Issue 2625).
+; So replace it with this function that also handles zero.
+function mds_keyword_set,socket=socket
+  if (n_elements(socket) gt 0) then begin
+    return, 1
+  endif else begin
+    return, 0
+  endelse
+end

--- a/idl/mds_keyword_set.pro
+++ b/idl/mds_keyword_set.pro
@@ -1,3 +1,4 @@
+; This function detects if an optional keyword is present, regardless of value.
 ; IDL's keyword_set() only detects non-zero optional keywords (see Issue 2625).
 ; So replace it with this function that also handles zero.
 function mds_keyword_set,socket=socket

--- a/idl/mdsconnect.pro
+++ b/idl/mdsconnect.pro
@@ -10,10 +10,11 @@ function sockmin
 end
 
 function mds$socket,quiet=quiet,status=status,socket=socket
+  forward_function mds_keyword_set
   status = 1
   sockmin=sockmin()
   sock=sockmin-1
-  if (keyword_set(socket)) then $
+  if (mds_keyword_set(socket=socket)) then $
       if (socket ge sockmin) then $
           return, socket
   defsysv,'!MDS_SOCKET',exists=old_sock
@@ -152,8 +153,9 @@ end
 
 
 pro mdsconnect,host,status=status,quiet=quiet,port=port,socket=socket
+  forward_function mds_keyword_set
   on_error,2
-  if (not keyword_set(socket)) then $
+  if (not mds_keyword_set(socket=socket)) then $
     mdsdisconnect,/quiet
   if n_elements(port) ne 0 then begin
     setenv_,'mdsip='+strtrim(port,2)
@@ -165,7 +167,7 @@ pro mdsconnect,host,status=status,quiet=quiet,port=port,socket=socket
   sockmin=sockmin()
   if (sock ge sockmin) then begin
     status = 1
-    if not keyword_set(socket) then $
+    if not mds_keyword_set(socket=socket) then $
       !MDS_SOCKET = sock $
     else $
       socket = sock

--- a/idl/mdsdisconnect.pro
+++ b/idl/mdsdisconnect.pro
@@ -8,7 +8,8 @@ pro mdsdisconnect,status=status,quiet=quiet, socket=socket
   else $
     sock = mds$socket(status=status,quiet=quiet)
   if status then begin
-    status = call_external(image,'DisconnectFromMds',sock,value=[1b])
+    ; IDL's AUTO_GLUE feature requires a C / C++ compiler on the system
+    status = call_external(image,'DisconnectFromMds',sock,value=[1b], /AUTO_GLUE) 
     if (status eq 0) then status = 1 else status = 0
     if not mds_keyword_set(socket=socket) then $
       !MDS_SOCKET = -1l

--- a/idl/mdsdisconnect.pro
+++ b/idl/mdsdisconnect.pro
@@ -1,15 +1,16 @@
 pro mdsdisconnect,status=status,quiet=quiet, socket=socket
+  forward_function mds_keyword_set
   forward_function mds$socket, MdsIPImage
   image = MdsIPImage()
   status = 1
-  if keyword_set(socket) then $
+  if mds_keyword_set(socket=socket) then $
     sock = socket $
   else $
     sock = mds$socket(status=status,quiet=quiet)
   if status then begin
     status = call_external(image,'DisconnectFromMds',sock,value=[1b])
     if (status eq 0) then status = 1 else status = 0
-    if not keyword_set(socket) then $
+    if not mds_keyword_set(socket=socket) then $
       !MDS_SOCKET = -1l
   endif
   return

--- a/idl/mdsisclient.pro
+++ b/idl/mdsisclient.pro
@@ -1,13 +1,20 @@
 function mdsisclient,socket=socket
-if (keyword_set(socket)) then $
-  if (socket ge 0) then $
-    return, 1 $
-  else $
-    return, 0
+  forward_function mds_keyword_set
+
+  ; If optional socket provided, use it
+  if (mds_keyword_set(socket=socket)) then $
+   if (socket ge 0) then $
+     return, 1 $
+   else $
+     return, 0
+
+  ; Otherwise use the last socket  
   defsysv,'!MDS_SOCKET',exists=mdsClient
   if (mdsClient) then begin
     value= (!MDS_SOCKET ge 0)
     return,value
+
+  ; Went awry, so return INVALID_IDL_CONNECTION
   endif else begin
     defsysv,'!MDS_SOCKET',-1
     return,0

--- a/idl/mdsisclient.pro
+++ b/idl/mdsisclient.pro
@@ -14,7 +14,7 @@ function mdsisclient,socket=socket
     value= (!MDS_SOCKET ge 0)
     return,value
 
-  ; Went awry, so return INVALID_IDL_CONNECTION
+  ; Went awry, so return INVALID_CONNECTION_ID
   endif else begin
     defsysv,'!MDS_SOCKET',-1
     return,0

--- a/mdstcpip/mdsipshr/Connections.c
+++ b/mdstcpip/mdsipshr/Connections.c
@@ -471,7 +471,7 @@ int AddConnection(Connection *c)
   do
   {
     id++; // find next free id
-  } while (id == INVALID_CONNECTION_ID && _FindConnection(id, NULL, MDSIPTHREADSTATIC_VAR));
+  } while ((id == INVALID_CONNECTION_ID) || _FindConnection(id, NULL, MDSIPTHREADSTATIC_VAR));
   c->id = id;
   pthread_mutex_unlock(&lock);
   c->state |= CON_INLIST;

--- a/python/MDSplus/connection.py
+++ b/python/MDSplus/connection.py
@@ -205,16 +205,12 @@ class _Connection:
             args = kwargs['arglist']
         timeout = kwargs.get('timeout', -1)
         num = len(args)+1
-        
-        exp = 'serializeout(`('+exp+'))'
-        
         exp = _ver.tobytes(exp)
         _exc.checkStatus(_SendArg(self.conid, 0, 14, num,
                                   len(exp), 0, 0, ctypes.c_char_p(exp)))
         for i, arg in enumerate(args):
             self._send_arg(arg, i+1, num)
-        retSerialized = self._get_answer(timeout)
-        return retSerialized.deserialize()
+        return self._get_answer(timeout)
 
 
 class Connection(object):


### PR DESCRIPTION
The IDL API has an issue with socket = 0 (aka connection ID) because IDL's `keyword_set()` function doesn't detect the presence of optional keyword arguments when they have a zero value.   This fix replaces the IDL function with a similar function that does handle zero.

And this PR also has these fixes:
- database proxy (established by `set_database`) is no longer trashed by a subsequent `mdsconnect`
- `mdsdisconnect` now processes the optional socket (if specified)
- partial rollback of PR #2620 that broke Python connections
- now does an integrity check when adding a new connection

However, it does not address the limit that there can be no more than 64 concurrent connections.