### PR TITLE
Fix: mdsip services zombie processes

### DIFF
--- a/pydevices/HtsDevices/acq2106_423st.py
+++ b/pydevices/HtsDevices/acq2106_423st.py
@@ -299,9 +299,14 @@ class _ACQ2106_423ST(MDSplus.Device):
                         while toread and self.running:
                             nbytes = s.recv_into(
                                 view, min(self.io_buffer_size, toread))
+                            
+                            if nbytes == 0 and not self.running:
+                                break                            
+                            
                             if first:
                                 self.trig_time = time.time()
                                 first = False
+                                
                             view = view[nbytes:]  # slicing views is cheap
                             toread -= nbytes
 

--- a/pydevices/HtsDevices/acq2106_423st.py
+++ b/pydevices/HtsDevices/acq2106_423st.py
@@ -296,7 +296,7 @@ class _ACQ2106_423ST(MDSplus.Device):
                     toread = self.segment_bytes
                     try:
                         view = memoryview(buf)
-                        while toread:
+                        while toread and self.running:
                             nbytes = s.recv_into(
                                 view, min(self.io_buffer_size, toread))
                             if first:

--- a/pydevices/HtsDevices/acq2106_435st.py
+++ b/pydevices/HtsDevices/acq2106_435st.py
@@ -354,12 +354,17 @@ class _ACQ2106_435ST(MDSplus.Device):
                     toread = self.segment_bytes
                     try:
                         view = memoryview(buf)
-                        while toread and self.running:
+                        while toread:
                             nbytes = s.recv_into(
                                 view, min(self.io_buffer_size, toread))
+                            
+                            if nbytes == 0 and not self.running:
+                                break
+                            
                             if first:
                                 self.trig_time = time.time()
                                 first = False
+                                
                             view = view[nbytes:]  # slicing views is cheap
                             toread -= nbytes
 

--- a/pydevices/HtsDevices/acq2106_435st.py
+++ b/pydevices/HtsDevices/acq2106_435st.py
@@ -354,7 +354,7 @@ class _ACQ2106_435ST(MDSplus.Device):
                     toread = self.segment_bytes
                     try:
                         view = memoryview(buf)
-                        while toread:
+                        while toread and self.running:
                             nbytes = s.recv_into(
                                 view, min(self.io_buffer_size, toread))
                             if first:


### PR DESCRIPTION
When executing a shot cycle using D-Tacq's digitizers, sometimes mdsip processes become zombie processes. This, in turn, will break the shot cycle for the user.

Those mdsip process will contain sockets that were kept open, even when no data was being received.

Solution: the while loop that controls the data being received from the socket (in the device driver) has now a new logic, that includes using the value of the running node (false or true) to exit the loop correctly when executing the stop method.

For this to work, the user needs to be sure it runs the stop method for the device.