### PR TITLE
Build: correctly format expected output for a MATLAB test

### DIFF
--- a/matlab/testing/run_tests.py
+++ b/matlab/testing/run_tests.py
@@ -96,7 +96,7 @@ parser.add_argument(
 
 parser.add_argument(
     '--signal-value',
-    default='"none   "    "25kHz  "    "50kHz  "    "83.3kHz"',
+    default="{'none   '}    {'25kHz  '}    {'50kHz  '}    {'83.3kHz'}",
     help='The value of evaluating the --signal expression, ignoring leading/trailing whitespace'
 )
 


### PR DESCRIPTION
Fix for Issue #2721.

Minor formatting change for one line of the expected output, so that comparison matches and the MATLAB test passes.