### PR TITLE
Fix test event port, collect and import test results into Jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -114,7 +114,8 @@ pipeline {
     post {
         always {
 
-            archiveArtifacts artifacts: '**/tests/**/*.log,**/tests/**/test-suite.tap,**/tests/**/core'
+            // TODO: Why does this hang on windows?
+            archiveArtifacts artifacts: '**/tests/**/*.log,**/tests/**/test-suite.tap,**/tests/**/core' excludes: 'windows/**/*'
 
             cleanWs disableDeferredWipeout: true, deleteDirs: true
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -124,7 +124,7 @@ pipeline {
             }
 
             // Collect TAP results, valgrind core dumps
-            archiveArtifacts artifacts: "**/test-suite.tap,**/core", exclude: '**/.wine'
+            archiveArtifacts artifacts: "**/test-suite.tap,**/core"
 
             cleanWs disableDeferredWipeout: true, deleteDirs: true
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -114,8 +114,16 @@ pipeline {
     post {
         always {
 
+            for (OS in OSList) {
+                ws("${WORKSPACE}/${OS}") {
+                    sh "./deploy/tap-to-junit.py --junit-suite-name=${OS}"
+                }
+            }
+            
+            junit skipPublishingChecks: true, testResults: '**/mdsplus-junit.xml'
+
             // TODO: Why does this hang on windows?
-            archiveArtifacts artifacts: '**/tests/**/*.log,**/tests/**/test-suite.tap,**/tests/**/core' excludes: 'windows/**/*'
+            // archiveArtifacts artifacts: '**/tests/**/*.log,**/tests/**/test-suite.tap,**/tests/**/core' excludes: 'windows/**/*'
 
             cleanWs disableDeferredWipeout: true, deleteDirs: true
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -121,11 +121,11 @@ pipeline {
                     }
                 }
             }
-            
+
             junit skipPublishingChecks: true, testResults: '**/mdsplus-junit.xml'
 
-            // TODO: Why does this hang on windows?
-            // archiveArtifacts artifacts: '**/tests/**/*.log,**/tests/**/test-suite.tap,**/tests/**/core' excludes: 'windows/**/*'
+            // Collect TAP results, valgrind core dumps
+            archiveArtifacts artifacts: "**/test-suite.tap,**/core"
 
             cleanWs disableDeferredWipeout: true, deleteDirs: true
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -114,9 +114,11 @@ pipeline {
     post {
         always {
 
-            for (OS in OSList) {
-                ws("${WORKSPACE}/${OS}") {
-                    sh "./deploy/tap-to-junit.py --junit-suite-name=${OS}"
+            script {
+                for (OS in OSList) {
+                    ws("${WORKSPACE}/${OS}") {
+                        sh "./deploy/tap-to-junit.py --junit-suite-name=${OS}"
+                    }
                 }
             }
             

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,11 +2,21 @@
 
 def OSList = [
     'windows',
-    'ubuntu18', 'ubuntu20', 'ubuntu22',
-    'rhel7', 'rhel8', 'rhel9',
-    // 'alpine3.9-armhf', 'alpine3.9-x86_64', 'alpine3.9-x86',
-    'debian9-64', 'debian10-64', 'debian11-64',
-    'test-asan', 'test-tsan', 'test-ubsan',
+    'ubuntu18',
+    'ubuntu20',
+    'ubuntu22',
+    'rhel7',
+    'rhel8',
+    'rhel9',
+    // 'alpine3.9-armhf',
+    // 'alpine3.9-x86_64',
+    // 'alpine3.9-x86',
+    'debian9-64',
+    'debian10-64',
+    'debian11-64',
+    'test-asan',
+    'test-tsan',
+    'test-ubsan',
 ]
 
 def AdminList = [
@@ -92,12 +102,8 @@ pipeline {
                             }
 
                             stage("${OS} Test") {
-                                sh "./deploy/build.sh --os=${OS} --test --eventport=\$((4100+\${EXECUTOR_NUMBER}))"
-
-                                // TODO: Why does this hang on windows?
-                                if (env.OS != "windows") {
-                                    archiveArtifacts artifacts: 'tests/**/*.log,tests/**/test-suite.tap,tests/**/core'
-                                }
+                                EVENT_PORT = OSList.indexOf(OS) + 4100
+                                sh "./deploy/build.sh --os=${OS} --test --eventport=${EVENT_PORT}"
                             }
                         }
                     }
@@ -107,6 +113,9 @@ pipeline {
     }
     post {
         always {
+
+            archiveArtifacts artifacts: '**/tests/**/*.log,**/tests/**/test-suite.tap,**/tests/**/core'
+
             cleanWs disableDeferredWipeout: true, deleteDirs: true
         }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -118,14 +118,13 @@ pipeline {
                 for (OS in OSList) {
                     ws("${WORKSPACE}/${OS}") {
                         sh "./deploy/tap-to-junit.py --junit-suite-name=${OS}"
+                        junit skipPublishingChecks: true, testResults: 'mdsplus-junit.xml'
                     }
                 }
             }
 
-            junit skipPublishingChecks: true, testResults: '**/mdsplus-junit.xml'
-
             // Collect TAP results, valgrind core dumps
-            archiveArtifacts artifacts: "**/test-suite.tap,**/core"
+            archiveArtifacts artifacts: "**/test-suite.tap,**/core", exclude: '**/.wine'
 
             cleanWs disableDeferredWipeout: true, deleteDirs: true
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -124,7 +124,7 @@ pipeline {
             }
 
             // Collect TAP results, valgrind core dumps
-            archiveArtifacts artifacts: "**/test-suite.tap,**/core"
+            archiveArtifacts artifacts: "**/test-suite.tap,**/core", followSymlinks: false
 
             cleanWs disableDeferredWipeout: true, deleteDirs: true
         }

--- a/deploy/platform/windows/windows_docker_build.sh
+++ b/deploy/platform/windows/windows_docker_build.sh
@@ -55,8 +55,8 @@ buildrelease() {
       popd
       pushd /workspace/releasebld/64/mdsobjects/cpp
       $MAKE generate-libs-from-dlls
-      HOME=/tmp/winebottle64 WINEARCH=win64\
-	wine cmd /C ${srcdir}/deploy/platform/windows/visual-studio-build.bat
+      HOME=/tmp/winebottle64 WINEPREFIX=/tmp/winebottle64 WINEARCH=win64\
+	        wine cmd /C ${srcdir}/deploy/platform/windows/visual-studio-build.bat
       cp /workspace/releasebld/64/bin_x86_64/MdsObjectsCppShr-VS.dll ${MDSPLUS_DIR}/bin_x86_64/
       cp /workspace/releasebld/64/bin_x86_64/*.lib ${MDSPLUS_DIR}/bin_x86_64/
       cp /workspace/releasebld/32/bin_x86/*.lib ${MDSPLUS_DIR}/bin_x86/

--- a/deploy/platform/windows/windows_docker_build.sh
+++ b/deploy/platform/windows/windows_docker_build.sh
@@ -13,18 +13,16 @@ srcdir=$(readlink -e $(dirname ${0})/../..)
 
 export JNI_INCLUDE_DIR=${srcdir}/3rd-party-apis/windows-jdk
 export JNI_MD_INCLUDE_DIR=${srcdir}/3rd-party-apis/windows-jdk/win32
-mkdir -p /tmp/winebottle64
-test64="64 x86_64-w64-mingw32 bin_x86_64 bin_x86_64 --with-winebottle=/tmp/winebottle64"
-mkdir -p /tmp/winebottle32
-test32="32 i686-w64-mingw32   bin_x86    bin_x86    --with-winebottle=/tmp/winebottle32"
+mkdir -p /workspace/winebottle64
+test64="64 x86_64-w64-mingw32 bin_x86_64 bin_x86_64 --with-winebottle=/workspace/winebottle64"
+mkdir -p /workspace/winebottle32
+test32="32 i686-w64-mingw32   bin_x86    bin_x86    --with-winebottle=/workspace/winebottle32"
 
 runtests() {
     # run tests with the platform specific params read from test32 and test64
     testarch ${test64}
     testarch ${test32};
     checktests;
-
-    rm -Rf /workspace/.wine
 }
 
 buildrelease() {
@@ -57,8 +55,8 @@ buildrelease() {
       popd
       pushd /workspace/releasebld/64/mdsobjects/cpp
       $MAKE generate-libs-from-dlls
-      WINEPREFIX=/tmp/winebottle64 WINEARCH=win64\
-	        wine cmd /C ${srcdir}/deploy/platform/windows/visual-studio-build.bat
+      HOME=/workspace/winebottle64 WINEARCH=win64\
+	wine cmd /C ${srcdir}/deploy/platform/windows/visual-studio-build.bat
       cp /workspace/releasebld/64/bin_x86_64/MdsObjectsCppShr-VS.dll ${MDSPLUS_DIR}/bin_x86_64/
       cp /workspace/releasebld/64/bin_x86_64/*.lib ${MDSPLUS_DIR}/bin_x86_64/
       cp /workspace/releasebld/32/bin_x86/*.lib ${MDSPLUS_DIR}/bin_x86/
@@ -68,17 +66,13 @@ buildrelease() {
     ###
     ### pack installer
     ###
-    if [ -z "$NOMAKE" ]; then
-      source ${srcdir}/deploy/packaging/windows/create_installer.sh
-    fi # NOMAKE
-
-    rm -Rf /workspace/.wine
+  if [ -z "$NOMAKE" ]; then
+    source ${srcdir}/deploy/packaging/windows/create_installer.sh
+  fi # NOMAKE
 }
 publish() {
     major=$(echo ${RELEASE_VERSION} | cut -d. -f1)
     minor=$(echo ${RELEASE_VERSION} | cut -d. -f2)
     release=$(echo ${RELEASE_VERSION} | cut -d. -f3)
     rsync -a /release/${FLAVOR}/MDSplus${BNAME}-${major}.${minor}-${release}.exe /publish/${FLAVOR}
-    
-    rm -Rf /workspace/.wine
 }

--- a/deploy/platform/windows/windows_docker_build.sh
+++ b/deploy/platform/windows/windows_docker_build.sh
@@ -23,6 +23,8 @@ runtests() {
     testarch ${test64}
     testarch ${test32};
     checktests;
+
+    rm -Rf /workspace/.wine
 }
 
 buildrelease() {
@@ -69,10 +71,14 @@ buildrelease() {
     if [ -z "$NOMAKE" ]; then
       source ${srcdir}/deploy/packaging/windows/create_installer.sh
     fi # NOMAKE
+
+    rm -Rf /workspace/.wine
 }
 publish() {
     major=$(echo ${RELEASE_VERSION} | cut -d. -f1)
     minor=$(echo ${RELEASE_VERSION} | cut -d. -f2)
     release=$(echo ${RELEASE_VERSION} | cut -d. -f3)
     rsync -a /release/${FLAVOR}/MDSplus${BNAME}-${major}.${minor}-${release}.exe /publish/${FLAVOR}
+    
+    rm -Rf /workspace/.wine
 }

--- a/deploy/platform/windows/windows_docker_build.sh
+++ b/deploy/platform/windows/windows_docker_build.sh
@@ -13,10 +13,10 @@ srcdir=$(readlink -e $(dirname ${0})/../..)
 
 export JNI_INCLUDE_DIR=${srcdir}/3rd-party-apis/windows-jdk
 export JNI_MD_INCLUDE_DIR=${srcdir}/3rd-party-apis/windows-jdk/win32
-mkdir -p /workspace/winebottle64
-test64="64 x86_64-w64-mingw32 bin_x86_64 bin_x86_64 --with-winebottle=/workspace/winebottle64"
-mkdir -p /workspace/winebottle32
-test32="32 i686-w64-mingw32   bin_x86    bin_x86    --with-winebottle=/workspace/winebottle32"
+mkdir -p /tmp/winebottle64
+test64="64 x86_64-w64-mingw32 bin_x86_64 bin_x86_64 --with-winebottle=/tmp/winebottle64"
+mkdir -p /tmp/winebottle32
+test32="32 i686-w64-mingw32   bin_x86    bin_x86    --with-winebottle=/tmp/winebottle32"
 
 runtests() {
     # run tests with the platform specific params read from test32 and test64
@@ -55,7 +55,7 @@ buildrelease() {
       popd
       pushd /workspace/releasebld/64/mdsobjects/cpp
       $MAKE generate-libs-from-dlls
-      HOME=/workspace/winebottle64 WINEARCH=win64\
+      HOME=/tmp/winebottle64 WINEARCH=win64\
 	wine cmd /C ${srcdir}/deploy/platform/windows/visual-studio-build.bat
       cp /workspace/releasebld/64/bin_x86_64/MdsObjectsCppShr-VS.dll ${MDSPLUS_DIR}/bin_x86_64/
       cp /workspace/releasebld/64/bin_x86_64/*.lib ${MDSPLUS_DIR}/bin_x86_64/

--- a/deploy/platform/windows/windows_docker_build.sh
+++ b/deploy/platform/windows/windows_docker_build.sh
@@ -55,7 +55,7 @@ buildrelease() {
       popd
       pushd /workspace/releasebld/64/mdsobjects/cpp
       $MAKE generate-libs-from-dlls
-      HOME=/tmp/winebottle64 WINEPREFIX=/tmp/winebottle64 WINEARCH=win64\
+      WINEPREFIX=/tmp/winebottle64 WINEARCH=win64\
 	        wine cmd /C ${srcdir}/deploy/platform/windows/visual-studio-build.bat
       cp /workspace/releasebld/64/bin_x86_64/MdsObjectsCppShr-VS.dll ${MDSPLUS_DIR}/bin_x86_64/
       cp /workspace/releasebld/64/bin_x86_64/*.lib ${MDSPLUS_DIR}/bin_x86_64/
@@ -66,9 +66,9 @@ buildrelease() {
     ###
     ### pack installer
     ###
-  if [ -z "$NOMAKE" ]; then
-    source ${srcdir}/deploy/packaging/windows/create_installer.sh
-  fi # NOMAKE
+    if [ -z "$NOMAKE" ]; then
+      source ${srcdir}/deploy/packaging/windows/create_installer.sh
+    fi # NOMAKE
 }
 publish() {
     major=$(echo ${RELEASE_VERSION} | cut -d. -f1)

--- a/deploy/tap-to-junit.py
+++ b/deploy/tap-to-junit.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python3
 
 import argparse
-import glob
 import os
 import sys
+
+from pathlib import Path
 
 import xml.etree.ElementTree as xml
 
@@ -17,10 +18,9 @@ parser.add_argument(
 
 args = parser.parse_args()
 
-tap_filename_list = glob.glob(
-    '**/*.trs',
-    recursive=True
-)
+# Using pathlib.Path.glob instead of glob.glob because it doesn't follow symlinks
+# and the windows build directory has recursive symlinks
+tap_filename_list = Path('.').glob('**/*.trs')
 
 all_tests = {}
 failed_test_count = 0

--- a/deploy/tap-to-junit.py
+++ b/deploy/tap-to-junit.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+
+import argparse
+import glob
+import os
+import sys
+
+import xml.etree.ElementTree as xml
+
+parser = argparse.ArgumentParser()
+
+parser.add_argument(
+    '--junit-suite-name',
+    metavar='',
+    help='',
+)
+
+args = parser.parse_args()
+
+tap_filename_list = glob.glob(
+    '**/*.trs',
+    recursive=True
+)
+
+all_tests = {}
+failed_test_count = 0
+
+for tap_filename in tap_filename_list:
+
+    name = os.path.relpath(os.path.splitext(tap_filename)[0], os.getcwd())
+
+    log_filename = os.path.splitext(tap_filename)[0] + '.log'
+    if not os.path.exists(log_filename):
+        print(log_filename, 'not found')
+        log_filename = None
+
+    result = None
+    
+    lines = open(tap_filename, 'rt').readlines()
+    for line in lines:
+        line = line.strip()
+        if line.startswith(':test-result: '):
+            result = line.removeprefix(':test-result: ')
+    
+    if result == 'FAIL':
+        failed_test_count += 1
+
+    all_tests[name] = {
+        'log': log_filename,
+        'result': result,
+    }
+
+root = xml.Element('testsuites')
+root.attrib['tests'] = str(len(all_tests))
+root.attrib['failures'] = str(failed_test_count)
+
+testsuite = xml.SubElement(root, 'testsuite')
+
+# TODO: Improve
+testsuite.attrib['name'] = 'mdsplus'
+if args.junit_suite_name is not None:
+    testsuite.attrib['name'] = args.junit_suite_name
+
+for test_name, test in all_tests.items():
+    testcase = xml.SubElement(testsuite, 'testcase')
+    testcase.attrib['name'] = test_name
+
+    system_out = xml.SubElement(testcase, 'system-out')
+    system_out.text = open(test['log']).read()
+
+    if test['result'] == 'FAIL':
+        failure = xml.SubElement(testcase, 'failure')
+        failure.attrib['message'] = 'Failed'
+
+    if test['result'] == 'SKIP':
+        failure = xml.SubElement(testcase, 'skipped')
+        failure.attrib['message'] = 'Skipped'
+
+print(f'Writing JUnit output to mdsplus-junit.xml')
+with open('mdsplus-junit.xml', 'wb') as f:
+    f.write(xml.tostring(root))


### PR DESCRIPTION
The event port is now computed from OSList.indexOf(OS) instead of $EXECUTOR_NUMBER Artifacts will now archive regardless of the build result