### PR TITLE
Fix: mdsip no longer accepts connections from unauthorized users

### DIFF
--- a/mdstcpip/mdsipshr/Connections.c
+++ b/mdstcpip/mdsipshr/Connections.c
@@ -558,6 +558,10 @@ int AcceptConnection(char *protocol, char *info_name, SOCKET readfd, void *info,
     // reply to client //
     status = SendMdsMsgC(c, msg, 0);
     free(msg);
+    // SsINTERNAL has low order bit set so is erroneously treated as OK.
+    if (status == SsINTERNAL) {
+      status = MDSplusERROR;
+    } 
     if (STATUS_OK)
     {
       if (usr)

--- a/mdstcpip/mdsipshr/Connections.c
+++ b/mdstcpip/mdsipshr/Connections.c
@@ -513,6 +513,7 @@ int AcceptConnection(char *protocol, char *info_name, SOCKET readfd, void *info,
     *usr = NULL;
   Connection *c = newConnection(protocol);
   INIT_STATUS_ERROR;
+  int auth_status = status;
   if (c)
   {
     Message *msg;
@@ -535,9 +536,9 @@ int AcceptConnection(char *protocol, char *info_name, SOCKET readfd, void *info,
     }
     c->rm_user = user;
     user_p = user ? user : "?";
-    status = authorize_client(c, user_p);
+    auth_status = authorize_client(c, user_p);
     // SET COMPRESSION //
-    if (STATUS_OK)
+    if (IS_OK(auth_status))
     {
       const int max_version = get_max_version();
       c->compression_level = msg->h.status & 0xf;
@@ -562,7 +563,7 @@ int AcceptConnection(char *protocol, char *info_name, SOCKET readfd, void *info,
     if (status == SsINTERNAL) {
       status = MDSplusERROR;
     } 
-    if (STATUS_OK)
+    if (STATUS_OK && IS_OK(auth_status))
     {
       if (usr)
         *usr = strdup(user_p);


### PR DESCRIPTION
Fixes Issue #2652.

The `Connections.c` code does two status checks.   The first determines if the user is authorized via the `mdsip.hosts` file.   The second determines if the initial message sent to the client-side was received without error.   Unfortunately, a single status variable was being used for both checks, which resulted in a bug that in some instances would allow unauthorized users to connect.

This fix uses two status variables, one for each check.   And thus prevents the bug from occurring.

Plus also properly handles the `SsINTERNAL` error that can bubble up from some lower level functions.