### PR TITLE
Build: Allocate ports to each test

### DIFF
--- a/java/mdsobjects/src/test/java/MDSplus/MdsConnectionTest.java
+++ b/java/mdsobjects/src/test/java/MDSplus/MdsConnectionTest.java
@@ -12,38 +12,46 @@ import org.junit.Test;
 
 public class MdsConnectionTest
 {
-	static int port = 8700;
+	// See testing/ports.csv
+	static int port = 8012;
 	static Process mdsip;
 
 	@BeforeClass
 	public static void setUpBeforeClass() throws Exception
 	{
-		for (; port < 8800; port++)
-		{
-			try
-			{
-				new DatagramSocket(port).close();
-				java.lang.String hostspath = System.getenv("MDSPLUS_DIR") + "/testing/mdsip.hosts";
-				if (!new File(hostspath).exists())
-				{
-					hostspath = "/etc/mdsip.hosts";
-					if (!new File(hostspath).exists())
-					{
-						System.exit(5);
-					}
-				}
-				final java.lang.String parts[] =
-				{ "mdsip", "-s", "-p", Integer.toString(port), "-h", hostspath };
-				System.out.println(java.lang.String.join(" ", parts));
-				final ProcessBuilder pb = new ProcessBuilder(parts);
-				mdsip = pb.start();
-				return;
+		int test_port_offset = 0;
+		java.lang.String test_port_offset_env = System.getenv("TEST_PORT_OFFSET");
+		if (test_port_offset_env != null) {
+			try {
+				test_port_offset = Integer.parseInt(test_port_offset_env);
 			}
-			catch (final SocketException exc)
+			catch (final NumberFormatException exc)
 			{}
 		}
-		System.out.println("Cannot find free port!");
-		System.exit(6);
+
+		port += test_port_offset;
+
+		try
+		{
+			new DatagramSocket(port).close();
+			java.lang.String hostspath = System.getenv("MDSPLUS_DIR") + "/testing/mdsip.hosts";
+			if (!new File(hostspath).exists())
+			{
+				hostspath = "/etc/mdsip.hosts";
+				if (!new File(hostspath).exists())
+				{
+					System.exit(5);
+				}
+			}
+			final java.lang.String parts[] =
+			{ "mdsip", "-s", "-p", Integer.toString(port), "-h", hostspath };
+			System.out.println(java.lang.String.join(" ", parts));
+			final ProcessBuilder pb = new ProcessBuilder(parts);
+			mdsip = pb.start();
+			return;
+		}
+		catch (final SocketException exc)
+		{}
 	}
 
 	@AfterClass

--- a/mdsobjects/cpp/testing/MdsConnectionTest.cpp
+++ b/mdsobjects/cpp/testing/MdsConnectionTest.cpp
@@ -138,6 +138,12 @@ void test_tree_open(const char *prot, const unsigned short port,
 
 int main(int argc, char *argv[])
 {
+  int test_port_offset = 0;
+  char * test_port_offset_env = getenv("TEST_PORT_OFFSET");
+  if (test_port_offset_env) {
+    test_port_offset = atoi(test_port_offset_env);
+  }
+
   int ipv6 = (argc > 1 && !strcmp(argv[1], "ipv6"));
   // TEST_TIMEOUT(30);
   setenv("t_connect_path", ".", 1);
@@ -184,41 +190,43 @@ int main(int argc, char *argv[])
   test_tree_open("local", 0, NULL);
   END_TESTING;
 
+	// See testing/ports.csv for all port number registrations
+
   // tcp //
   BEGIN_TESTING(Connection tcp - s);
-  test_tree_open("tcp", 8600, "-s");
+  test_tree_open("tcp", 8002 + test_port_offset, "-s");
   END_TESTING;
   BEGIN_TESTING(Connection tcp - m);
-  test_tree_open("tcp", 8601, "-m");
+  test_tree_open("tcp", 8003 + test_port_offset, "-m");
   END_TESTING;
 
   if (ipv6)
   {
     // tcpv6 //
     BEGIN_TESTING(Connection tcpv6 - s);
-    test_tree_open("tcpv6", 8602, "-s");
+    test_tree_open("tcpv6", 8004 + test_port_offset, "-s");
     END_TESTING;
     BEGIN_TESTING(Connection tcpv6 - m);
-    test_tree_open("tcpv6", 8603, "-m");
+    test_tree_open("tcpv6", 8005 + test_port_offset, "-m");
     END_TESTING;
   }
 #ifndef _WIN32
   // udt //
   BEGIN_TESTING(Connection udt - s);
-  test_tree_open("udt", 8604, "-s");
+  test_tree_open("udt", 8006 + test_port_offset, "-s");
   END_TESTING;
   BEGIN_TESTING(Connection udt - m);
-  test_tree_open("udt", 8605, "-m");
+  test_tree_open("udt", 8007 + test_port_offset, "-m");
   END_TESTING;
 
   if (ipv6)
   {
     // udtv6 //
     BEGIN_TESTING(Connection udtv6 - s);
-    test_tree_open("udtv6", 8606, "-s");
+    test_tree_open("udtv6", 8008 + test_port_offset, "-s");
     END_TESTING;
     BEGIN_TESTING(Connection udtv6 - m);
-    test_tree_open("udtv6", 8607, "-m");
+    test_tree_open("udtv6", 8009 + test_port_offset, "-m");
     END_TESTING;
   }
 #endif
@@ -233,8 +241,8 @@ int main(int argc, char *argv[])
 
       // gsi //
       BEGIN_TESTING(Connection gsi);
-      test_tree_open("gsi",8608,"-s");
-      test_tree_open("gsi",8608,"-m");
+      test_tree_open("gsi",8010 + test_port_offset,"-s");
+      test_tree_open("gsi",8011 + test_port_offset,"-m");
       END_TESTING;
   */
 }

--- a/mdstcpip/testing/MdsIpTest.c
+++ b/mdstcpip/testing/MdsIpTest.c
@@ -206,11 +206,22 @@ int main(int argc, char **argv)
   }
   else
   {
+    int test_port_offset = 0;
+    char * test_port_offset_env = getenv("TEST_PORT_OFFSET");
+    if (test_port_offset_env) {
+      test_port_offset = atoi(test_port_offset_env);
+    }
+
+	  // See testing/ports.csv
+    int port = 8001 + test_port_offset;
+    char port_str[12];
+    snprintf(port_str, sizeof(port_str), "%d", port);
+
     testio("thread://0");
     testio("local://0");
     char server[32] = "";
     mdsip_t mdsip = {0, NULL, NULL, 0};
-    if (!start_mdsip(&mdsip, "Tcp", MODE_SS, server, "12345"))
+    if (!start_mdsip(&mdsip, "Tcp", MODE_SS, server, port_str))
     {
       sleep(3);
       testio(server);

--- a/python/MDSplus/tests/_common.py
+++ b/python/MDSplus/tests/_common.py
@@ -200,13 +200,19 @@ class Tests(TestCase):
 
     @classmethod
     def main(cls):
+        if 'TEST_INDEX' in os.environ:
+            cls.index = int(os.environ['TEST_INDEX'])
+            
         cls.maxDiff = None  # show full diffs
         if cls.__module__ == '__main__':
             cls.__module__ = os.path.basename(sys.argv[0]).split('.', 1)[0]
             if len(sys.argv) == 2 and sys.argv[1] == 'all':
                 cls.runTests()
             elif len(sys.argv) > 1:
-                cls.runTests(sys.argv[1:])
+                tests = sys.argv[1:]
+                for i in range(len(tests)):
+                    tests[i] = tests[i].strip()
+                cls.runTests(tests)
             elif cls.__module__.endswith("_test"):
                 cls.runTests()
             else:

--- a/python/MDSplus/tests/connection_case.py
+++ b/python/MDSplus/tests/connection_case.py
@@ -44,7 +44,6 @@ _common = _mimport("_common")
 
 
 class Tests(_common.TreeTests, _common.MdsIp):
-    index = 0
     trees = ["consub"]
     tree = "con"
     treesub = "consub"
@@ -68,8 +67,13 @@ class Tests(_common.TreeTests, _common.MdsIp):
             except:
                 print(nci, t, l, c)
                 raise
-        server, server_port = self._setup_mdsip(
-            'ACTION_SERVER', 'ACTION_PORT', 7500+self.index, True)
+
+        test_port_offset = 0
+        if 'TEST_PORT_OFFSET' in os.environ:
+            test_port_offset = int(os.environ['TEST_PORT_OFFSET'])
+
+	    # See testing/ports.csv
+        server, server_port = self._setup_mdsip('ACTION_SERVER', 'ACTION_PORT', 8013 + test_port_offset, True)
 
         svr, svr_log = self._start_mdsip(server, server_port, 'thick')
         try:
@@ -176,8 +180,12 @@ class Tests(_common.TreeTests, _common.MdsIp):
         ))
 
     def tcp(self):
-        server, server_port = self._setup_mdsip(
-            'ACTION_SERVER', 'ACTION_PORT', 7510+self.index, True)
+        test_port_offset = 0
+        if 'TEST_PORT_OFFSET' in os.environ:
+            test_port_offset = int(os.environ['TEST_PORT_OFFSET'])
+
+	    # See testing/ports.csv
+        server, server_port = self._setup_mdsip('ACTION_SERVER', 'ACTION_PORT', 8014 + test_port_offset, True)
         svr, svr_log = self._start_mdsip(server, server_port, 'tcp')
         try:
             self._thread_test(server)
@@ -210,9 +218,13 @@ class Tests(_common.TreeTests, _common.MdsIp):
             test.assertEqual(i, count)
             print("%s: rate=%f, max_period=%f" %
                   (name, i / (end-start), max_period))
+        
+        test_port_offset = 0
+        if 'TEST_PORT_OFFSET' in os.environ:
+            test_port_offset = int(os.environ['TEST_PORT_OFFSET'])
 
-        server, server_port = self._setup_mdsip(
-            'ACTION_SERVER', 'ACTION_PORT', 7520+self.index, True)
+	    # See testing/ports.csv
+        server, server_port = self._setup_mdsip('ACTION_SERVER', 'ACTION_PORT', 8015 + test_port_offset, True)
         tempdir = tempfile.mkdtemp()
         try:
             svr, svr_log = self._start_mdsip(server, server_port, 'tcp')

--- a/python/MDSplus/tests/dcl_case.py
+++ b/python/MDSplus/tests/dcl_case.py
@@ -23,6 +23,7 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 
+import os
 import sys
 from MDSplus import Tree, Device, Connection
 from MDSplus import dcl, ccl, tcl, cts, mdsExceptions as Exc
@@ -119,11 +120,17 @@ class Tests(_common.TreeTests, _common.MdsIp):
             Device.PyDevice('TestDevice').Add(
                 pytree, 'TESTDEVICE_S', add_source=True)
             pytree.write()
-        monitor, monitor_port = self._setup_mdsip(
-            'ACTION_MONITOR', 'MONITOR_PORT', 7100+self.index, False)
+
+        test_port_offset = 0
+        if 'TEST_PORT_OFFSET' in os.environ:
+            test_port_offset = int(os.environ['TEST_PORT_OFFSET'])
+
+	    # See testing/ports.csv
+        monitor, monitor_port = self._setup_mdsip('ACTION_MONITOR', 'MONITOR_PORT', 8016 + test_port_offset, False)
         monitor_opt = "/monitor=%s" % monitor if monitor else ""
-        server, server_port = self._setup_mdsip(
-            'ACTION_SERVER', 'ACTION_PORT', 7110+self.index, True)
+
+	    # See testing/ports.csv
+        server, server_port = self._setup_mdsip('ACTION_SERVER', 'ACTION_PORT', 8017 + test_port_offset, True)
         pytree.normal()
         pytree.TESTDEVICE_I.ACTIONSERVER.no_write_shot = False
         pytree.TESTDEVICE_I.ACTIONSERVER.record = server
@@ -191,8 +198,13 @@ class Tests(_common.TreeTests, _common.MdsIp):
         def test_normal(c, expr, **kv):
             print(expr)
             c.get(expr, **kv)
-        server, server_port = self._setup_mdsip(
-            'ACTION_SERVER', 'ACTION_PORT', 7120+self.index, True)
+
+        test_port_offset = 0
+        if 'TEST_PORT_OFFSET' in os.environ:
+            test_port_offset = int(os.environ['TEST_PORT_OFFSET'])
+
+	    # See testing/ports.csv
+        server, server_port = self._setup_mdsip('ACTION_SERVER', 'ACTION_PORT', 8018 + test_port_offset, True)
 
         svr, svr_log = self._start_mdsip(server, server_port, 'timeout')
         try:

--- a/testing/ports.csv
+++ b/testing/ports.csv
@@ -1,0 +1,9 @@
+Test, Ports
+mdstcpip/testing/MdsIpTest, 8001
+mdsobjects/cpp/testing/MdsConnectionTest, 8002-8011
+java/mdsobjects/test/MdsConnectionTest, 8012
+python/MDSplus/tests/connection-thick, 8013
+python/MDSplus/tests/connection-tcp, 8014
+python/MDSplus/tests/connection-write, 8015
+python/MDSplus/tests/dcl-dispatcher, 8016-8017
+python/MDSplus/tests/dcl-timeout, 8018


### PR DESCRIPTION
This work was originally part of the CMake branch, which I am breaking up into smaller PRs
This will allow the tests to run in parallel, so long as `$TEST_INDEX` and `$TEST_PORT_OFFSET` are set appropriately.

The list of ports allocated to each test is in `testing/ports.csv`
Each test has been updated to use the specific ports from that CSV