### PR TITLE
Fix: the find_fun() function now checks the status variable

### DIFF
--- a/tdishr/TdiVar.c
+++ b/tdishr/TdiVar.c
@@ -726,7 +726,7 @@ static inline int findfile_fun(const mdsdsc_t *const entry,
     }
     else if (isext == EXT_PY)
     {
-      *pyfile = file;  //XMW was funfile
+      *pyfile = file;
     } else {
       status = TdiUNKNOWN_VAR;
     }

--- a/tdishr/TdiVar.c
+++ b/tdishr/TdiVar.c
@@ -688,6 +688,9 @@ static inline ext_t matchext(const mdsdsc_d_t *const file)
     return EXT_PY;
   return EXT_NONE;
 }
+
+// If successful, will have either a *.fun or *.py file, and also compiles.
+// On error, must return TdiUNKOWN_VAR so that _TreeAddConglom() works correctly.
 static inline int findfile_fun(const mdsdsc_t *const entry,
                                char **const funfile, char **const pyfile)
 {
@@ -717,33 +720,19 @@ static inline int findfile_fun(const mdsdsc_t *const entry,
   {
     char *file = memcpy(malloc(bufd.length + 1), bufd.pointer, bufd.length);
     file[bufd.length] = '\0';
-    if (isext == EXT_PY)
-    {
-      *pyfile = file;
-      isext = EXT_FUN;
-      bufd.pointer = realloc(bufd.pointer, ++bufd.length);
-      memcpy(bufd.pointer + bufd.length - 4, ".FUN", 4);
-    }
-    else
+    if (isext == EXT_FUN)
     {
       *funfile = file;
-      isext = EXT_PY;
-      bufd.pointer = realloc(bufd.pointer, --bufd.length);
-      memcpy(bufd.pointer + bufd.length - 3, ".PY", 3);
     }
-    if (IS_OK(
-            LibFindFileCaseBlind((mdsdsc_t *)&bufd, (mdsdsc_t *)&bufd, &ctx)))
+    else if (isext == EXT_PY)
     {
-      file = memcpy(malloc(bufd.length + 1), bufd.pointer, bufd.length);
-      file[bufd.length] = '\0';
-      if (isext == EXT_PY)
-        *pyfile = file;
-      else
-        *funfile = file;
+      *pyfile = file;  //XMW was funfile
+    } else {
+      status = TdiUNKNOWN_VAR;
     }
-    LibFindFileEnd(&ctx);
   }
   FREED_NOW(bufd);
+  if (STATUS_NOT_OK) status = TdiUNKNOWN_VAR;
   return status;
 }
 
@@ -821,29 +810,31 @@ static int find_fun(const mdsdsc_t *const ident_ptr, node_type **const node_ptr,
     INIT_AND_FREE_ON_EXIT(char *, funfile);
     // check if we can find method as either .py or .fun
     status = findfile_fun(ident_ptr, &funfile, &pyfile);
-    if (pyfile)
-    {
-      char *funname;
-      status = tdi_load_python_fun(pyfile, &funname);
-      if (STATUS_OK)
+    if (STATUS_OK) {
+      if (pyfile)
       {
-        mdsdsc_t function = {strlen(funname), DTYPE_T, CLASS_S, funname};
-        mdsdsc_xd_t tmp = EMPTY_XD;
-        status = MdsCopyDxXd((mdsdsc_t *)&function, &tmp);
-        free(funname);
+        char *funname;
+        status = tdi_load_python_fun(pyfile, &funname);
         if (STATUS_OK)
         {
-          status =
-              put_ident((mdsdsc_r_t *)ident_ptr, &tmp, TDITHREADSTATIC_VAR);
-          MdsFree1Dx(&tmp, NULL);
+          mdsdsc_t function = {strlen(funname), DTYPE_T, CLASS_S, funname};
+          mdsdsc_xd_t tmp = EMPTY_XD;
+          status = MdsCopyDxXd((mdsdsc_t *)&function, &tmp);
+          free(funname);
+          if (STATUS_OK)
+          {
+            status =
+                put_ident((mdsdsc_r_t *)ident_ptr, &tmp, TDITHREADSTATIC_VAR);
+            MdsFree1Dx(&tmp, NULL);
+          }
         }
+        if (STATUS_NOT_OK)
+          // unable to load python method try tdi alternative
+          status = compile_fun(ident_ptr, funfile);
       }
-      if (STATUS_NOT_OK)
-        // unable to load python method try tdi alternative
+      else // not a python method, load tdi fun
         status = compile_fun(ident_ptr, funfile);
     }
-    else // not a python method, load tdi fun
-      status = compile_fun(ident_ptr, funfile);
     FREE_NOW(funfile);
     FREE_NOW(pyfile);
     if (STATUS_OK)

--- a/tdishr/TdiVar.c
+++ b/tdishr/TdiVar.c
@@ -689,8 +689,8 @@ static inline ext_t matchext(const mdsdsc_d_t *const file)
   return EXT_NONE;
 }
 
-// If successful, will have either a *.fun or *.py file, and also compiles.
-// On error, must return TdiUNKOWN_VAR so that _TreeAddConglom() works correctly.
+// For TDI function <name>, search for <name>.fun and <name>.py.
+// If a directory contains both files, both will be returned.
 static inline int findfile_fun(const mdsdsc_t *const entry,
                                char **const funfile, char **const pyfile)
 {
@@ -720,19 +720,33 @@ static inline int findfile_fun(const mdsdsc_t *const entry,
   {
     char *file = memcpy(malloc(bufd.length + 1), bufd.pointer, bufd.length);
     file[bufd.length] = '\0';
-    if (isext == EXT_FUN)
-    {
-      *funfile = file;
-    }
-    else if (isext == EXT_PY)
+    if (isext == EXT_PY)
     {
       *pyfile = file;
-    } else {
-      status = TdiUNKNOWN_VAR;
+      isext = EXT_FUN;
+      bufd.pointer = realloc(bufd.pointer, ++bufd.length);
+      memcpy(bufd.pointer + bufd.length - 4, ".FUN", 4);
     }
+    else
+    {
+      *funfile = file;
+      isext = EXT_PY;
+      bufd.pointer = realloc(bufd.pointer, --bufd.length);
+      memcpy(bufd.pointer + bufd.length - 3, ".PY", 3);
+    }
+    if (IS_OK(
+            LibFindFileCaseBlind((mdsdsc_t *)&bufd, (mdsdsc_t *)&bufd, &ctx)))
+    {
+      file = memcpy(malloc(bufd.length + 1), bufd.pointer, bufd.length);
+      file[bufd.length] = '\0';
+      if (isext == EXT_PY)
+        *pyfile = file;
+      else
+        *funfile = file;
+    }
+    LibFindFileEnd(&ctx);
   }
   FREED_NOW(bufd);
-  if (STATUS_NOT_OK) status = TdiUNKNOWN_VAR;
   return status;
 }
 
@@ -809,7 +823,9 @@ static int find_fun(const mdsdsc_t *const ident_ptr, node_type **const node_ptr,
     INIT_AND_FREE_ON_EXIT(char *, pyfile);
     INIT_AND_FREE_ON_EXIT(char *, funfile);
     // check if we can find method as either .py or .fun
+    // An error status must be remapped so that _TreeAddConglom() works OK.
     status = findfile_fun(ident_ptr, &funfile, &pyfile);
+    if (STATUS_NOT_OK) status = TdiUNKNOWN_VAR;
     if (STATUS_OK) {
       if (pyfile)
       {


### PR DESCRIPTION
**Note: See next post for a better analysis.**

While troubleshooting an issue with a TDI *.fun file, noticed that the `findfile_fun()` function has a typo and some unnecessary code.

1. The `if (isext == EXT_PY)` is a typo because the associated block of code deals with *.fun files, not *.py files.
2. There is no need for the block to set the value of "isext" because it is already set prior to entering the `if()` test.
3. The search for the file uses two functions:`LibFindFileRecurseCaseBlind()` and `LibFindFileCaseBlind()`.   The debugger shows that the first function finds the full path to the *.fun file or *.py file (including the extent).  That full path is then passed in `bufd` to the second function which of course also finds the same file.   The second function is thus unnecessary.
4. After the second function is called, `pyfile` and `funfile` are left with their original paths, thus there is no need to uppercase the extents as is done after the first function.
5. Furthermore, there is no need to resize the `bufd` buffer, because it is only used for the unnecessary second function.

Also, the `find_fun()` function should test the status returned by its call of `findfile_fun()`.   That meant wrapping a block of code in an `if()` statement and indenting the block.   (Unfortunately, GitHub displays the indented code block in a visually cluttered way.)

The problems mentioned above apparently are from PR #2293 (which affected 625 files).

This PR simplifies the code and passes all the automated regression tests.

**_Note: Please scrutinize this PR closely.   In particular, look for any subtle side effects that would affect devices._**