### PR TITLE
Fix: the Fortran MacOS aliases now declare the remote calls

### DIFF
--- a/mdslib/fortran_aliases_mac.h
+++ b/mdslib/fortran_aliases_mac.h
@@ -122,3 +122,118 @@ mdsvalue2_(char *expression, int *a00, int *a01, int *a02, int *a03, int *a04,
       a72, a73, a74, a75, a76, a77, a78, a79, a80, a81, a82, a83, a84, a85, a86,
       a87, a88, a89, a90, a91, a92, a93, a94, a95, a96, a97, a98, a99);
 }
+
+// Fortran aliases for the remote calls
+EXPORT int mdsconnectr_(char *host) { return MdsConnectR(host); }
+EXPORT int mdscloser_(int *conid, char *tree, int *shot) { return MdsCloseR(conid, tree, shot); }
+EXPORT void mdsdisconnectr_(int *conid) { MdsDisconnectR(conid); }
+EXPORT int mdsopenr_(int *conid, char *tree, int *shot) { return MdsOpenR(conid, tree, shot); }
+EXPORT int mdssetdefaultr_(int *conid, char *node) { return MdsSetDefaultR(conid, node); }
+
+EXPORT int
+mdsputr_(int *conid, char *node, char *expression, int *a00, int *a01, int *a02, int *a03,
+        int *a04, int *a05, int *a06, int *a07, int *a08, int *a09, int *a10,
+        int *a11, int *a12, int *a13, int *a14, int *a15, int *a16, int *a17,
+        int *a18, int *a19, int *a20, int *a21, int *a22, int *a23, int *a24,
+        int *a25, int *a26, int *a27, int *a28, int *a29, int *a30, int *a31,
+        int *a32, int *a33, int *a34, int *a35, int *a36, int *a37, int *a38,
+        int *a39, int *a40, int *a41, int *a42, int *a43, int *a44, int *a45,
+        int *a46, int *a47, int *a48, int *a49, int *a50, int *a51, int *a52,
+        int *a53, int *a54, int *a55, int *a56, int *a57, int *a58, int *a59,
+        int *a60, int *a61, int *a62, int *a63, int *a64, int *a65, int *a66,
+        int *a67, int *a68, int *a69, int *a70, int *a71, int *a72, int *a73,
+        int *a74, int *a75, int *a76, int *a77, int *a78, int *a79, int *a80,
+        int *a81, int *a82, int *a83, int *a84, int *a85, int *a86, int *a87,
+        int *a88, int *a89, int *a90, int *a91, int *a92, int *a93, int *a94,
+        int *a95, int *a96, int *a97, int *a98, int *a99)
+{
+  return MdsPutR(
+      conid, node, expression, a00, a01, a02, a03, a04, a05, a06, a07, a08, a09, a10,
+      a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25,
+      a26, a27, a28, a29, a30, a31, a32, a33, a34, a35, a36, a37, a38, a39, a40,
+      a41, a42, a43, a44, a45, a46, a47, a48, a49, a50, a51, a52, a53, a54, a55,
+      a56, a57, a58, a59, a60, a61, a62, a63, a64, a65, a66, a67, a68, a69, a70,
+      a71, a72, a73, a74, a75, a76, a77, a78, a79, a80, a81, a82, a83, a84, a85,
+      a86, a87, a88, a89, a90, a91, a92, a93, a94, a95, a96, a97, a98, a99);
+}
+
+EXPORT int
+mdsvaluer_(int *conid, char *expression, int *a00, int *a01, int *a02, int *a03, int *a04,
+          int *a05, int *a06, int *a07, int *a08, int *a09, int *a10, int *a11,
+          int *a12, int *a13, int *a14, int *a15, int *a16, int *a17, int *a18,
+          int *a19, int *a20, int *a21, int *a22, int *a23, int *a24, int *a25,
+          int *a26, int *a27, int *a28, int *a29, int *a30, int *a31, int *a32,
+          int *a33, int *a34, int *a35, int *a36, int *a37, int *a38, int *a39,
+          int *a40, int *a41, int *a42, int *a43, int *a44, int *a45, int *a46,
+          int *a47, int *a48, int *a49, int *a50, int *a51, int *a52, int *a53,
+          int *a54, int *a55, int *a56, int *a57, int *a58, int *a59, int *a60,
+          int *a61, int *a62, int *a63, int *a64, int *a65, int *a66, int *a67,
+          int *a68, int *a69, int *a70, int *a71, int *a72, int *a73, int *a74,
+          int *a75, int *a76, int *a77, int *a78, int *a79, int *a80, int *a81,
+          int *a82, int *a83, int *a84, int *a85, int *a86, int *a87, int *a88,
+          int *a89, int *a90, int *a91, int *a92, int *a93, int *a94, int *a95,
+          int *a96, int *a97, int *a98, int *a99)
+{
+  return MdsValueR(
+      conid, expression, a00, a01, a02, a03, a04, a05, a06, a07, a08, a09, a10, a11,
+      a12, a13, a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26,
+      a27, a28, a29, a30, a31, a32, a33, a34, a35, a36, a37, a38, a39, a40, a41,
+      a42, a43, a44, a45, a46, a47, a48, a49, a50, a51, a52, a53, a54, a55, a56,
+      a57, a58, a59, a60, a61, a62, a63, a64, a65, a66, a67, a68, a69, a70, a71,
+      a72, a73, a74, a75, a76, a77, a78, a79, a80, a81, a82, a83, a84, a85, a86,
+      a87, a88, a89, a90, a91, a92, a93, a94, a95, a96, a97, a98, a99);
+}
+
+EXPORT int
+mdsput2r_(int *conid, char *node, char *expression, int *a00, int *a01, int *a02, int *a03,
+         int *a04, int *a05, int *a06, int *a07, int *a08, int *a09, int *a10,
+         int *a11, int *a12, int *a13, int *a14, int *a15, int *a16, int *a17,
+         int *a18, int *a19, int *a20, int *a21, int *a22, int *a23, int *a24,
+         int *a25, int *a26, int *a27, int *a28, int *a29, int *a30, int *a31,
+         int *a32, int *a33, int *a34, int *a35, int *a36, int *a37, int *a38,
+         int *a39, int *a40, int *a41, int *a42, int *a43, int *a44, int *a45,
+         int *a46, int *a47, int *a48, int *a49, int *a50, int *a51, int *a52,
+         int *a53, int *a54, int *a55, int *a56, int *a57, int *a58, int *a59,
+         int *a60, int *a61, int *a62, int *a63, int *a64, int *a65, int *a66,
+         int *a67, int *a68, int *a69, int *a70, int *a71, int *a72, int *a73,
+         int *a74, int *a75, int *a76, int *a77, int *a78, int *a79, int *a80,
+         int *a81, int *a82, int *a83, int *a84, int *a85, int *a86, int *a87,
+         int *a88, int *a89, int *a90, int *a91, int *a92, int *a93, int *a94,
+         int *a95, int *a96, int *a97, int *a98, int *a99)
+{
+  return MdsPut2R(
+      conid, node, expression, a00, a01, a02, a03, a04, a05, a06, a07, a08, a09, a10,
+      a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25,
+      a26, a27, a28, a29, a30, a31, a32, a33, a34, a35, a36, a37, a38, a39, a40,
+      a41, a42, a43, a44, a45, a46, a47, a48, a49, a50, a51, a52, a53, a54, a55,
+      a56, a57, a58, a59, a60, a61, a62, a63, a64, a65, a66, a67, a68, a69, a70,
+      a71, a72, a73, a74, a75, a76, a77, a78, a79, a80, a81, a82, a83, a84, a85,
+      a86, a87, a88, a89, a90, a91, a92, a93, a94, a95, a96, a97, a98, a99);
+}
+
+EXPORT int
+mdsvalue2r_(int *conid, char *expression, int *a00, int *a01, int *a02, int *a03, int *a04,
+           int *a05, int *a06, int *a07, int *a08, int *a09, int *a10, int *a11,
+           int *a12, int *a13, int *a14, int *a15, int *a16, int *a17, int *a18,
+           int *a19, int *a20, int *a21, int *a22, int *a23, int *a24, int *a25,
+           int *a26, int *a27, int *a28, int *a29, int *a30, int *a31, int *a32,
+           int *a33, int *a34, int *a35, int *a36, int *a37, int *a38, int *a39,
+           int *a40, int *a41, int *a42, int *a43, int *a44, int *a45, int *a46,
+           int *a47, int *a48, int *a49, int *a50, int *a51, int *a52, int *a53,
+           int *a54, int *a55, int *a56, int *a57, int *a58, int *a59, int *a60,
+           int *a61, int *a62, int *a63, int *a64, int *a65, int *a66, int *a67,
+           int *a68, int *a69, int *a70, int *a71, int *a72, int *a73, int *a74,
+           int *a75, int *a76, int *a77, int *a78, int *a79, int *a80, int *a81,
+           int *a82, int *a83, int *a84, int *a85, int *a86, int *a87, int *a88,
+           int *a89, int *a90, int *a91, int *a92, int *a93, int *a94, int *a95,
+           int *a96, int *a97, int *a98, int *a99)
+{
+  return MdsValue2R(
+      conid, expression, a00, a01, a02, a03, a04, a05, a06, a07, a08, a09, a10, a11,
+      a12, a13, a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26,
+      a27, a28, a29, a30, a31, a32, a33, a34, a35, a36, a37, a38, a39, a40, a41,
+      a42, a43, a44, a45, a46, a47, a48, a49, a50, a51, a52, a53, a54, a55, a56,
+      a57, a58, a59, a60, a61, a62, a63, a64, a65, a66, a67, a68, a69, a70, a71,
+      a72, a73, a74, a75, a76, a77, a78, a79, a80, a81, a82, a83, a84, a85, a86,
+      a87, a88, a89, a90, a91, a92, a93, a94, a95, a96, a97, a98, a99);
+}


### PR DESCRIPTION
On MacOS, the `mdslib_fremotetest.f` program did not build because of linker issues.   Turns out that  `mdslib/fortran_aliases_mac.h` was missing declarations for all "remote" calls.   (Which implies that this test never ran on MacOS.)

This PR adds those declarations.