### PR TITLE
Fix: Apple Silicon - defines for use with LibCallgFfi()

### DIFF
--- a/include/libroutines.h
+++ b/include/libroutines.h
@@ -16,6 +16,19 @@
 /// defined in MdsShr.so
 
 extern void *LibCallg();
+#ifdef MACOS_ARM64
+extern void *LibCallgFfi();
+#define NOT_VARIADIC 0
+#define VARIADIC_1_FIX_ARGS 1
+#define VARIADIC_2_FIX_ARGS 2
+#define VARIADIC_3_FIX_ARGS 3
+enum rtype_ffi { 
+    RTN_NONE = 0, 
+    RTN_POINTER = 1, 
+    RTN_INT32 = 2,
+    RTN_INT64 = 3
+};
+#endif
 extern int LibCreateVmZone(ZoneList **const zone);
 extern int LibDeleteVmZone(ZoneList **const zone);
 extern int LibResetVmZone(ZoneList **const zone);


### PR DESCRIPTION
The Apple Silicon port uses the `libffi` library for calling variadic functions from libraries.    These defines are only used for Apple Silicon and have no impact on Linux and Windows.   This PR must be merged before the remaining Apple Silicon PRs are submitted.

This is a partial fix for Issue #2597.