### PR TITLE
Fix: mdsip now sends proper auth status back to the client

### DIFF
--- a/mdstcpip/mdsipshr/Connections.c
+++ b/mdstcpip/mdsipshr/Connections.c
@@ -558,7 +558,7 @@ int AcceptConnection(char *protocol, char *info_name, SOCKET readfd, void *info,
       fprintf(stderr, "Access denied: %s\n", user_p);
     }
     msg->h.msglen = sizeof(MsgHdr);
-    msg->h.status = STATUS_OK ? (1 | (c->compression_level << 1)) : 0;
+    msg->h.status = IS_OK(auth_status) ? (1 | (c->compression_level << 1)) : 0;
     msg->h.ndims = 1;
     msg->h.dims[0] = MDSIP_VERSION;
     // reply to client //
@@ -578,6 +578,7 @@ int AcceptConnection(char *protocol, char *info_name, SOCKET readfd, void *info,
     else
     {
       destroyConnection(c);
+      status = MDSplusERROR;
     }
   }
   return status;


### PR DESCRIPTION
Fix for Issue #2750 and Issue #2652.

The original fix for Issue #2652 was incomplete.   Prior to that fix, the `status` variable was used both for network handshake status and user authorization status.   And consequently, the status was getting clobbered, thus in some instances allowing unauthorized users to connect to the mdsip server.   The fix for #2652 uses two variables: `status` and `auth_status`.   Unfortunately, that change overlooked the flag in the message header that gets returned to the client.

This fix remedies that situation.