### PR TITLE
Fix: mdsip_server no longer uses broken compression level

### DIFF
--- a/mdstcpip/mdsip_server
+++ b/mdstcpip/mdsip_server
@@ -38,7 +38,7 @@ fi
 mkdir -p $2
 if (test "$4" = "")
 then
-  exec $MDSPLUS_DIR/bin/mdsip -s -p $1 -h ${3:-/etc/mdsip.hosts} -c 9 >> $2/access 2>> $2/errors
+  exec $MDSPLUS_DIR/bin/mdsip -s -p $1 -h ${3:-/etc/mdsip.hosts} -c 0 >> $2/access 2>> $2/errors
 else
-  /usr/sbin/chroot $4 $MDSPLUS_DIR/bin/mdsip -s -p $1 -h ${3:-/etc/mdsip.hosts} -c 9 >> $2/access 2>> $2/errors
+  /usr/sbin/chroot $4 $MDSPLUS_DIR/bin/mdsip -s -p $1 -h ${3:-/etc/mdsip.hosts} -c 0 >> $2/access 2>> $2/errors
 fi


### PR DESCRIPTION

The `mdsip_server` script was using compression level `-c 9`.   This level is broken; it does not work.   Consequently, when using the `File->Connect` menu of `jTraverser2`, the connection hangs.

Changing the level to no compression, `-c 0`, enables the connection to work properly.