### PR TITLE
Build: Actually publish to the real directory

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -204,7 +204,7 @@ pipeline {
                                     }
 
                                     stage("${OS} Publish") {
-                                        sh "./deploy/build.sh --os=${OS} --publish=${new_version} --keys=/mdsplus/certs --publishdir=/tmp/publish"
+                                        sh "./deploy/build.sh --os=${OS} --publish=${new_version} --keys=/mdsplus/certs --publishdir=/mdsplus/dist"
                                     }
                                 }
                             }


### PR DESCRIPTION
This will publish to the local copy of the MDSplus repository mirror, an additional rsync will be needed to publish everything to the webserver