### PR TITLE
Build: Lower test timeout to 20 minutes

### DIFF
--- a/testing/testing.h
+++ b/testing/testing.h
@@ -138,7 +138,7 @@ void __mark_point(const char *__assertion, const char *__file,
 //  TEST  //////////////////////////////////////////////////////////////////////
 ////////////////////////////////////////////////////////////////////////////////
 
-#define TEST_DEFAULT_TIMEOUT 3600 // seconds
+#define TEST_DEFAULT_TIMEOUT 1200 // 20 minutes in seconds
 
 #define TEST_FORK(value) __test_setfork(value);
 


### PR DESCRIPTION
Some tests are spinning, so I'm lowering the global timeout to 20 minutes
We will need to investigate the spinning tests