### PR TITLE
Fix: String class breaks when using numpy >=2 with npbytes.

### DIFF
--- a/python/MDSplus/mdsscalar.py
+++ b/python/MDSplus/mdsscalar.py
@@ -417,10 +417,11 @@ class String(Scalar):
     """String"""
     dtype_id = 14
     
-    if sys.version_info[0] < 3:
-        _ntype = _ver.npbytes
-    else:
+    if int(_N.__version__[0]) > 2:
         _ntype = _ver.npunicode
+    else:
+        _ntype = _ver.npbytes
+
         
     def __init__(self, value):
         super(String, self).__init__(value)

--- a/python/MDSplus/mdsscalar.py
+++ b/python/MDSplus/mdsscalar.py
@@ -416,8 +416,12 @@ _dsc._add_dtype_to_class(ComplexD)
 class String(Scalar):
     """String"""
     dtype_id = 14
-    _ntype = _ver.npbytes
-
+    
+    if sys.version_info[0] < 3:
+        _ntype = _ver.npbytes
+    else:
+        _ntype = _ver.npunicode
+        
     def __init__(self, value):
         super(String, self).__init__(value)
         if not isinstance(self._value, str):


### PR DESCRIPTION
In the String class, check for Python version when using npbytes and npunicode 
Fixes #2807
