### PR TITLE
Fix: Close socket in MDSUdpEventCan

### DIFF
--- a/mdsshr/UdpEvents.c
+++ b/mdsshr/UdpEvents.c
@@ -324,6 +324,7 @@ int MDSUdpEventCan(int eventid)
   closesocket(ev->socket);
 #else
   pthread_cancel(ev->thread);
+  close(ev->socket);
 #endif
   pthread_join(ev->thread, NULL);
   free(ev);

--- a/mdsshr/UdpEvents.c
+++ b/mdsshr/UdpEvents.c
@@ -324,9 +324,13 @@ int MDSUdpEventCan(int eventid)
   closesocket(ev->socket);
 #else
   pthread_cancel(ev->thread);
-  close(ev->socket);
 #endif
   pthread_join(ev->thread, NULL);
+
+#ifndef _WIN32
+  close(ev->socket);
+#endif
+
   free(ev);
   return MDSplusSUCCESS;
 }


### PR DESCRIPTION
Fixes #2830 
When a UDP event listener is cancelled, the thread was killed but the socket was not closed.