### PR TITLE
Build: Fix 'HEAD' in `show version` and tag error

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -128,7 +128,7 @@ pipeline {
                                         checkout scm;
 
                                         if (new_tag) {
-                                            sh "git tag ${new_tag}"
+                                            sh "git tag ${new_tag} || true"
                                         }
                                     }
 

--- a/deploy/platform/bootstrap/bootstrap_build.sh
+++ b/deploy/platform/bootstrap/bootstrap_build.sh
@@ -14,6 +14,7 @@ trap cleanup EXIT INT
 docker run -t -a stdout -a stderr --cidfile=$cid \
    -u $(id -u):$(id -g) --privileged \
    -e "HOME=/tmp" \
+   -e "BRANCH" \
    -e "RELEASE_VERSION" \
    -v "${SRCDIR}:${DOCKER_SRCDIR}" \
    ${DOCKERIMAGE} "${DOCKER_SRCDIR}/bootstrap"


### PR DESCRIPTION
Jenkins builds in a detached HEAD state, which caused bootstrap to use HEAD as the branch name
We pass --branch= to the bootstrap call in Jenkins, but $BRANCH wasn't being passed into the bootstrap docker container 
Also, attempts to build alpha versions with tags that already existed failed