### PR TITLE
Feature: Enable optional args in python wrapper createPulse

### DIFF
--- a/python/MDSplus/tree.py
+++ b/python/MDSplus/tree.py
@@ -777,7 +777,7 @@ class Tree(object):
                     _TreeShr._TreeSetSubtree(self.ctx, nid))
         return TreeNode(nid.value, self)
 
-    def createPulse(self, shot, copy_only_this=0, node_or_nid=0):
+    def createPulse(self, shot, copy_only_this=False, node_or_nid=0):
         """Create pulse.
     
         @param shot: Shot number to create
@@ -789,10 +789,10 @@ class Tree(object):
         @rtype: None
         """
 
-        if isinstance(node_or_nid, type(self.getNode('\\TOP'))):
+        if isinstance(node_or_nid, TreeNode):
             node_or_nid = node_or_nid.getNid()  # Extract node ID
     
-        nid_pointer=_C.cast(_C.pointer(_C.c_int32(node_or_nid)),_C.c_void_p)
+        nid_pointer = _C.cast(_C.pointer(_C.c_int32(int(node_or_nid))),_C.c_void_p)
 
         _exc.checkStatus(
             _TreeShr._TreeCreatePulseFile(

--- a/python/MDSplus/tree.py
+++ b/python/MDSplus/tree.py
@@ -777,17 +777,31 @@ class Tree(object):
                     _TreeShr._TreeSetSubtree(self.ctx, nid))
         return TreeNode(nid.value, self)
 
-    def createPulse(self, shot):
+    def createPulse(self, shot, copy_only_this=0, node_or_nid=0):
         """Create pulse.
+    
         @param shot: Shot number to create
         @type shot: int
+        @param copy_only_this: Logical flag (0 or 1), defaults to 0
+        @type copy_only_this: int
+        @param node_or_nid: Either an integer (node ID) or a TreeNode object (defaults to 0)
+        @type node_or_nid: int or MDSplus.tree.TreeNode
         @rtype: None
         """
+
+        if isinstance(node_or_nid, type(self.getNode('\\TOP'))):
+            node_or_nid = node_or_nid.getNid()  # Extract node ID
+    
+        nid_pointer=_C.cast(_C.pointer(_C.c_int32(node_or_nid)),_C.c_void_p)
+
         _exc.checkStatus(
-            _TreeShr._TreeCreatePulseFile(self.ctx,
-                                          _C.c_int32(int(shot)),
-                                          _C.c_int32(0),
-                                          _C.c_void_p(0)))
+            _TreeShr._TreeCreatePulseFile(
+                self.ctx,
+                _C.c_int32(int(shot)),
+                _C.c_int32(int(copy_only_this)),
+                nid_pointer
+            )
+        )
 
     def deleteNode(self, wild):
         """Delete nodes (and all their descendants) from the tree. Note: If node is a member of a device,

--- a/python/MDSplus/tree.py
+++ b/python/MDSplus/tree.py
@@ -782,7 +782,7 @@ class Tree(object):
     
         @param shot: Shot number to create
         @type shot: int
-        @param copy_only_this: Logical flag (0 or 1), defaults to 0
+        @param copy_only_this: Logical flag, defaults to False
         @type copy_only_this: int
         @param node_or_nid: Either an integer (node ID) or a TreeNode object (defaults to 0)
         @type node_or_nid: int or MDSplus.tree.TreeNode


### PR DESCRIPTION
This commit enables passing optional arguments to…_TreeCreatePulseFile via python Tree wrapper method createPulse. In particular, it allows one to copy the top tree but not the subtree files. It's a bit related to issue #1326

**Context**:
* Certain data, like calibration shots, feed into version-controlled workflows and necessitate flexible data provenance (version control of the data stored in MDSplus). This data is outside of the normal pulse sequence collected from "normal" Tokamak experiments. 
* We do not use MDSplus native version control features.
* For the better or worse, we find it simple, robust and convenient to use dedicated pulse ranges to enable data provenance and security. A monotonically-increasing pulse number, within the designated pulse range, becomes equivalent to data version number. The file-system operations, such as permissions management, digital signature (md5sum), etc, further supplement this approach to data provencance and security.
* essentially, version number of the MDSplus-stored data = pulse number in the special reserved pulse range.
* copying an MDSplus tree from such a designated pulse range, with pulse==version, into the model -1 pulse becomes equivalent to "git checkout certain-version". Also, local copies of codes/workflows can use the pulse matching the version of the code/workflow rather than using data in -1 pulse.
* changing version of the code / workflow is accompanied by changing the model tree to match the workflow / code. This is done by copying the correct version(==pulse number) of the tree from a reserve pulse range into -1.

**Motivation for this commit**:
Given our approach to data provenance, we want to be able to copy files of the top tree without copying its subtrees. This is possible in MDSplus using TDI function TreeCreatePulseFile but the user-friendly python wrapper createPulse doesn't allow passing on the optional arguments.

More generally, a top tree and its subtree(s) in general have distinct user permissions. There are situations where the user is allowed to copy and overwrite the top tree but not its subtrees, reflecting the domain of responsibilities and competence of that user. 

**potential shortcomings of the commit**
* wanted to check if the 4th optional argument, node_or_nid, is of type "MDSplus.tree.TreeNode" but wasn't able to find the correct way to do it. So, as a work-around, I compare input argument to self.getNode('\\TOP') since I know the latter is of node type
* I allowed fourth input argument to be node id itself or a node object. Arguably this makes it more convenient. I did not allow it to be node path. These choices are subjective
* the third, optional, argument, "copy_only_this", is simply an integer 0 or 1. Arguably, a more user-friendly approach is to use kwargs** so that the user can specify "only_copy_this": True. However, in my opinion most users will not use these options anyways, and only "power" users or admins will use it. Hence I left it as is.

Thank you in advance for considering this pull request and for any feedback.
