### PR TITLE
Build: parameterize the "write" tree for MATLAB tests

### DIFF
--- a/matlab/testing/run_tests.py
+++ b/matlab/testing/run_tests.py
@@ -8,6 +8,7 @@ import os
 import subprocess
 import argparse
 import string
+import tempfile
 
 # The default values are intended to be used from within the PSFC network
 # If you want to run these tests on your own infrastructure, provide the
@@ -239,28 +240,9 @@ args = parser.parse_args()
 #---------------------------------------------------------------------------
 # Each write test should start with a clean tree.
 # Write tests use a local tree, but eventually will be upgraded to use mdsip.
-# TODO: The default_tree_path is temporary; will change when switch to mdsip.
 #
 def build_write_tree(tree, shot):
-    import os
     import MDSplus as mds
-
-    test_dir = os.getenv('MDSPLUS_DIR') + '/matlab/testing/'
-    os.environ['default_tree_path'] = test_dir  # required to write tree
-
-    tree_name = tree + '_' + str(shot)
-    tree_file = test_dir + tree_name
-
-    tc = tree_file + '.characteristics'
-    td = tree_file + '.datafile'
-    tt = tree_file + '.tree' 
-
-    if os.path.exists(tc):
-        os.remove(tc)
-    if os.path.exists(td):
-        os.remove(td)
-    if os.path.exists(tt):
-        os.remove(tt)
 
     t = mds.Tree(tree, shot, 'new')
 
@@ -281,8 +263,12 @@ def build_write_tree(tree, shot):
     t.close()
 
 
-build_write_tree(args.write_tree, args.write_shot)
+# Temporary directory for transient test scripts and artifacts
+TEST_DIR = tempfile.TemporaryDirectory(prefix='test_matlab_', dir='/tmp')
+os.environ['default_tree_path'] = TEST_DIR.name
+os.environ['MATLABPATH'] = os.getenv('MATLABPATH') + ':' + TEST_DIR.name
 
+build_write_tree(args.write_tree, args.write_shot)
 
 all_tests_passed = True
 def matlab_test(code, expected_output):
@@ -297,7 +283,8 @@ def matlab_test(code, expected_output):
     # Write the test to a MATLAB script file, test.m
 
     code = '% placeholder comment\n' + code + '\nexit\n'
-    open('test.m', 'wt').write(code)
+    test_file = TEST_DIR.name + '/test.m'
+    open(test_file, 'wt').write(code)
 
     expected_lines = [ line.strip() for line in expected_output.splitlines() ]
     expected_lines = list(filter(None, expected_lines))

--- a/matlab/testing/run_tests.py
+++ b/matlab/testing/run_tests.py
@@ -93,7 +93,6 @@ parser.add_argument(
     help='An expression to evaluate and compare against --signal-value'
 )
 
-#    default="{'none   '}    {'25kHz  '}    {'50kHz  '}    {'83.3kHz'}"
 parser.add_argument(
     '--signal-value',
     default='"none   "    "25kHz  "    "50kHz  "    "83.3kHz"',
@@ -222,6 +221,18 @@ parser.add_argument(
     help='The value of evaluating the --units-of expression, ignoring leading/trailing whitespace'
 )
 
+parser.add_argument(
+    '--write-tree',
+    default='matlab_tests',
+    help='Name of tree to create for exercising write functions of the API'
+)
+
+parser.add_argument(
+    '--write-shot',
+    default=100,
+    help='Shot number of tree to create for exercising write functions of the API'
+)
+
 args = parser.parse_args()
 
 
@@ -269,9 +280,8 @@ def build_write_tree(tree, shot):
     t.write()
     t.close()
 
-write_tree = 'write'
-write_shot = 123
-build_write_tree(write_tree, write_shot)
+
+build_write_tree(args.write_tree, args.write_shot)
 
 
 all_tests_passed = True
@@ -446,7 +456,7 @@ matlab_test(f'''
             
 testid = 'MATLAB-write-various';         
 
-mdsopen('{write_tree}', {write_shot});
+mdsopen('{args.write_tree}', {args.write_shot});
 mdsput('A_TEXT', ' "string_a" ');
 mdsput('B_NUM', '22');
 mdsput('C_SIGNAL', 'build_signal([10,-10,5,-5,0],[10.2,-10.2,5.4,-5.4,0.0], [0 .. 4])');
@@ -457,7 +467,7 @@ mdsput('.-.SUBTREE_2:F_NUM', '66');
 mdsput('\TAG_G', '77');
 mdsclose();
          
-mdsopen('{write_tree}', {write_shot});
+mdsopen('{args.write_tree}', {args.write_shot});
 disp(mdsvalue('A_TEXT'));
 disp(mdsvalue('B_NUM'));
 disp(transpose(mdsvalue('DATA(C_SIGNAL)')));


### PR DESCRIPTION
Refine fix for Issue #2673.

- no longer uses hard-coded tree name and shot number
- also deleted a comment that was no longer applicable