### PR TITLE
Fix conversion of floating values using TEXT

### DIFF
--- a/tdishr/TdiConvert.c
+++ b/tdishr/TdiConvert.c
@@ -1187,32 +1187,6 @@ static void DOUBLEC_TO_TEXT(int itype, char *pa, char *pb, int numb, int lenb, c
 #define Q_T(lena, pa, lenb, pb, numb) TO_TEXT(pa, int64_t, pb, numb, sprintf(text, "%" PRId64, *ip++))
 #define OU_T(lena, pa, lenb, pb, numb) TO_TEXT(pa, uint128_t, pb, numb, sprintf(text, "%s", uint128_deco(ip++, int128_buf)))
 #define O_T(lena, pa, lenb, pb, numb) TO_TEXT(pa, int128_t, pb, numb, sprintf(text, "%s", int128_deco(ip++, int128_buf)))
-#if DTYPE_F == DTYPE_NATIVE_FLOAT
-#define F_T(lena, pa, lenb, pb, numb)              \
-  FLOAT_TO_TEXT(DTYPE_F, pa, pb, numb, lenb, 'E'); \
-  status = 1
-#define FS_T(lena, pa, lenb, pb, numb)              \
-  FLOAT_TO_TEXT(DTYPE_FS, pa, pb, numb, lenb, 'S'); \
-  status = 1
-#define D_T(lena, pa, lenb, pb, numb)               \
-  DOUBLE_TO_TEXT(DTYPE_D, pa, pb, numb, lenb, 'D'); \
-  status = 1
-#define FT_T(lena, pa, lenb, pb, numb)               \
-  DOUBLE_TO_TEXT(DTYPE_FT, pa, pb, numb, lenb, 'T'); \
-  status = 1
-#define FC_T(lena, pa, lenb, pb, numb)              \
-  FLOATC_TO_TEXT(DTYPE_F, pa, pb, numb, lenb, 'E'); \
-  status = 1
-#define FSC_T(lena, pa, lenb, pb, numb)              \
-  FLOATC_TO_TEXT(DTYPE_FS, pa, pb, numb, lenb, 'S'); \
-  status = 1
-#define DC_T(lena, pa, lenb, pb, numb)               \
-  DOUBLEC_TO_TEXT(DTYPE_D, pa, pb, numb, lenb, 'D'); \
-  status = 1
-#define FTC_T(lena, pa, lenb, pb, numb)               \
-  DOUBLEC_TO_TEXT(DTYPE_FT, pa, pb, numb, lenb, 'T'); \
-  status = 1
-#else
 #define F_T(lena, pa, lenb, pb, numb)              \
   FLOAT_TO_TEXT(DTYPE_F, pa, pb, numb, lenb, 'F'); \
   status = 1
@@ -1237,7 +1211,6 @@ static void DOUBLEC_TO_TEXT(int itype, char *pa, char *pb, int numb, int lenb, c
 #define FTC_T(lena, pa, lenb, pb, numb)               \
   DOUBLEC_TO_TEXT(DTYPE_FT, pa, pb, numb, lenb, 'D'); \
   status = 1
-#endif
 #define G_T(lena, pa, lenb, pb, numb)               \
   DOUBLE_TO_TEXT(DTYPE_G, pa, pb, numb, lenb, 'G'); \
   status = 1


### PR DESCRIPTION
Fixes #2823.

The cause of the issue is that ever since 0d95b94c (which first appeared in the `stable_release-7-79-0`) `DTYPE_*` are not CPP macros anymore but enumerated types. Hence the CPP directive `#if DTYPE_F == DTYPE_NATIVE_FLOAT` was always true and the VMS settings were enforced.

Looking at `mdsdescrip.h` it seems that now the VMS build is not supported anymore and `DTYPE_NATIVE_FLOAT` is always defined to be `DTYPE_FS`, so I just removed the VMS option from `TdiConvert.c` as a fix.