### PR TITLE
Build: bootstrap - export PYTHON for scripts like python/generate_tests

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -31,6 +31,7 @@ testprog autoconf	autoconf
 testprog $PYTHON	python2 or python3
 testprog bison		bison
 testprog flex		flex
+export PYTHON
 
 if [ ! -z $abort ]
 then


### PR DESCRIPTION
If you do not have python or at least a link (python -> python3) bootstrap will fail as underlying scripts do not see the PYTHON environment. in particular python/generate_tests will try 'python' and fail.