### PR TITLE
Feature: jScope improvements

### DIFF
--- a/java/jscope/src/main/java/mds/jscope/jScopeMultiWave.java
+++ b/java/jscope/src/main/java/mds/jscope/jScopeMultiWave.java
@@ -142,8 +142,11 @@ public class jScopeMultiWave extends MultiWaveform implements UpdateEventListene
 	protected String getSignalInfo(int i)
 	{
 		String s;
-		final String name = (wi.in_label != null && wi.in_label[i] != null && wi.in_label[i].length() > 0)
-				? wi.in_label[i]
+//		final String name = (wi.in_label != null && wi.in_label[i] != null && wi.in_label[i].length() > 0)
+//				? wi.in_label[i]
+//				: wi.in_y[i];
+		final String name = (wi.eval_labels != null && wi.eval_labels[i] != null && wi.eval_labels[i].length() > 0)
+				? wi.eval_labels[i]
 				: wi.in_y[i];
 		final String er = (wi.w_error != null && wi.w_error[i] != null) ? " ERROR " : "";
 		// If the legend is defined in the signal, override it
@@ -239,7 +242,6 @@ public class jScopeMultiWave extends MultiWaveform implements UpdateEventListene
 			@Override
 			public void run()
 			{
-				// System.out.println("Evento su waveform "+e.name);
 				final WaveformEvent we = new WaveformEvent(jScopeMultiWave.this, WaveformEvent.EVENT_UPDATE,
 						"Update on event " + eventName);
 				dispatchWaveformEvent(we);
@@ -316,7 +318,6 @@ public class jScopeMultiWave extends MultiWaveform implements UpdateEventListene
 	@Override
 	public void removeNotify()
 	{
-		// System.out.println("Rimuovo jScopeMultiWave");
 		try
 		{
 			RemoveEvent();
@@ -375,8 +376,10 @@ public class jScopeMultiWave extends MultiWaveform implements UpdateEventListene
 				if (wi.signals[i] != null)
 				{
 					all_null = false;
-					if (wi.in_label[i] != null && wi.in_label[i].length() != 0)
-						wi.signals[i].setName(wi.in_label[i]);
+					//if (wi.in_label[i] != null && wi.in_label[i].length() != 0)
+					//	wi.signals[i].setName(wi.in_label[i]);
+					if (wi.eval_labels[i] != null && wi.eval_labels[i].length() != 0)
+						wi.signals[i].setName(wi.eval_labels[i]);
 					else
 						wi.signals[i].setName(wi.in_y[i]);
 					wi.signals[i].setMarker(wi.markers[i]);

--- a/java/jscope/src/main/java/mds/provider/AsciiDataProvider.java
+++ b/java/jscope/src/main/java/mds/provider/AsciiDataProvider.java
@@ -333,6 +333,13 @@ public class AsciiDataProvider implements DataProvider
 	}
 
 	@Override
+	public long getLastTime(String in, int row, int col, int index)
+	{
+		error = null;
+		return 0; //Fake implementation
+	}
+
+	@Override
 	public FrameData getFrameData(String in_y, String in_x, float time_min, float time_max) throws IOException
 	{
 		throw (new IOException("Frames visualization on DemoDataProvider not implemented"));

--- a/java/jscope/src/main/java/mds/provider/MdsDataProvider.java
+++ b/java/jscope/src/main/java/mds/provider/MdsDataProvider.java
@@ -559,19 +559,6 @@ public class MdsDataProvider implements DataProvider
 			return false;
 		}
 
-		public String duplicateBackslashes(String inStr)
-		{
-			final StringBuffer outStr = new StringBuffer();
-			for (int i = 0; i < inStr.length(); i++)
-			{
-				if (inStr.charAt(i) == '\\')
-				{
-					outStr.append('\\');
-				}
-				outStr.append(inStr.charAt(i));
-			}
-			return outStr.toString();
-		}
 
 		@Override
 		public XYData getData(double xmin, double xmax, int numPoints) throws IOException
@@ -1273,6 +1260,19 @@ public class MdsDataProvider implements DataProvider
 		// updateWorker = new UpdateWorker();
 		// updateWorker.start();
 	}
+        public String duplicateBackslashes(String inStr)
+        {
+                final StringBuffer outStr = new StringBuffer();
+                for (int i = 0; i < inStr.length(); i++)
+                {
+                        if (inStr.charAt(i) == '\\')
+                        {
+                                outStr.append('\\');
+                        }
+                        outStr.append(inStr.charAt(i));
+                }
+                return outStr.toString();
+        }
 
 	@Override
 	public synchronized void addConnectionListener(ConnectionListener l)
@@ -1572,6 +1572,15 @@ public class MdsDataProvider implements DataProvider
 			return null;
 		return realArray.getDoubleArray();
 	}
+	public long[] getLongArray(String in) throws IOException
+	{
+		if (debug)
+			System.out.println("GetDoubleArray " + in);
+		final RealArray realArray = GetRealArray(in);
+		if (realArray == null)
+                    throw new IOException("Failed to evaluate "+in);
+		return realArray.getLongArray();
+	}
 
 	@Override
 	public synchronized String getError()
@@ -1592,6 +1601,15 @@ public class MdsDataProvider implements DataProvider
 		return exp;
 	}
 
+        @Override
+	public synchronized long getLastTime(String in, int row, int col, int index) throws IOException
+	{
+            final String lastTimeExpr = "MdsMisc->GetLastTime:DSC(\"" + duplicateBackslashes(in) + "\")";
+	    final long[] retData = getLongArray(lastTimeExpr);
+            return retData[0];
+        }
+        
+        
 	@Override
 	public synchronized double getFloat(String in, int row, int col, int index) throws IOException
 	{

--- a/java/jscope/src/main/java/mds/provider/TwuDataProvider.java
+++ b/java/jscope/src/main/java/mds/provider/TwuDataProvider.java
@@ -1363,6 +1363,10 @@ public class TwuDataProvider implements DataProvider
 	{
 		return Double.parseDouble(in);
 	}
+	public long getLastTime(String in, int row, int col, int index)
+	{
+		return 0; //Fake implementation
+	}
 
 	// ---------------------------------------------------------------------------------------------
 	public synchronized float[] GetFloatArray(String in)

--- a/java/jscope/src/main/java/mds/provider/UniversalDataProvider.java
+++ b/java/jscope/src/main/java/mds/provider/UniversalDataProvider.java
@@ -82,6 +82,20 @@ public class UniversalDataProvider implements DataProvider
 	}
 
 	@Override
+	public long getLastTime(String in, int row, int col, int index)
+	{
+		try
+		{
+			return defaultProvider.getLastTime(in, row, col, index);
+		}
+		catch (final Exception exc)
+		{
+			error = "" + exc;
+			return 0;
+		}
+	}
+
+	@Override
 	public FrameData getFrameData(String in_y, String in_x, float time_min, float time_max) throws IOException
 	{
 		return null;

--- a/java/jscope/src/main/java/mds/wave/DataProvider.java
+++ b/java/jscope/src/main/java/mds/wave/DataProvider.java
@@ -93,16 +93,33 @@ public interface DataProvider extends AutoCloseable
 
 	/**
 	 * Method GetFloat is called by jScope to evaluate x min, x max, y min, y max
-	 * when defined in the stup data source popup form. The argument is in fact the
+	 * when defined in the setup data source popup form. The argument is in fact the
 	 * string typed by the user in the form. In its simplest implementation, method
 	 * GetFloat converts the string into a float value and returns it. Other data
 	 * providers, such as MdsDataProvider, evaluate, possibly remotely, the passed
 	 * string which may therefore be represented by an expression.
 	 *
 	 * @param in The specification of the value.
+         * @param row accessory information
+         * @param col accessory information
+         * @param index accessory information 
 	 * @return The evaluated value.
 	 */
 	public double getFloat(String in, int row, int col, int index) throws IOException;
+
+	/**
+	 * Method GetLastTime is called by jScope to evaluate window limits when displaying the last 
+         * part of a trend signal with absolute time when defined in the setup data source popup form. 
+         * In this case the xmin expression is terminates with a colon and it represents the window size
+         * in seconds
+	 *
+	 * @param in The specification of the value.
+         * @param row accessory information
+         * @param col accessory information
+         * @param index accessory information 
+	 * @return The absolute time of the last data point.
+	 */
+	public long getLastTime(String in, int row, int col, int index) throws IOException;
 
 	/**
 	 * GetFrameData is called by jScope to retrieve and display a frame sequence.

--- a/java/jscope/src/main/java/mds/wave/DataServerItem.java
+++ b/java/jscope/src/main/java/mds/wave/DataServerItem.java
@@ -35,6 +35,11 @@ public class DataServerItem
 		{
 			return Double.parseDouble(in);
 		}
+		@Override
+		public long getLastTime(String in, int row, int col, int index)
+		{
+			return 0;
+		}
 
 		@Override
 		public FrameData getFrameData(String in_y, String in_x, float time_min, float time_max) throws IOException

--- a/java/jscope/src/main/java/mds/wave/Signal.java
+++ b/java/jscope/src/main/java/mds/wave/Signal.java
@@ -2075,14 +2075,20 @@ public class Signal implements WaveDataListener
 	{
 		// if(!xLimitsInitialized)
 		// return -Double.MAX_VALUE;
-		return xmax;
+                if(longXLimits)
+                    return xMaxLong;
+                else
+                    return xmax;
 	}
 
 	public double getXmin()
 	{
 		// if(!xLimitsInitialized)
 		// return Double.MAX_VALUE;
-		return xmin;
+                if(longXLimits)
+                    return xMinLong;
+                else
+                    return xmin;
 	}
 
 	public float[] getY() throws IOException

--- a/java/mdsobjects/src/main/java/mds/connection/Descriptor.java
+++ b/java/mdsobjects/src/main/java/mds/connection/Descriptor.java
@@ -71,6 +71,13 @@ public class Descriptor
 		this.float_data = float_data;
 	}
 
+	public Descriptor(int dims[], double double_data[])
+	{
+		this.dtype = DTYPE_DOUBLE;
+		this.dims = dims;
+		this.double_data = double_data;
+	}
+
 	public Descriptor(int dims[], int int_data[])
 	{
 		this.dtype = DTYPE_LONG;

--- a/mdsmisc/ScopeUtilities.c
+++ b/mdsmisc/ScopeUtilities.c
@@ -1206,7 +1206,7 @@ EXPORT mdsdsc_xd_t *GetXYWave(char *inY, float *inXMin, float *inXMax,
 EXPORT mdsdsc_xd_t *GetLastTime(char *inY)
 {
   static EMPTYXD(xd);
-  int nid, numSegments, status;
+  int nid, numSegments = 0, status;
   EMPTYXD(segXd);
   EMPTYXD(dimXd);
   struct descriptor_a *arrD = NULL;

--- a/mdsmisc/ScopeUtilities.c
+++ b/mdsmisc/ScopeUtilities.c
@@ -1203,6 +1203,58 @@ EXPORT mdsdsc_xd_t *GetXYWave(char *inY, float *inXMin, float *inXMax,
   return &xd;
 }
 
+EXPORT mdsdsc_xd_t *GetLastTime(char *inY)
+{
+  static EMPTYXD(xd);
+  int nid, numSegments, status;
+  EMPTYXD(segXd);
+  EMPTYXD(dimXd);
+  struct descriptor_a *arrD = NULL;
+  int64_t lastTime = 0;
+  mdsdsc_t lastTimeD = {sizeof(int64_t), DTYPE_Q, CLASS_S, (char *)&lastTime};
+
+  nid = IsSegmented(inY);
+  if(nid == 0)
+  {
+        return (encodeError("Not a segmented node", __LINE__, &xd));
+  }
+  status = TreeGetNumSegments(nid, &numSegments);
+  if(STATUS_NOT_OK)
+  {
+    return (encodeError(MdsGetMsg(status), __LINE__, &xd));
+  }
+  if(numSegments == 0)
+  {
+    return (encodeError("Segments not found", __LINE__, &xd));
+  }
+  status = TreeGetSegment(nid, numSegments - 1, &segXd, &dimXd);
+  if(STATUS_NOT_OK)
+  {
+    return (encodeError(MdsGetMsg(status), __LINE__, &xd));
+  }
+  status = TdiData(dimXd.pointer, &dimXd MDS_END_ARG);
+  if (STATUS_NOT_OK) 
+  {
+    return (encodeError(MdsGetMsg(status), __LINE__, &xd));
+  }
+
+  if(dimXd.pointer && dimXd.pointer->class == CLASS_A && (dimXd.pointer->dtype == DTYPE_Q || dimXd.pointer->dtype == DTYPE_QU))
+  {
+    arrD = (struct  descriptor_a *)dimXd.pointer;
+    lastTime = ((int64_t *)arrD->pointer)[arrD->arsize/sizeof(int64_t) - 1];
+    MdsCopyDxXd((mdsdsc_t *)&lastTimeD, &xd);
+    MdsFree1Dx(&segXd, 0);    
+    MdsFree1Dx(&dimXd, 0);    
+  }
+  else
+  {
+    MdsFree1Dx(&segXd, 0);    
+    MdsFree1Dx(&dimXd, 0);    
+    return (encodeError("Dimension is not absolute times", __LINE__, &xd));
+  }
+  return &xd;
+}
+
 EXPORT mdsdsc_xd_t *GetXYWaveLongTimes(char *inY, int64_t *inXMin,
                                        int64_t *inXMax, int *reqNSamples)
 {


### PR DESCRIPTION
jScope improvements:

1) Allow using expressions also for signal labels
2) Allow defining a time window for the most recent samples in trend visualization (i.e. absolute times). This is configured by setting in xmin field <expression returning window size in seconds>: