### PR TITLE
Feature: Allow using mdsthin for the MATLAB-Python bridge

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -202,6 +202,7 @@ if (BRANCH_NAME == "stable") {
     schedule = "0 19 * * *";
 }
 
+def new_version = null;
 def new_tag = null;
 
 pipeline {
@@ -253,7 +254,7 @@ pipeline {
                 }
 
                 script {
-                    def new_version = sh(
+                    new_version = sh(
                         script: "/usr/bin/python3 deploy/get_new_version.py",
                         returnStdout: true
                     ).trim()
@@ -309,6 +310,9 @@ pipeline {
 
                             sh "deploy/publish.py --dist-dir=/mnt/mdsplus_staging/dist --cert-dir=/mnt/mdsplus_staging/certs --publish-info=mdsplus-publish.json"
                         }
+
+                        // Create a package containing only the MATLAB code, primarily for use with the mdsthin bridge
+                        tar(file: "packages/mdsplus_${BRANCH_NAME}_${new_version}_matlab.tgz", archive: true, compress: true, dir: "matlab/")
 
                         def release_file_list = [];
                         

--- a/matlab/mdsInfo.m
+++ b/matlab/mdsInfo.m
@@ -14,7 +14,10 @@ else
 end
 if nargin > 0
     MDSINFO.usePython = logical(varargin{1});
-    if nargin > 1
+    if ~MDSINFO.usePython
+        MDSINFO.usemdsthin = false;
+    end 
+    if (nargin > 1) && MDSINFO.usePython
         MDSINFO.usemdsthin = logical(varargin{2});
     end
 end
@@ -47,12 +50,14 @@ if ~all(ok)
         disp(strcat(' Java error: ', err{2}.message))
         disp(strcat(' Python error: ', err{1}.message))
         info = [];
-        MDSINFO = info;
+        MDSINFO = info; 
     elseif ~ok(2)
         disp('Unable to connect to MDSplus using java bridge, using python bridge instead')
         disp(strcat(' Java error: ', err{2}.message))
     else % ~ok(1)
-        disp('Unable to connect to MDSplus using python bridge')
+        disp('Unable to connect to MDSplus using python bridge, using java bridge instead')
         disp(strcat(' Python error: ', err{1}.message))
     end
 end
+
+info = MDSINFO; % success, so return updated structure

--- a/matlab/mdsInfo.m
+++ b/matlab/mdsInfo.m
@@ -8,11 +8,15 @@ else
     info.connection = [];
     info.connectedHost = '';
     info.usePython = false;
+    info.usemdsthin = false;
     info.isPythonConnection = false;
     MDSINFO = info;
 end
 if nargin > 0
     MDSINFO.usePython = logical(varargin{1});
+    if nargin > 1
+        MDSINFO.usemdsthin = logical(varargin{2});
+    end
 end
 err = {true, true};
 if MDSINFO.usePython
@@ -48,7 +52,7 @@ if ~all(ok)
         disp('Unable to connect to MDSplus using java bridge, using python bridge instead')
         disp(strcat(' Java error: ', err{2}.message))
     else % ~ok(1)
-        disp('Unable to connect to MDSplus using python bridge, using python bridge instead')
+        disp('Unable to connect to MDSplus using python bridge')
         disp(strcat(' Python error: ', err{1}.message))
     end
 end

--- a/matlab/mdsUsePython.m
+++ b/matlab/mdsUsePython.m
@@ -6,9 +6,11 @@ function mdsUsePython( varargin )
 %   bridge. This is not a permanent setting and only applies to the current
 %   invocation of matlab.
    if nargin == 0
-       mdsInfo(true);
-   else
+       mdsInfo(true, false);
+   elseif nargin == 1
        mdsInfo(varargin{1});
+   else
+       mdsInfo(varargin{1}, varargin{2});
    end
 end
 

--- a/matlab/mdsUsePython.m
+++ b/matlab/mdsUsePython.m
@@ -8,7 +8,7 @@ function mdsUsePython( varargin )
    if nargin == 0
        mdsInfo(true, false);
    elseif nargin == 1
-       mdsInfo(varargin{1});
+       mdsInfo(varargin{1}, false);
    else
        mdsInfo(varargin{1}, varargin{2});
    end

--- a/matlab/mdsconnect.m
+++ b/matlab/mdsconnect.m
@@ -21,6 +21,7 @@ function [ status ] = mdsconnect( host )
                 else
                     MDSINFO.connection.mdsdisconnect();
                 end
+            end
 
             if MDSINFO.usemdsthin
                 error("Using mdsconnect('local') with mdsthin is not supported")

--- a/matlab/mdsconnect.m
+++ b/matlab/mdsconnect.m
@@ -21,7 +21,11 @@ function [ status ] = mdsconnect( host )
                 else
                     MDSINFO.connection.mdsdisconnect();
                 end
+
+            if MDSINFO.usemdsthin
+                error("Using mdsconnect('local') with mdsthin is not supported")
             end
+            
             MDSINFO.isConnected = false;
             MDSINFO.connection = [];
             MDSINFO.connectedHost = host;

--- a/matlab/mdsdisconnect.m
+++ b/matlab/mdsdisconnect.m
@@ -4,10 +4,10 @@ function [ status ] = mdsdisconnect( )
 %      described routines to their local behaviors
     global MDSINFO
     if MDSINFO.usemdsthin
-        MDSINFO.connection = []
+        MDSINFO.connection = [];
         MDSINFO.connectedHost = '';
         MDSINFO.isConnected = false;
-        status = 1
+        status = 1;
     else
         status = mdsconnect('local');
     end

--- a/matlab/mdsdisconnect.m
+++ b/matlab/mdsdisconnect.m
@@ -2,6 +2,14 @@ function [ status ] = mdsdisconnect( )
 % MDSDISCONNECT  disconnect from  a remote mdsplus data server.   
 %      mdsdisconnect will destroy this connection, reverting the above
 %      described routines to their local behaviors
-    status = mdsconnect('local');
+    global MDSINFO
+    if MDSINFO.usemdsthin
+        MDSINFO.connection = []
+        MDSINFO.connectedHost = '';
+        MDSINFO.isConnected = false;
+        status = 1
+    else
+        status = mdsconnect('local');
+    end
 end
 

--- a/matlab/private/pythonActivate.m
+++ b/matlab/private/pythonActivate.m
@@ -5,7 +5,11 @@ if ~isempty(cache)
     err = cache;
 else
     try
-        MDSINFO.ispy2 = logical(py.MDSplus.version.ispy2);
+        if MDSINFO.usemdsthin
+            MDSINFO.ispy2 = false
+        else
+            MDSINFO.ispy2 = logical(py.MDSplus.version.ispy2);
+        end
         err = false;
         cache = err;
     catch err

--- a/matlab/private/pythonConnect.m
+++ b/matlab/private/pythonConnect.m
@@ -1,3 +1,8 @@
 function connection = pythonConnect( host )
-py_MDSplus_Connection = str2func('py.MDSplus.Connection');
+global MDSINFO
+if MDSINFO.usemdsthin
+    py_MDSplus_Connection = str2func('py.mdsthin.Connection');
+else
+    py_MDSplus_Connection = str2func('py.MDSplus.Connection');
+end
 connection = py_MDSplus_Connection(host);

--- a/matlab/private/pythonToMatlab.m
+++ b/matlab/private/pythonToMatlab.m
@@ -1,5 +1,5 @@
 function result = pythonToMatlab(value, info)
-if strncmp(class(value), 'py.MDSplus', 10)
+if strncmp(class(value), 'py.MDSplus', 10) || strncmp(class(value), 'py.mdsthin', 10)
     value = value.data();
 end
 if ~strncmp(class(value), 'py.numpy', 8)


### PR DESCRIPTION
This is a first pass at supporting mdsthin as a backend for connecting MATLAB to MDSplus The mechanism for enabling it is an extension of how you enable python
```matlab
% Use Java
mdsInfo()
% Use Python
mdsInfo(true)
% Use Python with mdsthin
mdsInfo(true, true)
```

Of course, it will throw an error if you attempt to `mdsconnect('local')` while using mdsthin