### PR TITLE
Fix: add missing va_end() statements

### DIFF
--- a/mdslib/MdsLib.c
+++ b/mdslib/MdsLib.c
@@ -135,6 +135,7 @@ extern EXPORT int descr(int *dtype, void *data, int *dim1, ...)
 
     va_start(incrmtr, dim1);
     dim = va_arg(incrmtr, int *);
+    va_end(incrmtr);
     if (*dim == 0)
     {
       GetDescriptorCache()[next] = malloc(sizeof(struct descriptor_a));
@@ -165,6 +166,7 @@ extern EXPORT int descr(int *dtype, void *data, int *dim1, ...)
       va_list incrmtr;
       va_start(incrmtr, dim1);
       dsc->length = *va_arg(incrmtr, int *);
+      va_end(incrmtr);
     }
     else
       dsc->length = dtype_length(
@@ -197,6 +199,7 @@ extern EXPORT int descr(int *dtype, void *data, int *dim1, ...)
     else
       dsc->length = dtype_length(
           dsc); /* must set length after dtype and data pointers are set */
+    va_end(incrmtr);
 
     if (ndim > 1)
     {
@@ -229,6 +232,7 @@ extern EXPORT int descr(int *dtype, void *data, int *dim1, ...)
         adsc->m[i] = *(va_arg(incrmtr, int *));
         totsize = totsize * adsc->m[i];
       }
+      va_end(incrmtr);
       for (i = ndim; i < MAX_DIMS; i++)
       {
         adsc->m[i] = 0;
@@ -288,6 +292,7 @@ EXPORT int descr2(int *dtype, int *dim1, ...)
 
     va_start(incrmtr, dim1);
     dim = va_arg(incrmtr, int *);
+    va_end(incrmtr);
     if (*dim == 0)
     {
       GetDescriptorCache()[next] = malloc(sizeof(struct descriptor_a));
@@ -319,6 +324,7 @@ EXPORT int descr2(int *dtype, int *dim1, ...)
       va_list incrmtr;
       va_start(incrmtr, dim1);
       dsc->length = *va_arg(incrmtr, int *);
+      va_end(incrmtr);
     }
     else
       dsc->length = dtype_length(
@@ -351,6 +357,7 @@ EXPORT int descr2(int *dtype, int *dim1, ...)
     else
       dsc->length = dtype_length(
           dsc); /* must set length after dtype and data pointers are set */
+    va_end(incrmtr);
 
     if (ndim > 1)
     {
@@ -382,6 +389,7 @@ EXPORT int descr2(int *dtype, int *dim1, ...)
         adsc->m[i] = *(va_arg(incrmtr, int *));
         totsize = totsize * adsc->m[i];
       }
+      va_end(incrmtr);
       for (i = ndim; i < MAX_DIMS; i++)
       {
         adsc->m[i] = 0;
@@ -678,14 +686,18 @@ EXPORT int MdsValueR(int *connection, char *expression, ...)
 {
   va_list incrmtr;
   va_start(incrmtr, expression);
-  return mds_value_vargs(incrmtr, *connection, expression);
+  int status = mds_value_vargs(incrmtr, *connection, expression); 
+  va_end(incrmtr);
+  return status;
 }
 
 EXPORT int MdsValue(char *expression, ...)
 {
   va_list incrmtr;
   va_start(incrmtr, expression);
-  return mds_value_vargs(incrmtr, MdsCONNECTION, expression);
+  int status = mds_value_vargs(incrmtr, MdsCONNECTION, expression);
+  va_end(incrmtr);
+  return status;
 }
 
 static inline int mds_value2_vargs(va_list incrmtr, int connection,
@@ -931,14 +943,18 @@ EXPORT int MdsValue2R(int *connection, char *expression, ...)
 {
   va_list incrmtr;
   va_start(incrmtr, expression);
-  return mds_value2_vargs(incrmtr, *connection, expression);
+  int status = mds_value2_vargs(incrmtr, *connection, expression);
+  va_end(incrmtr);
+  return status;
 }
 
 EXPORT int MdsValue2(char *expression, ...)
 {
   va_list incrmtr;
   va_start(incrmtr, expression);
-  return mds_value2_vargs(incrmtr, MdsCONNECTION, expression);
+  int status = mds_value2_vargs(incrmtr, MdsCONNECTION, expression);
+  va_end(incrmtr);
+  return status;
 }
 
 static inline int mds_put_vargs(va_list incrmtr, int connection, char *pathname,
@@ -1066,14 +1082,18 @@ EXPORT int MdsPutR(int *connection, char *node, char *expression, ...)
 {
   va_list incrmtr;
   va_start(incrmtr, expression);
-  return mds_put_vargs(incrmtr, *connection, node, expression);
+  int status = mds_put_vargs(incrmtr, *connection, node, expression);
+  va_end(incrmtr);
+  return status;
 }
 
 EXPORT int MdsPut(char *node, char *expression, ...)
 {
   va_list incrmtr;
   va_start(incrmtr, expression);
-  return mds_put_vargs(incrmtr, MdsCONNECTION, node, expression);
+  int status = mds_put_vargs(incrmtr, MdsCONNECTION, node, expression);
+  va_end(incrmtr);
+  return status;
 }
 
 static int mds_put2_vargs(va_list incrmtr, int connection, char *pathname,
@@ -1205,14 +1225,18 @@ EXPORT int MdsPut2R(int *connection, char *node, char *expression, ...)
 {
   va_list incrmtr;
   va_start(incrmtr, expression);
-  return mds_put2_vargs(incrmtr, *connection, node, expression);
+  int status = mds_put2_vargs(incrmtr, *connection, node, expression);
+  va_end(incrmtr);
+  return status;
 }
 
 EXPORT int MdsPut2(char *node, char *expression, ...)
 {
   va_list incrmtr;
   va_start(incrmtr, expression);
-  return mds_put2_vargs(incrmtr, MdsCONNECTION, node, expression);
+  int status = mds_put2_vargs(incrmtr, MdsCONNECTION, node, expression);
+  va_end(incrmtr);
+  return status;
 }
 
 static int dtype_length(struct descriptor *d)
@@ -1307,6 +1331,7 @@ extern EXPORT int *cdescr(int dtype, void *data, ...)
     dsc = va_arg(incrmtr, int);
     arglist[argidx++] = (void *)&dsc;
   }
+  va_end(incrmtr);
   arglist[argidx++] = MdsEND_ARG;
   *(int *)&arglist[0] = argidx - 1;
   status = (int)(intptr_t)LibCallg(arglist, descr);

--- a/mdsobjects/cpp/mdsdataobjects.cpp
+++ b/mdsobjects/cpp/mdsdataobjects.cpp
@@ -909,6 +909,7 @@ Data *MDSplus::compileWithArgs(const char *expr, Tree *tree, int nArgs...)
     Data *currArg = va_arg(v, Data *);
     args[i] = currArg->convertToDsc();
   }
+  va_end(v);
   int status;
   Data *res = (Data *)compileFromExprWithArgs(
       expr, nArgs, (void *)args, tree, (tree) ? tree->getCtx() : NULL, &status);
@@ -953,6 +954,7 @@ Data *MDSplus::executeWithArgs(const char *expr, int nArgs...)
     Data *currArg = va_arg(v, Data *);
     args[i] = currArg->convertToDsc();
   }
+  va_end(v);
   int status;
   Tree *actTree = 0;
   try
@@ -1028,6 +1030,7 @@ Data *MDSplus::executeWithArgs(const char *expr, Tree *tree, int nArgs...)
     Data *currArg = va_arg(v, Data *);
     args[i] = currArg->convertToDsc();
   }
+  va_end(v);
   int status;
   Data *compData =
       (Data *)compileFromExprWithArgs((char *)expr, nArgs, (void *)args, tree,

--- a/mdsshr/MDSprintf.c
+++ b/mdsshr/MDSprintf.c
@@ -86,7 +86,9 @@ EXPORT int MDSprintf(const char *const fmt, ...)
   if (!MDSvprintf)
     return (0);
   va_start(ap, fmt); /* initialize "ap"              */
-  return ((*MDSvprintf)(fmt, ap));
+  int status = ((*MDSvprintf)(fmt, ap));
+  va_end(ap);
+  return status;
 }
 
 /******************************************************************
@@ -95,13 +97,21 @@ EXPORT int MDSprintf(const char *const fmt, ...)
 int MDSfprintf(FILE *const fp, const char *const fmt, ...)
 {
   va_list ap;
+  int status;
 
   va_start(ap, fmt); /* initialize "ap"              */
-  if (fp != stderr && fp != stdout)
-    return (vfprintf(fp, fmt, ap));
-  if (!MDSvfprintf)
+  if (fp != stderr && fp != stdout) {
+    status = (vfprintf(fp, fmt, ap));
+    va_end(ap);
+    return(status);
+  }
+  if (!MDSvfprintf) {
+    va_end(ap);
     return (0);
-  return ((*MDSvfprintf)(fp, fmt, ap));
+  }
+  status = ((*MDSvfprintf)(fp, fmt, ap));
+  va_end(ap);
+  return status;
 }
 
 /***************************************************************

--- a/mdsshr/mdsmsg.c
+++ b/mdsshr/mdsmsg.c
@@ -132,6 +132,7 @@ EXPORT int MdsMsg(        /* Return: sts provided by user         */
   {
     va_start(ap, fmt); /* initialize "ap"                      */
     vsprintf(MDS_MDSMSG_CSTR, fmt, ap);
+    va_end(ap);
     if (sts)
     {
       MDSfprintf(stderr, "%s\n\r    sts=%s\n\n\r", MDS_MDSMSG_CSTR,

--- a/roam/roam_gridmap_callout.c
+++ b/roam/roam_gridmap_callout.c
@@ -109,6 +109,7 @@ EXPORT globus_result_t roam_gridmap_callout(va_list ap)
   int rc;
   int initiator;
 
+  // Note that the Globus calling routine apparently does the va_start(ap) and the va_end(ap)
   context = va_arg(ap, gss_ctx_id_t);
   service = va_arg(ap, char *);
   desired_identity = va_arg(ap, char *);

--- a/servershr/ServerSendMessage.c
+++ b/servershr/ServerSendMessage.c
@@ -197,6 +197,7 @@ int ServerSendMessage(int *msgid, char *server, int op, int *retstatus,
       MDSWRN("unexpected dtype = %d", arg->dtype);
     }
   }
+  va_end(vlist);
   *ccmd++ = ')';
   status = SendArg(conid, 0, DTYPE_CSTRING, 1, (short)(ccmd - cmd), 0, 0, cmd);
   if (STATUS_NOT_OK)

--- a/tdic/TdiShrExt.c
+++ b/tdic/TdiShrExt.c
@@ -356,6 +356,7 @@ EXPORT struct descriptor_xd *rMdsValue(struct descriptor *expression, ...)
     printf("Vararg [%d] for [0x%" PRIxPTR "]\n", nargs, (uintptr_t)tdiarg);
 #endif
   }
+  va_end(incrmtr);
   /* note minimum 1 arg I/P and 1 arg O/P */
   if (expression == NULL || nargs < 1)
   {


### PR DESCRIPTION
Variadic functions use the `va_start()`, `va_arg()` and `va_end()` macros to process the list of arguments.   Although the `gcc` compiler does nothing for `va_end()`, nonetheless the standard is to always call `va_end()`.   Doing so, makes it possible to port the code to other architectures / compilers that actually do emit code for `va_end()`.

Presently, about 50% of the MDSplus source code uses `va_end()`.

This PR supplies the missing `va_end()` calls so that all the source code conforms to the standard.

For more details refer to this `gcc` documentation:
[gcc arg macros](https://www.gnu.org/software/libc/manual/html_node/Argument-Macros.html)