### PR TITLE
WIP: Apple Silicon -- possible changes to TdiExtFunction.c

### DIFF
--- a/tdishr/TdiExtFunction.c
+++ b/tdishr/TdiExtFunction.c
@@ -85,13 +85,17 @@ static void tmp_cleanup(void *tmp_in)
   for (; --tmp->n >= 0;)
     MdsFree1Dx(&tmp->a[tmp->n], NULL);
 }
+
+// TDI's EXT_FUNCTION is used to execute *.fun files, but doesn't execute functions in external libraries.
 int Tdi1ExtFunction(opcode_t opcode __attribute__((unused)), int narg,
                     struct descriptor *list[], struct descriptor_xd *out_ptr)
 {
   int status;
   struct descriptor_d image = EMPTY_D, entry = EMPTY_D;
+  struct descriptor_d new_entry = EMPTY_D;
   FREED_ON_EXIT(&image);
   FREED_ON_EXIT(&entry);
+  FREED_ON_EXIT(&new_entry);
   status = MDSplusSUCCESS;
   if (list[0])
     status = TdiData(list[0], &image MDS_END_ARG);
@@ -112,7 +116,26 @@ int Tdi1ExtFunction(opcode_t opcode __attribute__((unused)), int narg,
     goto done;
   }
 
-  status = TdiFindImageSymbol(&image, &entry, &routine);
+
+  // (MW) TODOD: Consider deprecating the rest of this routine on all platforms.
+  // The EXT_FUNCTION feature to call a function in a library was broken on Ubuntu x86-64
+  // well before the port to Apple Silicon.  Thus the Apple Silicon code added here also segfaults.
+  // Note that BUILD_CALL (aka ->) is used for most calls to external libraries.
+  // ALso, MAKE_CALL creates / executes an EXT_FUNCTION (presumably just for *.fun files).
+  if (STATUS_OK) {
+    char *c_entry = MdsDescrToCstring(&entry);
+    char *hash_ptr =strrchr(c_entry, '#');
+    if (hash_ptr == NULL) {
+      status = TdiFindImageSymbol(&image, &entry, &routine);
+    } else {
+      char *dup_entry = strdup(strtok(c_entry, "#"));
+      new_entry.length = strlen(dup_entry);
+      new_entry.pointer = dup_entry;
+      status = TdiFindImageSymbol(&image, &new_entry, &routine);
+      free(dup_entry);
+    }
+    free(c_entry);
+  }
   /**********************************************
   Requires: image found and routine symbol found.
   **********************************************/
@@ -181,9 +204,37 @@ int Tdi1ExtFunction(opcode_t opcode __attribute__((unused)), int narg,
        *************************/
     if (STATUS_OK)
     {
-      struct descriptor_s out = {sizeof(void *), DTYPE_POINTER, CLASS_S,
-                                 LibCallg(&new[0], routine)};
-      MdsCopyDxXd((struct descriptor *)&out, out_ptr);
+
+      char *dup = strdup(entry.pointer);  // The routine's name  
+      char *token = strtok(dup, "#");
+      token = strtok(NULL, "#");
+      int num_fixed_args = 0;
+      if (token != NULL) {
+        num_fixed_args = atoi(token);
+      }
+      free(dup);
+#ifndef MACOS_ARM64
+      num_fixed_args = 0;  // zero means no varags on this function
+#endif
+
+      // Depending on the external function being called, additional "case" clauses might be required.
+      // Use of TRUE is because case must start with a statement.
+      // Struct declaration can't be declared here because it would evaluate the LibCallg*() prematurely.
+      switch(num_fixed_args) {
+#ifdef MACOS_ARM64  
+      case 1:
+        TRUE;
+        // Is RTN_POINTER correct here?   Chose that because the descriptor is DTYPE_POINTER.
+        struct descriptor_s out1 = {sizeof(void *), DTYPE_POINTER, CLASS_S, LibCallgFfi(&new[0], (routine), VARIADIC_1_FIX_ARGS, RTN_POINTER)};
+        MdsCopyDxXd((struct descriptor *)&out1, out_ptr);
+        break;
+#endif
+      default:
+        TRUE;
+        struct descriptor_s out = {sizeof(void *), DTYPE_POINTER, CLASS_S, LibCallg(&new[0], (routine))}; 
+        MdsCopyDxXd((struct descriptor *)&out, out_ptr);
+        break;
+      }
     }
     pthread_cleanup_pop(1);
   }
@@ -192,5 +243,6 @@ int Tdi1ExtFunction(opcode_t opcode __attribute__((unused)), int narg,
 done:;
   FREED_NOW(&entry);
   FREED_NOW(&image);
+  FREED_NOW(&new_entry);
   return status;
 }

--- a/tdishr/TdiExtFunction.c
+++ b/tdishr/TdiExtFunction.c
@@ -204,9 +204,10 @@ int Tdi1ExtFunction(opcode_t opcode __attribute__((unused)), int narg,
        *************************/
     if (STATUS_OK)
     {
-      
-      char *entry_dup = strdup(entry.pointer);  // The routine's name
-      char *hash_ptr = strrchr(entry_dup, '#');
+
+#ifdef MDSPLUS_USE_FFI
+      char *c_entry = MdsDescrToCstring(&entry);
+      char *hash_ptr = strrchr(c_entry, '#');
       int bypass_ffi = TRUE;
       int num_fixed_args = 0;
       if (hash_ptr != NULL) {
@@ -216,8 +217,8 @@ int Tdi1ExtFunction(opcode_t opcode __attribute__((unused)), int narg,
       if (num_fixed_args != 0) {
         bypass_ffi = FALSE;
       }
-      free(entry_dup);      
-#ifndef MDSPLUS_USE_FFI
+      free(c_entry);      
+#else
       bypass_ffi = TRUE;  // for Linux, Windows, and MacOS(Intel)
 #endif
 

--- a/tdishr/TdiExtFunction.c
+++ b/tdishr/TdiExtFunction.c
@@ -204,19 +204,19 @@ int Tdi1ExtFunction(opcode_t opcode __attribute__((unused)), int narg,
        *************************/
     if (STATUS_OK)
     {
-
-      char *dup = strdup(entry.pointer);  // The routine's name
-      char *token = strtok(dup, "#");
-      token = strtok(NULL, "#");
+      
+      char *entry_dup = strdup(entry.pointer);  // The routine's name
+      char *hash_ptr = strrchr(entry_dup, '#');
       int bypass_ffi = TRUE;
       int num_fixed_args = 0;
-      if (token != NULL) {
-        num_fixed_args = atoi(token);
+      if (hash_ptr != NULL) {
+        hash_ptr++;
+        num_fixed_args = atoi(hash_ptr);
       }
       if (num_fixed_args != 0) {
         bypass_ffi = FALSE;
       }
-      free(dup);
+      free(entry_dup);      
 #ifndef MDSPLUS_USE_FFI
       bypass_ffi = TRUE;  // for Linux, Windows, and MacOS(Intel)
 #endif

--- a/tdishr/TdiExtFunction.c
+++ b/tdishr/TdiExtFunction.c
@@ -205,35 +205,47 @@ int Tdi1ExtFunction(opcode_t opcode __attribute__((unused)), int narg,
     if (STATUS_OK)
     {
 
-      char *dup = strdup(entry.pointer);  // The routine's name  
+      char *dup = strdup(entry.pointer);  // The routine's name
       char *token = strtok(dup, "#");
       token = strtok(NULL, "#");
-      int num_fixed_args = MDS_BYPASS_FFI;
+      int bypass_ffi = TRUE;
+      int num_fixed_args = 0;
       if (token != NULL) {
         num_fixed_args = atoi(token);
       }
+      if (num_fixed_args != 0) {
+        bypass_ffi = FALSE;
+      }
       free(dup);
 #ifndef MDSPLUS_USE_FFI
-      num_fixed_args = MDS_BYPASS_FFI;  // zero means no varags on this function
+      bypass_ffi = TRUE;  // for Linux, Windows, and MacOS(Intel)
 #endif
+
+      if (bypass_ffi) {
+        struct descriptor_s out = {sizeof(void *), DTYPE_POINTER, CLASS_S, LibCallg(&new[0], (routine))}; 
+        MdsCopyDxXd((struct descriptor *)&out, out_ptr);
 
       // Depending on the external function being called, additional "case" clauses might be required.
       // Use of TRUE is because case must start with a statement.
       // Struct declaration can't be declared here because it would evaluate the LibCallg*() prematurely.
-      switch(num_fixed_args) {
-#ifdef MDSPLUS_USE_FFI  
-      case 1:
-        TRUE;
-        // Is MDS_FFI_RTN_POINTER correct here?   Chose that because the descriptor is DTYPE_POINTER.
-        struct descriptor_s out1 = {sizeof(void *), DTYPE_POINTER, CLASS_S, LibCallgFfi(&new[0], (routine), 1, MDS_FFI_RTN_POINTER)};
-        MdsCopyDxXd((struct descriptor *)&out1, out_ptr);
-        break;
-#endif
-      default:
-        TRUE;
-        struct descriptor_s out = {sizeof(void *), DTYPE_POINTER, CLASS_S, LibCallg(&new[0], (routine))}; 
-        MdsCopyDxXd((struct descriptor *)&out, out_ptr);
-        break;
+      // (MW) TODO: If it is decided to implement this WIP, then this code needs to be refactored for clarity,
+      // and edge cases need to be handled.
+      } else {
+        switch(num_fixed_args) {
+  #ifdef MDSPLUS_USE_FFI  
+        case 1:
+          TRUE;
+          // Is MDS_FFI_RTN_POINTER correct here?   Chose that because the descriptor is DTYPE_POINTER.
+          struct descriptor_s out1 = {sizeof(void *), DTYPE_POINTER, CLASS_S, LibCallgFfi(&new[0], (routine), 1, MDS_FFI_RTN_POINTER)};
+          MdsCopyDxXd((struct descriptor *)&out1, out_ptr);
+          break;
+  #endif
+        default:
+          TRUE;
+          struct descriptor_s out = {sizeof(void *), DTYPE_POINTER, CLASS_S, LibCallg(&new[0], (routine))}; 
+          MdsCopyDxXd((struct descriptor *)&out, out_ptr);
+          break;
+        }
       }
     }
     pthread_cleanup_pop(1);

--- a/tdishr/TdiExtFunction.c
+++ b/tdishr/TdiExtFunction.c
@@ -219,7 +219,7 @@ int Tdi1ExtFunction(opcode_t opcode __attribute__((unused)), int narg,
       }
       free(c_entry);      
 #else
-      bypass_ffi = TRUE;  // for Linux, Windows, and MacOS(Intel)
+      int bypass_ffi = TRUE;  // for Linux, Windows, and MacOS(Intel)
 #endif
 
       if (bypass_ffi) {

--- a/tdishr/TdiExtFunction.c
+++ b/tdishr/TdiExtFunction.c
@@ -225,7 +225,7 @@ int Tdi1ExtFunction(opcode_t opcode __attribute__((unused)), int narg,
       case 1:
         TRUE;
         // Is RTN_POINTER correct here?   Chose that because the descriptor is DTYPE_POINTER.
-        struct descriptor_s out1 = {sizeof(void *), DTYPE_POINTER, CLASS_S, LibCallgFfi(&new[0], (routine), VARIADIC_1_FIX_ARGS, RTN_POINTER)};
+        struct descriptor_s out1 = {sizeof(void *), DTYPE_POINTER, CLASS_S, LibCallgFfi(&new[0], (routine), VA_1_FIXED_ARG, RTN_POINTER)};
         MdsCopyDxXd((struct descriptor *)&out1, out_ptr);
         break;
 #endif

--- a/tdishr/TdiExtFunction.c
+++ b/tdishr/TdiExtFunction.c
@@ -220,6 +220,7 @@ int Tdi1ExtFunction(opcode_t opcode __attribute__((unused)), int narg,
       free(c_entry);      
 #else
       int bypass_ffi = TRUE;  // for Linux, Windows, and MacOS(Intel)
+      int num_fixed_args = 0;
 #endif
 
       if (bypass_ffi) {

--- a/tdishr/TdiExtFunction.c
+++ b/tdishr/TdiExtFunction.c
@@ -208,24 +208,24 @@ int Tdi1ExtFunction(opcode_t opcode __attribute__((unused)), int narg,
       char *dup = strdup(entry.pointer);  // The routine's name  
       char *token = strtok(dup, "#");
       token = strtok(NULL, "#");
-      int num_fixed_args = 0;
+      int num_fixed_args = MDS_BYPASS_FFI;
       if (token != NULL) {
         num_fixed_args = atoi(token);
       }
       free(dup);
-#ifndef MACOS_ARM64
-      num_fixed_args = 0;  // zero means no varags on this function
+#ifndef MDSPLUS_USE_FFI
+      num_fixed_args = MDS_BYPASS_FFI;  // zero means no varags on this function
 #endif
 
       // Depending on the external function being called, additional "case" clauses might be required.
       // Use of TRUE is because case must start with a statement.
       // Struct declaration can't be declared here because it would evaluate the LibCallg*() prematurely.
       switch(num_fixed_args) {
-#ifdef MACOS_ARM64  
+#ifdef MDSPLUS_USE_FFI  
       case 1:
         TRUE;
-        // Is RTN_POINTER correct here?   Chose that because the descriptor is DTYPE_POINTER.
-        struct descriptor_s out1 = {sizeof(void *), DTYPE_POINTER, CLASS_S, LibCallgFfi(&new[0], (routine), VA_1_FIXED_ARG, RTN_POINTER)};
+        // Is MDS_FFI_RTN_POINTER correct here?   Chose that because the descriptor is DTYPE_POINTER.
+        struct descriptor_s out1 = {sizeof(void *), DTYPE_POINTER, CLASS_S, LibCallgFfi(&new[0], (routine), 1, MDS_FFI_RTN_POINTER)};
         MdsCopyDxXd((struct descriptor *)&out1, out_ptr);
         break;
 #endif


### PR DESCRIPTION
The MDSplus website claims that TDI's `EXT_FUNCTION()` has three modes of operation.   However, it appears that both the documentation and code are broken.   Thus it is questionable if this routine should be ported to Apple Silicon.

The three modes:
1) EXT_FUNCTION(,routine, ...) = this works and is used extensively by MDSplus to execute *.fun files.
2) EXT_FUNCTION(image, routine, ...) = duplicates `BUILD_CALL` (aka `->`), segfaults on Ubuntu22 x86-64
3) EXT_FUNCTION(tdi_fun_file, ...) = doesn't seem to work, but didn't test it extensively.
[EXT_FUNCTION page](https://www.mdsplus.org/index.php/Documentation:Reference:TDI_E2#ext_function)

Here are the options (listed in order of recommendation):
a) Leave "as is" = executes *.fun files A-OK
b) delete all code associate with 2).
c) fix all three modes and port to Apple Silicon = however 2) has probably been broken for years, so why fix it and duplicate what BUILD_CALL already does?

If we choose option c), then the libffi code would be something along the lines of the WIP draft.