### PR TITLE
Fix: LibCallg() now has similar edits to LibCallgFfi()

### DIFF
--- a/mdsshr/librtl.c
+++ b/mdsshr/librtl.c
@@ -168,9 +168,17 @@ EXPORT char *Now32(char *const buf)
 ///
 EXPORT void *LibCallg(void **const a, void *(*const routine)())
 {
-  if (!routine)
-    abort(); // intercept definite stack corruption
-  switch (*(int *)a & 0xff)
+  assert(routine);  // in DEBUG mode checks for stack corruption
+
+  // The "a" parameter is the arglist for the "routine" and contains the following:
+  // arglist[0]        = N (total number of args excluding first and last elements of vector)
+  // arglist[1]        = expression
+  // arglist[2 .. N-1] = variable args (pointer to descriptors)
+  // arglist[N]        = result xd1 descriptor
+  // arglist[N+1]      = NULL 
+  int num_args = *(int *)a & 0xff;
+
+  switch (num_args)
   {
   case 0:
     return routine();
@@ -281,8 +289,7 @@ EXPORT void *LibCallg(void **const a, void *(*const routine)())
                    a[19], a[20], a[21], a[22], a[23], a[24], a[25], a[26],
                    a[27], a[28], a[29], a[30], a[31], a[32]);
   default:
-    printf("Error - currently no more than 32 arguments supported on external "
-           "calls\n");
+    printf("Error - currently no more than %d arguments supported on external calls\n", LIBCALLG_MAX_ARGS);
   }
   return 0;
 }

--- a/mdsshr/librtl.c
+++ b/mdsshr/librtl.c
@@ -168,7 +168,9 @@ EXPORT char *Now32(char *const buf)
 ///
 EXPORT void *LibCallg(void **const a, void *(*const routine)())
 {
-  assert(routine);  // in DEBUG mode checks for stack corruption
+  if (!routine) {
+    abort(); // intercept definite stack corruption
+  }
 
   // The "a" parameter is the arglist for the "routine" and contains the following:
   // arglist[0]        = N (total number of args excluding first and last elements of vector)
@@ -302,7 +304,9 @@ EXPORT void *LibCallg(void **const a, void *(*const routine)())
 // If the external function does not fit that constraint, users will have to write a shim function.
 EXPORT void *LibCallgFfi(void **const a, void *(*const routine)(), int num_fixed_args, int rtype)
 {
-  assert(routine);  // in DEBUG mode checks for stack corruption
+  if (!routine) {
+    abort(); // intercept definite stack corruption
+  }
 
   // The "a" parameter is the arglist for the "routine" and contains the following:
   // arglist[0]        = N (total number of args excluding first and last elements of vector)


### PR DESCRIPTION
The original `LibCallg()` function has been updated with the same improvements that the reviewer requested on the new `LibCallgFfi()` function (which was added on PR #2877).