### PR TITLE
Build: Monkeypatch nose to support python3

### DIFF
--- a/testing/testing.py
+++ b/testing/testing.py
@@ -104,6 +104,14 @@ class testing(object):
         tr.run(tests)
 
     def run_nose(self, module_name):
+        import collections
+
+        try:
+            collections.Callable
+        except:
+            import collections.abc
+            collections.Callable = collections.abc.Callable
+
         import nose
         import shutil
         f = self.test_format


### PR DESCRIPTION
In python3:
  collections.Callable -> collections.abc.Callable

So we test for collections.Callable and then monkeypatch collections if it's not there

Fixes our tests that simply SKIP on python3+ platforms

```
...
AttributeError: module 'collections' has no attribute 'Callable'
unrecoverable error from nose None
SKIP tree_node_test.py (exit status: 77)
```