### PR TITLE
Fix: Apple Silicon - add a define

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1225,6 +1225,13 @@ AH_VERBATIM([_WIN32], [
 #endif
 ])
 
+AH_VERBATIM([MACOS_ARM64],[
+// This define is used to bracket Apple Silicon specific code.
+#if defined(__APPLE__) && defined(__aarch64__)
+#define MACOS_ARM64
+#endif
+])
+
 dnl add here what goes on bottom of mdsconfig.h
 AH_BOTTOM(
 #endif // _MSC_VER else

--- a/include/mdsplus/mdsplus.h
+++ b/include/mdsplus/mdsplus.h
@@ -51,11 +51,6 @@
 #endif
 #endif
 
-// This define is used to bracket Apple Silicon specific code.
-// #if defined(__APPLE__) && defined(__aarch64__)
-// #define MACOS_ARM64
-// #endif
-
 #ifdef MDS_SHARED // defined if MDS is compiled as a shared library
 #define MDS_API_LOCAL MDS_API_HIDDEN
 #ifdef MDS_API_BUILD // defined if we are building the MDS library instead of  using it

--- a/include/mdsplus/mdsplus.h
+++ b/include/mdsplus/mdsplus.h
@@ -49,11 +49,12 @@
 #else
 #define MDS_ATTR_FALLTHROUGH
 #endif
+#endif
 
 // This define is used to bracket Apple Silicon specific code.
-#if defined(__APPLE__) && defined(__aarch64__)
-#define MACOS_ARM64
-#endif
+// #if defined(__APPLE__) && defined(__aarch64__)
+// #define MACOS_ARM64
+// #endif
 
 #ifdef MDS_SHARED // defined if MDS is compiled as a shared library
 #define MDS_API_LOCAL MDS_API_HIDDEN

--- a/include/mdsplus/mdsplus.h
+++ b/include/mdsplus/mdsplus.h
@@ -49,6 +49,10 @@
 #else
 #define MDS_ATTR_FALLTHROUGH
 #endif
+
+// This define is used to bracket Apple Silicon specific code.
+#if defined __APPLE__ && defined __aarch64__
+#define MACOS_ARM64
 #endif
 
 #ifdef MDS_SHARED // defined if MDS is compiled as a shared library

--- a/include/mdsplus/mdsplus.h
+++ b/include/mdsplus/mdsplus.h
@@ -51,7 +51,7 @@
 #endif
 
 // This define is used to bracket Apple Silicon specific code.
-#if defined __APPLE__ && defined __aarch64__
+#if defined(__APPLE__) && defined(__aarch64__)
 #define MACOS_ARM64
 #endif
 


### PR DESCRIPTION
The `MACOS_ARM64` define is used to isolate Apple Silicon specific code from all other platforms.   It is essential that this PR be merged before the rest of the Apple Silicon PRs.

In the `cmake` branch, this define was placed in the `mdsconfig.h.in` file.

When reviewing this PR, please decide if the name should be changed.   Note that Apple Silicon is based on the Arm Ltd. 64-bit architecture which Arm refers to as `aarch64`.   Some other possible names:
- MACOS_AARCH64
- APPLE_SILICON
- MACOS_M_CPUS

My preference is `MACOS_ARM64` to distinguish from the older MacOS (Intel) computers.

This PR is a partial fix for Issue #2597.