### PR TITLE
Fix: Apple Silicon -- add some of the code that uses `libffi`

### DIFF
--- a/javamds/mdsobjects.c
+++ b/javamds/mdsobjects.c
@@ -1441,7 +1441,11 @@ JNIEXPORT jobject JNICALL Java_MDSplus_Data_compile(JNIEnv *env,
   arglist[varIdx++] = &outXd;
   arglist[varIdx++] = MdsEND_ARG;
   *(int *)&arglist[0] = varIdx - 1;
+#ifdef MACOS_ARM64
+  status = (int)(intptr_t)LibCallgFfi(arglist, TdiCompile, VARIADIC_1_FIX_ARGS, RTN_INT32);
+#else
   status = (int)(intptr_t)LibCallg(arglist, TdiCompile);
+#endif
   (*env)->ReleaseStringUTFChars(env, jexpr, expr);
   for (i = 0; i < numArgs; i++)
     FreeDescrip(arglist[2 + i]);
@@ -1553,7 +1557,11 @@ JNIEXPORT jobject JNICALL Java_MDSplus_Data_execute(JNIEnv *env,
   arglist[varIdx++] = &outXd;
   arglist[varIdx++] = MdsEND_ARG;
   *(int *)&arglist[0] = varIdx - 1;
+#ifdef MACOS_ARM64
+  status = (int)(intptr_t)LibCallgFfi(arglist, TdiCompile, VARIADIC_1_FIX_ARGS, RTN_INT32);
+#else
   status = (int)(intptr_t)LibCallg(arglist, TdiCompile);
+#endif
   (*env)->ReleaseStringUTFChars(env, jexpr, expr);
   for (i = 0; i < numArgs; i++)
     FreeDescrip(arglist[2 + i]);
@@ -2235,7 +2243,11 @@ JNIEXPORT jobject JNICALL Java_MDSplus_Tree_compile(JNIEnv *env,
   arglist[varIdx++] = &outXd;
   arglist[varIdx++] = MdsEND_ARG;
   *(int *)&arglist[0] = varIdx - 1;
+#ifdef MACOS_ARM64
+  status = (int)(intptr_t)LibCallgFfi(arglist, _TdiCompile, VARIADIC_2_FIX_ARGS, RTN_INT32);
+#else
   status = (int)(intptr_t)LibCallg(arglist, _TdiCompile);
+#endif
   (*env)->ReleaseStringUTFChars(env, jexpr, expr);
   for (i = 0; i < numArgs; i++)
     FreeDescrip(arglist[3 + i]);
@@ -2291,7 +2303,11 @@ JNIEXPORT jobject JNICALL Java_MDSplus_Tree_execute(JNIEnv *env,
   arglist[varIdx++] = &outXd;
   arglist[varIdx++] = MdsEND_ARG;
   *(int *)&arglist[0] = varIdx - 1;
+#ifdef MACOS_ARM64
+  status = (int)(intptr_t)LibCallgFfi(arglist, _TdiExecute, VARIADIC_2_FIX_ARGS, RTN_INT32);
+#else
   status = (int)(intptr_t)LibCallg(arglist, _TdiExecute);
+#endif
   (*env)->ReleaseStringUTFChars(env, jexpr, expr);
   for (i = 0; i < numArgs; i++)
     FreeDescrip(arglist[3 + i]);
@@ -2331,7 +2347,11 @@ JNIEXPORT jobject JNICALL Java_MDSplus_Tree_data(JNIEnv *env,
   arglist[3] = &outXd;
   arglist[4] = MdsEND_ARG;
   *(int *)&arglist[0] = 4;
+#ifdef MACOS_ARM64
+  status = (int)(intptr_t)LibCallgFfi(arglist, _TdiData, VARIADIC_2_FIX_ARGS, RTN_INT32);
+#else
   status = (int)(intptr_t)LibCallg(arglist, _TdiData);
+#endif
   FreeDescrip(arglist[2]);
   if (STATUS_NOT_OK)
   {
@@ -2370,7 +2390,11 @@ JNIEXPORT jobject JNICALL Java_MDSplus_Tree_evaluate(JNIEnv *env,
   arglist[3] = &outXd;
   arglist[4] = MdsEND_ARG;
   *(int *)&arglist[0] = 4;
+#ifdef MACOS_ARM64
+  status = (int)(intptr_t)LibCallgFfi(arglist, _TdiEvaluate, VARIADIC_2_FIX_ARGS, RTN_INT32);
+#else
   status = (int)(intptr_t)LibCallg(arglist, _TdiEvaluate);
+#endif
   FreeDescrip(arglist[2]);
   if (STATUS_NOT_OK)
   {

--- a/mdslib/MdsLib.c
+++ b/mdslib/MdsLib.c
@@ -30,6 +30,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <mdsshr.h>
 #include <stdint.h>
 #include <strroutines.h>
+#include <libroutines.h>
 static int MdsCONNECTION = -1;
 #define NDESCRIP_CACHE 1024
 #ifndef _CLIENT_ONLY
@@ -42,7 +43,6 @@ extern int TdiExecute(mdsdsc_t *, ...);
 extern int TdiCompile(mdsdsc_t *, ...);
 extern int TdiData(mdsdsc_t *, ...);
 extern int TdiCvt(mdsdsc_t *, ...);
-extern void *LibCallg();
 extern int TreeFindNode();
 extern int TreePutRecord();
 extern int TreeWait();

--- a/mdslib/MdsLib.c
+++ b/mdslib/MdsLib.c
@@ -640,7 +640,11 @@ static inline int mds_value_vargs(va_list incrmtr, int connection,
     arglist[argidx++] = (void *)&xd1;
     arglist[argidx++] = MdsEND_ARG;
     *(int *)&arglist[0] = argidx - 1;
+#ifdef MACOS_ARM64
+    status = (int)(intptr_t)LibCallgFfi(arglist, TdiExecute, VARIADIC_1_FIX_ARGS, RTN_INT32);
+#else
     status = (int)(intptr_t)LibCallg(arglist, TdiExecute);
+#endif
 
     if (STATUS_OK)
     {
@@ -898,7 +902,11 @@ static inline int mds_value2_vargs(va_list incrmtr, int connection,
     arglist[argidx++] = (void *)&xd1;
     arglist[argidx++] = MdsEND_ARG;
     *(int *)&arglist[0] = argidx - 1;
+#ifdef MACOS_ARM64
+    status = (int)(intptr_t)LibCallgFfi(arglist, TdiExecute, VARIADIC_1_FIX_ARGS, RTN_INT32);
+#else
     status = (int)(intptr_t)LibCallg(arglist, TdiExecute);
+#endif
 
     if (STATUS_OK)
     {
@@ -1062,7 +1070,11 @@ static inline int mds_put_vargs(va_list incrmtr, int connection, char *pathname,
       arglist[argidx++] = MdsEND_ARG;
       *(int *)&arglist[0] = argidx - 1;
 
+#ifdef MACOS_ARM64
+      status = (int)(intptr_t)LibCallgFfi(arglist, TdiCompile, VARIADIC_1_FIX_ARGS, RTN_INT32);
+#else
       status = (int)(intptr_t)LibCallg(arglist, TdiCompile);
+#endif
 
       if (STATUS_OK)
       {
@@ -1205,7 +1217,11 @@ static int mds_put2_vargs(va_list incrmtr, int connection, char *pathname,
       arglist[argidx++] = MdsEND_ARG;
       *(int *)&arglist[0] = argidx - 1;
 
+#ifdef MACOS_ARM64
+      status = (int)(intptr_t)LibCallgFfi(arglist, TdiCompile, VARIADIC_1_FIX_ARGS, RTN_INT32);
+#else
       status = (int)(intptr_t)LibCallg(arglist, TdiCompile);
+#endif
 
       if (STATUS_OK)
       {
@@ -1334,7 +1350,11 @@ extern EXPORT int *cdescr(int dtype, void *data, ...)
   va_end(incrmtr);
   arglist[argidx++] = MdsEND_ARG;
   *(int *)&arglist[0] = argidx - 1;
+#ifdef MACOS_ARM64
+  status = (int)(intptr_t)LibCallgFfi(arglist, descr, VARIADIC_3_FIX_ARGS, RTN_INT32);
+#else
   status = (int)(intptr_t)LibCallg(arglist, descr);
+#endif
   return (&status);
 }
 #endif

--- a/mdslibidl/MdsLibIdl.c
+++ b/mdslibidl/MdsLibIdl.c
@@ -380,7 +380,11 @@ EXPORT int IdlMdsValue(int argc, void **argv)
   arglist[argidx++] = (void *)&tmp;
   arglist[argidx++] = MdsEND_ARG;
   *(long *)&arglist[0] = argidx;
+#ifdef MACOS_ARM64
+  status = (int)(intptr_t)LibCallgFfi(arglist, TdiExecute, VARIADIC_1_FIX_ARGS, RTN_INT32);
+#else
   status = (int)(intptr_t)LibCallg(arglist, TdiExecute);
+#endif
   if (STATUS_OK)
   {
     status = TdiData(tmp.pointer, &mdsValueAnswer MDS_END_ARG);
@@ -626,7 +630,11 @@ EXPORT int IdlMdsPut(int argc, void **argv)
     arglist[argidx++] = (void *)&tmp;
     arglist[argidx++] = MdsEND_ARG;
     *(int *)&arglist[0] = argidx;
+#ifdef MACOS_ARM64
+    status = (int)(intptr_t)LibCallgFfi(arglist, TdiCompile, VARIADIC_1_FIX_ARGS, RTN_INT32);
+#else
     status = (int)(intptr_t)LibCallg(arglist, TdiCompile);
+#endif
     if (STATUS_OK)
     {
       status = TreePutRecord(nid, (struct descriptor *)&tmp, 0);

--- a/mdsobjects/cpp/mdsdata.c
+++ b/mdsobjects/cpp/mdsdata.c
@@ -497,11 +497,19 @@ void *compileFromExprWithArgs(char *expr, int nArgs, void **args, void *tree,
 
   if (ctx)
   {
+#ifdef MACOS_ARM64
+    status = *retStatus = (int)(intptr_t)LibCallgFfi(arglist, _TdiCompile, VARIADIC_2_FIX_ARGS, RTN_INT32);
+#else
     status = *retStatus = (int)(intptr_t)LibCallg(arglist, _TdiCompile);
+#endif
   }
   else
   {
+#ifdef MACOS_ARM64
+    status = *retStatus = (int)(intptr_t)LibCallgFfi(arglist, TdiCompile, VARIADIC_1_FIX_ARGS, RTN_INT32);
+#else
     status = *retStatus = (int)(intptr_t)LibCallg(arglist, TdiCompile);
+#endif
   }
   if (STATUS_NOT_OK)
     return NULL;

--- a/mdsobjects/cpp/mdsobjects.c
+++ b/mdsobjects/cpp/mdsobjects.c
@@ -987,7 +987,11 @@ JNIEXPORT jobject JNICALL Java_mdsdata_Data_compileWithArgs(
   arglist[varIdx++] = (struct descriptor *)&outXd;
   arglist[varIdx++] = MdsEND_ARG;
   *(int *)&arglist[0] = varIdx - 1;
+#ifdef MACOS_ARM64
+  LibCallgFffi(arglist, TdiCompile, VARIADIC_1_FIX_ARGS, RTN_INT32);
+#else
   LibCallg(arglist, TdiCompile);
+#endif
   for (i = 0; i < argLen; i++)
     freeDescrip(arglist[2 + i]);
   (*env)->ReleaseStringUTFChars(env, jexpr, expr);

--- a/mitdevices/t4012.c
+++ b/mitdevices/t4012.c
@@ -418,6 +418,7 @@ static int ReadChannel(InStoreStruct * setup, int chunk, int samples, unsigned s
   return status;
 }
 
+// Usually called without a function, but once is called with TdiData().
 static int AccessTraq(InStoreStruct * setup, int data, int memsize, void *arglist,
 		      int (*routine) (struct descriptor *,...))
 {
@@ -434,7 +435,12 @@ static int AccessTraq(InStoreStruct * setup, int data, int memsize, void *arglis
   for (try = 0; (try < 30) && (!(CamQ(0) & 1)) && (STATUS_OK); try++) {
     if (arglist && !called) {
       called = 1;
+#ifdef MACOS_ARM64
+      // Only called with TdiData() which is an intrinsic thus RTN_INT32
+      LibCallgFfi(arglist, routine, VARIADIC_1_FIX_ARGS, RTN_INT32);
+#else
       LibCallg(arglist, routine);
+#endif
     } else
       DevWait((float).001);
     piomem(17, 0, &data, memsize);
@@ -442,7 +448,11 @@ static int AccessTraq(InStoreStruct * setup, int data, int memsize, void *arglis
   if (try == 30)
     status = DEV$_CAM_NOSQ;
   if (arglist && !called)
+#ifdef MACOS_ARM64
+    LibCallgFfi(arglist, routine, VARIADIC_1_FIX_ARGS, RTN_INT32);
+#else
     LibCallg(arglist, routine);
+#endif
   return status;
 }
 

--- a/tdishr/TdiDoTask.c
+++ b/tdishr/TdiDoTask.c
@@ -96,7 +96,11 @@ static int Doit(struct descriptor_routine *ptask,
     status = TdiData(pmethod->method, &method_d MDS_END_ARG);
     if (STATUS_OK)
       status = TdiGetNid(pmethod->object, &nid);
+#ifdef MACOS_ARM64
+    status = (int)(intptr_t)LibCallgFfi(arglist, TreeDoMethod, VARIADIC_2_FIX_ARGS, RTN_INT32);
+#else
     status = (int)(intptr_t)LibCallg(arglist, TreeDoMethod);
+#endif
     FREED_NOW(&method_d);
     status = TdiPutLong(&status, out_ptr);
     break;

--- a/tdishr/TdiExtPython.c
+++ b/tdishr/TdiExtPython.c
@@ -90,7 +90,11 @@ static int (*PyCallable_Check)() = NULL;
 static void (*PyErr_Clear)() = NULL;
 static PyObject *(*PyImport_AddModule)() = NULL;
 static PyObject *(*PyModule_AddObject)() = NULL;
+#ifdef MACOS_ARM64
+static PyObject *(*PyObject_CallFunctionObjArgs)(void *, ...) = NULL;
+#else
 static PyObject *(*PyObject_CallFunctionObjArgs)() = NULL;
+#endif
 static PyObject *(*PyString_FromString)() = NULL;
 // callPyFunction
 static PyObject *_Py_NoneStruct = NULL;
@@ -101,7 +105,11 @@ static int (*PyObject_IsSubclass)() = NULL;
 static void *(*PyLong_AsVoidPtr)() = NULL;
 static PyObject *(*PyObject_GetAttrString)() = NULL;
 // args_to_tuple
+#ifdef MACOS_ARM64
+static PyObject *(*PyObject_CallFunction)(void *, void *, ...) = NULL;
+#else
 static PyObject *(*PyObject_CallFunction)() = NULL;
+#endif
 static PyObject *(*PyTuple_New)() = NULL;
 static void (*PyTuple_SetItem)() = NULL;
 #ifdef USE_EXECFILE

--- a/tdishr/TdiExtPython.c
+++ b/tdishr/TdiExtPython.c
@@ -137,7 +137,11 @@ inline static void initialize()
     _putenv_s("PyLib", envsym);
 #else
     envsym = "python2.7";
+#ifdef MACOS_ARM64
+    const char *aspath = "/opt/local/lib/libpython2.7.dylib";   // (MW) TODO: for MacPorts version
+#else 
     const char *aspath = "/usr/lib/python2.7.so.1";
+#endif
     setenv("PyLib", envsym, B_FALSE);
 #endif
     fprintf(stderr,
@@ -177,9 +181,15 @@ inline static void initialize()
     }
     else
     {
+    #ifdef MACOS_ARM64
+      lib = strcpy((char *)malloc(strlen(envsym) + 10), "lib");
+      strcat(lib, envsym);
+      strcat(lib, ".dylib");
+    #else
       lib = strcpy((char *)malloc(strlen(envsym) + 7), "lib");
       strcat(lib, envsym);
       strcat(lib, ".so");
+    #endif
     }
 #endif
     handle = dlopen(lib, RTLD_NOW | RTLD_GLOBAL);

--- a/treeshr/TreeDoMethod.c
+++ b/treeshr/TreeDoMethod.c
@@ -171,6 +171,10 @@ int _TreeDoMethodA(void *dbid, mdsdsc_t *nid_dsc, mdsdsc_t *method_ptr,
       status = TdiINVDTYDSC;
       goto end;
     }
+    // MACOS_ARM64:  If the device calls a variadic function, then the call
+    // to _LibCallg() will segfault on Apple Silicon.   However, it is unlikely
+    // that Apple Silicon will be used for data acquistion servers (which are
+    // typically Linux).  Thus leaving this "as is" until bugs are reported.
     void (*addr)();
     status = LibFindImageSymbol(conglom_ptr->image, &method, &addr);
     if (STATUS_OK)


### PR DESCRIPTION
On Apple Silicon, the widely used `libffi` (aka Foreign Function Interface) library is used when calling variadic functions located in libraries.   This PR provides some of the associated code used by the Apple Silicon port of MDSplus.

This `libffi` code is not used by the MDSplus versions for Linux, Windows and MacOS (Intel).

This is a partial fix for Issue #2597.