### PR TITLE
Fix: remote_submit_helper.fun now accepts zero id and has a timeout

### DIFF
--- a/tdi/remote/MdsConnect.fun
+++ b/tdi/remote/MdsConnect.fun
@@ -13,6 +13,7 @@ call:	_host  = Host name eg elpp1.epfl.ch or elpp1.epfl.ch:9000
       write(*,"Host taken from MDS_HOST ["//_host//"]");
    }
    _status = TdiShrExt->rMdsConnect(ref(_host//char(0)));
-   if (present(_abort) && _status == 0) abort();
+   _invalid_id = -1
+   if (present(_abort) && _status == _invalid_id) abort();
    return(_status);
 }

--- a/tdi/remote/MdsConnect.fun
+++ b/tdi/remote/MdsConnect.fun
@@ -13,7 +13,7 @@ call:	_host  = Host name eg elpp1.epfl.ch or elpp1.epfl.ch:9000
       write(*,"Host taken from MDS_HOST ["//_host//"]");
    }
    _status = TdiShrExt->rMdsConnect(ref(_host//char(0)));
-   _invalid_id = -1
+   _invalid_id = -1;
    if (present(_abort) && _status == _invalid_id) abort();
    return(_status);
 }

--- a/tdi/remote/remote_submit_helper.fun
+++ b/tdi/remote/remote_submit_helper.fun
@@ -20,17 +20,25 @@ public fun remote_submit_helper(_host,_file,_shot)
   if (_host == "any")
   {
     _queues = remote_submit_queues();
-    _stat = 0;
-    while (_stat == 0)
+
+    _start = cvttime();
+    _elapsed = 0;
+    _max_seconds = 300;
+    _invalid_id = -1;
+
+    /* Note that mdsconnect() returns a connection id, not a status code */
+    _stat = _invalid_id;
+    while ((_stat == _invalid_id) AND (_elapsed < _max_seconds))
     {
       _host = _queues[long(random()*size(_queues))];
       write(*,"Trying ",_host);
       _stat = mdsconnect(_host);
+      _elapsed = cvttime() - _start;
     }
   }
   else
     _stat=mdsconnect(_host);
-  if (_stat > 0)
+  if (_stat > _invalid_id)
   {
     _stat=mdsvalue('tcl("spawn/nowait unix_submit '//_file//' '//_shot//'")');
   } else {


### PR DESCRIPTION
Fixes Issue #2887.

PR #2288 redefined `INVALID_CONNECTION_ID` to be `-1`, which means that `0` is a valid connection id.   Changed `remote_submit_helper.fun` accordingly.

Also added a timeout to the loop, so that it doesn't run forever and fill up the disk with a 128 GB log file.

The timeout value is 300 seconds (5 minutes) which is likely too generous.   (Experiments on a M2 MacBook Pro show that the loop executes ~100K iterations in ~5 seconds.)

Did not rename the `_stat` variable because the `return(_stat)` statement also can be the status value of the `mdsvalue()` statement at the bottom of the file.