### PR TITLE
Fix: delete references to deprecated data types

### DIFF
--- a/tdic/TdiShrExt.c
+++ b/tdic/TdiShrExt.c
@@ -803,32 +803,33 @@ static void bTest(struct descriptor *desc)
       break;
     case DTYPE_HC: /*      30              H_floating complex */
       break;
-    case DTYPE_CIT: /*      31              COBOL Intermediate Temporary */
-      break;
-    case DTYPE_VT: /*      37              varying character string;  16-bit
-                      count, followed by a string */
-      break;
-    case DTYPE_NU: /*      15              numeric string, unsigned */
-      break;
-    case DTYPE_NL: /*      16              numeric string, left separate sign */
-      break;
-    case DTYPE_NLO: /*      17              numeric string, left overpunched
-                       sign */
-      break;
-    case DTYPE_NR: /*      18              numeric string, right separate sign
-                    */
-      break;
-    case DTYPE_NRO: /*      19              numeric string, right overpunched
-                       sign */
-      break;
-    case DTYPE_NZ: /*      20              numeric string, zoned sign */
-      break;
-    case DTYPE_P: /*      21              packed decimal string */
-      break;
-    case DTYPE_V: /*      1               aligned bit string */
-      break;
-    case DTYPE_VU: /*      34              unaligned bit string */
-      break;
+    // These are deprecated data types, see dtypedef.h
+    // case DTYPE_CIT: /*      31              COBOL Intermediate Temporary */
+    //   break;
+    // case DTYPE_VT: /*      37              varying character string;  16-bit
+    //                   count, followed by a string */
+    //   break;
+    // case DTYPE_NU: /*      15              numeric string, unsigned */
+    //   break;
+    // case DTYPE_NL: /*      16              numeric string, left separate sign */
+    //   break;
+    // case DTYPE_NLO: /*      17              numeric string, left overpunched
+    //                    sign */
+    //   break;
+    // case DTYPE_NR: /*      18              numeric string, right separate sign
+    //                 */
+    //   break;
+    // case DTYPE_NRO: /*      19              numeric string, right overpunched
+    //                    sign */
+    //   break;
+    // case DTYPE_NZ: /*      20              numeric string, zoned sign */
+    //   break;
+    // case DTYPE_P: /*      21              packed decimal string */
+    //   break;
+    // case DTYPE_V: /*      1               aligned bit string */
+    //   break;
+    // case DTYPE_VU: /*      34              unaligned bit string */
+    //  break;
     case DTYPE_FS: /*      52              IEEE float basic single S */
       pntF = (float *)desc->pointer;
       for (i = 0; i++ < num;)

--- a/tdic/TdiShrExt.c
+++ b/tdic/TdiShrExt.c
@@ -803,33 +803,6 @@ static void bTest(struct descriptor *desc)
       break;
     case DTYPE_HC: /*      30              H_floating complex */
       break;
-    // These are deprecated data types, see dtypedef.h
-    // case DTYPE_CIT: /*      31              COBOL Intermediate Temporary */
-    //   break;
-    // case DTYPE_VT: /*      37              varying character string;  16-bit
-    //                   count, followed by a string */
-    //   break;
-    // case DTYPE_NU: /*      15              numeric string, unsigned */
-    //   break;
-    // case DTYPE_NL: /*      16              numeric string, left separate sign */
-    //   break;
-    // case DTYPE_NLO: /*      17              numeric string, left overpunched
-    //                    sign */
-    //   break;
-    // case DTYPE_NR: /*      18              numeric string, right separate sign
-    //                 */
-    //   break;
-    // case DTYPE_NRO: /*      19              numeric string, right overpunched
-    //                    sign */
-    //   break;
-    // case DTYPE_NZ: /*      20              numeric string, zoned sign */
-    //   break;
-    // case DTYPE_P: /*      21              packed decimal string */
-    //   break;
-    // case DTYPE_V: /*      1               aligned bit string */
-    //   break;
-    // case DTYPE_VU: /*      34              unaligned bit string */
-    //  break;
     case DTYPE_FS: /*      52              IEEE float basic single S */
       pntF = (float *)desc->pointer;
       for (i = 0; i++ < num;)


### PR DESCRIPTION
MDSplus has several deprecated data types inherited from VAX VMS (including a COBOL data type).   These obsolete data types caused compilation errors when activated the debug print statements in the TdiShrExt.c file.

However, did not delete them because they are referenced in these other MDSplus source files: `DTYPE.java` and `dtypedef.h`.   Thus, just commented out the lines referencing the obsolete data types.

An alternative approach would have been to rename them (e.g., `CIT` becomes `CIT_deprectated` as per `dtypedef.h`).