### PR TITLE
Build: Fix off-by-one versions produced by Jenkins

### DIFF
--- a/deploy/platform/bootstrap/bootstrap_build.sh
+++ b/deploy/platform/bootstrap/bootstrap_build.sh
@@ -14,5 +14,6 @@ trap cleanup EXIT INT
 docker run -t -a stdout -a stderr --cidfile=$cid \
    -u $(id -u):$(id -g) --privileged \
    -e "HOME=/tmp" \
+   -e "RELEASE_VERSION" \
    -v "${SRCDIR}:${DOCKER_SRCDIR}" \
    ${DOCKERIMAGE} "${DOCKER_SRCDIR}/bootstrap"


### PR DESCRIPTION
This fixes the bug where `--os=bootstrap` wasn't receiving the version from `--version=x.y.z` However, confusingly, this also changes the Jenkinsfile to not use that feature, and instead use `git tag` in order to embed the proper git information as well as the proper version information The `--os=bootstrap` and `--version` fix is still included just so that it doesn't break if someone else tries to use it