### PR TITLE
Fix imp deprecation

### DIFF
--- a/python/MDSplus/compound.py.in
+++ b/python/MDSplus/compound.py.in
@@ -32,7 +32,7 @@ try:
     with warnings.catch_warnings():
         warnings.filterwarnings("ignore", category=DeprecationWarning)
         import imp
-except:
+except ModuleNotFoundError:
     # imp was removed in 3.12
     from types import ModuleType
 

--- a/python/MDSplus/compound.py.in
+++ b/python/MDSplus/compound.py.in
@@ -28,7 +28,10 @@ import ctypes as _C
 import numpy as _N
 
 try:
-    import imp
+    import warnings
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", category=DeprecationWarning)
+        import imp
 except:
     # imp was removed in 3.12
     from types import ModuleType

--- a/python/MDSplus/compound.py.in
+++ b/python/MDSplus/compound.py.in
@@ -34,6 +34,7 @@ try:
         import imp
 except ModuleNotFoundError:
     # imp was removed in 3.12
+    # https://docs.python.org/3.12/whatsnew/3.12.html#imp
     from types import ModuleType
 
     class imp:


### PR DESCRIPTION
- fix the `imp` deprecation -- since it has been handled -- by suppressing the `DeprecationWarning`,
- specify the `ModuleNotFoundError` in the `except` clause,
- add a useful link next to the comment.