### PR TITLE
Feature: Add "Date:" to show version output

### DIFF
--- a/_include/_mdsversion.h.in
+++ b/_include/_mdsversion.h.in
@@ -8,6 +8,7 @@
 #define VERSIONCONST CONCAT(LIBPREFIX, Version)
 #define GETRELEASE CONCAT(LIBPREFIX, Release)
 #define GETRELEASEDSC CONCAT(LIBPREFIX, ReleaseDsc)
+#define GETRELEASEDATE CONCAT(LIBPREFIX, ReleaseDate)
 
 EXPORT
 const mds_version_t VERSIONCONST = {
@@ -17,10 +18,11 @@ const mds_version_t VERSIONCONST = {
 	"@RELEASE_BRANCH@",
 };
 
-
 static pthread_once_t once = PTHREAD_ONCE_INIT;
 static char tag[64];
 static mdsdsc_t RELEASE_D = { 0, DTYPE_T, CLASS_S, tag };
+
+static const char release_date[64] = "@RELEASE_DATE@";
 
 static void buildtag()
 {
@@ -43,4 +45,10 @@ const mdsdsc_t *GETRELEASEDSC()
 {
 	pthread_once(&once, buildtag);
 	return &RELEASE_D;
+}
+
+EXPORT
+const char *GETRELEASEDATE()
+{
+	return release_date;
 }

--- a/mdsdcl/mdsdcl_show_version.c
+++ b/mdsdcl/mdsdcl_show_version.c
@@ -13,17 +13,19 @@
 extern MDSplusGitVersionInfo MDSplusGitVersion;
 extern const mds_version_t MdsVersion;
 extern const char *MdsRelease();
+extern const char *MdsReleaseDate();
 
 EXPORT int mdsdcl_show_version(void *ctx __attribute__((unused)),
                                char **error __attribute__((unused)),
                                char **output)
 {
+  const char *tag = MdsRelease();
   char *info = *output = malloc(1024);
   info += sprintf(info, "\n\n");
   info += sprintf(info, "MDSplus version: %d.%d.%d\n", MdsVersion.MAJOR, MdsVersion.MINOR, MdsVersion.MICRO);
   info += sprintf(info, "----------------------\n");
-  const char *tag = MdsRelease();
   info += sprintf(info, "  Release:  %s\n", tag);
+  info += sprintf(info, "  Date:     %s\n", MdsReleaseDate());
   info += sprintf(info, "  Browse:   https://github.com/MDSplus/mdsplus/tree/%s\n", tag);
   info += sprintf(info, "  Download: https://github.com/MDSplus/mdsplus/releases/tag/%s\n", tag);
   info += sprintf(info, "\n\n");


### PR DESCRIPTION
Implements #2766 

Example:
```
$ mdstcl sho ver

MDSplus version: 7.140.75
----------------------
  Release:  alpha_release-7-140-75
  Date:     Thu May 16 17:43:14 UTC 2024
  Browse:   https://github.com/MDSplus/mdsplus/tree/alpha_release-7-140-75
  Download: https://github.com/MDSplus/mdsplus/releases/tag/alpha_release-7-140-75
```