### PR TITLE
Build: Fix version bumping

### DIFF
--- a/deploy/get_new_version.py
+++ b/deploy/get_new_version.py
@@ -67,8 +67,11 @@ else:
 
 if version_bump == 'MAJOR':
     major += 1
+    minor = 0
+    patch = 0
 elif version_bump == 'MINOR':
     minor += 1
+    patch = 0
 elif version_bump == 'PATCH':
     patch += 1
 


### PR DESCRIPTION
`get_new_version.py` was never resetting the minor or patch portions of the version
So 1.2.3 with a feature commit would give you 1.3.3, instead of 1.3.0