### PR TITLE
Fix: Resolve issues with numpy >= 2.3

### DIFF
--- a/python/MDSplus/compound.py.in
+++ b/python/MDSplus/compound.py.in
@@ -286,7 +286,10 @@ class Conglom(_dat.TreeRefX, Compound):
                 module = imp.new_module(unique)
                 qualifiers = self.qualifiers.data()
                 if isinstance(qualifiers, _N.ndarray) and qualifiers.dtype == _N.uint8:
-                    qualifiers = qualifiers.tostring()
+                    if hasattr(qualifiers, 'tobytes'):
+                        qualifiers = qualifiers.tobytes()
+                    else:
+                        qualifiers = qualifiers.tostring()
                 elif isinstance(qualifiers, _N.generic):
                     qualifiers = qualifiers.tolist()
                     if isinstance(qualifiers, list):
@@ -595,8 +598,12 @@ class Opaque(_dat.TreeRefX, Compound):
             fn, typestring = os.path.splitext(filename)
         f = open(filename, 'rb')
         try:
-            opq = cls(_dat.Data(_N.fromstring(
-                f.read(), dtype="uint8")), typestring)
+            if hasattr(_N, 'frombuffer'):
+                f_bytes = _N.frombuffer(f.read(), dtype="uint8")
+            else:
+                f_bytes = _N.fromstring(f.read(), dtype="uint8")
+
+            opq = cls(_dat.Data(f_bytes), typestring)
         finally:
             f.close()
         return opq

--- a/python/MDSplus/tree.py
+++ b/python/MDSplus/tree.py
@@ -4079,9 +4079,12 @@ If you did intend to write to a subnode of the device you should check the prope
         source = self.head.record.qualifiers.data()
         if isinstance(source, _N.ndarray) and source.dtype == _N.uint8:
             import difflib
-            inrecord = _ver.tostr(source.tostring()).splitlines(1)
-            infile = _ver.tostr(self.__read_source(
-                self.__class__.__name__, sourcefile).tostring()).splitlines(1)
+            if hasattr(source, 'tobytes'):
+                inrecord = _ver.tostr(source.tobytes()).splitlines(1)
+                infile = _ver.tostr(self.__read_source(self.__class__.__name__, sourcefile).tobytes()).splitlines(1)
+            else:
+                inrecord = _ver.tostr(source.tostring()).splitlines(1)
+                infile = _ver.tostr(self.__read_source(self.__class__.__name__, sourcefile).tostring()).splitlines(1)
             diff = difflib.unified_diff(inrecord, infile)
             diff = ''.join(diff)
             return diff

--- a/python/MDSplus/version.py
+++ b/python/MDSplus/version.py
@@ -187,7 +187,7 @@ def _encode(string):
 def hash64(bytes):
     import hashlib
     import numpy
-    return numpy.frombuffer(hashlib.md5(bytes.tostring()).digest(), numpy.uint64).sum()
+    return numpy.frombuffer(hashlib.md5(bytes).digest(), numpy.uint64).sum()
 
 
 def _tostring(string, targ, nptarg, conv, lstres):


### PR DESCRIPTION
Conditionally replace calls to tostring() with tobytes()
Conditionally replace calls to fromstring() with frombuffer()
Pass the numpy object directly to hashlib, instead of calling tostring()