### PR TITLE
Fix: mdstcl's `show current` no longer segfaults when no tree paths defined

### DIFF
--- a/tcl/tcl_show_current.c
+++ b/tcl/tcl_show_current.c
@@ -56,7 +56,7 @@ EXPORT int TclShowCurrent(void *ctx, char **error, char **output)
   }
   else
   {
-    *error = strdup("Failed to get shotid.  (Means no 'set current', mispelled tree or bad tree path.)\n");
+    *error = strdup("Failed to get shotid.  (Means no 'set current', misspelled tree or bad tree path.)\n");
   }
   free(experiment);
   return 1;

--- a/tcl/tcl_show_current.c
+++ b/tcl/tcl_show_current.c
@@ -56,7 +56,7 @@ EXPORT int TclShowCurrent(void *ctx, char **error, char **output)
   }
   else
   {
-    *error = strdup("Failed to get shotid.  (Means no 'set current', misspelled tree or bad tree path.)\n");
+    *error = strdup("Failed to get shotid.\n");
   }
   free(experiment);
   return 1;

--- a/tcl/tcl_show_current.c
+++ b/tcl/tcl_show_current.c
@@ -56,7 +56,7 @@ EXPORT int TclShowCurrent(void *ctx, char **error, char **output)
   }
   else
   {
-    *error = strdup("Failed to get shotid.\n");
+    *error = strdup("Failed to get shotid.  (Means no 'set current', mispelled tree or bad tree path.)\n");
   }
   free(experiment);
   return 1;

--- a/treeshr/TreeGetSetShotId.c
+++ b/treeshr/TreeGetSetShotId.c
@@ -137,6 +137,7 @@ int WriteShotId(char * filename, int shot, int mode)
   return status;
 }
 
+// On error returns 0 (a non-MDSplus error viewed as failure by the status macros)
 int TreeGetCurrentShotId(char const *experiment)
 {
   int shot = 0;
@@ -144,6 +145,9 @@ int TreeGetCurrentShotId(char const *experiment)
   char experiment_lower[16] = {0};
   size_t slen;
   char * pathlist = TreePath(experiment, experiment_lower);
+  if (pathlist == NULL) {
+    return 0;
+  }
   char * filename;
   char * saveptr = NULL;
   char * path = strtok_r(pathlist, TREE_PATH_LIST_DELIM, &saveptr);


### PR DESCRIPTION
This fixes Issue #2751.

It applies to `show current` with local access when no tree path or `default_tree_path` has been defined.