### PR TITLE
build: ignore test output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,15 @@
+# test outputs
+**/testing/*
+!**/testing/*.*
+**/testing/*.characteristics
+**/testing/*.datafile
+**/testing/*.tree
+**/testing/*.hosts
+**/testing/*.txt
+*.tap
+*.tmp
+*.trs
+
 Makefile
 .deps
 config.log


### PR DESCRIPTION
ignore test outputs when using ./configure in source