### PR TITLE
Improve Performance of Interpolate Function

### DIFF
--- a/tdi/math/interpolate.fun
+++ b/tdi/math/interpolate.fun
@@ -13,8 +13,7 @@ public fun interpolate(in _x, in _xarr, in _yarr)
     if(_x <= _xarr[0]) return (_yarr[0]);
     if(_x >= _xarr[_n - 1]) return (_yarr[_n - 1]);
 
-    _i = 0;
-    while(_x > _xarr[_i]) _i++;
+    _i = size(pack(_xarr,_xarr<=_x));
     return (_yarr[_i - 1] + (_x - _xarr[_i - 1]) * (_yarr[_i] - _yarr [_i - 1])/(_xarr[_i] - _xarr[_i - 1]));
 
 }


### PR DESCRIPTION
The interpolate_ga.fun has been in use for ~10+ years; there is no real to not incorporate it upstream.

As I understand, the performance boost comes from preallocating the output data structure.

This is a one line fix to an uncommon feature, testing is as simple as building this branch and calling the TDI function.