### PR TITLE
Fix: Remove toLowerCase() from y expression in jScope

### DIFF
--- a/java/jscope/src/main/java/mds/jscope/MdsWaveInterface.java
+++ b/java/jscope/src/main/java/mds/jscope/MdsWaveInterface.java
@@ -459,7 +459,7 @@ class MdsWaveInterface extends WaveInterface
 				StringTokenizer st_x = null;
 				num_shot = 1;
 				String token = null;
-				String y_str = prop.toLowerCase();
+				String y_str = prop;
 				String x_str = null;
 				y_str = RemoveNewLineCode(y_str);
 				if (in_x != null && in_x.length != 0)


### PR DESCRIPTION
This fixes expressions like `MdsMisc->Resample()`
