### PR TITLE
Fix: ensure SsINTERNAL not treated as OK status

### DIFF
--- a/mdstcpip/mdsipshr/ConnectToMds.c
+++ b/mdstcpip/mdsipshr/ConnectToMds.c
@@ -90,6 +90,10 @@ static int do_login(Connection *c)
   else
   {
     Message *mrecv = GetMdsMsgTOC(c, &status, 10000);
+    // SsINTERNAL has low order bit set so is erroneously treated as OK.
+    if (status == SsINTERNAL) {
+      status = MDSplusERROR;
+    }
     if (STATUS_NOT_OK)
     {
       perror("Error during login: recv");

--- a/mdstcpip/mdsipshr/Connections.c
+++ b/mdstcpip/mdsipshr/Connections.c
@@ -526,6 +526,10 @@ int AcceptConnection(char *protocol, char *info_name, SOCKET readfd, void *info,
     // SET INFO //
     ConnectionSetInfo(c, info_name, readfd, info, info_len);
     msg = GetMdsMsgTOC(c, &status, 10000);
+    // SsINTERNAL has low order bit set so is erroneously treated as OK.
+    if (status == SsINTERNAL) {
+      status = MDSplusERROR;
+    }
     if (!msg || STATUS_NOT_OK)
     {
       free(msg);

--- a/mdstcpip/mdsipshr/DoMessage.c
+++ b/mdstcpip/mdsipshr/DoMessage.c
@@ -43,6 +43,10 @@ int ConnectionDoMessage(Connection *connection)
   err = 1;
   int status = MDSplusFATAL;
   message = GetMdsMsgTOC(connection, &status, -1);
+  // SsINTERNAL has low order bit set so is erroneously treated as OK.
+  if (status == SsINTERNAL) {
+    status = MDSplusERROR;
+  }
   err = !(message && STATUS_OK && ProcessMessage(connection, message));
   FREE_IF(message, err);
   return !err;

--- a/mdstcpip/mdsipshr/GetAnswerInfo.c
+++ b/mdstcpip/mdsipshr/GetAnswerInfo.c
@@ -74,7 +74,10 @@ int GetAnswerInfoTO(int id, char *dtype, short *length, char *ndims, int *dims,
     CloseConnection(id);
     status = MDSplusERROR;
   }
-  if (status == SsINTERNAL) status = MDSplusERROR;
+  // SsINTERNAL has low order bit set so is erroneously treated as OK.
+  if (status == SsINTERNAL) {
+    status = MDSplusERROR;
+  }
   if (STATUS_NOT_OK)
   {
     free(m);

--- a/mdstcpip/mdsipshr/GetMdsMsg.c
+++ b/mdstcpip/mdsipshr/GetMdsMsg.c
@@ -155,6 +155,10 @@ Message *GetMdsMsgTO(int id, int *status, int to_msec)
     CloseConnection(id);
     *status = MDSplusERROR;
   }
+  // SsINTERNAL has low order bit set so is erroneously treated as OK.
+  if (*status == SsINTERNAL) {
+    *status = MDSplusERROR;
+  }
   return msg;
 }
 

--- a/mdstcpip/mdsipshr/SendArg.c
+++ b/mdstcpip/mdsipshr/SendArg.c
@@ -103,7 +103,10 @@ int SendArg(int id, unsigned char idx, char dtype, unsigned char nargs,
   m->h.message_id = (idx == 0 || nargs == 0) ? ConnectionIncMessageId(c)
                                              : c->message_id;
   int status = m->h.message_id ? SendMdsMsgC(c, m, 0) : MDSplusERROR;
-  if (status == SsINTERNAL) status = MDSplusERROR;
+  // SsINTERNAL has low order bit set so is erroneously treated as OK.
+  if (status == SsINTERNAL) {
+    status = MDSplusERROR;
+  }
   free(m);
   if (STATUS_NOT_OK)
     UnlockConnection(c);

--- a/tdishr/TdiEvaluate.c
+++ b/tdishr/TdiEvaluate.c
@@ -56,6 +56,7 @@ extern int TdiCall();
 extern int TdiImpose();
 extern int Tdi1Vector();
 
+// Can return non-MDSplus error code, SsINTERNAL
 EXPORT int Tdi1Evaluate(opcode_t opcode __attribute__((unused)),
                         int narg __attribute__((unused)),
                         struct descriptor *list[],


### PR DESCRIPTION
This is a partial fix for Issue #2741.  (There are other occurrences of `SsINTERNAL` in the source code that still need to be fixed.)

Note that `SsINTERNAL` is NOT an MDSplus error code.  Because `SsINTERNAL` has a value of `-1`, its low-order bit is set.   Therefore, if `SsINTERNAL` is passed to a macro that tests MDSplus error codes, the macro will erroneously treat `SsINTERNAL` as a flavor of "success".

The long-term fix is to eventually change `SsINTERNAL` to be `-2` or some other value that will be a valid MDSplus error code.   However, extensive cross-version testing will be needed before that switch can be made.