### PR TITLE
Fix: correct miscellaneous typos, add comments, disable a debug

### DIFF
--- a/include/mds_stdarg.h
+++ b/include/mds_stdarg.h
@@ -39,9 +39,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  * arglist:	target array of pointers
  * nargs:	int value returns the total number of args
  * pre:		offset in the arglist, so you can prepend your own
- * post:	added to nargs, so you can append some, if 1, last arg will be
- * <end> anchor:	last fix argument just before ... end:
- * terminating value, e.g. NULL or MdsEND_ARG
+ * post:	added to nargs, so you can append some, if 1, last arg will be <end> 
+ * anchor:	last fix argument just before ... 
+ * end: terminating value, e.g. NULL or MdsEND_ARG
  */
 #define VA_LIST_TO_ARGLIST(arglist, nargs, pre, post, anchor, end)         \
   {                                                                        \

--- a/mdslib/MdsLib.c
+++ b/mdslib/MdsLib.c
@@ -458,8 +458,10 @@ static inline int mds_value_vargs(va_list incrmtr, int connection,
   static int clear = 0;
   static DESCRIPTOR_LONG(clear_d, &clear);
 #endif
+  // On entry, incrmtr points to the expression.  Save it so can scan the list of arguments later.
   va_copy(initial_incrmtr, incrmtr);
 
+  //loops: #0 = &status var above (ignored), #1 = &dsc arg, #2 = &dsc, etc, #<last> = null terminator.
   for (a_count = 0; *descnum != 0; a_count++)
   {
     descnum = va_arg(incrmtr, int *);
@@ -619,6 +621,7 @@ static inline int mds_value_vargs(va_list incrmtr, int connection,
   }
 #else
   {
+    // Also includes overhead arguments, thus function called receives MAXARGS - 4 actual args
     void *arglist[MAXARGS];
     struct descriptor *dsc;
     struct descriptor dexpression = {0, DTYPE_T, CLASS_S, 0};
@@ -629,6 +632,12 @@ static inline int mds_value_vargs(va_list incrmtr, int connection,
     int i;
     dexpression.length = strlen((char *)expression);
     dexpression.pointer = (char *)expression;
+    // Creates arglist vector as follows: 
+    // arglist[0]        = N (total number of args excluding first and last elements of vector)
+    // arglist[1]        = expression
+    // arglist[2 .. N-1] = variable args (pointer to descriptors)
+    // arglist[N]        = result xd1 descriptor
+    // arglist[N+1]      = NULL 
     arglist[argidx++] = (void *)&dexpression;
     va_copy(incrmtr, initial_incrmtr);
     for (i = 1; i < a_count; i++)

--- a/mdsshr/librtl.c
+++ b/mdsshr/librtl.c
@@ -2137,7 +2137,7 @@ static int find_file(const mdsdsc_t *const filespec, mdsdsc_t *const result,
     fspec[filespec->length] = '\0';
     *ctx = (void *)findfilestart(fspec, recursively, case_blind);
 #ifdef DEBUG
-    fprintf(stderr, "locking for %s: ", fspec);
+    fprintf(stderr, "looking for %s: ", fspec);
 #endif
     free(fspec);
     if (!*ctx)

--- a/mdstcpip/mdsipshr/MdsIpThreadStatic.c
+++ b/mdstcpip/mdsipshr/MdsIpThreadStatic.c
@@ -36,7 +36,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <_mdsversion.h>
 #include "mdsipthreadstatic.h"
 
-#define DEBUG
+// #define DEBUG
 #include <mdsmsg.h>
 
 static void buffer_free(MDSIPTHREADSTATIC_ARG)

--- a/tdishr/TdiDefFunction.c
+++ b/tdishr/TdiDefFunction.c
@@ -33,6 +33,11 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <mds_stdarg.h>
 #include <tdishr.h>
 
+// TDI Intrinsic functions have these parameters:
+//    first -- descriptor pointer for result, or NULL for no output
+//    [<args1> .. <argsN>] -- optional descriptor pointers for input arguments
+//    MdsEND_ARG (aka 1) -- denotes end of variable arguments
+
 #define COM
 #define OPC(name, NAME, ...)                                              \
   extern EXPORT int Tdi##name(mdsdsc_t *first, ...)                       \


### PR DESCRIPTION
Miscellaneous corrections to typos, add some comments, and comment out an unneeded `DEBUG` define.