### PR TITLE
Fix: Update JAVASOURCE to 8 to support JDK 17

### DIFF
--- a/java/mdsobjects/Makefile.am
+++ b/java/mdsobjects/Makefile.am
@@ -1,4 +1,4 @@
-JAVASOURCE = 6
+JAVASOURCE = 8
 DEPENDENCIES = $(srcdir)/src/main/resources/javax.json-1.0.4.jar
 include ../Makefile.inc.am
 

--- a/java/mdsplus/Makefile.am
+++ b/java/mdsplus/Makefile.am
@@ -1,4 +1,4 @@
-JAVASOURCE = 6
+JAVASOURCE = 8
 include ../Makefile.inc.am
 
 java_srcdir = $(srcdir)/src/main/java


### PR DESCRIPTION
As of Java 17, we can no longer pass `-source 6` to `javac`
This updates the two straggling libraries (`mdsplus` and `mdsobjects`) to version 8, which matches the other java libraries.

With Ubuntu 24.04 and Debian 12, we can no longer install Java 11, so we need to update to support 17