### PR TITLE
Work on isolating each build/test in their own network

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -87,8 +87,6 @@ pipeline {
                         OS: OSList
                     ],
                     actions: {
-                        network="jenkins-${EXECUTOR_NUMBER}-${OS}"
-
                         ws("${WORKSPACE}/${OS}") {
 
                             stage("${OS} Clone") {
@@ -104,6 +102,7 @@ pipeline {
                             }
 
                             stage("${OS} Test") {
+                                network="jenkins-${EXECUTOR_NUMBER}-${OS}"
                                 sh "./deploy/build.sh --os=${OS} --test --dockernetwork=${network}"
                             }
                         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -87,6 +87,8 @@ pipeline {
                         OS: OSList
                     ],
                     actions: {
+                        network="jenkins-${EXECUTOR_NUMBER}-${OS}"
+
                         ws("${WORKSPACE}/${OS}") {
 
                             stage("${OS} Clone") {
@@ -102,8 +104,7 @@ pipeline {
                             }
 
                             stage("${OS} Test") {
-                                EVENT_PORT = OSList.indexOf(OS) + 4100
-                                sh "./deploy/build.sh --os=${OS} --test --eventport=${EVENT_PORT}"
+                                sh "./deploy/build.sh --os=${OS} --test --dockernetwork=${network}"
                             }
                         }
                     }

--- a/deploy/build.sh
+++ b/deploy/build.sh
@@ -177,6 +177,10 @@ OPTIONS
        before performing the build. If a docker image is not already
        present on the system it will automatically pulled from dockerhub
        even without the --dockerpull option.
+    
+    --dockernetwork
+       If specified, a docker network with this name will be created,
+       used for the docker container, and then removed.
 
     --keys=dir
        Specifies a directory containing signing keys and certificates
@@ -355,6 +359,9 @@ parsecmd() {
 		;;
 	    --dockerfile=*)
 		eval "DOCKERFILE=${i#*=}"
+		;;
+	    --dockernetwork=*)
+		eval "DOCKERNETWORK=${i#*=}"
 		;;
 	    --keys=*)
 		eval "KEYS=${i#*=}"
@@ -644,6 +651,7 @@ OS=${OS} \
   PUBLISHDIR=${PUBLISHDIR} \
   DOCKERIMAGE=${DOCKERIMAGE} \
   DOCKERFILE=${DOCKERFILE} \
+  DOCKERNETWORK=${DOCKERNETWORK} \
   KEYS=${KEYS} \
   DISTNAME=${DISTNAME} \
   UPDATEPKG=${UPDATEPKG} \


### PR DESCRIPTION
Add --dockernetwork to build.sh
Default to "jenkins-$EXECUTOR_NUMBER-$OS_INDEX"
    e.g. jenkins-3-ubuntu22
Create/Use/Delete the network with docker, if specified