### PR TITLE
Changes to support numpy 2+

### DIFF
--- a/python/MDSplus/mdsdata.py
+++ b/python/MDSplus/mdsdata.py
@@ -149,7 +149,7 @@ class Data(NoTreeRef):
 
     @property  # numpy array
     def __array_interface__(self):
-        data = _N.array(self.data(), copy=False)
+        data = _N.asarray(self.data())
         aif = data.__array_interface__
         aif['data'] = data
         return aif

--- a/python/MDSplus/tree.py
+++ b/python/MDSplus/tree.py
@@ -3154,7 +3154,7 @@ class TreeNodeArray(_dat.TreeRef, _arr.Int32Array):  # HINT: TreeNodeArray begin
         nids = _N.array(nids)
         if len(nids.shape) == 0:  # happens if value has been a scalar, e.g. int
             nids = nids.reshape(1)
-        self._value = _N.array(nids, dtype=_N.int32, copy=False)
+        self._value = _N.asarray(nids, dtype=_N.int32)
         if 'tree' in kw:
             self.tree = tree
         elif isinstance(tree[0], (Tree,)):


### PR DESCRIPTION
Replace instances of `.array(copy=False)` with `.asarray()` as per numpy errors
Add error handling to scalar and array types to handle numpy 2+ throwing OverflowError exceptions when passed a negative or oversided number for the given type, e.g. `Uint8(-1)`
It will now explicitly calls the equivalent ctypes type to do the integer wrapping for us, which will be quite slow by comparison
Rewrite the `data_scalars` and `data_arrays` test cases to use more sensible numbers that can fit within a Int8, plus some cleanup

This fixes #2807 and replaces #2808

This will rely on https://github.com/MDSplus/Docker/pull/34 being merged to fully test

This will need to be tested on a wider range of python/numpy versions before I'm comfortable merging it, but I wanted to open the PR to let the automated testing work on it