### PR TITLE
Fix: Release versioning was always 1 behind

### DIFF
--- a/deploy/build.sh
+++ b/deploy/build.sh
@@ -321,6 +321,9 @@ parsecmd() {
 		eval "RELEASE_VERSION=${i#*=}"
 		PUBLISH=yes
 		;;
+	    --version=*)
+		eval "RELEASE_VERSION=${i#*=}"
+		;;
 	    --platform=*)
 		eval "PLATFORM=${i#*=}"
 		;;

--- a/deploy/git_revision.sh
+++ b/deploy/git_revision.sh
@@ -2,9 +2,7 @@
 SRC=$(realpath "$(dirname "$0")/..")
 GIT="git --git-dir=${SRC}/.git --work-tree=${SRC}"
 GIT_TAG="$(${GIT} describe --tag)"
-if [ -z "${GIT_BRANCH}" ]; then
-	GIT_BRANCH="$(${GIT} rev-parse --abbrev-ref HEAD)"
-fi
+GIT_BRANCH="$(${GIT} rev-parse --abbrev-ref HEAD)"
 GIT_REMOTE="$(${GIT} config branch.${GIT_BRANCH}.remote)"
 GIT_REMOTE_URL="$(${GIT} config remote.${GIT_REMOTE}.url)"
 GIT_COMMIT="$(${GIT} rev-parse HEAD)"


### PR DESCRIPTION
Jenkins now re-runs bootstrap after calculating and tagging the new version
This also moves the --release/--publish=VERSION into a separate parameter called --version=VERSION
This now properly passes the BRANCH/RELEASE_VERSION into bootstrap for us to override the git info