### PR TITLE
Fix: Apple Silicon -- traverser now calls TDI functions directly

### DIFF
--- a/xmdsshr/XmdsExpr.c
+++ b/xmdsshr/XmdsExpr.c
@@ -372,7 +372,7 @@ EXPORT struct descriptor *XmdsExprGetXd(Widget w)
       TreeGetDefaultNid(&old_def);
       TreeSetDefaultNid(def_nid);
     }
-    status = TdiCompile(&text_dsc, ans MDS_END_ARG);
+    status = TdiCompile((mdsdsc_t *)&text_dsc, ans MDS_END_ARG);
     if ((STATUS_OK) == 0)
     {
       TdiComplain(w);
@@ -755,7 +755,7 @@ static void LoadExpr(XmdsExprWidget w, struct descriptor *dsc)
         TreeGetDefaultNid(&old_def);
         TreeSetDefaultNid(def_nid);
       }
-      status = TdiDecompile(xd, &text MDS_END_ARG);
+      status = TdiDecompile((mdsdsc_t *)xd, &text MDS_END_ARG);
       w->expr.is_text = 0;
       if (STATUS_OK)
       {

--- a/xmdsshr/XmdsExpr.c
+++ b/xmdsshr/XmdsExpr.c
@@ -372,7 +372,7 @@ EXPORT struct descriptor *XmdsExprGetXd(Widget w)
       TreeGetDefaultNid(&old_def);
       TreeSetDefaultNid(def_nid);
     }
-    status = TdiCompile(&text_dsc, ans MDS_END_ARG);  // calling directly avoids segfault on Apple Silicon
+    status = TdiCompile(&text_dsc, ans MDS_END_ARG);
     if ((STATUS_OK) == 0)
     {
       TdiComplain(w);
@@ -755,7 +755,7 @@ static void LoadExpr(XmdsExprWidget w, struct descriptor *dsc)
         TreeGetDefaultNid(&old_def);
         TreeSetDefaultNid(def_nid);
       }
-      status = TdiDecompile(xd, &text MDS_END_ARG);  // calling directly avoids segfault on Apple Silicon
+      status = TdiDecompile(xd, &text MDS_END_ARG);
       w->expr.is_text = 0;
       if (STATUS_OK)
       {

--- a/xmdsshr/XmdsExpr.c
+++ b/xmdsshr/XmdsExpr.c
@@ -372,7 +372,7 @@ EXPORT struct descriptor *XmdsExprGetXd(Widget w)
       TreeGetDefaultNid(&old_def);
       TreeSetDefaultNid(def_nid);
     }
-    status = (*ew->expr.compile)(&text_dsc, ans MDS_END_ARG);
+    status = TdiCompile(&text_dsc, ans MDS_END_ARG);  // calling directly avoids segfault on Apple Silicon
     if ((STATUS_OK) == 0)
     {
       TdiComplain(w);
@@ -755,7 +755,7 @@ static void LoadExpr(XmdsExprWidget w, struct descriptor *dsc)
         TreeGetDefaultNid(&old_def);
         TreeSetDefaultNid(def_nid);
       }
-      status = (*w->expr.decompile)(xd, &text MDS_END_ARG);
+      status = TdiDecompile(xd, &text MDS_END_ARG);  // calling directly avoids segfault on Apple Silicon
       w->expr.is_text = 0;
       if (STATUS_OK)
       {


### PR DESCRIPTION
The `traverser` tool that is part of MDSplus is a Motif application that is used to examine trees.   (It is similar to `jTraverser` and `jTraverser2`.)   This PR eliminates a segfault that occurs when the `traverser` is run on Apple Silicon.   This change has no impact on Linux or Windows.

The issue is that `traverser` creates a function pointer to some TDI intrinsic functions that are variadic.   On Apple Silicon, the compiler gets confused so emits the wrong calling code, causing a segfault.   The remedy is to skip the function pointer and just directly call the TDI functions.

This is a partial fix for Issue #2597.