### PR TITLE
Fix:remove race conditions leading to deadlock

### DIFF
--- a/java/jscope/src/main/java/mds/jscope/MdsWaveInterface.java
+++ b/java/jscope/src/main/java/mds/jscope/MdsWaveInterface.java
@@ -918,7 +918,7 @@ class MdsWaveInterface extends WaveInterface
 		return 0;
 	}
 
-	public synchronized void refresh() throws Exception
+	public  void refresh() throws Exception
 	{
 		try
 		{
@@ -941,7 +941,7 @@ class MdsWaveInterface extends WaveInterface
 		}
 	}
 
-	public synchronized boolean refreshOnEvent() throws Exception
+	public boolean refreshOnEvent() throws Exception
 	{
 		final long shots[] = GetShots();
 		if (shots == null)
@@ -957,7 +957,7 @@ class MdsWaveInterface extends WaveInterface
 			{
 				if (!signals[sigIdx].supportsStreaming() || !signals[sigIdx].updateSignal())
 					return false;
-				signals[sigIdx].mergeRegions();
+				//signals[sigIdx].mergeRegions();
 			}
 		}
 		return true;

--- a/java/jscope/src/main/java/mds/jscope/MdsWaveInterface.java
+++ b/java/jscope/src/main/java/mds/jscope/MdsWaveInterface.java
@@ -957,7 +957,6 @@ class MdsWaveInterface extends WaveInterface
 			{
 				if (!signals[sigIdx].supportsStreaming() || !signals[sigIdx].updateSignal())
 					return false;
-				//signals[sigIdx].mergeRegions();
 			}
 		}
 		return true;

--- a/java/jscope/src/main/java/mds/jscope/jScopeFacade.java
+++ b/java/jscope/src/main/java/mds/jscope/jScopeFacade.java
@@ -2478,6 +2478,17 @@ public class jScopeFacade extends JFrame implements ActionListener, ItemListener
 	}
 
 	public void UpdateAllWaves()
+        {
+            SwingUtilities.invokeLater(new Runnable()
+            {
+                    @Override
+                    public void run()
+                    {
+                            intUpdateAllWaves();
+                    }
+            });
+        }
+	public void intUpdateAllWaves()
 	{
 		final String s = shot_t.getText();
 		final String s1 = def_values.shot_str;

--- a/java/jscope/src/main/java/mds/jscope/jScopeMultiWave.java
+++ b/java/jscope/src/main/java/mds/jscope/jScopeMultiWave.java
@@ -210,7 +210,7 @@ public class jScopeMultiWave extends MultiWaveform implements UpdateEventListene
 		wi.Erase();
 	}
 
-	public synchronized void jScopeWaveUpdate()
+	public void jScopeWaveUpdate()
 	{
 		if (wi.isAddSignal())
 		{

--- a/java/jscope/src/main/java/mds/jscope/jScopeWaveContainer.java
+++ b/java/jscope/src/main/java/mds/jscope/jScopeWaveContainer.java
@@ -118,7 +118,7 @@ class jScopeWaveContainer extends WaveformContainer implements Printable
 		abort = true;
 	}
 
-	public synchronized void AddAllEvents(UpdateEventListener l) throws IOException
+	public  void AddAllEvents(UpdateEventListener l) throws IOException
 	{
 		jScopeMultiWave w;
 		if (dp == null)
@@ -588,7 +588,7 @@ class jScopeWaveContainer extends WaveformContainer implements Printable
 		return (JFrame) c;
 	}
 
-	public synchronized void getjScopeMultiWave()
+	public  void getjScopeMultiWave()
 	{
 		wave_all = new jScopeMultiWave[getGridComponentCount()];
 		for (int i = 0, k = 0; i < 4; i++)
@@ -789,7 +789,7 @@ class jScopeWaveContainer extends WaveformContainer implements Printable
 		}
 	}
 
-	public synchronized void Refresh(jScopeMultiWave w, String label)
+	public  void Refresh(jScopeMultiWave w, String label)
 	{
 		Point p = null;
 		if (add_sig)
@@ -1134,7 +1134,7 @@ class jScopeWaveContainer extends WaveformContainer implements Printable
 			{
 				main_shot_str = null;
 				main_shot_error = "Main Shots evaluations error : \n" + exc.getMessage();
-				JOptionPane.showMessageDialog(this, main_shot_error, "alert SetMainShot", JOptionPane.ERROR_MESSAGE);
+				//JOptionPane.showMessageDialog(this, main_shot_error, "alert SetMainShot", JOptionPane.ERROR_MESSAGE);
 			}
 		}
 	}
@@ -1302,7 +1302,7 @@ public void ShowBrowseSignals()
 		}
 	}
 
-	public synchronized void UpdateAllWave() throws Exception
+	public  void UpdateAllWave() throws Exception
 	{
 		WaveContainerEvent wce;
 		try

--- a/java/jscope/src/main/java/mds/provider/MdsDataProvider.java
+++ b/java/jscope/src/main/java/mds/provider/MdsDataProvider.java
@@ -819,7 +819,7 @@ public class MdsDataProvider implements DataProvider
 		@Override
 		public int getNumDimension() throws IOException
 		{
-                   			if (numDimensions != UNKNOWN)
+            if (numDimensions != UNKNOWN)
 				return numDimensions;
 			String expr;
 			if (_jscope_set)

--- a/java/jscope/src/main/java/mds/provider/MdsDataProvider.java
+++ b/java/jscope/src/main/java/mds/provider/MdsDataProvider.java
@@ -271,7 +271,6 @@ public class MdsDataProvider implements DataProvider
 		private float times[] = null;
 		private Dimension dim = null;
 		private int header_size = 0;
-
 		public SimpleFrameData(String in_y, String in_x, float time_min, float time_max) throws Exception
 		{
 			int i;
@@ -635,14 +634,14 @@ public class MdsDataProvider implements DataProvider
 			}
 			else
 			{
-				args.addElement(new Descriptor(null, new float[]
-				{ (float) xmin }));
-				args.addElement(new Descriptor(null, new float[]
-				{ (float) xmax }));
+				args.addElement(new Descriptor(null, new double[]
+				{ (double) xmin }));
+				args.addElement(new Descriptor(null, new double[]
+				{ (double) xmax }));
 			}
 			args.addElement(new Descriptor(null, new int[]
 			{ numPoints }));
-			byte[] retData;
+			byte[] retData = null;
 			int nSamples;
 			try
 			{
@@ -651,11 +650,30 @@ public class MdsDataProvider implements DataProvider
 				if (numPoints == Integer.MAX_VALUE)
 					throw new Exception("Use Old Method for getting data");
 				if (isLong)
-//                      retData = GetByteArray(setTimeContext+" MdsMisc->GetXYSignalLongTimes:DSC", args);
 					retData = GetByteArray(" MdsMisc->GetXYSignalLongTimes:DSC", args);
 				else
-//                      retData = GetByteArray(setTimeContext+" MdsMisc->GetXYSignal:DSC", args);
-					retData = GetByteArray(" MdsMisc->GetXYSignal:DSC", args);
+                                {
+                                    try {
+ 					retData = GetByteArray(" MdsMisc->GetXYSignalDoubleLimits:DSC", args);
+                                    }catch(Exception exc)
+                                    {
+                                        //Try old method in case the mdsip server is not up-to-date
+                                         final Vector<Descriptor> newArgs = new Vector<>();
+                                         for(int i = 0; i < args.size() - 3; i++)
+                                        {
+                                            newArgs.addElement(args.elementAt(i));
+                                        }
+                                        newArgs.addElement(new Descriptor(null, new float[]
+                                                { (float) xmin }));
+                                        newArgs.addElement(new Descriptor(null, new float[]
+                                                { (float) xmax }));
+                                        newArgs.addElement(new Descriptor(null, new int[]
+                                                { numPoints }));
+                                         try {
+                                                retData = GetByteArray(" MdsMisc->GetXYSignal:DSC", newArgs);
+                                         } catch(Exception exc1){System.out.println(exc1);}
+                                    }
+                                }
 				/*
 				 * Decode data: Format: -retResolution(float) ----Gabriele Feb 2019 NEW: if
 				 * retResolution == 0 then the following int is the number of bytes of the error
@@ -706,8 +724,14 @@ public class MdsDataProvider implements DataProvider
 				{
 					final double[] x = new double[nSamples];
 					for (int i = 0; i < nSamples; i++)
+                                        {
 						x[i] = dis.readDouble();
-					res = new XYData(x, y, dRes);
+                                                if(i > 0 && x[i-1] > x[i])
+                                                {
+                                                    System.out.println("Internal error: non increasing dimension ("+i+" "+nSamples+")");
+                                                }
+                                        }        
+                                        res = new XYData(x, y, dRes);
 				}
 				else // float X
 				{
@@ -795,7 +819,7 @@ public class MdsDataProvider implements DataProvider
 		@Override
 		public int getNumDimension() throws IOException
 		{
-			if (numDimensions != UNKNOWN)
+                   			if (numDimensions != UNKNOWN)
 				return numDimensions;
 			String expr;
 			if (_jscope_set)
@@ -803,9 +827,11 @@ public class MdsDataProvider implements DataProvider
 			else
 			{
 				if (segmentMode == SEGMENTED_YES)
-					expr = "shape(GetSegment(" + segmentNodeName + ",0))";
-//	            expr = "shape(GetSegment(" + in_y +",0))";
-				else
+                                {
+                                    expr = "shape("+in_y.replace(segmentNodeName, "GetSegment("+segmentNodeName+",0)")+")";
+//	expr = "shape(GetSegment(" + segmentNodeName + ",0))";
+                                }
+	        		else
 				{
 					_jscope_set = true;
 					expr = "( _jscope_" + v_idx + " = (" + in_y + ";), shape(_jscope_" + v_idx + "))";
@@ -1106,11 +1132,15 @@ public class MdsDataProvider implements DataProvider
 				this.isXLong = isXLong;
 				this.updateTime = updateTime;
 			}
+                        public String toString()
+                        {
+                            return "Lower Bound: "+updateLowerBound+"\nUpper Bound: "+updateUpperBound+"\nupdatePoints: "+updatePoints;
+                        }
 		}
 
 		boolean enabled = true;
 		Vector<UpdateDescriptor> requestsV = new Vector<>();
-
+                UpdateDescriptor currUpdate;
 		boolean stopWorker = false;
 
 		synchronized void enableAsyncUpdate(boolean enabled)
@@ -1153,10 +1183,14 @@ public class MdsDataProvider implements DataProvider
 					if (!enabled)
 						break;
 					// Take most recent request
-					final UpdateDescriptor currUpdate = requestsV.elementAt(requestsV.size() - 1);
+					currUpdate = requestsV.elementAt(requestsV.size() - 1);
 					try
 					{
 						requestsV.removeElementAt(requestsV.size() - 1);
+                                                //requestsV.clear(); //Older requests are ignored
+                                                
+                                                
+                                                
 						final XYData currData = currUpdate.simpleWaveData.getData(currUpdate.updateLowerBound,
 								currUpdate.updateUpperBound, currUpdate.updatePoints, currUpdate.isXLong);
 						if (debug)
@@ -1179,6 +1213,8 @@ public class MdsDataProvider implements DataProvider
 					{
 						final Date d = new Date();
 						System.out.println(d + " Error in asynchUpdate: " + exc);
+                                                System.out.println(currUpdate);
+                                                exc.printStackTrace();
 					}
 				}
 			}
@@ -1376,7 +1412,7 @@ public class MdsDataProvider implements DataProvider
 		}
 		if (open)
 		{
-			if (defaultNode != null && (prev_default_node == null || !defaultNode.equals(prev_default_node)))
+			if (defaultNode != null && (prev_default_node == null || (!defaultNode.trim().equals("") && !defaultNode.equals(prev_default_node))))
 			{
 				Descriptor descr;
 				if (default_node.trim().charAt(0) == '\\')
@@ -1395,6 +1431,7 @@ public class MdsDataProvider implements DataProvider
 				mds.MdsValue("TreeSetDefault(\"\\\\::TOP\")");
 				prev_default_node = null;
 			}
+                        prev_default_node = default_node;
 		}
 		return true;
 	}

--- a/java/jscope/src/main/java/mds/wave/Grid.java
+++ b/java/jscope/src/main/java/mds/wave/Grid.java
@@ -64,8 +64,8 @@ public class Grid implements Serializable
 		y_values = new double[50];
 		this.xmax = xmax;
 		x_dim = BuildGrid(x_values, IS_X, xmax, ymax, xmin, ymin, xlog, ylog);
-		y_dim = BuildGrid(y_values, IS_Y, xmax, ymax, xmin, ymin, xlog, ylog);
-	}
+ 		y_dim = BuildGrid(y_values, IS_Y, xmax, ymax, xmin, ymin, xlog, ylog);
+ 	}
 
 	private int BuildGrid(double val[], int mode, double xmax, double ymax, double xmin, double ymin, boolean xlog,
 			boolean ylog)
@@ -125,8 +125,11 @@ public class Grid implements Serializable
 		curr = (long) (curr_min / step) * step;
 		if (curr > curr_min)
 			curr -= (long) ((curr - curr_min) / step) * step;
-		while (curr >= curr_min)
+                int maxSteps = 1000;
+                for(int j = 0; j < maxSteps && (curr >= curr_min); j++)
+                {
 			curr -= step;
+                }
 		for (i = 0; i < 50 && curr < curr_max + step; i++)
 		{
 			val[i] = (long) (curr / step + 0.5) * step;

--- a/java/jscope/src/main/java/mds/wave/Grid.java
+++ b/java/jscope/src/main/java/mds/wave/Grid.java
@@ -13,6 +13,7 @@ public class Grid implements Serializable
 	 *
 	 */
 	private static final long serialVersionUID = 1L;
+	private static final int MAX_STEPS = 1000; //Maximum number of steps in the tick selection agorithm
 	static final long dayMilliSeconds = 86400000; // 24 * 60 * 60 * 1000;
 	final static int IS_X = 0, IS_Y = 1;
 	public final static int IS_DOTTED = 0;
@@ -125,7 +126,7 @@ public class Grid implements Serializable
 		curr = (long) (curr_min / step) * step;
 		if (curr > curr_min)
 			curr -= (long) ((curr - curr_min) / step) * step;
-                int maxSteps = 1000;
+                int maxSteps = MAX_STEPS;
                 for(int j = 0; j < maxSteps && (curr >= curr_min); j++)
                 {
 			curr -= step;

--- a/java/jscope/src/main/java/mds/wave/Signal.java
+++ b/java/jscope/src/main/java/mds/wave/Signal.java
@@ -20,6 +20,9 @@ import java.util.Vector;
  */
 public class Signal implements WaveDataListener
 {
+        static final int DIM_THRESHOLD = 5000; //Number of 1D data points triggering reallocation of X and Y arrays
+    
+    
 	static class RegionDescriptor
 	{
 		double lowerBound, upperBound;
@@ -53,7 +56,13 @@ public class Signal implements WaveDataListener
 			// Skip disjoint regions with lower bounds
 			if (newReg.upperBound < newReg.lowerBound)
 			{
-				System.err.println("INTERNAL ERROR: LOWER BOUND > UPPER BOUND!!!!!");
+				System.err.println("INTERNAL ERROR : LOWER BOUND "+ newReg.lowerBound +" > UPPER BOUND ("+newReg.upperBound+")");
+                                try {
+                                    throw(new Exception());
+                                }catch(Exception exc)
+                                {
+                                    exc.printStackTrace();
+                                }
 			}
 			int idx;
 			RegionDescriptor currRegion;
@@ -170,8 +179,9 @@ public class Signal implements WaveDataListener
 			}
 		}
 
+                
 		// Check if the passed interval intersects any low resolution region
-		Vector<RegionDescriptor> getLowerResRegions(double lowerInt, double upperInt, double resolution)
+		synchronized Vector<RegionDescriptor> getLowerResRegions(double lowerInt, double upperInt, double resolution)
 		{
 			final Vector<RegionDescriptor> retRegions = new Vector<>();
 			for (int i = 0; i < lowResRegions.size(); i++)
@@ -1457,18 +1467,69 @@ public class Signal implements WaveDataListener
 		}
 	}
 
-	@Override
-	public void dataRegionUpdated(double[] regX, float[] regY, double resolution)
+        static final int UPDATE_LIMITS = 0;
+        static final int DO_NOT_UPDATE_LIMITS = 1;
+        static final int UPDATE_PENDING = 2;
+                
+        @Override       
+        public void dataRegionUpdated(double[] inRegX, float[] inRegY, double resolution)
+        {
+            int updateStatus = updateDataRegion(inRegX, inRegY, resolution);
+            if(updateStatus == UPDATE_LIMITS)
+            {
+                fireSignalUpdated(true);
+            }
+            else if (updateStatus == DO_NOT_UPDATE_LIMITS)
+            {
+                 fireSignalUpdated(false);
+           }
+        }
+        
+        
+
+	public synchronized int updateDataRegion(double[] inRegX, float[] inRegY, double resolution)
 	{
+            
+            if(inRegX != null && inRegX.length > 1 && inRegX[inRegX.length - 1] < inRegX[0])
+            {
+                System.out.println("INTERNAL ERROR IN UPDATE DATA REGION REGION: Inconsistent dimension, update skipped");
+                return UPDATE_PENDING;
+            }
+            double[] regX;
+            float[] regY;
+            try {
+                if(inRegX.length == inRegY.length)
+                {
+                    regX = inRegX;
+                    regY = inRegY;
+                }
+                else if (inRegX.length > inRegY.length)
+                {
+                    regY = inRegY;
+                    regX = new double[inRegY.length];
+                    System.arraycopy(inRegX, 0, regX, 0, inRegY.length);
+                }
+                else // inRegX.length < inRegY.length
+                {
+                    regX = inRegX;
+                    regY = new float[inRegX.length];
+                    System.arraycopy(inRegY, 0, regY, 0, inRegX.length);
+                }
+                
 		if (regX == null || regX.length == 0)
-			return;
+			return UPDATE_PENDING;
+                if(regX.length != regY.length)
+                {
+                    System.out.println("INTERNAL ERROR in Signal.dataRegionUpdated: regX.length = "+regX.length+"  regY.length = "+regY.length);
+                    return UPDATE_PENDING;
+                }
 		if (debug)
 			System.out.println("dataRegionUpdated " + resolutionManager.lowResRegions.size() + " new data len:"
 					+ regX.length + " XMIN:" + regX[0] + "  XMAX: " + regX[regX.length - 1]);
 		if (freezeMode != NOT_FREEZED) // If zooming in ANY part of the signal
 		{
 			pendingUpdatesV.addElement(new XYData(regX, regY, resolution, true, regX[0], regX[regX.length - 1]));
-			return;
+			return UPDATE_PENDING;
 		}
 		int samplesBefore, samplesAfter;
 		// if(regX.length == 0) return;
@@ -1505,28 +1566,51 @@ public class Signal implements WaveDataListener
 				xmax = newX[newX.length - 1];
 			x = newX;
 			y = newY;
-			fireSignalUpdated(true);
+                        checkSize();
+			return UPDATE_LIMITS;
 		}
 		else
 		{
-			resolutionManager.addRegion(new RegionDescriptor(regX[0], regX[regX.length - 1], resolution));
+                        resolutionManager.addRegion(new RegionDescriptor(regX[0], regX[regX.length - 1], resolution));
 			x = newX;
 			y = newY;
-			fireSignalUpdated(false);
+			return DO_NOT_UPDATE_LIMITS;
 		}
+            }catch(Exception exc)
+            {
+                System.out.println("Exception in Signal.dataRegionUpdated");
+                exc.printStackTrace();
+            }
+            return UPDATE_PENDING;
 	}
 
 	@Override
 	public void dataRegionUpdated(long[] regX, float[] regY, double resolution)
+        {
+            int updateStatus = updateDataRegion(regX, regY, resolution);
+            if(updateStatus == UPDATE_LIMITS)
+            {
+                fireSignalUpdated(true);
+            }
+            else if (updateStatus == DO_NOT_UPDATE_LIMITS)
+            {
+                 fireSignalUpdated(false);
+           }
+       }
+	
+                
+                
+                
+	public synchronized int updateDataRegion(long[] regX, float[] regY, double resolution)
 	{
 		if (regX == null || regX.length == 0)
-			return;
+			return UPDATE_PENDING;
 		if (debug)
 			System.out.println("dataRegionUpdated " + resolutionManager.lowResRegions.size());
 		if (freezeMode == FREEZED_BLOCK) // If zooming in some inner part of the signal
 		{
 			pendingUpdatesV.addElement(new XYData(regX, regY, resolution, true));
-			return;
+			return UPDATE_PENDING;
 		}
 		/*
 		 * if(freezeMode == FREEZED_SCROLL) //If zooming the end of the signal do the
@@ -1550,7 +1634,7 @@ public class Signal implements WaveDataListener
 			for (int i = 0; i < regX.length; i++)
 				x[i] = regX[i];
 			y = regY;
-			fireSignalUpdated(true);
+                        return UPDATE_LIMITS;
 		}
 		else // Data Appended
 		{
@@ -1603,7 +1687,7 @@ public class Signal implements WaveDataListener
 				x = newX;
 				xLong = newXLong;
 				y = newY;
-				fireSignalUpdated(true);
+				return UPDATE_LIMITS;
 			}
 			else
 			{
@@ -1611,10 +1695,32 @@ public class Signal implements WaveDataListener
 				x = newX;
 				xLong = newXLong;
 				y = newY;
-				fireSignalUpdated(false);
+				return DO_NOT_UPDATE_LIMITS;
 			}
 		}
-	}
+ 	}
+        
+// Management of data reduction in case of append
+        synchronized void checkSize()
+        {
+            if(longXLimits) //On the  fly compression not performed for absolute times
+            {
+                return;
+            }
+            if(x == null || x.length < DIM_THRESHOLD)
+            {
+                return;
+            }
+            double xMin = x[0];
+            double xMax = x[x.length - 1];
+            if(xMin >= xMax) 
+            {
+                return;
+            }
+            mergeRegions();
+        }
+         
+        
 
 	public void decShow()
 	{
@@ -2301,14 +2407,18 @@ public class Signal implements WaveDataListener
 
 	// reset all region info building a single region with
 	// resolution=NUM_POINTS/(xmax - xmin)
-	public void mergeRegions()
+	public synchronized void mergeRegions()
 	{
 		if (x == null || x.length < 1)
 			return;
-		final double currXMin = x[0];
+                if (x.length < DIM_THRESHOLD) //Do the Job only if it is worth
+                    return;
+                final double currXMin = x[0];
 		final double currXMax = x[x.length - 1];
-		final double currResolution = 3 * NUM_POINTS / (currXMax - currXMin);
-		final double currDelta = (currXMax - currXMin) / (3 * NUM_POINTS);
+		final double currResolution = NUM_POINTS / (currXMax - currXMin);
+		//final double currResolution = 3 * NUM_POINTS / (currXMax - currXMin);
+		//final double currDelta = (currXMax - currXMin) / (3 * NUM_POINTS);
+		final double currDelta = (currXMax - currXMin) / NUM_POINTS;
 		int newPoints = 0;
 		double currX = currXMin - currDelta / 2;
 		int currIdx = 0;
@@ -2833,7 +2943,7 @@ public class Signal implements WaveDataListener
 			if (((mode & DO_NOT_UPDATE) == 0)
 					&& (currLower != saved_xmin || currUpper != saved_xmax || (mode & AT_CREATION) == 0))
                         {
-				data.getDataAsync(currLower, currUpper, NUM_POINTS);
+ 				data.getDataAsync(currLower, currUpper, NUM_POINTS);
                         }
 		}
 		// fireSignalUpdated();

--- a/java/jscope/src/main/java/mds/wave/WaveInterface.java
+++ b/java/jscope/src/main/java/mds/wave/WaveInterface.java
@@ -448,7 +448,7 @@ public class WaveInterface
 		evaluated = null;
 	}
 
-	public synchronized boolean EvaluateOthers()
+	public  boolean EvaluateOthers()
 	{
 		int curr_wave;
 		if (is_image)
@@ -509,7 +509,7 @@ public class WaveInterface
 		return retStatus;
 	}
 
-	public synchronized void EvaluateShot(long shot) throws Exception
+	public  void EvaluateShot(long shot) throws Exception
 	{
 		int curr_wave;
 		if (is_image)

--- a/java/jscope/src/main/java/mds/wave/Waveform.java
+++ b/java/jscope/src/main/java/mds/wave/Waveform.java
@@ -11,8 +11,10 @@ import java.util.Vector;
 
 import javax.swing.BorderFactory;
 import javax.swing.JComponent;
+import javax.swing.SwingUtilities;
 import javax.swing.border.BevelBorder;
 import javax.swing.border.Border;
+import mds.jscope.jScopeMultiWave;
 
 public class Waveform extends JComponent implements SignalListener
 {
@@ -358,7 +360,7 @@ public class Waveform extends JComponent implements SignalListener
 		waveform_listener.addElement(l);
 	}
 
-	synchronized public void appendPaint(Graphics g, Dimension d)
+	 public void appendPaint(Graphics g, Dimension d)
 	{
 		setFont(g);
 		g.setColor(Color.black);
@@ -469,7 +471,25 @@ public class Waveform extends JComponent implements SignalListener
 		setBorder(unselect_border);
 	}
 
-	protected synchronized void dispatchWaveformEvent(WaveformEvent e)
+        protected void dispatchWaveformEvent(WaveformEvent e)
+        {
+            class Invoker implements Runnable {
+                WaveformEvent e;
+                public Invoker(WaveformEvent e) 
+                {
+                    this.e = e;
+                }
+                public void run()
+                {
+                    intDispatchWaveformEvent(e);
+                }
+            }
+            SwingUtilities.invokeLater(new Invoker(e));
+	}
+   
+                
+        
+	protected void intDispatchWaveformEvent(WaveformEvent e)
 	{
 		if (e == null || !event_enabled)
 		{
@@ -1462,7 +1482,7 @@ public class Waveform extends JComponent implements SignalListener
 			sendProfileEvent();
 	}
 
-	synchronized public void PaintImage(Graphics g, Dimension d, int print_mode)
+	 public void PaintImage(Graphics g, Dimension d, int print_mode)
 	{
 		if (frames != null)
 		{
@@ -1482,7 +1502,7 @@ public class Waveform extends JComponent implements SignalListener
 		}
 	}
 
-	synchronized protected void PaintSignal(Graphics g, Dimension dim, int print_mode)
+	 protected void PaintSignal(Graphics g, Dimension dim, int print_mode)
 	{
 		Dimension d;
 		String orizLabel = x_label;
@@ -1642,7 +1662,7 @@ public class Waveform extends JComponent implements SignalListener
 		return is_playing;
 	}
 
-	public synchronized void removeWaveformListener(WaveformListener l)
+	public void removeWaveformListener(WaveformListener l)
 	{
 		if (l == null)
 		{
@@ -2753,7 +2773,7 @@ public class Waveform extends JComponent implements SignalListener
 		repaint();
 	}
 
-	synchronized public void StopFrame()
+         public void StopFrame()
 	{
 		if (is_image && is_playing)
 		{
@@ -2809,7 +2829,7 @@ public class Waveform extends JComponent implements SignalListener
 		repaint();
 	}
 
-	synchronized public void Update(Signal s)
+	 public void Update(Signal s)
 	{
 		update_timestamp++;
 		waveform_signal = s;
@@ -2840,7 +2860,7 @@ public class Waveform extends JComponent implements SignalListener
 		UpdatePoint(curr_x, Double.NaN);
 	}
 
-	public synchronized void UpdatePoint(double curr_x, double curr_y)
+	public  void UpdatePoint(double curr_x, double curr_y)
 	{
 		final Dimension d = getWaveSize();
 		if (curr_x == curr_point && !dragging)

--- a/java/jscope/src/main/java/mds/wave/WaveformContainer.java
+++ b/java/jscope/src/main/java/mds/wave/WaveformContainer.java
@@ -142,18 +142,6 @@ public class WaveformContainer extends RowColumnContainer implements WaveformMan
 					w.SetYScale(curr_w);
 		}
 	}
-/*
-	public void appendUpdateWaveforms()
-	{
-		Waveform w;
-		for (int i = 0; i < getGridComponentCount(); i++)
-		{
-			w = GetWavePanel(i);
-			if (w != null)
-				w.appendUpdate();
-		}
-	}
-*/
 	@Override
 	public void autoscaleAll()
 	{
@@ -1009,16 +997,4 @@ public class WaveformContainer extends RowColumnContainer implements WaveformMan
 				w.UpdatePoint(x, y);
 		}
 	}
-/*
-        public void updateWaveforms()
-	{
-		Waveform w;
-		for (int i = 0; i < getGridComponentCount(); i++)
-		{
-			w = GetWavePanel(i);
-			if (w != null)
-				w.Update();
-		}
-	}
-*/
 }

--- a/java/jscope/src/main/java/mds/wave/WaveformContainer.java
+++ b/java/jscope/src/main/java/mds/wave/WaveformContainer.java
@@ -84,7 +84,7 @@ public class WaveformContainer extends RowColumnContainer implements WaveformMan
 	 *
 	 * @param l the waveform container listener
 	 */
-	public synchronized void addWaveContainerListener(WaveContainerListener l)
+	public  void addWaveContainerListener(WaveContainerListener l)
 	{
 		if (l == null)
 		{
@@ -142,8 +142,8 @@ public class WaveformContainer extends RowColumnContainer implements WaveformMan
 					w.SetYScale(curr_w);
 		}
 	}
-
-	synchronized public void appendUpdateWaveforms()
+/*
+	public void appendUpdateWaveforms()
 	{
 		Waveform w;
 		for (int i = 0; i < getGridComponentCount(); i++)
@@ -153,7 +153,7 @@ public class WaveformContainer extends RowColumnContainer implements WaveformMan
 				w.appendUpdate();
 		}
 	}
-
+*/
 	@Override
 	public void autoscaleAll()
 	{
@@ -590,7 +590,7 @@ public class WaveformContainer extends RowColumnContainer implements WaveformMan
 	 *
 	 * @param l the waveform container listener
 	 */
-	public synchronized void removeContainerListener(ActionListener l)
+	public void removeContainerListener(ActionListener l)
 	{
 		if (l == null)
 		{
@@ -1009,8 +1009,8 @@ public class WaveformContainer extends RowColumnContainer implements WaveformMan
 				w.UpdatePoint(x, y);
 		}
 	}
-
-	synchronized public void updateWaveforms()
+/*
+        public void updateWaveforms()
 	{
 		Waveform w;
 		for (int i = 0; i < getGridComponentCount(); i++)
@@ -1020,4 +1020,5 @@ public class WaveformContainer extends RowColumnContainer implements WaveformMan
 				w.Update();
 		}
 	}
+*/
 }

--- a/java/mdsobjects/src/main/java/mds/connection/MdsConnection.java
+++ b/java/mdsobjects/src/main/java/mds/connection/MdsConnection.java
@@ -3,7 +3,7 @@ package mds.connection;
 import java.io.*;
 import java.net.*;
 import java.util.*;
-
+import javax.swing.*;
 public class MdsConnection
 {
 	public static final int DEFAULT_PORT = 8000;
@@ -81,9 +81,23 @@ public class MdsConnection
 			if (MdsConnection.this.busy)
 				return;
 			if (eventName != null)
-				dispatchUpdateEvent(eventName);
+                        {
+                            SwingUtilities.invokeLater(new Runnable() {
+                                public void run()
+                                {
+                                    dispatchUpdateEvent(eventName);
+                                }
+                            });
+                        }
 			else if (eventId != -1)
-				dispatchUpdateEvent(eventId);
+                        {
+                            SwingUtilities.invokeLater(new Runnable() {
+                                public void run()
+                                {
+                                    dispatchUpdateEvent(eventId);
+                                }
+                            });
+                        }
 		}
 
 		public void SetEventid(int id)
@@ -236,7 +250,7 @@ public class MdsConnection
 	public String getProviderUser()
 	{ return (user != null ? user : DEFAULT_USER); }
 
-	public synchronized String getProviderHost()
+	public String getProviderHost()
 	{
 		if (provider == null)
 			return null;
@@ -252,7 +266,7 @@ public class MdsConnection
 		return address.trim();
 	}
 
-	public synchronized int getProviderPort() throws NumberFormatException
+	public int getProviderPort() throws NumberFormatException
 	{
 		if (provider == null)
 			return DEFAULT_PORT;
@@ -263,7 +277,7 @@ public class MdsConnection
 		return port;
 	}
 
-	public synchronized Descriptor getAnswer() throws IOException
+	public Descriptor getAnswer() throws IOException
 	{
 		final Descriptor out = new Descriptor();
 		final MdsMessage message = receiveThread.GetMessage();
@@ -506,7 +520,7 @@ public class MdsConnection
 		return eventid;
 	}
 
-	public synchronized void dispatchUpdateEvent(int eventid)
+	public void dispatchUpdateEvent(int eventid)
 	{
 		if (hashEventId.containsKey(eventid))
 		{
@@ -514,7 +528,7 @@ public class MdsConnection
 		}
 	}
 
-	public synchronized void dispatchUpdateEvent(String eventName)
+	public void dispatchUpdateEvent(String eventName)
 	{
 		if (hashEventName.containsKey(eventName))
 		{

--- a/java/mdsobjects/src/main/java/mds/connection/MdsMessage.java
+++ b/java/mdsobjects/src/main/java/mds/connection/MdsMessage.java
@@ -123,7 +123,7 @@ public class MdsMessage extends Object
 		return (short) ((ch1) + (ch2));
 	}
 
-	synchronized protected void dispatchConnectionEvent(ConnectionEvent e)
+	protected void dispatchConnectionEvent(ConnectionEvent e)
 	{
 		if (connectionListeners != null)
 			for (final ConnectionListener listener : connectionListeners)
@@ -162,7 +162,7 @@ public class MdsMessage extends Object
 		return (arr[idx] == 0 && arr[idx + 1] == 0 && arr[idx + 2] == -128 && arr[idx + 3] == 0);
 	}
 
-	protected synchronized void ReadBuf(byte buf[], InputStream dis) throws IOException
+	protected  void ReadBuf(byte buf[], InputStream dis) throws IOException
 	{
 		ConnectionEvent e;
 		int bytes_to_read = buf.length, read_bytes = 0, curr_offset = 0;

--- a/java/mdsplus-api/src/main/java/mds/MdsMisc.java
+++ b/java/mdsplus-api/src/main/java/mds/MdsMisc.java
@@ -10,6 +10,7 @@ import mds.data.CTX;
 import mds.data.descriptor.Descriptor;
 import mds.data.descriptor_a.Uint8Array;
 import mds.data.descriptor_s.Float32;
+import mds.data.descriptor_s.Float64;
 import mds.data.descriptor_s.Int32;
 import mds.data.descriptor_s.Int64;
 

--- a/java/mdsplus-api/src/main/java/mds/MdsMisc.java
+++ b/java/mdsplus-api/src/main/java/mds/MdsMisc.java
@@ -230,6 +230,15 @@ public class MdsMisc extends Mdsdcl
 		return this.mds.getByteArray(ctx, request);
 	}
 
+	private final byte[] _miscGetXYSignalDoubleLimits(final CTX ctx, final String ydata, final String xdata, final double xmin,
+			final double xmax, final int num_samples) throws MdsException
+	{
+		final Request<Uint8Array> request = new MiscCall<>(Uint8Array.class, "GetXYSignalDoubleLimits:DSC")//
+				.ref(Descriptor.valueOf(ydata)).ref(Descriptor.valueOf(xdata)).ref(new Float64(xmin))
+				.ref(new Float64(xmax)).ref(new Int32(num_samples)).fin();
+		return this.mds.getByteArray(ctx, request);
+	}
+
 	private final byte[] _miscGetXYSignalLongTimes(final CTX ctx, final String ydata, final String xdata,
 			final long xmin, final long xmax, final int num_samples) throws MdsException
 	{

--- a/mdsmisc/ScopeUtilities.c
+++ b/mdsmisc/ScopeUtilities.c
@@ -1116,8 +1116,9 @@ static mdsdsc_xd_t *getPackedDsc(mdsdsc_xd_t *retXd)
   return retXd;
 }
 
-EXPORT mdsdsc_xd_t *GetXYSignal(char *inY, char *inX, float *inXMin,
-                                float *inXMax, int *reqNSamples)
+
+EXPORT mdsdsc_xd_t *GetXYSignalDoubleLimits(char *inY, char *inX, double *inXMin,
+                                double *inXMax, int *reqNSamples)
 {
   static EMPTYXD(retXd);
   const size_t len = strlen(inY);
@@ -1127,8 +1128,8 @@ EXPORT mdsdsc_xd_t *GetXYSignal(char *inY, char *inX, float *inXMin,
     return (encodeError("Y data must not be NULL or empty.", __LINE__, &retXd));
   EMPTYXD(yXd);
   EMPTYXD(xXd);
-  mdsdsc_t xMinD = {sizeof(float), DTYPE_FLOAT, CLASS_S, (char *)inXMin};
-  mdsdsc_t xMaxD = {sizeof(float), DTYPE_FLOAT, CLASS_S, (char *)inXMax};
+  mdsdsc_t xMinD = {sizeof(double), DTYPE_DOUBLE, CLASS_S, (char *)inXMin};
+  mdsdsc_t xMaxD = {sizeof(double), DTYPE_DOUBLE, CLASS_S, (char *)inXMax};
   int status;
   {
     mdsdsc_t expY = {len, DTYPE_T, CLASS_S, inY};
@@ -1149,6 +1150,7 @@ EXPORT mdsdsc_xd_t *GetXYSignal(char *inY, char *inX, float *inXMin,
     return (encodeError(MdsGetMsg(status), __LINE__, &retXd));
   return getPackedDsc(&retXd);
 }
+
 
 EXPORT mdsdsc_xd_t *GetXYSignalLongTimes(char *inY, char *inX, int64_t *inXMin,
                                          int64_t *inXMax, int *reqNSamples)

--- a/mdsmisc/resample.c
+++ b/mdsmisc/resample.c
@@ -59,9 +59,9 @@ dsc$descriptor *x);
 #include <mdsdescrip.h>
 #include <mdsshr.h>
 
-extern int TdiData(mdsdsc_t *, ...);
-extern int TdiCvt(mdsdsc_t *, ...);
-extern int TdiDimOf(mdsdsc_t *, ...);
+extern int TdiData();
+extern int TdiCvt();
+extern int TdiDimOf();
 struct descriptor *Resample(struct descriptor *in_sig, struct descriptor *in_x);
 
 EXPORT struct descriptor *resample(struct descriptor *in_sig,
@@ -115,19 +115,19 @@ EXPORT struct descriptor *Resample(struct descriptor *in_sig,
     sig = (struct descriptor_signal *)sig->pointer;
   while (x->dtype == DTYPE_DSC)
     x = (struct descriptor *)x->pointer;
-  return_on_error(TdiData((mdsdsc_t *)sig, &xd1 MDS_END_ARG),
+  return_on_error(TdiData(sig, &xd1 MDS_END_ARG),
                   ((struct descriptor *)&bad_sig_in));
-  return_on_error(TdiCvt((mdsdsc_t *)&xd1, &float_dsc, &sig_y_xd MDS_END_ARG),
+  return_on_error(TdiCvt(&xd1, &float_dsc, &sig_y_xd MDS_END_ARG),
                   (struct descriptor *)&bad_sig_in);
   sig_y = (struct descriptor_a *)sig_y_xd.pointer;
   if (sig_y->class != CLASS_A)
     return (struct descriptor *)&bad_sig_in;
   sig_y_f = (float *)sig_y->pointer;
-  return_on_error(TdiDimOf((mdsdsc_t *)sig, &xd1 MDS_END_ARG),
+  return_on_error(TdiDimOf(sig, &xd1 MDS_END_ARG),
                   (struct descriptor *)&bad_sig_in);
-  return_on_error(TdiData((mdsdsc_t *)&xd1, &xd2 MDS_END_ARG),
+  return_on_error(TdiData(&xd1, &xd2 MDS_END_ARG),
                   (struct descriptor *)&bad_sig_in);
-  return_on_error(TdiCvt((mdsdsc_t *)&xd2, &float_dsc, &sig_x_xd MDS_END_ARG),
+  return_on_error(TdiCvt(&xd2, &float_dsc, &sig_x_xd MDS_END_ARG),
                   (struct descriptor *)&bad_sig_in);
   sig_x = (struct descriptor_a *)sig_x_xd.pointer;
   if (sig_x->class != CLASS_A)
@@ -135,7 +135,7 @@ EXPORT struct descriptor *Resample(struct descriptor *in_sig,
   sig_x_f = (float *)sig_x->pointer;
   return_on_error(TdiData(x, &xd1 MDS_END_ARG),
                   (struct descriptor *)&bad_time_in);
-  return_on_error(TdiCvt((mdsdsc_t *)&xd1, &float_dsc, &new_x_xd MDS_END_ARG),
+  return_on_error(TdiCvt(&xd1, &float_dsc, &new_x_xd MDS_END_ARG),
                   (struct descriptor *)&bad_time_in);
   new_x = (struct descriptor_a *)new_x_xd.pointer;
   if (new_x->class != CLASS_A)

--- a/mdsmisc/step_resample.c
+++ b/mdsmisc/step_resample.c
@@ -59,10 +59,10 @@ struct descriptor_xd *STEP_RESAMPLE(struct descriptor *sig,struct descriptor
 #include <mdsdescrip.h>
 #include <mdsshr.h>
 
-extern int TdiData(mdsdsc_t *, ...);
-extern int TdiByte(mdsdsc_t *, ...);
-extern int TdiDimOf(mdsdsc_t *, ...);
-extern int TdiCvt(mdsdsc_t *, ...);
+extern int TdiData();
+extern int TdiByte();
+extern int TdiDimOf();
+extern int TdiCvt();
 
 EXPORT struct descriptor *StepResample(struct descriptor *in_sig,
                                        struct descriptor *in_x)
@@ -104,21 +104,21 @@ EXPORT struct descriptor *StepResample(struct descriptor *in_sig,
     sig = (struct descriptor_signal *)sig->pointer;
   while (x->dtype == DTYPE_DSC)
     x = (struct descriptor *)x->pointer;
-  return_on_error(TdiData((mdsdsc_t *)sig, &xd1 MDS_END_ARG));
-  return_on_error(TdiByte((mdsdsc_t *)&xd1, &sig_y_xd MDS_END_ARG));
+  return_on_error(TdiData(sig, &xd1 MDS_END_ARG));
+  return_on_error(TdiByte(&xd1, &sig_y_xd MDS_END_ARG));
   sig_y = (struct descriptor_a *)sig_y_xd.pointer;
   if (sig_y->class != CLASS_A)
     return 0;
   sig_y_b = sig_y->pointer;
-  return_on_error(TdiDimOf((mdsdsc_t *)sig, &xd1 MDS_END_ARG));
-  return_on_error(TdiData((mdsdsc_t *)&xd1, &xd2 MDS_END_ARG));
-  return_on_error(TdiCvt((mdsdsc_t *)&xd2, &float_dsc, &sig_x_xd MDS_END_ARG));
+  return_on_error(TdiDimOf(sig, &xd1 MDS_END_ARG));
+  return_on_error(TdiData(&xd1, &xd2 MDS_END_ARG));
+  return_on_error(TdiCvt(&xd2, &float_dsc, &sig_x_xd MDS_END_ARG));
   sig_x = (struct descriptor_a *)sig_x_xd.pointer;
   if (sig_x->class != CLASS_A)
     return 0;
   sig_x_f = (float *)sig_x->pointer;
   return_on_error(TdiData(x, &xd1 MDS_END_ARG));
-  return_on_error(TdiCvt((mdsdsc_t *)&xd1, &float_dsc, &new_x_xd MDS_END_ARG));
+  return_on_error(TdiCvt(&xd1, &float_dsc, &new_x_xd MDS_END_ARG));
   new_x = (struct descriptor_a *)new_x_xd.pointer;
   if (new_x->class != CLASS_A)
     return 0;


### PR DESCRIPTION
When interacting with jScope during automatic update, jScope often freezes. 
This is due to deadlock conditions that occurred when  an update event was received during interaction operations (e.g. zooming). 
This issue has been fixed by removing the useless synchronized option to several methods, and ensuring that critical concurrent operations were carried out by the main Swing thread. 

In addition, a fix has been carried out in the resampling management, mainly due to the usage of float instead of double for the specification of time windows. This led to missing resampling for high frequencies. For this purpose, a new routine (GetXYSignalDoubleLimits) has been added to mdsmisc/ScopeUtilities.c. This routine is called by the new jScope version. The older routine (GetXYSignal) has been retained for compatibility with the older jScope versions. 
