### PR TITLE
Fix: User provided fix to prevent rare segfault on device deletion

### DIFF
--- a/treeshr/TreeDeleteNode.c
+++ b/treeshr/TreeDeleteNode.c
@@ -165,7 +165,8 @@ static void check_nid(PINO_DATABASE *dblist, NID *nid, int *count)
           0xFFFFFF;
       elt_nid.tree = nid->tree;
       elt_node = nid_to_node(dblist, &elt_nid);
-      for (; swapint16(&elt_node->conglomerate_elt) == elt_num;
+      for (; swapint16(&elt_node->conglomerate_elt) == elt_num 
+                && elt_nid.node < dblist->tree_info->header->nodes;
            elt_nid.node++, elt_num++, elt_node++)
         check_nid(dblist, &elt_nid, count);
     }


### PR DESCRIPTION
Fixes Issue #2659

MDSplus "devices" (aka "conglomerates") consist of multiple adjacent nodes.   The `conglomerate_elt` is a node attribute that contains the index of that element in the set of nodes that comprise the device.

The code that deletes a device failed to handle the case when the device nodes are at the end of the node array, and thus would occasionally step beyond the node array and segfault.

This fix adds a check to prevent stepping beyond the node array.

It eliminated the segfault condition for the customer.   And also passed testing (with injected faults).