### PR TITLE
Fix: local RHEL builds don't sign RPM metadata

### DIFF
--- a/deploy/platform/redhat/redhat_docker_build.sh
+++ b/deploy/platform/redhat/redhat_docker_build.sh
@@ -24,7 +24,9 @@ do_createrepo() {
   : && createrepo -q $update_args -o ${tmpdir} ${repodir}/${FLAVOR}/RPMS
   checkstatus abort "Failure: Problem creating rpm repository in ${repodir}!" $?
   rm -f ${tmpdir}/repodata/repomd.xml.asc
-  GNUPGHOME=/sign_keys/.gnupg gpg --local-user MDSplus --detach-sign --armor ${tmpdir}/repodata/repomd.xml
+  if [ -d /sign_keys/.gnupg ]; then
+    GNUPGHOME=/sign_keys/.gnupg gpg --local-user MDSplus --detach-sign --armor ${tmpdir}/repodata/repomd.xml
+  fi  
   : && rsync -a ${tmpdir}/repodata ${repodir}/${FLAVOR}/RPMS/
 }
 


### PR DESCRIPTION
This fixes Issue #2800.

Signing the RPM package repo's metadata should only be done on the MDSplus project's build server.

Customers doing manual local RHEL builds can only do "unsigned" builds, thus the packaging script has been fixed so it no longer attempts to sign the metadata for a local build.