### PR TITLE
Fix: corrected typo that caused MdsPut2() to clear all flags

### DIFF
--- a/mdslib/MdsLib.c
+++ b/mdslib/MdsLib.c
@@ -1192,8 +1192,7 @@ static int mds_put2_vargs(va_list incrmtr, int connection, char *pathname,
       if (STATUS_OK)
       {
         if ((status =
-                 TreePutRecord(nid, (struct descriptor *)arglist[argidx - 2]),
-             0) &
+                 TreePutRecord(nid, (struct descriptor *)arglist[argidx - 2], 0)) &
             1)
         {
           TreeWait();

--- a/mdslib/MdsLib.c
+++ b/mdslib/MdsLib.c
@@ -1050,8 +1050,7 @@ static inline int mds_put_vargs(va_list incrmtr, int connection, char *pathname,
 
       if (STATUS_OK)
       {
-        if ((status = 
-                 TreePutRecord(nid, (struct descriptor *)arglist[argidx - 2], 0)) & 1)
+        if ((status = TreePutRecord(nid, (struct descriptor *)arglist[argidx - 2], 0)) & 1)
         {
           TreeWait();
         }
@@ -1190,8 +1189,7 @@ static int mds_put2_vargs(va_list incrmtr, int connection, char *pathname,
 
       if (STATUS_OK)
       {
-        if ((status =
-                 TreePutRecord(nid, (struct descriptor *)arglist[argidx - 2], 0)) & 1)
+        if ((status = TreePutRecord(nid, (struct descriptor *)arglist[argidx - 2], 0)) & 1)
         {
           TreeWait();
         }

--- a/mdslib/MdsLib.c
+++ b/mdslib/MdsLib.c
@@ -1050,9 +1050,8 @@ static inline int mds_put_vargs(va_list incrmtr, int connection, char *pathname,
 
       if (STATUS_OK)
       {
-        if ((status = TreePutRecord(
-                 nid, (struct descriptor *)arglist[argidx - 2], 0)) &
-            1)
+        if ((status = 
+                 TreePutRecord(nid, (struct descriptor *)arglist[argidx - 2], 0)) & 1)
         {
           TreeWait();
         }
@@ -1192,8 +1191,7 @@ static int mds_put2_vargs(va_list incrmtr, int connection, char *pathname,
       if (STATUS_OK)
       {
         if ((status =
-                 TreePutRecord(nid, (struct descriptor *)arglist[argidx - 2], 0)) &
-            1)
+                 TreePutRecord(nid, (struct descriptor *)arglist[argidx - 2], 0)) & 1)
         {
           TreeWait();
         }


### PR DESCRIPTION
Fixes Issue #2658

The `mds_put2_vargs()` function is a clone of the original `mds_put_vargs()`, with some minor edits.   

Unfortunately, the edits introduced a typo in `mds_put2_vargs()`.   The fix involved undoing the typo and using the same construct seen in `mds_put_vargs()` at the following source line.

[MdsLib.c, line 1054, mds_put_vargs()](https://github.com/MDSplus/mdsplus/blob/dae624da75b90a4f1fadae2ed5e285b4988ce79d/mdslib/MdsLib.c#L1054)