### PR TITLE
Add define for DbiTREE_VERSION to alpha

### DIFF
--- a/include/dbidef.h
+++ b/include/dbidef.h
@@ -24,6 +24,7 @@
 #define DbiREADONLY 12             /* True if making tree readonly */
 #define DbiDISPATCH_TABLE 13       /* Tree dispatch table */
 #define DbiALTERNATE_COMPRESSION 14 /* Set to true to enable extended compression methods */
+#define DbiTREE_VERSION 15         /* Tree format version number, reserved for MDSplus 8 */
 typedef struct dbi_itm
 {
   short int buffer_length;


### PR DESCRIPTION
Fix for issue #2681.

Both branches, mdsplus8 and alpha, now use the same define for the "tree version".   This is needed because there are are two file formats: 12-character node names (v7 and earlier) and 63-character node names (v8).

