### PR TITLE
Fix: "set current" now works with thick-client

### DIFF
--- a/treeshr/RemoteAccess.c
+++ b/treeshr/RemoteAccess.c
@@ -981,7 +981,7 @@ int TreeSetCurrentShotIdRemote(const char *treearg, char *path, int shot)
 {
   int status = 0;
   int conid = remote_connect(path);
-  if (conid > 0)
+  if (conid >= 0)
   {
     struct descrip ans = {0};
     struct descrip tree = STR2DESCRIP(treearg);


### PR DESCRIPTION
Fix for Issue #2687.

The fix is the same as PR #2418 for "show current" (i.e., zero is a valid `mdsip` socket connection).

For comparison, here is the equivalent line in the `TreeGetCurrentShotIdRemote()` function.
[line 961](https://github.com/MDSplus/mdsplus/blob/5955c39b41d60b83997e5b55c9cf7c103cc55932/treeshr/RemoteAccess.c#L961)