### PR TITLE
Feature: Deprecate TreeNOTOPEN in favor of TreeNOT_OPEN

### DIFF
--- a/treeshr/TreeSetNci.c
+++ b/treeshr/TreeSetNci.c
@@ -180,7 +180,7 @@ int _TreeSetNci(void *dbid, int nid_in, NCI_ITM *nci_itm_ptr)
   int putnci = 0;
 
   if (!(IS_OPEN(dblist)))
-    return TreeNOTOPEN;
+    return TreeNOT_OPEN;
   if (dblist->open_readonly)
     return TreeREADONLY;
   if (dblist->remote)
@@ -263,7 +263,7 @@ int _TreeFlushOff(void *dbid, int nid)
   NID *nid_ptr = (NID *)&nid;
   TREE_INFO *tree_info;
   if (!(IS_OPEN(dblist)))
-    return TreeNOTOPEN;
+    return TreeNOT_OPEN;
   if (dblist->remote)
     return TreeFlushOffRemote(dbid, nid);
   nid_to_tree(dblist, nid_ptr, tree_info);
@@ -279,7 +279,7 @@ int _TreeFlushReset(void *dbid, int nid)
   NID *nid_ptr = (NID *)&nid;
   TREE_INFO *tree_info;
   if (!(IS_OPEN(dblist)))
-    return TreeNOTOPEN;
+    return TreeNOT_OPEN;
   if (dblist->remote)
     return TreeFlushResetRemote(dbid, nid);
   nid_to_tree(dblist, nid_ptr, tree_info);

--- a/treeshr/treeshr_messages.xml
+++ b/treeshr/treeshr_messages.xml
@@ -60,7 +60,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
     <status name="NOTCHILDLESS" value="4127" severity="Error" text="Node must be childless to become subtree reference"/>
     <status name="NOT_IN_LIST" value="4152" severity="Error" text="Tree being opened was not in the list"/>
     <status name="NOTMEMBERLESS" value="4142" severity="Error" text="Subtree reference can not have members"/>
-    <status name="NOTOPEN" value="4125" severity="Error" text="No tree file currently open"/>
+    <status name="NOTOPEN" value="4125" severity="Error" text="No tree file currently open" deprecated="TreeNOT_OPEN"/>
     <status name="NOTSON" value="4143" severity="Error" text="Subtree reference cannot be a member"/>
     <status name="NOT_CONGLOM" value="4140" severity="Error" text="Head node of conglomerate does not contain a DTYPE_CONGLOM record"/>
     <status name="NOT_OPEN" value="4117" severity="Warning" text="Tree not currently open"/>


### PR DESCRIPTION
This work was originally part of the CMake branch, which I am breaking up into smaller PRs

This is not quite as open and shut as I would like, but there's only one file that uses `TreeNOTOPEN` and that's in `TreeSetNci.c`
That and the two names are very confusing

Setting `TreeNOTOPEN` as deprecated will inform how the exception classes are generated, and should clean some things up

~~We could consider removing the `TreeNOTOPEN` returns from `TreeSetNci.c`, however I'm worried this will break someone else's code that was looking for those values.~~

This now includes the changes to `TreeSetNci.c`