### PR TITLE
Fix: IDL tests now have correct paths

### DIFF
--- a/idl/mdsconnect.pro
+++ b/idl/mdsconnect.pro
@@ -6,7 +6,7 @@ endcase
 end
 
 function sockmin
-  if !version.os eq 'linux' then return, 0 else return, 11-(!version.os eq 'MacOS')
+  if ((!version.os eq 'linux') or (!version.os eq 'darwin')) then return, 0 else return, 11-(!version.os eq 'MacOS')
 end
 
 function mds$socket,quiet=quiet,status=status,socket=socket

--- a/idl/mdsconnect.pro
+++ b/idl/mdsconnect.pro
@@ -6,7 +6,7 @@ endcase
 end
 
 function sockmin
-  if ((!version.os eq 'linux') or (!version.os eq 'darwin')) then return, 0 else return, 11-(!version.os eq 'MacOS')
+  if !version.os eq 'linux' then return, 0 else return, 11-(!version.os eq 'MacOS')
 end
 
 function mds$socket,quiet=quiet,status=status,socket=socket

--- a/idl/testing/run_tests.py
+++ b/idl/testing/run_tests.py
@@ -109,7 +109,7 @@ parser.add_argument(
 
 parser.add_argument(
     '--relative-def',
-    default='\CMOD::TOP.ELECTRONS.ECE',
+    default='\\CMOD::TOP.ELECTRONS.ECE',
     help='An expression to change the default position in the tree'
 )
 
@@ -127,7 +127,7 @@ parser.add_argument(
 
 parser.add_argument(
     '--reset-def',
-    default='\CMOD::TOP',
+    default='\\CMOD::TOP',
     help='An expression to reset the default position to the top of the tree'
 )
 
@@ -152,7 +152,7 @@ parser.add_argument(
 
 parser.add_argument(
     '--wildcard-value',
-    default='\CMOD::TOP.DNB.MIT_CXRS:CPLD_START',
+    default='\\CMOD::TOP.DNB.MIT_CXRS:CPLD_START',
     help='The value of evaluating the --wildcard expression, ignoring leading/trailing whitespace'
 )
 
@@ -1565,11 +1565,11 @@ mdsopen, '{args.write_tree}', '{args.write_shot}'
 mdsput, 'A_TEXT', ' "string_a" '
 mdsput, 'B_NUM', '22'
 mdsput, 'C_SIGNAL', 'build_signal([10,-10,5,-5,0],[10.2,-10.2,5.4,-5.4,0.0], [0 .. 4])'
-mdsput, '\TOP.SUBTREE_1:D_TEXT', ' "string_d" '
+mdsput, '\\TOP.SUBTREE_1:D_TEXT', ' "string_d" '
 mdsput, 'SUBTREE_1.E_UNITS', 'build_with_units(55, "volts")'
 mdsset_def, 'SUBTREE_1'
 mdsput, '.-.SUBTREE_2:F_NUM', '66'
-mdsput, '\TAG_G', '77'
+mdsput, '\\TAG_G', '77'
 mdsclose, '{args.write_tree}', '{args.write_shot}'
          
 mdsopen, '{args.write_tree}', '{args.write_shot}'


### PR DESCRIPTION
The Python program that tests the MDSplus API for IDL references several nodes in trees.   Some of the node paths were missing `\\`, which was causing error messages to be displayed when the test was run.   This PR fixes those typos.

When the Jenkins build system is configured to automatically run the IDL tests, it might be necessary to revisit this PR.   (A vague recollection is that the output from running the test varied a bit depending on which MDSplus archive server was used.)