### PR TITLE
Fix: remove extra call serializeout connection.py

### DIFF
--- a/python/MDSplus/connection.py
+++ b/python/MDSplus/connection.py
@@ -212,9 +212,10 @@ class _Connection:
         for i, arg in enumerate(args):
             self._send_arg(arg, i+1, num)
         retSerialized = self._get_answer(timeout)
-        if isinstance(retSerialized, _sca.Scalar):
-            return retSerialized
-        return retSerialized.deserialize()
+        return retSerialized
+#        if isinstance(retSerialized, _sca.Scalar):
+#            return retSerialized
+#        return retSerialized.deserialize()
 
 
 class Connection(object):

--- a/python/MDSplus/connection.py
+++ b/python/MDSplus/connection.py
@@ -205,7 +205,7 @@ class _Connection:
             args = kwargs['arglist']
         timeout = kwargs.get('timeout', -1)
         num = len(args)+1
-        exp = 'serializeout(`(data('+exp+')))'
+#        exp = 'serializeout(`(data('+exp+')))'
         exp = _ver.tobytes(exp)
         _exc.checkStatus(_SendArg(self.conid, 0, 14, num,
                                   len(exp), 0, 0, ctypes.c_char_p(exp)))


### PR DESCRIPTION
https://github.com/MDSplus/mdsplus/pull/2661 changed the expr to be evaluated enclosing it in a call to `serializeout`

When connecting to older mdsip servers - like:
```
TCL> show version

MDSplus version: 7.78.6
----------------------
  Release:  alpha_release-7-78-6
  Browse:   https://github.com/MDSplus/mdsplus/tree/alpha_release-7-78-6
  Download: https://github.com/MDSplus/mdsplus/archive/alpha_release-7-78-6.tar.gz
  Build date: Wed Jun 26 18:51:44 UTC 2019

TCL>
```
This causes calls like TreeOpen('tree', shot) to generate an infinte recursion error,

This PR removes line 208 from connection.py

GABRIELE:  Does this break #2660/#2661 ??