### PR TITLE
Feature: Fix compiler warnings, Refactor and Cleanup

### DIFF
--- a/camshr/QueryHighwayType.c
+++ b/camshr/QueryHighwayType.c
@@ -81,7 +81,7 @@ static char *ShowType(int type);
 int QueryHighwayType(char *serial_hwy_driver)
 {
   char line[80];
-  char tmpVendor[9], tmpModel[17], tmpRev[5];
+  char tmpVendor[9], tmpModel[17], tmpRev[6];
   int foundHost, foundVendor, highwayType = TYPE_UNKNOWN, host_adapter, scsi_id,
                               tmpHost, tmpId;
   int status = SUCCESS; // optimistic

--- a/camshr/RSD.h
+++ b/camshr/RSD.h
@@ -1,7 +1,7 @@
 // RSD.h -- request sense data
 #ifndef __RSD_H
 #define __RSD_H
-#pragma pack(1)
+#pragma pack(push, 1)
 // for Linux on x86
 // NB! order of members is different from original
 //      to get data to pack into same size memory, ie
@@ -65,5 +65,5 @@ typedef struct
 
   __u32 stacnt;
 } RequestSenseData;
-#pragma pack(4)
+#pragma pack(pop)
 #endif

--- a/camshr/cam_functions.c
+++ b/camshr/cam_functions.c
@@ -997,7 +997,7 @@ static int CamAssign(char *Name, CamKey *Key)
   if (strchr(Name, ':'))
   { // physical names contain a ':'
     str2upcase(Name);
-    sscanf(Name, "GK%1s%1d%2d:N%d", &ha, &id, &crate, &slot);
+    sscanf(Name, "GK%c%1d%2d:N%d", &ha, &id, &crate, &slot);
     Key->scsi_port = ha;
     Key->scsi_address = id;
     Key->crate = crate;

--- a/camshr/check_sema4.c
+++ b/camshr/check_sema4.c
@@ -79,7 +79,7 @@ union semun {
 int check_sema4()
 {
   int count;
-  union semun u;
+  union semun u = {};
 
   extern int semid;
 

--- a/camshr/scsi_io.c
+++ b/camshr/scsi_io.c
@@ -87,7 +87,7 @@ int SGSetMAXBUF(int scsiDevice, int new)
   int old = -1;
   char *bufptr;
   int fd = -1;
-  if (scsiDevice >= 0 || scsiDevice <= 9)
+  if (scsiDevice >= 0 && scsiDevice <= 9)
   {
     old = MAXBUF[scsiDevice];
     if (new >= MIN_MAXBUF)
@@ -112,7 +112,7 @@ int SGSetMAXBUF(int scsiDevice, int new)
 
 int SGGetMAXBUF(int scsiDevice)
 {
-  if (scsiDevice >= 0 || scsiDevice <= 9)
+  if (scsiDevice >= 0 && scsiDevice <= 9)
   {
     char *bufptr;
     OpenScsi(scsiDevice, &bufptr);
@@ -127,7 +127,7 @@ static int OpenScsi(int scsiDevice, char **buff_out)
   char *buff = 0;
   static char *BUFFS[10] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
   int fd = -1;
-  if (scsiDevice >= 0 || scsiDevice <= 9)
+  if (scsiDevice >= 0 && scsiDevice <= 9)
   {
     if (FDS[scsiDevice] >= 0)
     {

--- a/examples/demoadc/DemoAdc.c
+++ b/examples/demoadc/DemoAdc.c
@@ -53,7 +53,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define PI 3.14159265358
 static int totSamples = 65536;
 static double frequency;
-static int pts;
+// static int pts;
 static int confOk;
 // Return 0 if succesful, -1 if any argument is not correct
 int initialize(char *name, int clockFreq, int postTriggerSamples)
@@ -89,7 +89,7 @@ int initialize(char *name, int clockFreq, int postTriggerSamples)
   return 1;
 }
 
-int acquire(char *name, short *c1, short *c2, short *c3, short *c4)
+int acquire(char *name __attribute__((unused)), short *c1, short *c2, short *c3, short *c4)
 {
   int i;
   printf("ACQUIRE\n");
@@ -109,7 +109,7 @@ int acquire(char *name, short *c1, short *c2, short *c3, short *c4)
 static long currSamples;
 static double currPeriod;
 static double trigger;
-int initializeStream(char *name, float clockFreq, float trigTime)
+int initializeStream(char *name __attribute__((unused)), float clockFreq, float trigTime)
 {
     printf("INITIALIZE STREAM: %s, %f, %f\n", name, clockFreq, trigTime);
     currPeriod = 1./clockFreq;

--- a/examples/demoadc/DemoAdc.c
+++ b/examples/demoadc/DemoAdc.c
@@ -53,7 +53,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define PI 3.14159265358
 static int totSamples = 65536;
 static double frequency;
-// static int pts;
 static int confOk;
 // Return 0 if succesful, -1 if any argument is not correct
 int initialize(char *name, int clockFreq, int postTriggerSamples)

--- a/include/dtypedef.h
+++ b/include/dtypedef.h
@@ -1,24 +1,21 @@
 /*
  *	atomic data types 0 - 37, 51-55
  */
-DEFINE(MISSING, 0)      /* no data */
-DEFINE(V_deprecated, 1) /* aligned bit string */
-DEFINE(BU, 2)           /* byte (unsigned);  8-bit unsigned quantity */
-DEFINE(WU, 3)           /* word (unsigned);  16-bit unsigned quantity */
-DEFINE(LU, 4)           /* longword (unsigned);  32-bit unsigned quantity */
-DEFINE(QU, 5)           /* quadword (unsigned);  64-bit unsigned quantity */
-DEFINE(B, 6)            /* byte integer (signed);  8-bit signed 2's-complement integer */
-DEFINE(W, 7)            /* word integer (signed);  16-bit signed 2's-complement integer */
-DEFINE(L,
-       8) /* longword integer (signed);  32-bit signed 2's-complement integer */
-DEFINE(Q,
-       9)                  /* quadword integer (signed);  64-bit signed 2's-complement integer */
+DEFINE(MISSING, 0)         /* no data */
+DEFINE(V_deprecated, 1)    /* aligned bit string */
+DEFINE(BU, 2)              /* byte (unsigned);  8-bit unsigned quantity */
+DEFINE(WU, 3)              /* word (unsigned);  16-bit unsigned quantity */
+DEFINE(LU, 4)              /* longword (unsigned);  32-bit unsigned quantity */
+DEFINE(QU, 5)              /* quadword (unsigned);  64-bit unsigned quantity */
+DEFINE(B, 6)               /* byte integer (signed);  8-bit signed 2's-complement integer */
+DEFINE(W, 7)               /* word integer (signed);  16-bit signed 2's-complement integer */
+DEFINE(L, 8)               /* longword integer (signed);  32-bit signed 2's-complement integer */
+DEFINE(Q, 9)               /* quadword integer (signed);  64-bit signed 2's-complement integer */
 DEFINE(F, 10)              /* F_floating;	32-bit single-precision floating point */
 DEFINE(D, 11)              /* D_floating;	64-bit double-precision floating point */
 DEFINE(FC, 12)             /* F_floating complex */
 DEFINE(DC, 13)             /* D_floating complex */
-DEFINE(T, 14)              /* character string;  a single 8-bit character or a sequence of
-                  characters */
+DEFINE(T, 14)              /* character string;  a single 8-bit character or a sequence of characters */
 DEFINE(NU_deprecated, 15)  /* numeric string) unsigned */
 DEFINE(NL_deprecated, 16)  /* numeric string) left separate sign */
 DEFINE(NLO_deprecated, 17) /* numeric string) left overpunched sign */
@@ -30,9 +27,7 @@ DEFINE(ZI_deprecated, 22)  /* sequence of instructions */
 DEFINE(ZEM_deprecated, 23) /* procedure entry mask */
 DEFINE(DSC, 24)            /* descriptor */
 DEFINE(OU, 25)             /* octaword (unsigned);  128-bit unsigned quantity */
-DEFINE(
-    O,
-    26)                    /* octaword integer (signed);  128-bit signed 2's-complement integer */
+DEFINE(O, 26)              /* octaword integer (signed);  128-bit signed 2's-complement integer */
 DEFINE(G, 27)              /* G_floating;	64-bit double-precision floating point */
 DEFINE(H, 28)              /* H_floating;	128-bit quadruple-precision floating point */
 DEFINE(GC, 29)             /* G_floating complex */
@@ -42,8 +37,7 @@ DEFINE(BPV_deprecated, 32) /* bound procedure value */
 DEFINE(BLV_deprecated, 33) /* bound label value */
 DEFINE(VU_deprecated, 34)  /* unaligned bit string */
 DEFINE(ADT_deprecated, 35) /* absolute date and time */
-DEFINE(VT_deprecated,
-       37) /* varying character string;  16-bit count) followed by a string */
+DEFINE(VT_deprecated, 37)  /* varying character string;  16-bit count) followed by a string */
 /*
  *	38 - 50 might have been used for RESERVED purposes
  */

--- a/include/mdsdescrip.h
+++ b/include/mdsdescrip.h
@@ -110,16 +110,11 @@ typedef struct descriptor_d
 typedef struct
 {
   unsigned __char_align__ : 3; /* reserved;  must be zero */
-  unsigned __char_align__
-      binscale : 1; /* if set, scale is a power-of-two, otherwise, -ten */
-  unsigned __char_align__
-      redim : 1; /* if set, indicates the array can be redimensioned */
-  unsigned __char_align__
-      column : 1; /* if set, indicates column-major order (FORTRAN) */
-  unsigned __char_align__
-      coeff : 1; /* if set, indicates the multipliers block is present */
-  unsigned __char_align__
-      bounds : 1; /* if set, indicates the bounds block is present */
+  unsigned __char_align__ binscale : 1; /* if set, scale is a power-of-two, otherwise, -ten */
+  unsigned __char_align__ redim : 1; /* if set, indicates the array can be redimensioned */
+  unsigned __char_align__ column : 1; /* if set, indicates column-major order (FORTRAN) */
+  unsigned __char_align__ coeff : 1; /* if set, indicates the multipliers block is present */
+  unsigned __char_align__ bounds : 1; /* if set, indicates the bounds block is present */
 } aflags_t;       /* array flag bits */
 
 typedef int8_t scale_t;

--- a/mdslib/testing/mdslib_ctest.c
+++ b/mdslib/testing/mdslib_ctest.c
@@ -282,8 +282,7 @@ int main(int argc, char *argv[])
     socket = MdsConnect("local://0");
     TEST((socket != INVALID_SOCKET));
   }
-  TEST(
-      MdsValue("TreeOpenNew('" TREE "'," SHOTS ")", &dsc, &null, &returnlength))
+  TEST(MdsValue("TreeOpenNew('" TREE "'," SHOTS ")", &dsc, &null, &returnlength))
   TEST(MdsValue("{_=-1;TreeAddNode('A',_,'ANY');}", &dsc, &null, &returnlength))
   TEST(MdsValue("TreeWrite('" TREE "'," SHOTS ")", &dsc, &null, &returnlength))
   TEST(MdsValue("TreeClose('" TREE "'," SHOTS ")", &dsc, &null, &returnlength))

--- a/mdsobjects/cpp/mdsdataobjects.cpp
+++ b/mdsobjects/cpp/mdsdataobjects.cpp
@@ -1880,7 +1880,7 @@ Data *Uint8Array::deserialize() { return (Data *)deserializeData(ptr); }
 void Scope::show()
 {
   char expr[256];
-  std::sprintf(expr, "JavaShowWindow(%d, %d, %d, %d, %d)", idx, x, y, width,
+  std::snprintf(expr, sizeof(expr), "JavaShowWindow(%d, %d, %d, %d, %d)", idx, x, y, width,
                height);
   Data *ris = execute(expr);
   deleteData(ris);
@@ -1900,7 +1900,7 @@ Scope::Scope(const char *name, int x, int y, int width, int height)
 void Scope::plot(Data *x, Data *y, int row, int col, const char *color)
 {
   char expr[256];
-  std::sprintf(expr, "JavaReplaceSignal(%d, $1, $2, %d, %d, \"%s\")", idx, row,
+  std::snprintf(expr, sizeof(expr), "JavaReplaceSignal(%d, $1, $2, %d, %d, \"%s\")", idx, row,
                col, color);
   Data *ris = executeWithArgs(expr, 2, x, y);
   deleteData(ris);
@@ -1908,7 +1908,7 @@ void Scope::plot(Data *x, Data *y, int row, int col, const char *color)
 void Scope::oplot(Data *x, Data *y, int row, int col, const char *color)
 {
   char expr[256];
-  std::sprintf(expr, "JavaAddSignal(%d, $1, $2, %d, %d, \"%s\")", idx, row, col,
+  std::snprintf(expr, sizeof(expr), "JavaAddSignal(%d, $1, $2, %d, %d, \"%s\")", idx, row, col,
                color);
   Data *ris = executeWithArgs(expr, 2, x, y);
   deleteData(ris);

--- a/mdsobjects/cpp/mdsipobjects.cpp
+++ b/mdsobjects/cpp/mdsipobjects.cpp
@@ -677,7 +677,7 @@ void Connection::setDefault(char *path)
 TreeNodeThinClient *Connection::getNode(char *path)
 {
   char expr[256];
-  sprintf(expr, "GETNCI(%s, \'NID_NUMBER\')", path);
+  snprintf(expr, sizeof(expr), "GETNCI(%s, \'NID_NUMBER\')", path);
   AutoData<Data> nidData(get(expr));
   if (!nidData)
     throw MdsException("Cannot get remote nid in Connection::getNode");
@@ -690,7 +690,7 @@ void Connection::registerStreamListener(DataStreamListener *listener,
                                         char *expr, char *tree, int shot)
 {
   char regExpr[64 + strlen(expr) + strlen(tree)];
-  sprintf(regExpr, "MdsObjectsCppShr->registerListener(\"%s\",\"%s\",val(%d))",
+  snprintf(regExpr, sizeof(regExpr), "MdsObjectsCppShr->registerListener(\"%s\",\"%s\",val(%d))",
           expr, tree, shot);
 
   AutoData<Data> idData(get(regExpr, NULL, 0));
@@ -710,7 +710,7 @@ void Connection::unregisterStreamListener(DataStreamListener *listener)
     return;
   int id = listenerIdV[idx];
   char regExpr[64];
-  sprintf(regExpr, "MdsObjectsCppShr->unregisterListener(val(%d))", id);
+  snprintf(regExpr, sizeof(regExpr), "MdsObjectsCppShr->unregisterListener(val(%d))", id);
   get(regExpr);
   listenerV.erase(listenerV.begin() + idx);
   listenerIdV.erase(listenerIdV.begin() + idx);

--- a/mdsobjects/cpp/mdstreeobjects.cpp
+++ b/mdsobjects/cpp/mdstreeobjects.cpp
@@ -2464,7 +2464,7 @@ TreeNodeThinClient::TreeNodeThinClient(int nid, Connection *connection,
 std::string TreeNodeThinClient::getNciString(int itm)
 {
   char expr[64];
-  sprintf(expr, "GETNCI(%d,%s)", nid, convertNciItm(itm));
+  snprintf(expr, sizeof(expr), "GETNCI(%d,%s)", nid, convertNciItm(itm));
   AutoData<Data> retStringData(connection->get(expr));
   if (!retStringData.get())
     throw MdsException("Error in Remote evaluation of getnci");
@@ -2476,7 +2476,7 @@ std::string TreeNodeThinClient::getNciString(int itm)
 char TreeNodeThinClient::getNciChar(int itm)
 {
   char expr[64];
-  sprintf(expr, "GETNCI(%d,%s)", nid, convertNciItm(itm));
+  snprintf(expr, sizeof(expr), "GETNCI(%d,%s)", nid, convertNciItm(itm));
   AutoData<Data> retData(connection->get(expr));
   if (!retData.get())
     throw MdsException("Error in Remote evaluation of getnci");
@@ -2487,7 +2487,7 @@ char TreeNodeThinClient::getNciChar(int itm)
 int TreeNodeThinClient::getNciInt(int itm)
 {
   char expr[64];
-  sprintf(expr, "GETNCI(%d,%s)", nid, convertNciItm(itm));
+  snprintf(expr, sizeof(expr), "GETNCI(%d,%s)", nid, convertNciItm(itm));
   AutoData<Data> retData(connection->get(expr));
   if (!retData.get())
     throw MdsException("Error in Remote evaluation of getnci");
@@ -2497,7 +2497,7 @@ int TreeNodeThinClient::getNciInt(int itm)
 int64_t TreeNodeThinClient::getNciInt64(int itm)
 {
   char expr[64];
-  sprintf(expr, "GETNCI(%d,%s)", nid, convertNciItm(itm));
+  snprintf(expr, sizeof(expr), "GETNCI(%d,%s)", nid, convertNciItm(itm));
   AutoData<Data> retData(connection->get(expr));
   if (!retData.get())
     throw MdsException("Error in Remote evaluation of getnci");
@@ -2507,7 +2507,7 @@ int64_t TreeNodeThinClient::getNciInt64(int itm)
 char *TreeNodeThinClient::getPath()
 {
   char expr[64];
-  sprintf(expr, "GETNCI(%d,\'PATH\')", nid);
+  snprintf(expr, sizeof(expr), "GETNCI(%d,\'PATH\')", nid);
   AutoData<Data> retData(connection->get(expr));
   if (!retData.get())
     throw MdsException("Error in Remote evaluation of getnci(path)");
@@ -2517,7 +2517,7 @@ char *TreeNodeThinClient::getPath()
 EXPORT Data *TreeNodeThinClient::getData()
 {
   char expr[64];
-  sprintf(expr, "GETNCI(%d,\'RECORD\')", nid);
+  snprintf(expr, sizeof(expr), "GETNCI(%d,\'RECORD\')", nid);
   Data *retData = connection->get(expr);
   if (!retData)
     throw MdsException("Error in Remote evaluation of getnci(record)");
@@ -2542,7 +2542,7 @@ EXPORT void TreeNodeThinClient::deleteData()
 EXPORT bool TreeNodeThinClient::isOn()
 {
   char expr[64];
-  sprintf(expr, "GETNCI(%d,\'STATE\')", nid);
+  snprintf(expr, sizeof(expr), "GETNCI(%d,\'STATE\')", nid);
   AutoData<Data> retData(connection->get(expr));
   if (!retData.get())
     throw MdsException("Error in Remote evaluation of getnci(state)");
@@ -2555,9 +2555,9 @@ EXPORT void TreeNodeThinClient::setOn(bool on)
 {
   char expr[64];
   if (on)
-    sprintf(expr, "TreeTurnOn(%d)", nid);
+    snprintf(expr, sizeof(expr), "TreeTurnOn(%d)", nid);
   else
-    sprintf(expr, "TreeTurnOff(%d)", nid);
+    snprintf(expr, sizeof(expr), "TreeTurnOff(%d)", nid);
   AutoData<Data> retData(connection->get(expr));
 }
 
@@ -2569,7 +2569,7 @@ EXPORT void TreeNodeThinClient::beginSegment(Data *start, Data *end, Data *time,
                             initialData->data()};
   Data *args[] = {argsD[0].get(), argsD[1].get(), argsD[2].get(),
                   argsD[3].get()};
-  sprintf(expr, "BeginSegment(%d, $1, $2, $3, $4, -1)", nid);
+  snprintf(expr, sizeof(expr), "BeginSegment(%d, $1, $2, $3, $4, -1)", nid);
   AutoData<Data> retData(connection->get(expr, args, 4));
 }
 
@@ -2581,7 +2581,7 @@ EXPORT void TreeNodeThinClient::makeSegment(Data *start, Data *end, Data *time,
                             initialData->data()};
   Data *args[] = {argsD[0].get(), argsD[1].get(), argsD[2].get(),
                   argsD[3].get()};
-  sprintf(expr, "MakeSegment(%d, $1, $2, $3, $4, -1, size($4))", nid);
+  snprintf(expr, sizeof(expr), "MakeSegment(%d, $1, $2, $3, $4, -1, size($4))", nid);
   AutoData<Data> retData(connection->get(expr, args, 4));
 }
 
@@ -2590,14 +2590,14 @@ EXPORT void TreeNodeThinClient::putSegment(Array *data, int ofs)
   char expr[256];
   AutoData<Data> argsD[] = {data->data()};
   Data *args[] = {argsD[0].get()};
-  sprintf(expr, "PutSegment(%d, %d, $1)", nid, ofs);
+  snprintf(expr, sizeof(expr), "PutSegment(%d, %d, $1)", nid, ofs);
   AutoData<Data> retData(connection->get(expr, args, 1));
 }
 
 EXPORT int TreeNodeThinClient::getNumSegments()
 {
   char expr[64];
-  sprintf(expr, "GetNumSegments(%d)", nid);
+  snprintf(expr, sizeof(expr), "GetNumSegments(%d)", nid);
   AutoData<Data> data(connection->get(expr));
   if (!data.get())
     throw MdsException("Error in Remote evaluation of GetNumSegmentss");
@@ -2608,7 +2608,7 @@ EXPORT void TreeNodeThinClient::getSegmentLimits(int segmentIdx, Data **start,
                                                  Data **end)
 {
   char expr[64];
-  sprintf(expr, "GetSegmentLimits(%d, %d)", nid, segmentIdx);
+  snprintf(expr, sizeof(expr), "GetSegmentLimits(%d, %d)", nid, segmentIdx);
   AutoData<Array> limitsArr((Array *)connection->get(expr));
   if (!limitsArr)
     throw MdsException("Error in Remote evaluation of GetSegmentLimits");
@@ -2620,7 +2620,7 @@ EXPORT void TreeNodeThinClient::getSegmentLimits(int segmentIdx, Data **start,
 EXPORT Array *TreeNodeThinClient::getSegment(int segIdx)
 {
   char expr[64];
-  sprintf(expr, "GetSegment(%d, %d)", nid, segIdx);
+  snprintf(expr, sizeof(expr), "GetSegment(%d, %d)", nid, segIdx);
   Array *retSegment = (Array *)connection->get(expr);
   if (!retSegment)
     throw MdsException("Error in Remote evaluation of GetSegment");
@@ -2630,7 +2630,7 @@ EXPORT Array *TreeNodeThinClient::getSegment(int segIdx)
 EXPORT Data *TreeNodeThinClient::getSegmentDim(int segIdx)
 {
   char expr[64];
-  sprintf(expr, "DIM_OF(GetSegment(%d, %d))", nid, segIdx);
+  snprintf(expr, sizeof(expr), "DIM_OF(GetSegment(%d, %d))", nid, segIdx);
   Data *retDim = connection->get(expr);
   if (!retDim)
     throw MdsException("Error in Remote evaluation of dim_of(GetSegment)");
@@ -2642,9 +2642,9 @@ EXPORT void TreeNodeThinClient::getSegmentAndDimension(int segIdx,
                                                        Data *&dimension)
 {
   char expr[64];
-  sprintf(expr, "GetSegment(%d, %d)", nid, segIdx);
+  snprintf(expr, sizeof(expr), "GetSegment(%d, %d)", nid, segIdx);
   segment = (Array *)connection->get(expr);
-  sprintf(expr, "DIM_OF(GetSegment(%d, %d))", nid, segIdx);
+  snprintf(expr, sizeof(expr), "DIM_OF(GetSegment(%d, %d))", nid, segIdx);
   dimension = connection->get(expr);
   if (!segment || !dimension)
     throw MdsException("Error in Remote evaluation of GetSegment");
@@ -2655,7 +2655,7 @@ EXPORT void TreeNodeThinClient::beginTimestampedSegment(Array *initData)
   char expr[64];
   AutoData<Data> argsD[] = {initData->data()};
   Data *args[] = {argsD[0].get()};
-  sprintf(expr, "BeginTimestampedSegment(%d, $1, -1)", nid);
+  snprintf(expr, sizeof(expr), "BeginTimestampedSegment(%d, $1, -1)", nid);
   AutoData<Data> retData(connection->get(expr, args, 1));
 }
 
@@ -2666,7 +2666,7 @@ EXPORT void TreeNodeThinClient::putTimestampedSegment(Array *data,
   int len = data->getSize();
   AutoData<Data> argsD[] = {new Int64Array(times, len), data->data()};
   Data *args[] = {argsD[0].get(), argsD[1].get()};
-  sprintf(expr, "PutTimestampedSegment(%d, $1, $2)", nid);
+  snprintf(expr, sizeof(expr), "PutTimestampedSegment(%d, $1, $2)", nid);
   AutoData<Data> retData(connection->get(expr, args, 2));
 }
 
@@ -2682,14 +2682,14 @@ EXPORT void TreeNodeThinClient::putRow(Data *data, int64_t *time, int size)
   AutoData<Data> argsD[] = {new Int64(*time), data->data()};
   Data *args[] = {argsD[0].get(), argsD[1].get()};
   char expr[64];
-  sprintf(expr, "PutRow(%d, %d, $1, $2)", nid, size);
+  snprintf(expr, sizeof(expr), "PutRow(%d, %d, $1, $2)", nid, size);
   AutoData<Data> retData(connection->get(expr, args, 2));
 }
 
 EXPORT StringArray *TreeNodeThinClient::findTags()
 {
   char expr[64];
-  sprintf(expr, "TreeFindNodeTags(%d)", nid);
+  snprintf(expr, sizeof(expr), "TreeFindNodeTags(%d)", nid);
   AutoData<Data> retData(connection->get(expr));
   if (!retData.get())
     throw MdsException("Error in Remote evaluation of TreeFindNodeTags");

--- a/mdsobjects/cpp/testing/MdsScalarTest_NumericLimits.cpp
+++ b/mdsobjects/cpp/testing/MdsScalarTest_NumericLimits.cpp
@@ -122,9 +122,9 @@ namespace testing
 
     // TODO: check limits for arrays //
     template <typename _MdsT>
-    static void test_type_conversion_array(const std::string &tmin = "",
-                                           const std::string &teps = "",
-                                           const std::string &tmax = "") {}
+    static void test_type_conversion_array(const std::string &tmin __attribute__((unused)) = "",
+                                           const std::string &teps __attribute__((unused)) = "",
+                                           const std::string &tmax __attribute__((unused)) = "") {}
   };
 
   // SPECIAL TRAIT FOR FLOAT  ..  //

--- a/mdsobjects/labview/mdsdataobjectswrp.cpp
+++ b/mdsobjects/labview/mdsdataobjectswrp.cpp
@@ -6500,269 +6500,270 @@ namespace MDSplus
       deleteLvData(lvUint8ArrayPtr);
     }
 
-    ////////////////////////////////TEMPORARY TEST
-    ///ROUTINES///////////////////////////
+    // (SLW) Commented out, they aren't called from anywhere and generate many compiler warnings
 
-    EXPORT void prova1() { std::cout << "CIAO SONO PROVA1\n"; }
+    ////////////////////////////////TEMPORARY TEST ROUTINES///////////////////////////
 
-    EXPORT void prova2()
-    {
-      try
-      {
-        MDSplus::Tree *tree = new Tree("CACCA", -1);
-      }
-      catch (const MdsException &exc)
-      {
-        std::cout << exc.what() << std::endl;
-      }
-      std::cout << "CIAO SONO PROVA2\n";
-    }
+    // EXPORT void prova1() { std::cout << "CIAO SONO PROVA1\n"; }
 
-    EXPORT void prova3(int inInt, int *outInt, ErrorCluster *error)
-    {
-      MgErr errorCode = noErr;
-      const char *errorSource = __FUNCTION__;
-      char const *errorMessage = "";
-      *outInt = inInt;
-      fillErrorCluster(errorCode, errorSource, errorMessage, error);
-    }
+    // EXPORT void prova2()
+    // {
+    //   try
+    //   {
+    //     MDSplus::Tree *tree = new Tree("CACCA", -1);
+    //   }
+    //   catch (const MdsException &exc)
+    //   {
+    //     std::cout << exc.what() << std::endl;
+    //   }
+    //   std::cout << "CIAO SONO PROVA2\n";
+    // }
 
-    EXPORT void prova4(int inInt, int *outInt, ErrorCluster *error)
-    {
-      MgErr errorCode = noErr;
-      const char *errorSource = __FUNCTION__;
-      char const *errorMessage = "";
-      int i;
-      try
-      {
-        MDSplus::Tree *tree = new Tree("CACCA", -1);
-      }
-      catch (const MdsException &exc)
-      {
-        i = 0;
-      }
+    // EXPORT void prova3(int inInt, int *outInt, ErrorCluster *error)
+    // {
+    //   MgErr errorCode = noErr;
+    //   const char *errorSource = __FUNCTION__;
+    //   char const *errorMessage = "";
+    //   *outInt = inInt;
+    //   fillErrorCluster(errorCode, errorSource, errorMessage, error);
+    // }
 
-      *outInt = inInt;
-      fillErrorCluster(errorCode, errorSource, errorMessage, error);
-    }
-    EXPORT void prova41(int inInt, int *outInt, ErrorCluster *error)
-    {
-      MgErr errorCode = noErr;
-      const char *errorSource = __FUNCTION__;
-      char const *errorMessage = "";
-      int i;
-      try
-      {
-        MDSplus::Tree *tree = new Tree("CACCA", -1);
-      }
-      catch (const MdsException &exc)
-      {
-        i = 0;
-      }
+    // EXPORT void prova4(int inInt, int *outInt, ErrorCluster *error)
+    // {
+    //   MgErr errorCode = noErr;
+    //   const char *errorSource = __FUNCTION__;
+    //   char const *errorMessage = "";
+    //   int i;
+    //   try
+    //   {
+    //     MDSplus::Tree *tree = new Tree("CACCA", -1);
+    //   }
+    //   catch (const MdsException &exc)
+    //   {
+    //     i = 0;
+    //   }
 
-      *outInt = inInt;
-      errorMessage = (char *)"CAZZACICCIA";
-      errorCode = bogusError;
-      fillErrorCluster(errorCode, errorSource, errorMessage, error);
-    }
-    EXPORT void prova40(int inInt, int *outInt, ErrorCluster *error)
-    {
-      MgErr errorCode = noErr;
-      const char *errorSource = __FUNCTION__;
-      char const *errorMessage = "";
-      int i;
-      *outInt = inInt;
-      errorMessage = (char *)"CAZZACICCIA";
-      errorCode = bogusError;
-      fillErrorCluster(errorCode, errorSource, errorMessage, error);
-    }
-    EXPORT void prova42(int inInt, int *outInt, ErrorCluster *error)
-    {
-      MgErr errorCode = noErr;
-      const char *errorSource = __FUNCTION__;
-      char const *errorMessage = "";
-      int i;
-      try
-      {
-        MDSplus::Tree *tree = new Tree("CACCA", -1);
-      }
-      catch (const MdsException &exc)
-      {
-        errorMessage = (char *)"CAZZACICCIA";
-        errorCode = bogusError;
-      }
+    //   *outInt = inInt;
+    //   fillErrorCluster(errorCode, errorSource, errorMessage, error);
+    // }
+    // EXPORT void prova41(int inInt, int *outInt, ErrorCluster *error)
+    // {
+    //   MgErr errorCode = noErr;
+    //   const char *errorSource = __FUNCTION__;
+    //   char const *errorMessage = "";
+    //   int i;
+    //   try
+    //   {
+    //     MDSplus::Tree *tree = new Tree("CACCA", -1);
+    //   }
+    //   catch (const MdsException &exc)
+    //   {
+    //     i = 0;
+    //   }
 
-      *outInt = inInt;
-      fillErrorCluster(errorCode, errorSource, errorMessage, error);
-    }
-    EXPORT void prova43(int inInt, int *outInt, ErrorCluster *error)
-    {
-      MgErr errorCode = noErr;
-      const char *errorSource = __FUNCTION__;
-      char const *errorMessage = "";
-      int i;
-      try
-      {
-        MDSplus::Tree *tree = new Tree("CACCA", -1);
-      }
-      catch (const MdsException &exc)
-      {
-        char *currErr = (char *)exc.what();
-        errorMessage = (char *)"CAZZACICCIA";
-        errorCode = bogusError;
-      }
+    //   *outInt = inInt;
+    //   errorMessage = (char *)"CAZZACICCIA";
+    //   errorCode = bogusError;
+    //   fillErrorCluster(errorCode, errorSource, errorMessage, error);
+    // }
+    // EXPORT void prova40(int inInt, int *outInt, ErrorCluster *error)
+    // {
+    //   MgErr errorCode = noErr;
+    //   const char *errorSource = __FUNCTION__;
+    //   char const *errorMessage = "";
+    //   int i;
+    //   *outInt = inInt;
+    //   errorMessage = (char *)"CAZZACICCIA";
+    //   errorCode = bogusError;
+    //   fillErrorCluster(errorCode, errorSource, errorMessage, error);
+    // }
+    // EXPORT void prova42(int inInt, int *outInt, ErrorCluster *error)
+    // {
+    //   MgErr errorCode = noErr;
+    //   const char *errorSource = __FUNCTION__;
+    //   char const *errorMessage = "";
+    //   int i;
+    //   try
+    //   {
+    //     MDSplus::Tree *tree = new Tree("CACCA", -1);
+    //   }
+    //   catch (const MdsException &exc)
+    //   {
+    //     errorMessage = (char *)"CAZZACICCIA";
+    //     errorCode = bogusError;
+    //   }
 
-      *outInt = inInt;
-      fillErrorCluster(errorCode, errorSource, errorMessage, error);
-    }
-    EXPORT void prova44(int inInt, int *outInt, ErrorCluster *error)
-    {
-      MgErr errorCode = noErr;
-      const char *errorSource = __FUNCTION__;
-      //
-      char const *errorMessage = "";
-      int i;
-      try
-      {
-        MDSplus::Tree *tree = new Tree("CACCA", -1);
-      }
-      catch (const MdsException &exc)
-      {
-        //      char *currErr = (char *)exc.what();
-        //      errorMessage = strdup(currErr);
-        errorCode = bogusError;
-      }
+    //   *outInt = inInt;
+    //   fillErrorCluster(errorCode, errorSource, errorMessage, error);
+    // }
+    // EXPORT void prova43(int inInt, int *outInt, ErrorCluster *error)
+    // {
+    //   MgErr errorCode = noErr;
+    //   const char *errorSource = __FUNCTION__;
+    //   char const *errorMessage = "";
+    //   int i;
+    //   try
+    //   {
+    //     MDSplus::Tree *tree = new Tree("CACCA", -1);
+    //   }
+    //   catch (const MdsException &exc)
+    //   {
+    //     char *currErr = (char *)exc.what();
+    //     errorMessage = (char *)"CAZZACICCIA";
+    //     errorCode = bogusError;
+    //   }
 
-      *outInt = inInt;
-      //  fillErrorCluster(errorCode, errorSource, errorMessage, error);
-      fillErrorCluster(errorCode, errorSource, "", error);
-    }
+    //   *outInt = inInt;
+    //   fillErrorCluster(errorCode, errorSource, errorMessage, error);
+    // }
+    // EXPORT void prova44(int inInt, int *outInt, ErrorCluster *error)
+    // {
+    //   MgErr errorCode = noErr;
+    //   const char *errorSource = __FUNCTION__;
+    //   //
+    //   char const *errorMessage = "";
+    //   int i;
+    //   try
+    //   {
+    //     MDSplus::Tree *tree = new Tree("CACCA", -1);
+    //   }
+    //   catch (const MdsException &exc)
+    //   {
+    //     //      char *currErr = (char *)exc.what();
+    //     //      errorMessage = strdup(currErr);
+    //     errorCode = bogusError;
+    //   }
 
-    EXPORT void prova45(int inInt, int *outInt, ErrorCluster *error)
-    {
-      MgErr errorCode = noErr;
-      const char *errorSource = __FUNCTION__;
-      char const *errorMessage = "";
-      int i;
-      try
-      {
-        MDSplus::Tree *tree = new Tree("CACCA", -1);
-      }
-      catch (const MdsException &exc)
-      {
-        char *currErr = (char *)exc.what();
-        errorMessage = strdup(currErr);
-        errorCode = bogusError;
-      }
+    //   *outInt = inInt;
+    //   //  fillErrorCluster(errorCode, errorSource, errorMessage, error);
+    //   fillErrorCluster(errorCode, errorSource, "", error);
+    // }
 
-      *outInt = inInt;
-      fillErrorCluster(errorCode, errorSource, errorMessage, error);
-    }
+    // EXPORT void prova45(int inInt, int *outInt, ErrorCluster *error)
+    // {
+    //   MgErr errorCode = noErr;
+    //   const char *errorSource = __FUNCTION__;
+    //   char const *errorMessage = "";
+    //   int i;
+    //   try
+    //   {
+    //     MDSplus::Tree *tree = new Tree("CACCA", -1);
+    //   }
+    //   catch (const MdsException &exc)
+    //   {
+    //     char *currErr = (char *)exc.what();
+    //     errorMessage = strdup(currErr);
+    //     errorCode = bogusError;
+    //   }
 
-    EXPORT void prova5(int inInt, int *outInt, ErrorCluster *error)
-    {
-      MgErr errorCode = noErr;
-      const char *errorSource = __FUNCTION__;
-      char const *errorMessage = "";
-      int i;
-      try
-      {
-        MDSplus::Tree *tree = new Tree("CACCA", -1);
-      }
-      catch (const MdsException &exc)
-      {
-        fillErrorCluster(bogusError, errorSource, exc.what(), error);
-        return;
-      }
+    //   *outInt = inInt;
+    //   fillErrorCluster(errorCode, errorSource, errorMessage, error);
+    // }
 
-      *outInt = inInt;
-      fillErrorCluster(errorCode, errorSource, errorMessage, error);
-    }
+    // EXPORT void prova5(int inInt, int *outInt, ErrorCluster *error)
+    // {
+    //   MgErr errorCode = noErr;
+    //   const char *errorSource = __FUNCTION__;
+    //   char const *errorMessage = "";
+    //   int i;
+    //   try
+    //   {
+    //     MDSplus::Tree *tree = new Tree("CACCA", -1);
+    //   }
+    //   catch (const MdsException &exc)
+    //   {
+    //     fillErrorCluster(bogusError, errorSource, exc.what(), error);
+    //     return;
+    //   }
 
-    EXPORT void prova6(int inInt, int *outInt, ErrorCluster *error)
-    {
-      MgErr errorCode = noErr;
-      const char *errorSource = __FUNCTION__;
-      char const *errorMessage = "";
-      try
-      {
-        MDSplus::Data *d = new Int32(123);
-      }
-      catch (const MdsException &exc)
-      {
-        errorCode = bogusError;
-        errorMessage = const_cast<char *>(exc.what());
-      }
-    }
+    //   *outInt = inInt;
+    //   fillErrorCluster(errorCode, errorSource, errorMessage, error);
+    // }
 
-    EXPORT void prova7(int inInt, int *outInt, ErrorCluster *error)
-    {
-      MgErr errorCode = noErr;
-      const char *errorSource = __FUNCTION__;
-      char const *errorMessage = "";
-      try
-      {
-        MDSplus::Tree *tree = new Tree("test", -1);
-      }
-      catch (const MdsException &exc)
-      {
-        errorCode = bogusError;
-        errorMessage = const_cast<char *>(exc.what());
-      }
+    // EXPORT void prova6(int inInt, int *outInt, ErrorCluster *error)
+    // {
+    //   MgErr errorCode = noErr;
+    //   const char *errorSource = __FUNCTION__;
+    //   char const *errorMessage = "";
+    //   try
+    //   {
+    //     MDSplus::Data *d = new Int32(123);
+    //   }
+    //   catch (const MdsException &exc)
+    //   {
+    //     errorCode = bogusError;
+    //     errorMessage = const_cast<char *>(exc.what());
+    //   }
+    // }
 
-      *outInt = inInt;
-      fillErrorCluster(errorCode, errorSource, errorMessage, error);
-    }
+    // EXPORT void prova7(int inInt, int *outInt, ErrorCluster *error)
+    // {
+    //   MgErr errorCode = noErr;
+    //   const char *errorSource = __FUNCTION__;
+    //   char const *errorMessage = "";
+    //   try
+    //   {
+    //     MDSplus::Tree *tree = new Tree("test", -1);
+    //   }
+    //   catch (const MdsException &exc)
+    //   {
+    //     errorCode = bogusError;
+    //     errorMessage = const_cast<char *>(exc.what());
+    //   }
 
-    EXPORT void prova8()
-    {
-      Int64 *timeInsertedData = new Int64(0);
-      Data *retTimeStr = executeWithArgs("date_time(0)", 0);
-      std::cout << "FATTO EXECUTE WITH ARGS" << std::endl;
-      std::cout << "FATTO EXECUTE WITH ARGS" << (void *)retTimeStr << std::endl;
+    //   *outInt = inInt;
+    //   fillErrorCluster(errorCode, errorSource, errorMessage, error);
+    // }
 
-      std::cout << retTimeStr->getString() << std::endl;
-    }
+    // EXPORT void prova8()
+    // {
+    //   Int64 *timeInsertedData = new Int64(0);
+    //   Data *retTimeStr = executeWithArgs("date_time(0)", 0);
+    //   std::cout << "FATTO EXECUTE WITH ARGS" << std::endl;
+    //   std::cout << "FATTO EXECUTE WITH ARGS" << (void *)retTimeStr << std::endl;
 
-    EXPORT void prova9()
-    {
-      Int64 *timeInsertedData = new Int64(0);
-      Data *retTimeStr = executeWithArgs("date_time($)", 1, timeInsertedData);
-      std::cout << "FATTO EXECUTE WITH ARGS" << std::endl;
+    //   std::cout << retTimeStr->getString() << std::endl;
+    // }
 
-      std::cout << retTimeStr->getString() << std::endl;
-    }
-    EXPORT void prova10()
-    {
-      Int32 *timeInsertedData = new Int32(0);
-      Data *retTimeStr = executeWithArgs("date_time($)", 1, timeInsertedData);
+    // EXPORT void prova9()
+    // {
+    //   Int64 *timeInsertedData = new Int64(0);
+    //   Data *retTimeStr = executeWithArgs("date_time($)", 1, timeInsertedData);
+    //   std::cout << "FATTO EXECUTE WITH ARGS" << std::endl;
 
-      std::cout << retTimeStr->getString() << std::endl;
-    }
+    //   std::cout << retTimeStr->getString() << std::endl;
+    // }
+    // EXPORT void prova10()
+    // {
+    //   Int32 *timeInsertedData = new Int32(0);
+    //   Data *retTimeStr = executeWithArgs("date_time($)", 1, timeInsertedData);
 
-    EXPORT void prova11()
-    {
-      try
-      {
-        Tree *tree = new Tree("test", 1);
-        TreeNode *n = tree->getNode("SIG");
-        n->deleteData();
-        Data *start = new Float32(0);
-        Data *end = new Float32(9);
-        Data *delta = new Float32(1);
-        Data *dim = new Range(start, end, delta);
-        float *floatArr = new float[10];
-        for (int i = 0; i < 10; i++)
-          floatArr[i] = i;
-        Data *arrD = new Float32Array(floatArr, 10);
-        n->makeSegment(start, end, dim, (Array *)arrD);
-      }
-      catch (const MdsException &exc)
-      {
-        std::cout << "ERRORE: " << exc.what() << std::endl;
-      }
-      std::cout << "FINITO CACCONA www\n";
-    }
+    //   std::cout << retTimeStr->getString() << std::endl;
+    // }
+
+    // EXPORT void prova11()
+    // {
+    //   try
+    //   {
+    //     Tree *tree = new Tree("test", 1);
+    //     TreeNode *n = tree->getNode("SIG");
+    //     n->deleteData();
+    //     Data *start = new Float32(0);
+    //     Data *end = new Float32(9);
+    //     Data *delta = new Float32(1);
+    //     Data *dim = new Range(start, end, delta);
+    //     float *floatArr = new float[10];
+    //     for (int i = 0; i < 10; i++)
+    //       floatArr[i] = i;
+    //     Data *arrD = new Float32Array(floatArr, 10);
+    //     n->makeSegment(start, end, dim, (Array *)arrD);
+    //   }
+    //   catch (const MdsException &exc)
+    //   {
+    //     std::cout << "ERRORE: " << exc.what() << std::endl;
+    //   }
+    //   std::cout << "FINITO CACCONA www\n";
+    // }
 
   } // End Extern "C"
 } // End Namespace MDSplus

--- a/mdsobjects/labview/mdsipobjectswrp.cpp
+++ b/mdsobjects/labview/mdsipobjectswrp.cpp
@@ -34,8 +34,7 @@ EXPORT void mdsplus_connection_constructor(void **lvConnectionPtrOut,
   char const *errorMessage = (char *)"";
   try
   {
-    MDSplus::Connection *connectionPtrOut =
-        new MDSplus::Connection(const_cast<char *>(ipPortIn));
+    connectionPtrOut = new MDSplus::Connection(const_cast<char *>(ipPortIn));
     *lvConnectionPtrOut = reinterpret_cast<void *>(connectionPtrOut);
   }
   catch (const MDSplus::MdsException &e)
@@ -50,8 +49,7 @@ EXPORT void mdsplus_connection_constructor(void **lvConnectionPtrOut,
 
 EXPORT void mdsplus_connection_destructor(void **lvConnectionPtr)
 {
-  MDSplus::Connection *connectionPtr =
-      reinterpret_cast<MDSplus::Connection *>(*lvConnectionPtr);
+  MDSplus::Connection *connectionPtr = reinterpret_cast<MDSplus::Connection *>(*lvConnectionPtr);
   delete connectionPtr;
   *lvConnectionPtr = NULL;
 }

--- a/mdsshr/testing/UdpEventsTest.c
+++ b/mdsshr/testing/UdpEventsTest.c
@@ -66,7 +66,7 @@ void eventAstSecond(void *arg, int len __attribute__((unused)),
   pthread_mutex_unlock(&second_lock);
 }
 
-static void wait()
+static void short_wait()
 {
   static const struct timespec tspec = {0, 100000000};
   nanosleep(&tspec, 0);
@@ -97,15 +97,15 @@ int main(int argc, char **args)
 
     status = MDSEventAst(eventname, eventAst, eventname, &ev_id);
     TEST0(status % 1);
-    wait();
+    short_wait();
     status = MDSEvent(eventname, 0, 0);
     TEST0(status % 1);
     status = MDSEvent(eventname, 0, 0);
     TEST0(status % 1);
-    wait();
+    short_wait();
     status = MDSEventCan(ev_id);
     TEST0(status % 1);
-    wait();
+    short_wait();
   }
   pthread_mutex_lock(&astCount_lock);
   TEST1(astCount == 2 * iterations);
@@ -116,9 +116,9 @@ int main(int argc, char **args)
   sprintf(eventname, "test_event_%d", getpid());
   status = MDSEventAst(eventname, eventAstFirst, "first", &id1);
   status = MDSEventAst(eventname, eventAstSecond, "second", &id2);
-  wait();
+  short_wait();
   status = MDSEvent(eventname, 0, 0);
-  wait();
+  short_wait();
   pthread_mutex_lock(&first_lock);
   pthread_mutex_lock(&second_lock);
   printf("first = %d, second = %d\n", first, second);

--- a/mdsshr/testing/UdpEventsTestStatics.c
+++ b/mdsshr/testing/UdpEventsTestStatics.c
@@ -59,6 +59,7 @@ void eventAst(void *arg, int len, char *buf)
   { // this will trigger asan if len is invalid
     access ^= buf[i];
   }
+  (void)access; // silence warning "set but unused"
   pthread_mutex_lock(&astCount_mutex);
   astCount++;
   pthread_mutex_unlock(&astCount_mutex);

--- a/xmdsshr/ListTree.c
+++ b/xmdsshr/ListTree.c
@@ -567,8 +567,10 @@ static void InitializeGeometry(ListTreeWidget w)
          w->list.preferredHeight);
 }
 
-static void Initialize(Widget request, Widget tnew, ArgList args,
-                       Cardinal *num)
+static void Initialize(Widget request __attribute__((unused)),
+                       Widget tnew,
+                       ArgList args __attribute__((unused)),
+                       Cardinal *num __attribute__((unused)))
 {
   ListTreeWidget w;
 
@@ -624,7 +626,9 @@ static void Destroy(ListTreeWidget w)
   FreePixmap(w, &w->list.LeafOpen);
 }
 
-static void Redisplay(Widget aw, XExposeEvent *event, Region region)
+static void Redisplay(Widget aw,
+                      XExposeEvent *event,
+                      Region region __attribute__((unused)))
 {
   ListTreeWidget w = (ListTreeWidget)aw;
 
@@ -648,8 +652,11 @@ static void Redisplay(Widget aw, XExposeEvent *event, Region region)
                  Prim_ShadowThickness(w), XmSHADOW_IN);
 }
 
-static Boolean SetValues(Widget current, Widget request, Widget reply,
-                         ArgList args, Cardinal *nargs)
+static Boolean SetValues(Widget current,
+                         Widget request __attribute__((unused)),
+                         Widget reply __attribute__((unused)),
+                         ArgList args __attribute__((unused)),
+                         Cardinal *nargs __attribute__((unused)))
 {
   if (!XtIsRealized(current))
     return False;
@@ -759,7 +766,8 @@ static void SetScrollbars(ListTreeWidget w)
   MDSDBG("item=%d visible=%d\n", w->list.itemCount, w->list.visibleCount);
 }
 
-static void VSBCallback(Widget scrollbar, XtPointer client_data,
+static void VSBCallback(Widget scrollbar __attribute__((unused)),
+                        XtPointer client_data,
                         XtPointer call_data)
 {
   ListTreeWidget w = (ListTreeWidget)client_data;
@@ -788,7 +796,8 @@ static void VSBCallback(Widget scrollbar, XtPointer client_data,
 #endif
 }
 
-static void HSBCallback(Widget scrollbar, XtPointer client_data,
+static void HSBCallback(Widget scrollbar __attribute__((unused)),
+                        XtPointer client_data,
                         XtPointer call_data)
 {
   ListTreeWidget w = (ListTreeWidget)client_data;
@@ -1120,7 +1129,8 @@ static void SelectDouble(ListTreeWidget w)
 }
 
 /* ARGSUSED */
-static void SelectSingle(XtPointer client_data, XtIntervalId *idp)
+static void SelectSingle(XtPointer client_data,
+                         XtIntervalId *idp __attribute__((unused)))
 {
   ListTreeWidget w = (ListTreeWidget)client_data;
 
@@ -1144,8 +1154,10 @@ static void SelectSingle(XtPointer client_data, XtIntervalId *idp)
 }
 
 /* ARGSUSED */
-static void select_start(Widget aw, XEvent *event, String *params,
-                         Cardinal *num_params)
+static void select_start(Widget aw,
+                         XEvent *event,
+                         String *params __attribute__((unused)),
+                         Cardinal *num_params __attribute__((unused)))
 {
   ListTreeWidget w = (ListTreeWidget)aw;
 
@@ -1181,8 +1193,10 @@ static void select_start(Widget aw, XEvent *event, String *params,
 }
 
 /* ARGSUSED */
-static void extend_select_start(Widget aw, XEvent *event, String *params,
-                                Cardinal *num_params)
+static void extend_select_start(Widget aw,
+                                XEvent *event,
+                                String *params __attribute__((unused)),
+                                Cardinal *num_params __attribute__((unused)))
 {
   ListTreeWidget w = (ListTreeWidget)aw;
 
@@ -1199,8 +1213,10 @@ static void extend_select_start(Widget aw, XEvent *event, String *params,
 }
 
 /* ARGSUSED */
-static void extend_select(Widget aw, XEvent *event, String *params,
-                          Cardinal *num_params)
+static void extend_select(Widget aw,
+                          XEvent *event,
+                          String *params __attribute__((unused)),
+                          Cardinal *num_params __attribute__((unused)))
 {
   ListTreeItem *item;
   ListTreeWidget w = (ListTreeWidget)aw;
@@ -1250,8 +1266,10 @@ static void extend_select(Widget aw, XEvent *event, String *params,
 }
 
 /* ARGSUSED */
-static void unset(Widget aw, XEvent *event, String *params,
-                  Cardinal *num_params)
+static void unset(Widget aw,
+                  XEvent *event,
+                  String *params __attribute__((unused)),
+                  Cardinal *num_params __attribute__((unused)))
 {
   ListTreeItem *item;
   ListTreeWidget w = (ListTreeWidget)aw;
@@ -1267,8 +1285,10 @@ static void unset(Widget aw, XEvent *event, String *params,
 }
 
 /* ARGSUSED */
-static void notify(Widget aw, XEvent *event, String *params,
-                   Cardinal *num_params)
+static void notify(Widget aw,
+                   XEvent *event __attribute__((unused)),
+                   String *params __attribute__((unused)),
+                   Cardinal *num_params __attribute__((unused)))
 {
   ListTreeWidget w = (ListTreeWidget)aw;
 
@@ -1317,10 +1337,10 @@ static void focus_out(Widget aw, XEvent *event, String *params,
 }
 
 /* ARGSUSED */
-static void menu(aw, event, params, num_params) Widget aw;
-XEvent *event;
-String *params;
-Cardinal *num_params;
+static void menu(Widget aw,
+                 XEvent *event,
+                 String *params __attribute__((unused)),
+                 Cardinal *num_params __attribute__((unused)))
 {
   ListTreeWidget w = (ListTreeWidget)aw;
   ListTreeItem *item;
@@ -1343,10 +1363,10 @@ Cardinal *num_params;
 }
 
 /* ARGSUSED */
-static void keypress(aw, event, params, num_params) Widget aw;
-XEvent *event;
-String *params;
-Cardinal *num_params;
+static void keypress(Widget aw __attribute__((unused)),
+                     XEvent *event __attribute__((unused)),
+                     String *params __attribute__((unused)),
+                     Cardinal *num_params __attribute__((unused)))
 {
   MDSDBG("keypress\n");
 }
@@ -1681,7 +1701,10 @@ static void GotoPosition(ListTreeWidget w)
   GotoPositionChildren(w, w->list.topItem, -1);
 }
 
-static int CountItem(ListTreeWidget w, ListTreeItem *item, int x, int y)
+static int CountItem(ListTreeWidget w,
+                     ListTreeItem *item,
+                     int x,
+                     int y __attribute__((unused)))
 {
   int height;
   int xtext;
@@ -2107,8 +2130,10 @@ ListTreeItem *ListTreeAddLeaf(ListTreeWidget w, ListTreeItem *parent,
   return (AddItem(w, parent, string, ItemLeafType));
 }
 
-void ListTreeSetItemPixmaps(ListTreeWidget w, ListTreeItem *item,
-                            Pixmap openPixmap, Pixmap closedPixmap)
+void ListTreeSetItemPixmaps(ListTreeWidget w __attribute__((unused)),
+                            ListTreeItem *item,
+                            Pixmap openPixmap,
+                            Pixmap closedPixmap)
 {
   item->openPixmap = openPixmap;
   item->closedPixmap = closedPixmap;
@@ -2298,7 +2323,8 @@ int ListTreeOrderChildren(ListTreeWidget w, ListTreeItem *item)
   return 1;
 }
 
-ListTreeItem *ListTreeFindSiblingName(ListTreeWidget w, ListTreeItem *item,
+ListTreeItem *ListTreeFindSiblingName(ListTreeWidget w __attribute__((unused)),
+                                      ListTreeItem *item,
                                       char *name)
 {
   TreeCheck(w, "in ListTreeFindSiblingName");

--- a/xmdsshr/XmdsExpr.c
+++ b/xmdsshr/XmdsExpr.c
@@ -514,8 +514,9 @@ EXPORT void XmdsExprSetXd(Widget w, struct descriptor *dsc)
   Resize((Widget)ew);
 }
 
-static XtGeometryResult GeometryManager(Widget w, XtWidgetGeometry *desired,
-                                        XtWidgetGeometry *allowed)
+static XtGeometryResult GeometryManager(Widget w __attribute__((unused)),
+                                        XtWidgetGeometry *desired __attribute__((unused)),
+                                        XtWidgetGeometry *allowed __attribute__((unused)))
 {
   return XtGeometryYes;
 }
@@ -683,7 +684,8 @@ static Boolean SetValues(Widget old, Widget req, Widget new, ArgList args,
   return 0;
 }
 
-static void ChangeQuotes(Widget q_w, XmdsExprWidget e_w)
+static void ChangeQuotes(Widget q_w __attribute__((unused)),
+                         XmdsExprWidget e_w)
 {
   char *text = GetString(e_w->expr.text_widget);
   int text_len = strlen(text);

--- a/xmdsshr/XmdsNidOptionMenu.c
+++ b/xmdsshr/XmdsNidOptionMenu.c
@@ -211,7 +211,9 @@ _Pragma("GCC diagnostic ignored \"-Wcast-function-type\"")
   return w;
 }
 
-static void Destroy(Widget w, Resources *info, XtPointer cb)
+static void Destroy(Widget w __attribute__((unused)),
+                    Resources *info,
+                    XtPointer cb __attribute__((unused)))
 {
   int num;
   Widget *labels;
@@ -407,7 +409,8 @@ EXPORT int XmdsNidOptionMenuApply(Widget w)
   return status;
 }
 
-static void MenuChanged(Widget w, Resources *info,
+static void MenuChanged(Widget w __attribute__((unused)),
+                        Resources *info,
                         XmRowColumnCallbackStruct *cb)
 {
   if (cb->reason == XmCR_ACTIVATE)
@@ -429,7 +432,10 @@ static void MenuChanged(Widget w, Resources *info,
   }
 }
 
-static void ButtonPushed(Widget w, int index, XmPushButtonCallbackStruct *cb) {}
+static void ButtonPushed(Widget w __attribute__((unused)),
+                         int index __attribute__((unused)),
+                         XmPushButtonCallbackStruct *cb __attribute__((unused)))
+{ }
 
 EXPORT void XmdsNidOptionMenuSetButton(Widget w, int idx, String text)
 {

--- a/xmdsshr/XmdsOkButtons.c
+++ b/xmdsshr/XmdsOkButtons.c
@@ -155,7 +155,8 @@ static int Apply(Widget w, XtCallbackList callbacks)
   return status;
 }
 
-static void Destroy(Widget w, XtCallbackList callbacks)
+static void Destroy(Widget w __attribute__((unused)),
+                    XtCallbackList callbacks)
 {
   XtFree((char *)callbacks);
 }

--- a/xmdsshr/XmdsOnOffToggleButton.c
+++ b/xmdsshr/XmdsOnOffToggleButton.c
@@ -138,7 +138,9 @@ EXPORT Widget XmdsCreateOnOffToggleButton(Widget parent, String name,
   return w;
 }
 
-static void Destroy(Widget w, Resources *info, XtPointer cb)
+static void Destroy(Widget w __attribute__((unused)),
+                    Resources *info,
+                    XtPointer cb __attribute__((unused)))
 {
   XtFree((char *)info);
 }

--- a/xmdsshr/XmdsWavedraw.c
+++ b/xmdsshr/XmdsWavedraw.c
@@ -397,7 +397,7 @@ EXPORT Widget XmdsCreateWavedraw(Widget parent, char *name, ArgList args,
   return XtCreateWidget(name, xmdsWavedrawWidgetClass, parent, args, argcount);
 }
 
-static void ClassPartInitialize(XmdsWavedrawWidgetClass class)
+static void ClassPartInitialize(XmdsWavedrawWidgetClass class __attribute__((unused)))
 {
 
 #define initTrans(field, deftrans)             \
@@ -830,8 +830,12 @@ static Boolean MovePoint(XmdsWavedrawWidget w, int idx, float *desired_x,
   return stat;
 }
 
-static void SlideStretch(XmdsWavedrawWidget w, int idx, float *desired_x,
-                         float *desired_y, float *new_x, float *new_y,
+static void SlideStretch(XmdsWavedrawWidget w,
+                         int idx,
+                         float *desired_x,
+                         float *desired_y,
+                         float *new_x __attribute__((unused)),
+                         float *new_y __attribute__((unused)),
                          Boolean callcallbacks, XEvent *event,
                          Boolean stretch)
 {

--- a/xmdsshr/XmdsWaveform.c
+++ b/xmdsshr/XmdsWaveform.c
@@ -477,8 +477,10 @@ static void ClassPartInitialize(XmdsWaveformWidgetClass class)
     class->waveform_class.set_wave_proc = SetWave;
 }
 
-static void Initialize(XmdsWaveformWidget req, XmdsWaveformWidget w,
-                       ArgList args, Cardinal *num_args)
+static void Initialize(XmdsWaveformWidget req,
+                       XmdsWaveformWidget w,
+                       ArgList args __attribute__((unused)),
+                       Cardinal *num_args __attribute__((unused)))
 {
   XGCValues values;
   static char dashes[] = {1, 4};
@@ -1004,9 +1006,11 @@ static void Align(XmdsWaveformWidget w, XButtonEvent *event)
   XtCallCallbacks((Widget)w, XmdsNalignCallback, &limits);
 }
 
-static Boolean SetValues(XmdsWaveformWidget old, XmdsWaveformWidget req,
-                         XmdsWaveformWidget new, ArgList args,
-                         Cardinal *num_args)
+static Boolean SetValues(XmdsWaveformWidget old,
+                         XmdsWaveformWidget req,
+                         XmdsWaveformWidget new,
+                         ArgList args __attribute__((unused)),
+                         Cardinal *num_args __attribute__((unused)))
 {
   Boolean values_changed = SetupXandY(old, req, new);
   Boolean limits_changed =
@@ -1812,7 +1816,7 @@ static void AutoScale(int num, float *value, float *minval, float *maxval,
   vmax = max(vmin, min(vmax, huge));
   if (vmax == vmin)
   {
-    if (vmin == huge)
+    if (vmin == (float)huge)
       vmin = vmax = 0.0;
     span = fabs(vmax);
     if (span <= 0.0)
@@ -2088,10 +2092,15 @@ EXPORT void XmdsWaveformSetWave(Widget w, int count, float *x, float *y,
                                        autoscale, defer_update);
 }
 
-static void Update(Widget w_in, XmdsWaveformValStruct *x,
-                   XmdsWaveformValStruct *y, char *title, float *xmin,
-                   float *xmax, float *ymin, float *ymax,
-                   Boolean defer_update)
+static void Update(Widget w_in,
+                   XmdsWaveformValStruct *x,
+                   XmdsWaveformValStruct *y,
+                   char *title,
+                   float *xmin,
+                   float *xmax,
+                   float *ymin,
+                   float *ymax,
+                   Boolean defer_update __attribute__((unused)))
 {
   XmdsWaveformWidget w = (XmdsWaveformWidget)w_in;
   int old_count = waveformCount(w);
@@ -2134,9 +2143,14 @@ static void Update(Widget w_in, XmdsWaveformValStruct *x,
     Plot(w, 1);
 }
 
-static void SetWave(Widget w_in, int count, float *x, float *y,
-                    Boolean *waveformSelections, Boolean *waveformPenDown,
-                    Boolean autoscale, Boolean defer_update)
+static void SetWave(Widget w_in,
+                    int count,
+                    float *x,
+                    float *y,
+                    Boolean *waveformSelections,
+                    Boolean *waveformPenDown,
+                    Boolean autoscale,
+                    Boolean defer_update __attribute__((unused)))
 {
   XmdsWaveformWidget w = (XmdsWaveformWidget)w_in;
   int old_count = waveformCount(w);
@@ -2723,8 +2737,13 @@ static void Print(XmdsWaveformWidget w, FILE *filefid, int inp_total_width,
   fprintf(printfid, "\nshowpage\n");
 }
 
-static void DrawLines(Display *display, Window win, GC gc, XPoint *point,
-                      int kp, Dimension pwidth, Dimension pheight)
+static void DrawLines(Display *display,
+                      Window win,
+                      GC gc,
+                      XPoint *point,
+                      int kp,
+                      Dimension pwidth,
+                      Dimension pheight __attribute__((unused)))
 {
   static int i, imax, imin, ymax, ymin;
   if (!waveformPrint)
@@ -3090,8 +3109,14 @@ static void DrawSegments(Display *display, Window win, GC gc, float *crosshairs,
   }
 }
 
-static void DrawString(XmdsWaveformWidget w, Display *display, Window win,
-                       GC gc, float x, float y, char *label, int length)
+static void DrawString(XmdsWaveformWidget w __attribute__((unused)),
+                       Display *display,
+                       Window win,
+                       GC gc,
+                       float x,
+                       float y,
+                       char *label,
+                       int length)
 {
   if (!waveformPrint)
   {

--- a/xmdsshr/XmdsWidgetCallbacks.c
+++ b/xmdsshr/XmdsWidgetCallbacks.c
@@ -101,11 +101,23 @@ void XmdsManageWindow(Widget w)
     XmdsRaiseWindow(w);
 }
 
-void XmdsManageChildCallback(Widget w1, Widget *w2) { XmdsManageWindow(*w2); }
+void XmdsManageChildCallback(Widget w1 __attribute__((unused)),
+                             Widget *w2)
+{
+  XmdsManageWindow(*w2);
+}
 
-void XmdsUnmanageChildCallback(Widget w1, Widget *w2) { XtUnmanageChild(*w2); }
+void XmdsUnmanageChildCallback(Widget w1 __attribute__((unused)),
+                               Widget *w2)
+{
+  XtUnmanageChild(*w2);
+}
 
-void XmdsDestroyWidgetCallback(Widget w1, Widget *w2) { XtDestroyWidget(*w2); }
+void XmdsDestroyWidgetCallback(Widget w1 __attribute__((unused)),
+                               Widget *w2)
+{
+  XtDestroyWidget(*w2);
+}
 
 void XmdsRegisterWidgetCallback(Widget w1, Widget *w2) { *w2 = w1; }
 

--- a/xmdsshr/XmdsXdBox.c
+++ b/xmdsshr/XmdsXdBox.c
@@ -701,7 +701,9 @@ static Boolean SetValues(Widget old, Widget req, Widget new)
   return 0;
 }
 
-static void ActionCreate(XmdsXdBoxWidget w, ArgList args, Cardinal argcount)
+static void ActionCreate(XmdsXdBoxWidget w,
+                         ArgList args __attribute__((unused)),
+                         Cardinal argcount __attribute__((unused)))
 {
   MrmType class;
   XmdsXdUserPart *user_part =
@@ -851,7 +853,9 @@ struct descriptor_xd *ActionUnload(Widget w)
 /*
  * Routines for Axis type.
  */
-static void AxisCreate(XmdsXdBoxWidget w, ArgList args, Cardinal argcount)
+static void AxisCreate(XmdsXdBoxWidget w,
+                       ArgList args __attribute__((unused)),
+                       Cardinal argcount __attribute__((unused)))
 {
   MrmType class;
   XmdsXdUserPart *user_part =
@@ -1004,7 +1008,9 @@ struct descriptor_xd *AxisUnload(Widget w)
 /*
  * Routines for Dispatch type.
  */
-static void DispatchCreate(XmdsXdBoxWidget w, ArgList args, Cardinal argcount)
+static void DispatchCreate(XmdsXdBoxWidget w,
+                           ArgList args __attribute__((unused)),
+                           Cardinal argcount __attribute__((unused)))
 {
   MrmType class;
   XmdsXdUserPart *user_part =
@@ -1128,8 +1134,9 @@ EXPORT struct descriptor_xd *DispatchUnload(Widget w)
   return ans;
 }
 
-static void ExpressionCreate(XmdsXdBoxWidget w, ArgList args,
-                             Cardinal argcount)
+static void ExpressionCreate(XmdsXdBoxWidget w,
+                             ArgList args __attribute__((unused)),
+                             Cardinal argcount __attribute__((unused)))
 {
   MrmType class;
   XmdsXdUserPart *user_part =
@@ -1249,7 +1256,9 @@ static struct descriptor_xd *ExpressionUnload(Widget w)
 /*
  * Routines for Task type.
  */
-static void TaskCreate(XmdsXdBoxWidget w, ArgList args, Cardinal argcount)
+static void TaskCreate(XmdsXdBoxWidget w,
+                       ArgList args __attribute__((unused)),
+                       Cardinal argcount __attribute__((unused)))
 {
   MrmType class;
   XmdsXdUserPart *user_part =
@@ -1483,7 +1492,9 @@ EXPORT struct descriptor_xd *TaskUnload(Widget w)
   return data;
 }
 
-static void WindowCreate(XmdsXdBoxWidget w, ArgList args, Cardinal argcount)
+static void WindowCreate(XmdsXdBoxWidget w,
+                         ArgList args __attribute__((unused)),
+                         Cardinal argcount __attribute__((unused)))
 {
   MrmType class;
   XmdsXdUserPart *user_part =

--- a/xmdsshr/XmdsXdBoxDialog.c
+++ b/xmdsshr/XmdsXdBoxDialog.c
@@ -144,7 +144,8 @@ EXPORT Widget XmdsCreateXdBoxDialog(Widget parent, char *name, ArgList args,
   return widg;
 }
 
-static void LoadDialog(Widget shell, void *xdbw,
+static void LoadDialog(Widget shell __attribute__((unused)),
+                       void *xdbw,
                        void *unused __attribute__((unused)))
 {
   XmdsXdBoxLoad((Widget)xdbw);

--- a/xmdsshr/XmdsXdBoxDialogButton.c
+++ b/xmdsshr/XmdsXdBoxDialogButton.c
@@ -121,12 +121,16 @@ EXPORT Widget XmdsCreateXdBoxDialogButton(Widget parent, String name,
   return w;
 }
 
-static void Destroy(Widget w, Resources *info, XtPointer cb)
+static void Destroy(Widget w __attribute__((unused)),
+                    Resources *info,
+                    XtPointer cb __attribute__((unused)))
 {
   XtFree((char *)info);
 }
 
-static void Popup(Widget w, Resources *info, XtPointer cb)
+static void Popup(Widget w __attribute__((unused)),
+                  Resources *info,
+                  XtPointer cb __attribute__((unused)))
 {
   if (info->popup_w)
     XmdsManageWindow(info->popup_w);

--- a/xmdsshr/XmdsXdBoxOnOffButton.c
+++ b/xmdsshr/XmdsXdBoxOnOffButton.c
@@ -138,13 +138,16 @@ EXPORT Widget XmdsCreateXdBoxOnOffButton(Widget parent, String name,
   return w;
 }
 
-static void SetXdState(Widget w, Widget xd_w,
+static void SetXdState(Widget w __attribute__((unused)),
+                       Widget xd_w,
                        XmToggleButtonCallbackStruct *cb)
 {
   XmdsXdBoxSetState(xd_w, cb->set);
 }
 
-static void SetTbState(Widget w, Widget oo_w, XmdsButtonCallbackStruct *cb)
+static void SetTbState(Widget w __attribute__((unused)),
+                       Widget oo_w,
+                       XmdsButtonCallbackStruct *cb)
 {
   XmToggleButtonSetState(oo_w, cb->on_off, 0);
 }


### PR DESCRIPTION
This work was originally part of the CMake branch, which I am breaking up into smaller PRs

Add fixes for many compiler errors
Mostly this is just adding `__attribute__((unused))`
Fix some of the formatting broken by clang-format
Replace many `sprintf` with `snprintf`
Rename `wait` to `short_wait` to avoid name conflicts in `UdpEventsTest`
Remove unused test functions for labview