### PR TITLE
Fix: remove abort flag from RfxDevices DIO2 initialization

### DIFF
--- a/tdi/RfxDevices/DIO2__init.fun
+++ b/tdi/RfxDevices/DIO2__init.fun
@@ -92,7 +92,7 @@ public fun DIO2__init(as_is _nid, optional _method)
 	if(_remote != 0)
 	{
 	
-		_cmd = 'MdsConnect("'//_ip_addr//'",1)';
+		_cmd = 'MdsConnect("'//_ip_addr//'")';
 		_status = execute(_cmd);
 
 


### PR DESCRIPTION
Fixes issue #2768.

Makes the `tdi/RfxDevices/DIO2` initialization behave the same way that the LHCD team was using the `DIO2` device from 16-Feb-2023 through 9-Mar-2024.