### PR TITLE
Feature: Add python copyTo method to Tree and TreeNode

### DIFF
--- a/python/MDSplus/tree.py
+++ b/python/MDSplus/tree.py
@@ -3278,10 +3278,35 @@ class TreeNode(_dat.TreeRef, _dat.Data):
                         dst_node.makeSegment(start, end, dim, data)
                         index += seg_len
                 else:
-                    # Regular data is decompiled/recompiled to preserve node references
+                    def _update_tree_paths(data, new_tree):
+                        # TreePath is a subclass of TreeNode so we need to do this first
+                        if isinstance(data, TreePath):
+                            return data
+                        
+                        elif isinstance(data, TreeNode):
+                            try:
+                                return new_tree.getNode(data.minpath)
+                            except _exc.TreeNNF:
+                                return TreePath(data.path, new_tree)
+
+                        elif isinstance(data, _cmp.Compound):
+                            for i in range(data.getNumDescs()):
+                                data.setDescAt(i, _update_tree_paths(data.getDescAt(i), new_tree))
+                            return data
+
+                        elif isinstance(data, _apd.List):
+                            return _apd.List([ _update_tree_paths(v, new_tree) for v in data.value ])
+
+                        elif isinstance(data, _apd.Dictionary):
+                            return _apd.Dictionary({ _update_tree_paths(k, new_tree): _update_tree_paths(v, new_tree) for k, v in data.value })
+
+                        return data
+
                     try:
-                        deco = src_node.record.decompile()
-                        dst_node.record = dst.tree.tdiCompile(deco)
+                        # Decompiling/Compiling the data loses floating point precision
+                        # so we manually traverse the data to update node references
+                        dst_node.record = _update_tree_paths(src_node.record, dst_node.tree)
+
                     except _exc.TreeNODATA:
                         pass
                     except Exception as e:

--- a/python/MDSplus/tree.py
+++ b/python/MDSplus/tree.py
@@ -1196,7 +1196,7 @@ class Tree(object):
         kwargs['tree'] = self.tree
         return _dat.TdiData(arg, **kwargs)
 
-    def copyTo(src, dst, **kwargs):
+    def copyTo(self, src, dst, **kwargs):
         """Alias for self.top.copyTo(dst, **kwargs), see TreeNode.copyTo for details"""
         return self.top.copyTo(dst, **kwargs)
 
@@ -3124,7 +3124,7 @@ class TreeNode(_dat.TreeRef, _dat.Data):
         """Recursively copy a portion of one tree to another.
         @param src: The source TreeNode to copy nodes from
         @param dst: The destination TreeNode to copy nodes to
-        @param node_filter: An optional function that takes a source node and returns True if it should be included in the copy, or false otherwise.
+        @param node_filter: An optional function that takes a source node and returns True if it should be included in the copy, or False otherwise.
         @param copy_tags: True if tags should be copied as well. Existing tags will not be overwritten.
         @param copy_data: True if the data for nodes should be copied as well.
         @param copy_nci: True if NCI properties should be copied as well.

--- a/python/MDSplus/tree.py
+++ b/python/MDSplus/tree.py
@@ -3285,7 +3285,7 @@ class TreeNode(_dat.TreeRef, _dat.Data):
                         
                         elif isinstance(data, TreeNode):
                             try:
-                                return new_tree.getNode(data.minpath)
+                                return new_tree.getDefault().getNode(data.minpath)
                             except _exc.TreeNNF:
                                 return TreePath(data.path, new_tree)
 

--- a/python/MDSplus/tree.py
+++ b/python/MDSplus/tree.py
@@ -1196,7 +1196,7 @@ class Tree(object):
         kwargs['tree'] = self.tree
         return _dat.TdiData(arg, **kwargs)
 
-    def copyTo(self, src, dst, **kwargs):
+    def copyTo(self, dst, **kwargs):
         """Alias for self.top.copyTo(dst, **kwargs), see TreeNode.copyTo for details"""
         return self.top.copyTo(dst, **kwargs)
 

--- a/python/MDSplus/tree.py
+++ b/python/MDSplus/tree.py
@@ -3243,7 +3243,7 @@ class TreeNode(_dat.TreeRef, _dat.Data):
                     # Ensure that we don't overwrite existing tags
                     try:
                         existing_node = dst.tree.getNode('\\{}'.format(tag))
-                        print('Warning: Tag "{}" already exists and points to {}'.foramt(tag, existing_node.fullpath))
+                        print('Warning: Tag "{}" already exists and points to {}'.format(tag, existing_node.fullpath))
                         continue
                     except _exc.TreeNNF:
                         pass
@@ -3281,13 +3281,19 @@ class TreeNode(_dat.TreeRef, _dat.Data):
                     def _update_tree_paths(data, new_tree):
                         # TreePath is a subclass of TreeNode so we need to do this first
                         if isinstance(data, TreePath):
-                            return data
+                            new_path = data.tree_path.replace(src.fullpath, dst.fullpath)
+                            return TreePath(new_path, new_tree)
                         
                         elif isinstance(data, TreeNode):
+                            # After the first node in a data structure is updated, the tree for the entire
+                            # data structure changes, this means that we need to manually get the nodes by
+                            # their NIDs, otherwise we accidentally get nodes from the new tree with those nids
+                            real_node = TreeNode(data.nid, src.tree)
+                            new_path = real_node.fullpath.replace(src.fullpath, dst.fullpath)
                             try:
-                                return new_tree.getDefault().getNode(data.minpath)
+                                return new_tree.getNode(new_path)
                             except _exc.TreeNNF:
-                                return TreePath(data.path, new_tree)
+                                return TreePath(new_path, new_tree)
 
                         elif isinstance(data, _cmp.Compound):
                             for i in range(data.getNumDescs()):

--- a/python/MDSplus/tree.py
+++ b/python/MDSplus/tree.py
@@ -3121,8 +3121,7 @@ class TreeNode(_dat.TreeRef, _dat.Data):
                                         _C.c_int32(int(idx))))
 
     def copyTo(self, dst, node_filter=None, copy_tags=True, copy_data=True, copy_nci=True, copy_xnci=True):
-        """Recursively copy a portion of one tree to another.
-        @param src: The source TreeNode to copy nodes from
+        """Recursively copy a portion of one tree to another from this node to the dst node.
         @param dst: The destination TreeNode to copy nodes to
         @param node_filter: An optional function that takes a source node and returns True if it should be included in the copy, or False otherwise.
         @param copy_tags: True if tags should be copied as well. Existing tags will not be overwritten.

--- a/python/MDSplus/tree.py
+++ b/python/MDSplus/tree.py
@@ -3137,7 +3137,7 @@ class TreeNode(_dat.TreeRef, _dat.Data):
         if type(dst) == Tree:
             dst = dst.top
 
-        print(f'Copying from {src.fullpath} to {dst.fullpath}')
+        print('Copying from {} to {}'.format(src.fullpath, dst.fullpath))
 
         if not dst.tree.open_for_edit:
             print('Destination tree must be open for edit')
@@ -3164,6 +3164,7 @@ class TreeNode(_dat.TreeRef, _dat.Data):
                 return 1
             return 0
 
+        import functools
         src_nodes = sorted(list(src.getNodeWild('***')), key=functools.cmp_to_key(compare_nodes))
         skip_nodes = []
 
@@ -3188,17 +3189,17 @@ class TreeNode(_dat.TreeRef, _dat.Data):
                 dst_node = dst.getNode(dst_path)
 
                 if dst_node.usage != src_node.usage:
-                    print(f'Node {dst_node.fullpath} already exists but with a different usage, updating')
+                    print('Node {} already exists but with a different usage, updating'.format(dst_node.fullpath))
                     dst_node.usage = src_node.usage
 
                 if dst_node.conglomerate_elt != src_node.conglomerate_elt:
-                    print(f'Node {dst_node.fullpath} already exists would conflict with the conglomerate, removing it and all children')
+                    print('Node {} already exists would conflict with the conglomerate, removing it and all children'.format(dst_node.fullpath))
 
                     # Skip this node and all children
                     skip_nodes.extend(list(src_node.getNodeWild('***')))
 
                 continue
-            except mdsExceptions.TreeNNF:
+            except _exc.TreeNNF:
                 pass
 
         # Remove nodes that shouldn't be copied
@@ -3220,7 +3221,7 @@ class TreeNode(_dat.TreeRef, _dat.Data):
 
             try:
                 dst.addNode(dst_path, src_node.usage)
-            except mdsExceptions.TreeALREADY_THERE:
+            except _exc.TreeALREADY_THERE:
                 pass
 
             if remaining_conglomerate_nodes > 0:
@@ -3240,10 +3241,10 @@ class TreeNode(_dat.TreeRef, _dat.Data):
 
                     # Ensure that we don't overwrite existing tags
                     try:
-                        existing_node = dst.tree.getNode(f'\\{tag}')
-                        print(f'Warning: Tag "{tag}" already exists and points to {existing_node.fullpath}')
+                        existing_node = dst.tree.getNode('\\{}'.format(tag))
+                        print('Warning: Tag "{}" already exists and points to {}'.foramt(tag, existing_node.fullpath))
                         continue
-                    except mdsExceptions.TreeNNF:
+                    except _exc.TreeNNF:
                         pass
 
                     dst_node.addTags(tag, replace=False)
@@ -3280,7 +3281,7 @@ class TreeNode(_dat.TreeRef, _dat.Data):
                     try:
                         deco = src_node.record.decompile()
                         dst_node.record = dst.tree.tdiCompile(deco)
-                    except mdsExceptions.TreeNODATA:
+                    except _exc.TreeNODATA:
                         pass
                     except Exception as e:
                         print(e)

--- a/python/MDSplus/tree.py
+++ b/python/MDSplus/tree.py
@@ -1196,6 +1196,10 @@ class Tree(object):
         kwargs['tree'] = self.tree
         return _dat.TdiData(arg, **kwargs)
 
+    def copyTo(src, dst, **kwargs):
+        """Alias for self.top.copyTo(dst, **kwargs), see TreeNode.copyTo for details"""
+        return self.top.copyTo(dst, **kwargs)
+
 
 # HINT: TreeNode begin  (maybe subclass of _scr.Int32 some day)
 class TreeNode(_dat.TreeRef, _dat.Data):
@@ -3116,6 +3120,201 @@ class TreeNode(_dat.TreeRef, _dat.Data):
                                         None,
                                         _C.c_int32(int(idx))))
 
+    def copyTo(src, dst, node_filter=None, copy_tags=True, copy_data=True, copy_nci=True, copy_xnci=True):
+        """Recursively copy a portion of one tree to another.
+        @param src: The source TreeNode to copy nodes from
+        @param dst: The destination TreeNode to copy nodes to
+        @param node_filter: An optional function that takes a source node and returns True if it should be included in the copy, or false otherwise.
+        @param copy_tags: True if tags should be copied as well. Existing tags will not be overwritten.
+        @param copy_data: True if the data for nodes should be copied as well.
+        @param copy_nci: True if NCI properties should be copied as well.
+        @param copy_xnci: True if XNCI properties should be copied as well.
+        """
+
+        if type(src) == Tree:
+            src = src.top
+
+        if type(dst) == Tree:
+            dst = dst.top
+
+        print(f'Copying from {src.fullpath} to {dst.fullpath}')
+
+        if not dst.tree.open_for_edit:
+            print('Destination tree must be open for edit')
+            return
+
+        if src.tree == dst.tree:
+            print('Cannot currently copy within a tree')
+            return
+
+        original_src_default = src.tree.getDefault()
+        original_dst_default = dst.tree.getDefault()
+
+        src.tree.setDefault(src)
+        dst.tree.setDefault(dst)
+
+        root_src = src.fullpath
+        root_dst = dst.fullpath
+
+        # Sort by conglomerate_elt to keep conglomerates together
+        def compare_nodes(a, b):
+            if a.conglomerate_elt < b.conglomerate_elt:
+                return -1
+            elif a.conglomerate_elt > b.conglomerate_elt:
+                return 1
+            return 0
+
+        src_nodes = sorted(list(src.getNodeWild('***')), key=functools.cmp_to_key(compare_nodes))
+        skip_nodes = []
+
+        # Filter out nodes that the user doesn't want
+        if node_filter is not None:
+            for src_node in src_nodes:
+                # We can't filter out nodes that are part of a conglomerate, except the head node
+                if src_node.conglomerate_elt > 1:
+                    continue
+
+                copy_this_node = node_filter(src_node)
+
+                # Skip this node and all children
+                if not copy_this_node:
+                    skip_nodes.extend(list(src_node.getNodeWild('***')))
+
+        # Handle existing nodes with discrepancies
+        for src_node in src_nodes:
+            dst_path = src_node.fullpath.replace(root_src, root_dst)
+
+            try:
+                dst_node = dst.getNode(dst_path)
+
+                if dst_node.usage != src_node.usage:
+                    print(f'Node {dst_node.fullpath} already exists but with a different usage, updating')
+                    dst_node.usage = src_node.usage
+
+                if dst_node.conglomerate_elt != src_node.conglomerate_elt:
+                    print(f'Node {dst_node.fullpath} already exists would conflict with the conglomerate, removing it and all children')
+
+                    # Skip this node and all children
+                    skip_nodes.extend(list(src_node.getNodeWild('***')))
+
+                continue
+            except mdsExceptions.TreeNNF:
+                pass
+
+        # Remove nodes that shouldn't be copied
+        for node in skip_nodes:
+            try:
+                src_nodes.remove(node)
+            except ValueError:
+                pass
+        
+        # Add missing nodes, starting/ending conglomerates as needed
+        remaining_conglomerate_nodes = 0
+        for src_node in src_nodes:
+            dst_path = src_node.fullpath.replace(root_src, root_dst)
+
+            if remaining_conglomerate_nodes == 0:
+                if src_node.conglomerate_elt == 1:
+                    remaining_conglomerate_nodes = src_node.number_of_elts
+                    _TreeShr._TreeStartConglomerate(dst.tree.ctx, remaining_conglomerate_nodes)
+
+            try:
+                dst.addNode(dst_path, src_node.usage)
+            except mdsExceptions.TreeALREADY_THERE:
+                pass
+
+            if remaining_conglomerate_nodes > 0:
+                remaining_conglomerate_nodes -= 1
+                if remaining_conglomerate_nodes == 0:
+                    _TreeShr._TreeEndConglomerate(dst.tree.ctx)
+
+        # Copy tags, data, XNCIs and NCIs
+        for src_node in src_nodes:
+            dst_path = src_node.fullpath.replace(root_src, root_dst)
+            dst_node = dst.getNode(dst_path)
+
+            if copy_tags:
+                tags = src_node.getTags()
+                for tag in tags:
+                    tag = str(tag)
+
+                    # Ensure that we don't overwrite existing tags
+                    try:
+                        existing_node = dst.tree.getNode(f'\\{tag}')
+                        print(f'Warning: Tag "{tag}" already exists and points to {existing_node.fullpath}')
+                        continue
+                    except mdsExceptions.TreeNNF:
+                        pass
+
+                    dst_node.addTags(tag, replace=False)
+
+
+            original_no_write_model = dst_node.no_write_model
+            original_no_write_shot = dst_node.no_write_shot
+            original_write_once = dst_node.write_once
+
+            # Temporarily disable write protections if writing data or XNCIs
+            if copy_data or copy_xnci:
+                dst_node.no_write_model = False
+                dst_node.no_write_shot = False
+                dst_node.write_once = False
+
+            if copy_data:
+
+                if src_node.isSegmented():
+                    # Segmented records need to be treated differently
+
+                    index = 0
+                    for i in range(src_node.getNumSegments()):
+                        seg = src_node.getSegment(i)
+                        data = seg.value
+                        seg_len = len(data)
+                        dim = seg.dim_of()
+
+                        start = index
+                        end = index + seg_len - 1
+                        dst_node.makeSegment(start, end, dim, data)
+                        index += seg_len
+                else:
+                    # Regular data is decompiled/recompiled to preserve node references
+                    try:
+                        deco = src_node.record.decompile()
+                        dst_node.record = dst.tree.tdiCompile(deco)
+                    except mdsExceptions.TreeNODATA:
+                        pass
+                    except Exception as e:
+                        print(e)
+
+            # XNCI attributes are technically data, so they need to be copied while the write protections are disabled
+            if copy_xnci:
+                xncis = src_node.getExtendedAttributes()
+                if xncis is not None:
+                    for key, value in xncis.items():
+                        try:
+                            deco = value.decompile()
+                            dst_node.setExtendedAttribute(key, dst.tree.tdiCompile(deco))
+                        except Exception as e:
+                            print(e)
+
+            # Enable write protections, unless we're copying NCIs, then they would be overwritten
+            if copy_data or copy_xnci and not copy_nci:
+                dst_node.no_write_model = original_no_write_model
+                dst_node.no_write_shot = original_no_write_shot
+                dst_node.write_once = original_write_once
+
+            if copy_nci:
+                dst_node.compress_segments = src_node.compress_segments
+                dst_node.essential = src_node.essential
+                dst_node.do_not_compress = src_node.do_not_compress
+                dst_node.compress_on_put = src_node.compress_on_put
+                dst_node.include_in_pulse = src_node.include_in_pulse
+                dst_node.no_write_model = src_node.no_write_model
+                dst_node.no_write_shot = src_node.no_write_shot
+                dst_node.state = src_node.state
+                dst_node.write_once = src_node.write_once
+
+        src.tree.setDefault(original_src_default)
+        dst.tree.setDefault(original_dst_default)
 
 class TreePath(TreeNode):  # HINT: TreePath begin
     """Class to represent an MDSplus node reference (path)."""

--- a/python/MDSplus/tree.py
+++ b/python/MDSplus/tree.py
@@ -3238,7 +3238,7 @@ class TreeNode(_dat.TreeRef, _dat.Data):
             if copy_tags:
                 tags = src_node.getTags()
                 for tag in tags:
-                    tag = str(tag)
+                    tag = str(tag).strip()
 
                     # Ensure that we don't overwrite existing tags
                     try:

--- a/python/MDSplus/tree.py
+++ b/python/MDSplus/tree.py
@@ -3120,7 +3120,7 @@ class TreeNode(_dat.TreeRef, _dat.Data):
                                         None,
                                         _C.c_int32(int(idx))))
 
-    def copyTo(src, dst, node_filter=None, copy_tags=True, copy_data=True, copy_nci=True, copy_xnci=True):
+    def copyTo(self, dst, node_filter=None, copy_tags=True, copy_data=True, copy_nci=True, copy_xnci=True):
         """Recursively copy a portion of one tree to another.
         @param src: The source TreeNode to copy nodes from
         @param dst: The destination TreeNode to copy nodes to
@@ -3130,6 +3130,8 @@ class TreeNode(_dat.TreeRef, _dat.Data):
         @param copy_nci: True if NCI properties should be copied as well.
         @param copy_xnci: True if XNCI properties should be copied as well.
         """
+
+        src = self
 
         if type(src) == Tree:
             src = src.top


### PR DESCRIPTION
This adds the copyTo method to Tree and TreeNode in the python API copyTo allows you to copy a portion of a tree to another tree, optionally:
* Filtering unwanted nodes
* Copying data
* Copying tags
* Copying XNCIs
* Copying NCIs

Example:
```py
t1 = Tree('testsrc', -1, 'READONLY')
t2 = Tree('testdst', -1, 'EDIT')

def skip_devices(node):
    return (node.conglomerate_elt == 0)

t1.BRANCH.copyTo(t2.SECTION, node_filter=skip_devices, copy_xnci=False)

t1.close()
t2.write()
t2.close()
```