### PR TITLE
Build: Increase default test timeout to 1h

### DIFF
--- a/mdsobjects/cpp/testing/MdsConnectionTest.cpp
+++ b/mdsobjects/cpp/testing/MdsConnectionTest.cpp
@@ -139,7 +139,7 @@ void test_tree_open(const char *prot, const unsigned short port,
 int main(int argc, char *argv[])
 {
   int ipv6 = (argc > 1 && !strcmp(argv[1], "ipv6"));
-  TEST_TIMEOUT(30);
+  // TEST_TIMEOUT(30);
   setenv("t_connect_path", ".", 1);
 
 #ifdef _WIN32

--- a/mdsobjects/cpp/testing/MdsTdiTest.cpp
+++ b/mdsobjects/cpp/testing/MdsTdiTest.cpp
@@ -176,7 +176,7 @@ int main(int argc, char *argv[])
   if (single)
     exit(1);
 
-  TEST_TIMEOUT(100);
+  // TEST_TIMEOUT(100);
 
   // TODO: Query the stack size for windows
   if (stksize < 0x40000)

--- a/mdsobjects/cpp/testing/MdsTreeNodeTest.cpp
+++ b/mdsobjects/cpp/testing/MdsTreeNodeTest.cpp
@@ -136,7 +136,7 @@ namespace testing
 
 void main_test()
 {
-  TEST_TIMEOUT(100);
+  // TEST_TIMEOUT(100);
   BEGIN_TESTING(TreeNode);
 
   

--- a/mdsobjects/cpp/testing/MdsTreeSegments.cpp
+++ b/mdsobjects/cpp/testing/MdsTreeSegments.cpp
@@ -350,7 +350,7 @@ int main(int argc __attribute__((unused)),
          char *argv[] __attribute__((unused)))
 {
   setenv("t_treeseg_path", ".", 1);
-  TEST_TIMEOUT(100);
+  // TEST_TIMEOUT(100);
   TEST(putSegment);
   TEST(BlockAndRows);
   TEST(makeSegment);

--- a/mdsobjects/cpp/testing/MdsTreeTest.cpp
+++ b/mdsobjects/cpp/testing/MdsTreeTest.cpp
@@ -111,7 +111,7 @@ using namespace testing;
 int main(int argc __attribute__((unused)),
          char *argv[] __attribute__((unused)))
 {
-  TEST_TIMEOUT(100);
+  // TEST_TIMEOUT(100);
   BEGIN_TESTING(Tree);
 
 #ifdef _WIN32

--- a/testing/testing.h
+++ b/testing/testing.h
@@ -138,7 +138,7 @@ void __mark_point(const char *__assertion, const char *__file,
 //  TEST  //////////////////////////////////////////////////////////////////////
 ////////////////////////////////////////////////////////////////////////////////
 
-#define TEST_DEFAULT_TIMEOUT 10 // seconds
+#define TEST_DEFAULT_TIMEOUT 3600 // seconds
 
 #define TEST_FORK(value) __test_setfork(value);
 


### PR DESCRIPTION
When the build server(s) are at capacity, it's not unreasonable for a test to take more than 10 seconds, which was the old default timeout
This sets the default to 1h, and removes the overrides in various tests