### PR TITLE
Fix: in mdsconnect.pro,  add a test for darwin which is what IDL returns for MacOS

### DIFF
--- a/idl/mdsconnect.pro
+++ b/idl/mdsconnect.pro
@@ -6,7 +6,7 @@ endcase
 end
 
 function sockmin
-  if !version.os eq 'linux' then return, 0 else return, 11-(!version.os eq 'MacOS')
+  if ((!version.os eq 'linux') or (!version.os eq 'darwin')) then return, 0 else return, 11-(!version.os eq 'MacOS')
 end
 
 function mds$socket,quiet=quiet,status=status,socket=socket


### PR DESCRIPTION
For many years, IDL has been returning `darwin` as the value of the IDL system variable, `!version.os`.

For more details, refer to NV5's documentation on the `!VERSION` structure (towards the bottom of the following link).
[IDL System Variables](https://www.nv5geospatialsoftware.com/docs/IDL_Environment_System_V.html)

This PR is needed for IDL on MacOS (Intel) and MacOS (Apple Silicon).

This is a partial fix for Issue #2597.

Note that the reference to `'MacOS'` in the if statement is surely obsolete code.   It will be removed in a future PR.   Refer to Issues #2637 and #2875 for more details.