### PR TITLE
Fix: mdsip compression

### DIFF
--- a/mdstcpip/mdsipshr/GetMdsMsg.c
+++ b/mdstcpip/mdsipshr/GetMdsMsg.c
@@ -121,13 +121,15 @@ Message *GetMdsMsgTOC(Connection *c, int *status, int to_msec)
     {
       Message *m;
       memcpy(&msglen, msg->bytes, 4);
-      dlen = msglen - sizeof(MsgHdr);
       if (Endian(header.client_type) != Endian(ClientType()))
+      {
         FlipBytes(4, (char *)&msglen);
+      }
+      dlen = msglen - sizeof(MsgHdr);
       m = malloc(msglen);
       m->h = header;
       *status = uncompress((unsigned char *)m->bytes, &dlen,
-                           (unsigned char *)msg->bytes + 4, dlen - 4) == Z_OK;
+                           (unsigned char *)msg->bytes + 4, msg->h.msglen - 4 - sizeof(MsgHdr)) == Z_OK;
       if (IS_OK(*status))
       {
         m->h.msglen = msglen;

--- a/mdstcpip/mdsipshr/SendMdsMsg.c
+++ b/mdstcpip/mdsipshr/SendMdsMsg.c
@@ -112,7 +112,7 @@ int SendMdsMsgC(Connection *c, Message *m, int msg_options)
     cm->h = m->h;
     cm->h.client_type |= COMPRESSED;
     memcpy(cm->bytes, &cm->h.msglen, 4);
-    int msglen = cm->h.msglen = clength + 4 + sizeof(MsgHdr);
+    unsigned int msglen = cm->h.msglen = clength + 4 + sizeof(MsgHdr);
     MDSDBG(MESSAGE_PRI, MESSAGE_VAR(cm));
     if (do_swap)
       FlipBytes(4, (char *)&cm->h.msglen);


### PR DESCRIPTION
- Set `dlen` after potentially flipping the bytes in `msglen`
- Correctly pass the compressed length to `uncompress()`
- Use the correct type (unsigned) for the compressed message length