### PR TITLE
Fix: sign the RPM package repo's metadata

### DIFF
--- a/deploy/platform/redhat/redhat_docker_build.sh
+++ b/deploy/platform/redhat/redhat_docker_build.sh
@@ -25,7 +25,7 @@ do_createrepo() {
   checkstatus abort "Failure: Problem creating rpm repository in ${repodir}!" $?
   rm -f ${tmpdir}/repodata/repomd.xml.asc
   export GNUPGHOME=/sign_keys/.gnupg
-  gpg --local-user RPM-GPG-KEY-MDSplus --detach-sign --armor ${tmpdir}/repodata/repomd.xml
+  gpg --local-user MDSplus --detach-sign --armor ${tmpdir}/repodata/repomd.xml
   unset GNUPGHOME
   : && rsync -a ${tmpdir}/repodata ${repodir}/${FLAVOR}/RPMS/
 }

--- a/deploy/platform/redhat/redhat_docker_build.sh
+++ b/deploy/platform/redhat/redhat_docker_build.sh
@@ -24,9 +24,7 @@ do_createrepo() {
   : && createrepo -q $update_args -o ${tmpdir} ${repodir}/${FLAVOR}/RPMS
   checkstatus abort "Failure: Problem creating rpm repository in ${repodir}!" $?
   rm -f ${tmpdir}/repodata/repomd.xml.asc
-  export GNUPGHOME=/sign_keys/.gnupg
-  gpg --local-user MDSplus --detach-sign --armor ${tmpdir}/repodata/repomd.xml
-  unset GNUPGHOME
+  GNUPGHOME=/sign_keys/.gnupg gpg --local-user MDSplus --detach-sign --armor ${tmpdir}/repodata/repomd.xml
   : && rsync -a ${tmpdir}/repodata ${repodir}/${FLAVOR}/RPMS/
 }
 

--- a/deploy/platform/redhat/redhat_docker_build.sh
+++ b/deploy/platform/redhat/redhat_docker_build.sh
@@ -23,6 +23,10 @@ do_createrepo() {
   fi
   : && createrepo -q $update_args -o ${tmpdir} ${repodir}/${FLAVOR}/RPMS
   checkstatus abort "Failure: Problem creating rpm repository in ${repodir}!" $?
+  rm -f ${tmpdir}/repodata/repomd.xml.asc
+  export GNUPGHOME=/sign_keys/.gnupg
+  gpg --local-user RPM-GPG-KEY-MDSplus --detach-sign --armor ${tmpdir}/repodata/repomd.xml
+  unset GNUPGHOME
   : && rsync -a ${tmpdir}/repodata ${repodir}/${FLAVOR}/RPMS/
 }
 


### PR DESCRIPTION
CentOS and RHEL use RPM packages.   The metadata for the MDSplus RPM package repository is in the `repodata/repomd.xml` file.   To ensure that the contents of the file have not been altered, it should be protected with a "detached" digital signature.

This fix creates that digital signature.

**Note 1:**  Although this change works OK on a development system using a fake signing key, that environment is not identical to the build system's environment.   And thus this proposed change deserves extra scrutiny before being merged to alpha.

**Note 2:**  This change should also be cherry-picked to the stable branch.

**Note 3:**  This is related to PR #2770 (labeled as "Fix:") and thus this PR should also be labelled with "Fix:" (not "Build:").
