### PR TITLE
Fix: delete extra arg to GetAnswerInfoTS()

### DIFF
--- a/servershr/ServerGetInfo.c
+++ b/servershr/ServerGetInfo.c
@@ -113,7 +113,7 @@ EXPORT char *ServerGetInfo(int full __attribute__((unused)), char *server_in)
         int numbytes;
         char *reply;
         if (IS_NOT_OK(GetAnswerInfoTS(
-                conid, &dtype, &len, &ndims, dims, &numbytes, &reply, &mem, 10)) ||
+                conid, &dtype, &len, &ndims, dims, &numbytes, &reply, &mem)) ||
             (dtype != DTYPE_CSTRING))
         {
           ans = "Invalid response from server";


### PR DESCRIPTION
The `ServerGetInfo.c` file has a call to `GetAnswerInfoTS()` that has an extra argument, namely nine total.  However, the declaration of `GetAnswerInfoTS()` in `GetAnswerInfo.c` only accepts eight arguments.

This PR removes the extra argument.

Note that an alternate solution likely would have been to switch to `GetAnswerInfoTO()` which does accept an additional ninth argument, namely `timeout_msec`.   However, because the existing code has used `GetAnswerInfoTS()` for years, this PR uses the more conservative option of using the existing function and dropping the unneeded argument.