### PR TITLE
Fix: mdsconnect's use of $MDS_HOST

### DIFF
--- a/tdi/remote/MdsConnect.fun
+++ b/tdi/remote/MdsConnect.fun
@@ -1,4 +1,4 @@
-public fun mdsconnect(in _host, optional in _abort)
+public fun mdsconnect(optional in _host, optional in _abort)
 /* mdsconnect(in _host)
 
 Open a remote tdi session using mdsip
@@ -9,7 +9,7 @@ call:	_host  = Host name eg elpp1.epfl.ch or elpp1.epfl.ch:9000
 */
 {
    if(!present(_host))  {
-      _host=TranslateLogical("MDS_HOST")//"::";
+      _host=TranslateLogical("MDS_HOST");
       write(*,"Host taken from MDS_HOST ["//_host//"]");
    }
    _status = TdiShrExt->rMdsConnect(ref(_host//char(0)));


### PR DESCRIPTION
Fix (or possibly implement) the use of `$MDS_HOST` in `mdsconnect()`.
This will allow users or administrators to define `MDS_HOST` to point at a default thin client host, allowing users to easily type `mdsconnect()` and not worry about where it needs to connect to.

e.g.
```
$ export MDS_HOST=server
$ tdic
TDI> mdsconnect()
Host taken from MDS_HOST [server]
0
TDI> 
```