### PR TITLE
Fix: 64-bit windows server ptr and socket length

### DIFF
--- a/mdstcpip/io_routines/ioroutinesx.h
+++ b/mdstcpip/io_routines/ioroutinesx.h
@@ -256,9 +256,9 @@ static inline SOCKET get_single_server_socket(char *name)
   HANDLE shutdownEvent, waitHandle;
   HANDLE h;
   int ppid;
-  SOCKET psock;
+  SOCKET psock = INVALID_SOCKET;
   char shutdownEventName[120];
-  if (name == 0 || sscanf(name, "%d:%d", &ppid, (int *)&psock) != 2)
+  if (name == 0 || sscanf(name, "%d:%lld", &ppid, &psock) != 2)
   {
     fprintf(stderr, "Mdsip single connection server can only be started from "
                     "windows service\n");

--- a/mdstcpip/io_routines/ioroutinesx.h
+++ b/mdstcpip/io_routines/ioroutinesx.h
@@ -250,6 +250,11 @@ VOID CALLBACK ShutdownEvent(PVOID arg __attribute__((unused)),
   fprintf(stderr, "Service shut down\n");
   exit(0);
 }
+#ifdef _WiN64
+#define SOCKET_FMT "%d:%lld"
+#else
+#define SOCKET_FMT "%d:%d"
+#endif
 
 static inline SOCKET get_single_server_socket(char *name)
 {
@@ -258,7 +263,7 @@ static inline SOCKET get_single_server_socket(char *name)
   int ppid;
   SOCKET psock = INVALID_SOCKET;
   char shutdownEventName[120];
-  if (name == 0 || sscanf(name, "%d:%lld", &ppid, &psock) != 2)
+  if (name == 0 || sscanf(name, SOCKET_FMT, &ppid, &psock) != 2)
   {
     fprintf(stderr, "Mdsip single connection server can only be started from "
                     "windows service\n");

--- a/mdstcpip/io_routines/ioroutinesx.h
+++ b/mdstcpip/io_routines/ioroutinesx.h
@@ -250,7 +250,7 @@ VOID CALLBACK ShutdownEvent(PVOID arg __attribute__((unused)),
   fprintf(stderr, "Service shut down\n");
   exit(0);
 }
-#ifdef _WiN64
+#ifdef _WIN64
 #define SOCKET_FMT "%d:%lld"
 #else
 #define SOCKET_FMT "%d:%d"


### PR DESCRIPTION
Addresses https://github.com/MDSplus/mdsplus/issues/2794

On windows 64 bit, mdsip service failed to start a user specific process because only the low 32 bits of the socket were being filled in.  In addition, the high longword of the socket was unitialized.

Now initialized and filled with correct bytes.