### PR TITLE
Fix: Apple Silicon - eliminate traverser segfault associated with TDI intrinsic functions

### DIFF
--- a/xmdsshr/XmdsExpr.c
+++ b/xmdsshr/XmdsExpr.c
@@ -372,7 +372,7 @@ EXPORT struct descriptor *XmdsExprGetXd(Widget w)
       TreeGetDefaultNid(&old_def);
       TreeSetDefaultNid(def_nid);
     }
-    status = (*ew->expr.compile)(&text_dsc, ans MDS_END_ARG);
+    status = ((int (*)(mdsdsc_t *, ...))(*ew->expr.compile))((mdsdsc_t *)&text_dsc, ans MDS_END_ARG);
     if ((STATUS_OK) == 0)
     {
       TdiComplain(w);
@@ -755,7 +755,7 @@ static void LoadExpr(XmdsExprWidget w, struct descriptor *dsc)
         TreeGetDefaultNid(&old_def);
         TreeSetDefaultNid(def_nid);
       }
-      status = (*w->expr.decompile)(xd, &text MDS_END_ARG);
+      status = ((int (*)(mdsdsc_t *, ...))(*w->expr.decompile))((mdsdsc_t *)xd, &text MDS_END_ARG);
       w->expr.is_text = 0;
       if (STATUS_OK)
       {


### PR DESCRIPTION

This replaces PR #2869, which was reverted by PR #2872.

On Apple Silicon, the `traverser` application segfaults because `TdiCompile()` and `TdiDecompile()` are called via function pointers.   The compiler gets confused by the function pointer and thus uses the wrong calling sequence.

The remedy is to cast the definition of the function pointer.

A related change is to cast the first parameter to `mdsdsc_t *`, which is a consequence of PR #2863 replacing `structure descriptor *` with `mdsdsc_t *`.

The changes in the PR should be A-OK for all platforms: Linux, Windows, MacOS (Intel) and MacOS (Apple Silicon).