### PR TITLE
Fix: When activate debug trace, now compiles without error.

### DIFF
--- a/_include/mdsmsg.h
+++ b/_include/mdsmsg.h
@@ -1,6 +1,8 @@
 #include <stdio.h>
 #include <time.h>
+#include <string.h>
 
+// To activate the MDSDBG() debug messages, uncomment the following line.
 //#define DEBUG
 //#undef DEBUG
 #ifdef MDSDBG
@@ -27,7 +29,7 @@
 #define __MDSMSGPREFIX(LV) (                                  \
     {                                                         \
       pos = __FILE__;                                         \
-      while (!strncmp(pos, "../", 3))                         \
+      while (!strncmp(pos, "../", (unsigned long int) 3))                         \
         pos += 3;                                             \
       pos = msg + sprintf(msg, "%c, %u:%lu, %u.%09u: %s:%d ", \
                           LV, getpid(), CURRENT_THREAD_ID(),  \

--- a/mdstcpip/mdsipshr/MdsValue.c
+++ b/mdstcpip/mdsipshr/MdsValue.c
@@ -77,11 +77,11 @@ EXPORT int MdsIpGetDescriptor(int id, const char *expression, int nargs,
       strcat(newexp, ",__si($)");
     strcat(newexp, "))");
     nargs += 2;
-    MDSDBG(newexp);
+    MDSDBG("%s", newexp);
     status = SendArg(id, 0, DTYPE_CSTRING, nargs, strlen(newexp), 0, &dim,
                      (char *)newexp);
     free(newexp);
-    MDSDBG(expression);
+    MDSDBG("%s", expression);
     struct descriptor_a *arr;
     status = SendArg(id, 1, DTYPE_CSTRING, nargs, strlen(expression), 0, &dim,
                      (char *)expression);

--- a/servershr/ServerSendMessage.c
+++ b/servershr/ServerSendMessage.c
@@ -393,13 +393,14 @@ static void receiver_thread(void *sockptr)
   FD_ZERO(&fdactive);
   FD_SET(sock, &fdactive);
   int rep;
+  int num = 0;
   struct timeval readto, timeout = {10, 0};
   for (rep = 0; rep < 10; rep++)
   {
     for (readfds = fdactive, readto = timeout;;
          readfds = fdactive, readto = timeout, rep = 0)
     {
-      int num = select(FD_SETSIZE, &readfds, NULL, NULL, &readto);
+      num = select(FD_SETSIZE, &readfds, NULL, NULL, &readto);
       if (num < 0)
         break;
       if (num == 0)


### PR DESCRIPTION
This fixes Issue #2734.

In `mdsmsg.h`, the addition of `#include <string.h>` is needed for the `memset()` calls later in the same file.

In `ServerSendMessage.c`, the declaration of `num` was moved out of the loop to eliminate a compiler error about "longjmp" or "vfork()" potentially clobbering the value of `num`.

Note that this PR is being used to help diagnose / fix Issue #2731.  And thus this PR should also be cherry-picked into the "GA" branch.