### PR TITLE
Fix: Apple Silicon - specify default for PyLib for MacOS

### DIFF
--- a/tdishr/TdiExtPython.c
+++ b/tdishr/TdiExtPython.c
@@ -129,7 +129,11 @@ inline static void initialize()
     _putenv_s("PyLib", envsym);
 #else
     envsym = "python2.7";
+#ifdef MACOS_ARM64
+    const char *aspath = "/opt/local/lib/libpython2.7.dylib";   // (MW) TODO: for MacPorts version
+#else 
     const char *aspath = "/usr/lib/python2.7.so.1";
+#endif
     setenv("PyLib", envsym, B_FALSE);
 #endif
     fprintf(stderr,
@@ -169,9 +173,15 @@ inline static void initialize()
     }
     else
     {
+    #ifdef MACOS_ARM64
+      lib = strcpy((char *)malloc(strlen(envsym) + 10), "lib");
+      strcat(lib, envsym);
+      strcat(lib, ".dylib");
+    #else
       lib = strcpy((char *)malloc(strlen(envsym) + 7), "lib");
       strcat(lib, envsym);
       strcat(lib, ".so");
+    #endif
     }
 #endif
     handle = dlopen(lib, RTLD_NOW | RTLD_GLOBAL);


### PR DESCRIPTION
On 14-Mar-2017, commit `433cb19` added hardcoded default paths to be used if the user forgets to set the `PyLib` environment variable.

This PR, updates the hardcoded path used by MacOS (both Apple Silicon and Intel).

Note that portions of MDSplus require Python 2.7 and a compatible Numpy to be installed.   This is problematic on Apple Silicon because Apple now ships Python 3.x with MacOS (pretty sure Apple no longer ships Python 2.7).   Thus one must use package managers, such as Brew or MacPorts, to install the older Python and Numpy.   The location of the Python library therefore depends on which package manager is installed.

This PR uses the path for Python 2.7 installed by MacPorts.

There are two strategies for dealing with the hardcoded paths:

1. Revise this PR to include a new default path mechanism if the PyLib environment variable is missing.
2. Or approve this PR "as is", get the rest of the Apple Silicon port checked-in, and revise the paths when configuring the Jenkins build system to generate Apple Silicon releases of MDSplus.