### PR TITLE
Feature: add TreeNode::dim_of() and TreeNode::units_of()

### DIFF
--- a/include/mdsobjects.h
+++ b/include/mdsobjects.h
@@ -3073,6 +3073,10 @@ namespace MDSplus
     virtual void putData(Data *data);
     virtual void deleteData();
 
+    virtual Data *dim_of();
+    virtual Data *units_of();
+
+
     /// virtual function to resolve node id in the active tree.
     /// This is called each time a path to nid conversion is needed.
     virtual void resolveNid() {}

--- a/mdsobjects/cpp/mdstreeobjects.cpp
+++ b/mdsobjects/cpp/mdstreeobjects.cpp
@@ -714,6 +714,27 @@ Data *TreeNode::data()
   return outD;
 }
 
+
+Data *TreeNode::dim_of()
+{
+    if(tree)
+      return tree->tdiExecute("DIM_OF($)", this);
+    else
+      return executeWithArgs("DIM_OF($)", 1, this);
+}
+
+Data *TreeNode::units_of()
+{
+    if(tree)
+      return tree->tdiExecute("UNITS_OF($)", this);
+    else
+      return executeWithArgs("UNITS_OF($)", 1, this);
+}
+
+
+
+
+
 char TreeNode::getByte()
 {
   Data *d = data();

--- a/mdsobjects/cpp/testing/MdsTreeNodeTest.cpp
+++ b/mdsobjects/cpp/testing/MdsTreeNodeTest.cpp
@@ -702,13 +702,19 @@ void main_test()
 
       // putTimestampedSegment of size 2
       ts_node->putTimestampedSegment(
-          unique_ptr<Array>(new Int32Array(array, 2)), times);
+          unique_ptr<Array>(new Int32Array(array, 2)), &times[1]);
 
       // putrow puts single element into segment
-      ts_node->putRow(unique_ptr<Array>(new Int32Array(array, 1)), times);
+      ts_node->putRow(unique_ptr<Array>(new Int32Array(array, 1)), &times[3]);
 
       // putrow puts two elements into segment
-      ts_node->putRow(unique_ptr<Array>(new Int32Array(array, 2)), times);
+      ts_node->putRow(unique_ptr<Array>(new Int32Array(array, 2)), &times[4]);
+
+      // putrow puts two elements into segment
+      ts_node->putRow(unique_ptr<Array>(new Int32Array(array, 2)), &times[6]);
+
+      // putrow puts two elements into segment
+      ts_node->putRow(unique_ptr<Array>(new Int32Array(array, 2)), &times[8]);
 
       // Now putRow does not throw exception !
       //            TEST_EXCEPTION(
@@ -716,6 +722,8 @@ void main_test()
       //                        Int32Array(array,2)), times), MdsException );
 
       // makeTimestampedSegment
+      TEST1(AutoString(unique_ptr<Data>(ts_node->dim_of())->decompile())
+                .string == "[1Q,1Q,2Q,3Q,5Q,8Q,13Q,21Q,34Q,55Q]");
       ts_node->makeTimestampedSegment(array_data, times);
       TEST1(ts_node->getNumSegments() == 2);
       TEST1(AutoString(unique_ptr<Data>(ts_node->getSegmentDim(1))->decompile())


### PR DESCRIPTION
Added TreeNode methods dim_of() and units_of() in order to make them compatible with python API and to ensure that dimension evaluation is made in the context of the tree referenced by the TreeNode object.

A test for this added in testing