### PR TITLE
Fix: optional port parameter in IDL's mdsconnect()

### DIFF
--- a/idl/mdsconnect.pro
+++ b/idl/mdsconnect.pro
@@ -115,9 +115,7 @@ pro mds$connect,host,status=status,quiet=quiet,port=port
   on_error,2
   mds$disconnect,/quiet
   if n_elements(port) ne 0 then begin
-    setenv_,'mdsip='+strtrim(port,2)
-  endif else if getenv('mdsip') eq '' then begin
-    setenv_,'mdsip=8000'
+    host = host+':'+strtrim(port,2)
   endif
   if (!version.release ne '5.0.3') then !ERROR_STATE.MSG="About to connect"
   sock = call_external(MdsIPImage(),'IdlConnectToMds',host,value=[byte(!version.os ne 'windows')])
@@ -158,9 +156,7 @@ pro mdsconnect,host,status=status,quiet=quiet,port=port,socket=socket
   if (not mds_keyword_set(socket=socket)) then $
     mdsdisconnect,/quiet
   if n_elements(port) ne 0 then begin
-    setenv_,'mdsip='+strtrim(port,2)
-  endif else if getenv('mdsip') eq '' then begin
-    setenv_,'mdsip=8000'
+    host = host+':'+strtrim(port,2)
   endif
 
   sock = call_external(MdsIPImage(),'IdlConnectToMds',host,value=[byte(!version.os ne 'windows')])


### PR DESCRIPTION
Also fixed in mds$connect()
This now takes the port and concatenates it with the hostname as `host+':'+port` if specified
Previously this set an enviornment variable named `$mdsip` which is not used anywhere