### PR TITLE
Fix: putMany

### DIFF
--- a/mdsobjects/cpp/mdsdata.c
+++ b/mdsobjects/cpp/mdsdata.c
@@ -925,7 +925,7 @@ struct descriptor_xd EXPORT *GetManyExecute(char *serializedIn)
   return &xd;
 }
 
-struct descriptor_xd *PutManyExecute(char *serializedIn)
+struct descriptor_xd EXPORT *PutManyExecute(char *serializedIn)
 {
   static EMPTYXD(xd);
   struct descriptor *serResult;

--- a/mdsobjects/cpp/mdsipobjects.cpp
+++ b/mdsobjects/cpp/mdsipobjects.cpp
@@ -302,8 +302,8 @@ void *putManyObj(char *serializedIn)
       result->setItem(nodeNameData.get(), errorData.get());
     }
 
-    for (void * dsc : actualDscList) {
-      freeDsc(dsc);
+    for (size_t i = 0; i < actualDscList.size(); ++i) {
+      freeDsc(actualDscList[i]);
     }
   }
 

--- a/mdsobjects/cpp/mdsipobjects.cpp
+++ b/mdsobjects/cpp/mdsipobjects.cpp
@@ -74,6 +74,7 @@ extern "C" int SetCompressionLevel(int level);
 extern "C" int MdsSetCompression(int id, int level);
 extern "C" void DisconnectFromMds(int sockId);
 extern "C" void FreeMessage(void *m);
+extern "C" void freeDsc(void *dscPtr);
 
 #define DTYPE_UCHAR_IP 2
 #define DTYPE_USHORT_IP 3
@@ -275,16 +276,20 @@ void *putManyObj(char *serializedIn)
     AutoArray<char> expr(exprData->getString());
     AutoData<List> argsData((List *)currArg->getItem(&argsKey));
 
-    int nPutArgs = 0;
-    if (argsData.get())
-      nPutArgs = argsData->len();
+    std::vector<void *> actualDscList;
+    if (argsData.get()) {
+      Data ** dataList = argsData->getDscs();
+      for (size_t i = 0; i < argsData->len(); ++i) {
+        actualDscList.push_back(dataList[i]->convertToDsc());
+      }
+    }
 
     try
     {
       AutoPointer<Tree> tree(getActiveTree());
       int retStatus;
       AutoData<Data> compiledData = (Data *)compileFromExprWithArgs(
-          expr.get(), nPutArgs, (argsData.get()) ? argsData->getDscs() : 0,
+          expr.get(), actualDscList.size(), actualDscList.data(),
           tree.get(), nullptr, &retStatus);
       AutoPointer<TreeNode> node = tree->getNode(nodeNameData.get());
       node->putData(compiledData.get());
@@ -295,6 +300,10 @@ void *putManyObj(char *serializedIn)
     {
       AutoData<String> errorData(new String(e.what()));
       result->setItem(nodeNameData.get(), errorData.get());
+    }
+
+    for (void * dsc : actualDscList) {
+      freeDsc(dsc);
     }
   }
 


### PR DESCRIPTION
There are two issues fixed, the first is that the `EXPORT` on `PutManyExecute` was missing, leading to the `LibKEYNOTFOU` error when calling the method from TDI

The second is in `putManyObj`, where we were passing `argsData->getDscs()` as `mdsdsc_t` pointers, when they were in fact `Data` pointers.

There is now a temporary vector that holds the results of `convertToDsc()` for each `Data`, and then calls `freeDsc` at the end of the function.

This fixes #2813 and unblocks the mdsthin putMany test

As part of the testing rehaul, we need to add GetMany and PutMany tests to catch this sort of thing.