### PR TITLE
Fix: errors with asan and tsan

### DIFF
--- a/mdstcpip/io_routines/IoRoutinesThread.c
+++ b/mdstcpip/io_routines/IoRoutinesThread.c
@@ -36,17 +36,16 @@ static int io_disconnect(Connection *c)
   io_pipes_t *p = get_pipes(c);
   if (p && p->pth != PARENT_THREAD)
   {
-#ifdef _WIN32
     close_pipe(p->in);
     close_pipe(p->out);
+
+#ifdef _WIN32
     if (WaitForSingleObject(p->pid, 100) == WAIT_TIMEOUT)
       TerminateThread(p->pid, 0);
     CloseHandle(p->pid);
 #else
     pthread_cancel(p->pth);
     pthread_join(p->pth, NULL);
-    close_pipe(p->in);
-    close_pipe(p->out);
 #endif
   }
   return C_OK;

--- a/treeshr/TreeOpen.c
+++ b/treeshr/TreeOpen.c
@@ -152,9 +152,10 @@ EXPORT char *TreePath(char const *tree, char *tree_lower_out)
 
 static char *ReplaceAliasTrees(char *tree_in)
 {
+  char * saveptr = NULL;
   size_t buflen = strlen(tree_in) + 1;
   char *ans = calloc(1, buflen);
-  char *tree = strtok(tree_in, ",");
+  char *tree = strtok_r(tree_in, ",", &saveptr);
   size_t i;
   while (tree)
   {
@@ -175,7 +176,7 @@ static char *ReplaceAliasTrees(char *tree_in)
       strcat(ans, tree);
     }
     free(treepath);
-    tree = strtok(0, ",");
+    tree = strtok_r(0, ",", &saveptr);
   }
   free(tree_in);
   for (i = 0; i < buflen; ++i)


### PR DESCRIPTION
Update `strtok` to `strtok_r` in `ReplaceAliasTrees` to prevent issues when multithreading. The internal `saveptr` was being clobbered, so this moves it into the function, and therefore safely in the thread.
Reorder the `io_disconnect` function for the thread backend. The cleanup of the last request/response messages were being interrupted by the `pthread_cancel`, which is fixed by moving the `pipe_close` calls above it, matching the windows implementation.