### PR TITLE
Build: Update Linux dependencies

### DIFF
--- a/deploy/packaging/linux.xml
+++ b/deploy/packaging/linux.xml
@@ -843,63 +843,63 @@ rm -f /etc/ld.so.conf.d/mdsplus.conf 2&gt;/dev/null
    <numpy package="python3-numpy"/>
    <java package="java-runtime"/>
    <readline package="libreadline8"/>
-   <libmotif package="libmrm4">
+   <libmotif package="libmrm4"/>
  </external_packages>
 
  <external_packages dist="Ubuntu22">
    <numpy package="python3-numpy"/>
    <java package="java-runtime"/>
    <readline package="libreadline8"/>
-   <libmotif package="libmrm4">
+   <libmotif package="libmrm4"/>
  </external_packages>
 
  <external_packages dist="Ubuntu20">
    <numpy package="python3-numpy"/>
    <java package="java-runtime"/>
    <readline package="libreadline8"/>
-   <libmotif package="libmrm4">
+   <libmotif package="libmrm4"/>
  </external_packages>
 
  <external_packages dist="Ubuntu18">
    <numpy package="python3-numpy"/>
    <java package="java-runtime"/>
    <readline package="libreadline7"/>
-   <libmotif package="libmrm4">
+   <libmotif package="libmrm4"/>
  </external_packages>
 
  <external_packages dist="DebianBookworm">
    <numpy package="python3-numpy"/>
    <java package="java-runtime"/>
    <readline package="libreadline8"/>
-   <libmotif package="motif">
+   <libmotif package="motif"/>
  </external_packages>
 
  <external_packages dist="DebianBullseye">
    <numpy package="python3-numpy"/>
    <java package="java-runtime"/>
    <readline package="libreadline8"/>
-   <libmotif package="motif">
+   <libmotif package="motif"/>
  </external_packages>
 
  <external_packages dist="el9">
    <numpy package="python3-numpy"/>
    <java/>
    <readline/>
-   <libmotif package="motif">
+   <libmotif package="motif"/>
  </external_packages>
 
  <external_packages dist="el8">
    <numpy package="python3-numpy"/>
    <java/>
    <readline/>
-   <libmotif package="motif">
+   <libmotif package="motif"/>
  </external_packages>
 
  <external_packages dist="el7">
    <python-numpy package="numpy"/>
    <java/>
    <readline/>
-   <libmotif package="motif">
+   <libmotif package="motif"/>
  </external_packages>
 
  <!-- platform last -->
@@ -907,20 +907,20 @@ rm -f /etc/ld.so.conf.d/mdsplus.conf 2&gt;/dev/null
    <numpy/>
    <java/>
    <readline/>
-   <libmotif package="motif">
+   <libmotif package="motif"/>
  </external_packages>
 
  <external_packages platform="alpine">
    <numpy package="py-numpy"/>
    <java package="openjdk8-jre"/>
    <readline/>
-   <libmotif package="motif">
+   <libmotif package="motif"/>
  </external_packages>
 
  <external_packages platform="debian">
    <numpy package="python-numpy"/>
    <java package="java-runtime"/>
-   <libmotif package="libmrm4">
+   <libmotif package="libmrm4"/>
  </external_packages>
 
 </deploy>

--- a/deploy/packaging/linux.xml
+++ b/deploy/packaging/linux.xml
@@ -269,6 +269,8 @@ fi
   </package>
 
   <package name="motif_bin" arch="bin" summary="Libraries, UIDS and binary applications required for Motif APS" description="Libraries, UIDS and binary applications required for Motif APS">
+    <requires package="libmotif" external=""/>
+    <requires package="libmrm" external=""/>
     <include file="/usr/local/mdsplus/bin/dw*"/>
     <include file="/usr/local/mdsplus/bin/ScopePrinters"/>
     <include file="/usr/local/mdsplus/bin/actmon"/>
@@ -842,54 +844,63 @@ rm -f /etc/ld.so.conf.d/mdsplus.conf 2&gt;/dev/null
    <numpy package="python3-numpy"/>
    <java package="java-runtime"/>
    <readline package="libreadline8"/>
+   <libmotif package="libmrm4">
  </external_packages>
 
  <external_packages dist="Ubuntu22">
    <numpy package="python3-numpy"/>
    <java package="java-runtime"/>
    <readline package="libreadline8"/>
+   <libmotif package="libmrm4">
  </external_packages>
 
  <external_packages dist="Ubuntu20">
    <numpy package="python3-numpy"/>
    <java package="java-runtime"/>
    <readline package="libreadline8"/>
- </external_packages>
-
- <external_packages dist="DebianBookworm">
-   <numpy package="python3-numpy"/>
-   <java package="java-runtime"/>
-   <readline package="libreadline8"/>
- </external_packages>
-
- <external_packages dist="DebianBullseye">
-   <numpy package="python3-numpy"/>
-   <java package="java-runtime"/>
-   <readline package="libreadline8"/>
+   <libmotif package="libmrm4">
  </external_packages>
 
  <external_packages dist="Ubuntu18">
    <numpy package="python3-numpy"/>
    <java package="java-runtime"/>
    <readline package="libreadline7"/>
+   <libmotif package="libmrm4">
+ </external_packages>
+
+ <external_packages dist="DebianBookworm">
+   <numpy package="python3-numpy"/>
+   <java package="java-runtime"/>
+   <readline package="libreadline8"/>
+   <libmotif package="motif">
+ </external_packages>
+
+ <external_packages dist="DebianBullseye">
+   <numpy package="python3-numpy"/>
+   <java package="java-runtime"/>
+   <readline package="libreadline8"/>
+   <libmotif package="motif">
  </external_packages>
 
  <external_packages dist="el9">
    <numpy package="python3-numpy"/>
    <java/>
    <readline/>
+   <libmotif package="motif">
  </external_packages>
 
  <external_packages dist="el8">
    <numpy package="python3-numpy"/>
    <java/>
    <readline/>
+   <libmotif package="motif">
  </external_packages>
 
  <external_packages dist="el7">
    <python-numpy package="numpy"/>
    <java/>
    <readline/>
+   <libmotif package="motif">
  </external_packages>
 
  <!-- platform last -->
@@ -897,17 +908,20 @@ rm -f /etc/ld.so.conf.d/mdsplus.conf 2&gt;/dev/null
    <numpy/>
    <java/>
    <readline/>
+   <libmotif package="motif">
  </external_packages>
 
  <external_packages platform="alpine">
    <numpy package="py-numpy"/>
    <java package="openjdk8-jre"/>
    <readline/>
+   <libmotif package="motif">
  </external_packages>
 
  <external_packages platform="debian">
    <numpy package="python-numpy"/>
    <java package="java-runtime"/>
+   <libmotif package="libmrm4">
  </external_packages>
 
 </deploy>

--- a/deploy/packaging/linux.xml
+++ b/deploy/packaging/linux.xml
@@ -568,6 +568,7 @@ rm -f /etc/profile.d/mdsplus.csh
 
   <package name="kernel_bin" arch="bin" summary="MDSplus core binaries" description="MDSplus core binaries">
     <requires package="readline" external=""/>
+    <requires package="libxml" external=""/>
     <include dir="/usr/local/mdsplus/bin"/>
     <exclude file="/usr/local/mdsplus/bin/ScopePrinters"/>
     <exclude file="/usr/local/mdsplus/bin/dw*"/>
@@ -844,6 +845,7 @@ rm -f /etc/ld.so.conf.d/mdsplus.conf 2&gt;/dev/null
    <java package="java-runtime"/>
    <readline package="libreadline8"/>
    <libmotif package="libmrm4"/>
+   <libxml package="libxml2"/>
  </external_packages>
 
  <external_packages dist="Ubuntu22">
@@ -851,6 +853,7 @@ rm -f /etc/ld.so.conf.d/mdsplus.conf 2&gt;/dev/null
    <java package="java-runtime"/>
    <readline package="libreadline8"/>
    <libmotif package="libmrm4"/>
+   <libxml package="libxml2"/>
  </external_packages>
 
  <external_packages dist="Ubuntu20">
@@ -858,6 +861,7 @@ rm -f /etc/ld.so.conf.d/mdsplus.conf 2&gt;/dev/null
    <java package="java-runtime"/>
    <readline package="libreadline8"/>
    <libmotif package="libmrm4"/>
+   <libxml package="libxml2"/>
  </external_packages>
 
  <external_packages dist="Ubuntu18">
@@ -865,6 +869,7 @@ rm -f /etc/ld.so.conf.d/mdsplus.conf 2&gt;/dev/null
    <java package="java-runtime"/>
    <readline package="libreadline7"/>
    <libmotif package="libmrm4"/>
+   <libxml package="libxml2"/>
  </external_packages>
 
  <external_packages dist="DebianBookworm">
@@ -872,6 +877,7 @@ rm -f /etc/ld.so.conf.d/mdsplus.conf 2&gt;/dev/null
    <java package="java-runtime"/>
    <readline package="libreadline8"/>
    <libmotif package="motif"/>
+   <libxml package="libxml2"/>
  </external_packages>
 
  <external_packages dist="DebianBullseye">
@@ -879,6 +885,7 @@ rm -f /etc/ld.so.conf.d/mdsplus.conf 2&gt;/dev/null
    <java package="java-runtime"/>
    <readline package="libreadline8"/>
    <libmotif package="motif"/>
+   <libxml package="libxml2"/>
  </external_packages>
 
  <external_packages dist="el9">
@@ -886,6 +893,7 @@ rm -f /etc/ld.so.conf.d/mdsplus.conf 2&gt;/dev/null
    <java/>
    <readline/>
    <libmotif package="motif"/>
+   <libxml package="libxml2"/>
  </external_packages>
 
  <external_packages dist="el8">
@@ -893,6 +901,7 @@ rm -f /etc/ld.so.conf.d/mdsplus.conf 2&gt;/dev/null
    <java/>
    <readline/>
    <libmotif package="motif"/>
+   <libxml package="libxml2"/>
  </external_packages>
 
  <external_packages dist="el7">
@@ -900,6 +909,7 @@ rm -f /etc/ld.so.conf.d/mdsplus.conf 2&gt;/dev/null
    <java/>
    <readline/>
    <libmotif package="motif"/>
+   <libxml package="libxml2"/>
  </external_packages>
 
  <!-- platform last -->
@@ -908,6 +918,7 @@ rm -f /etc/ld.so.conf.d/mdsplus.conf 2&gt;/dev/null
    <java/>
    <readline/>
    <libmotif package="motif"/>
+   <libxml package="libxml2"/>
  </external_packages>
 
  <external_packages platform="alpine">
@@ -915,12 +926,14 @@ rm -f /etc/ld.so.conf.d/mdsplus.conf 2&gt;/dev/null
    <java package="openjdk8-jre"/>
    <readline/>
    <libmotif package="motif"/>
+   <libxml package="libxml2"/>
  </external_packages>
 
  <external_packages platform="debian">
    <numpy package="python-numpy"/>
    <java package="java-runtime"/>
    <libmotif package="libmrm4"/>
+   <libxml package="libxml2"/>
  </external_packages>
 
 </deploy>

--- a/deploy/packaging/linux.xml
+++ b/deploy/packaging/linux.xml
@@ -270,7 +270,6 @@ fi
 
   <package name="motif_bin" arch="bin" summary="Libraries, UIDS and binary applications required for Motif APS" description="Libraries, UIDS and binary applications required for Motif APS">
     <requires package="libmotif" external=""/>
-    <requires package="libmrm" external=""/>
     <include file="/usr/local/mdsplus/bin/dw*"/>
     <include file="/usr/local/mdsplus/bin/ScopePrinters"/>
     <include file="/usr/local/mdsplus/bin/actmon"/>

--- a/deploy/packaging/linux.xml
+++ b/deploy/packaging/linux.xml
@@ -842,74 +842,60 @@ rm -f /etc/ld.so.conf.d/mdsplus.conf 2&gt;/dev/null
  <!-- dist first -->
   <external_packages dist="Ubuntu24">
    <numpy package="python3-numpy"/>
-   <java package="java-runtime"/>
    <readline package="libreadline8"/>
-   <libmotif package="libmrm4"/>
-   <libxml package="libxml2"/>
  </external_packages>
 
  <external_packages dist="Ubuntu22">
    <numpy package="python3-numpy"/>
-   <java package="java-runtime"/>
    <readline package="libreadline8"/>
-   <libmotif package="libmrm4"/>
-   <libxml package="libxml2"/>
  </external_packages>
 
  <external_packages dist="Ubuntu20">
    <numpy package="python3-numpy"/>
-   <java package="java-runtime"/>
    <readline package="libreadline8"/>
-   <libmotif package="libmrm4"/>
-   <libxml package="libxml2"/>
  </external_packages>
 
  <external_packages dist="Ubuntu18">
    <numpy package="python3-numpy"/>
-   <java package="java-runtime"/>
    <readline package="libreadline7"/>
-   <libmotif package="libmrm4"/>
-   <libxml package="libxml2"/>
  </external_packages>
 
  <external_packages dist="DebianBookworm">
    <numpy package="python3-numpy"/>
-   <java package="java-runtime"/>
    <readline package="libreadline8"/>
-   <libmotif package="motif"/>
-   <libxml package="libxml2"/>
  </external_packages>
 
  <external_packages dist="DebianBullseye">
    <numpy package="python3-numpy"/>
-   <java package="java-runtime"/>
    <readline package="libreadline8"/>
-   <libmotif package="motif"/>
-   <libxml package="libxml2"/>
+ </external_packages>
+
+ <external_packages dist="DebianBuster">
+   <numpy package="python3-numpy"/>
+   <readline package="libreadline8"/>
+ </external_packages>
+
+ <external_packages dist="DebianStretch">
+   <numpy package="python3-numpy"/>
+   <readline package="libreadline7"/>
  </external_packages>
 
  <external_packages dist="el9">
    <numpy package="python3-numpy"/>
    <java/>
    <readline/>
-   <libmotif package="motif"/>
-   <libxml package="libxml2"/>
  </external_packages>
 
  <external_packages dist="el8">
    <numpy package="python3-numpy"/>
    <java/>
    <readline/>
-   <libmotif package="motif"/>
-   <libxml package="libxml2"/>
  </external_packages>
 
  <external_packages dist="el7">
    <python-numpy package="numpy"/>
    <java/>
    <readline/>
-   <libmotif package="motif"/>
-   <libxml package="libxml2"/>
  </external_packages>
 
  <!-- platform last -->

--- a/deploy/packaging/linux_build_packages.py
+++ b/deploy/packaging/linux_build_packages.py
@@ -38,11 +38,14 @@ def get_root():
 def external_package(info, root, package):
     for extpackages in root.iter('external_packages'):
         dist = extpackages.attrib.get('dist', None)
+        pkg = None
         if dist:
             if info['dist'] != dist:
                 continue
             selected = dist
-        else:
+            pkg = extpackages.find(package)
+
+        if pkg is None:
             platform = extpackages.attrib.get('platform', None)
             if platform:
                 if info['platform'] != platform:
@@ -50,7 +53,7 @@ def external_package(info, root, package):
                 selected = platform
             else:
                 continue
-        pkg = extpackages.find(package)
+            pkg = extpackages.find(package)
         if pkg is not None:  # found and include dependency
             pkg = pkg.attrib.get('package', package)
             print('REQUIRES: %s' % (pkg,))


### PR DESCRIPTION
Change linux_build_packages.py to correctly fallback to platform if distribution is not set.
Update Linux xml to default to platform for common packages.
Add a dependencies for libxml2 and motif/libmrm4.

Fixes #2819