### PR TITLE
Revert "Fix: Apple Silicon -- traverser now calls TDI functions directly (#2869)"

### DIFF
--- a/xmdsshr/XmdsExpr.c
+++ b/xmdsshr/XmdsExpr.c
@@ -372,7 +372,7 @@ EXPORT struct descriptor *XmdsExprGetXd(Widget w)
       TreeGetDefaultNid(&old_def);
       TreeSetDefaultNid(def_nid);
     }
-    status = TdiCompile((mdsdsc_t *)&text_dsc, ans MDS_END_ARG);
+    status = (*ew->expr.compile)(&text_dsc, ans MDS_END_ARG);
     if ((STATUS_OK) == 0)
     {
       TdiComplain(w);
@@ -755,7 +755,7 @@ static void LoadExpr(XmdsExprWidget w, struct descriptor *dsc)
         TreeGetDefaultNid(&old_def);
         TreeSetDefaultNid(def_nid);
       }
-      status = TdiDecompile((mdsdsc_t *)xd, &text MDS_END_ARG);
+      status = (*w->expr.decompile)(xd, &text MDS_END_ARG);
       w->expr.is_text = 0;
       if (STATUS_OK)
       {


### PR DESCRIPTION

This reverts commit fff60ae80593f19588894e65302b6ca92e744ad1.

The traverser will be fixed with a new PR that uses casts.