### PR TITLE
Build: configure PYTHONPATH for IDL test harness

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -175,7 +175,7 @@ pipeline {
                                 sh """
                                     set +x
                                     . \$MDSPLUS_DIR/setup.sh
-                                    export PYTHONPATH=$MDSPLUS_DIR/python/
+                                    export PYTHONPATH=${MDSPLUS_DIR}/python/
                                     set -x
                                     ./idl/testing/run_tests.py
                                 """

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -175,7 +175,7 @@ pipeline {
                                 sh """
                                     set +x
                                     . \$MDSPLUS_DIR/setup.sh
-                                    export PYTHONPATH=${MDSPLUS_DIR}/python/
+                                    export PYTHONPATH=\$MDSPLUS_DIR/python/
                                     set -x
                                     ./idl/testing/run_tests.py
                                 """

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -175,6 +175,7 @@ pipeline {
                                 sh """
                                     set +x
                                     . \$MDSPLUS_DIR/setup.sh
+                                    export PYTHONPATH=$MDSPLUS_DIR/python/
                                     set -x
                                     ./idl/testing/run_tests.py
                                 """


### PR DESCRIPTION
Partial fix for Issue #2650.

The enhanced IDL test harness creates a tiny local tree that is used for ensuring that the IDL API can write to a tree.   The Python code that creates that tree, imports the MDSplus Python API, thus needs the PYTHONPATH environment variable configured accordingly.