### PR TITLE
Build: Add include/opcbuiltins.h to the .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -145,6 +145,7 @@ include/tcl_messages.h
 include/tdishr_messages.h
 include/tdishr.h
 include/treeshr_messages.h
+include/opcbuiltins.h
 java/Makefile.in
 java/devicebeans/Makefile.in
 java/jdevices/Makefile.in


### PR DESCRIPTION
This is due to PR #2818 that generates opcbuiltins.h during bootstrapping