### PR TITLE
Fix: mdsdisconnect for MATLAB java bridge no longer uses Java finalize()

### DIFF
--- a/java/mdsobjects/src/main/java/MDSplus/Connection.java
+++ b/java/mdsobjects/src/main/java/MDSplus/Connection.java
@@ -64,8 +64,7 @@ public class Connection
 		isConnected = true;
 	}
 
-	@Override
-	protected void finalize()
+	public void mdsdisconnect()
 	{
 		if (sockId >= 0)
 			disconnectFromMds(sockId);

--- a/java/mdsobjects/src/main/java/MDSplus/Connection.java
+++ b/java/mdsobjects/src/main/java/MDSplus/Connection.java
@@ -71,6 +71,13 @@ public class Connection
 		isConnected = false;
 	}
 
+	// Deprecated in Java 9 to Java 22; will be removed in future Java.
+	@Override
+	protected void finalize()
+	{
+		mdsdisconnect();
+	}
+
 	public void openTree(java.lang.String name, int shot) throws MdsException
 	{
 		openTree(sockId, name, shot);

--- a/matlab/mdsconnect.m
+++ b/matlab/mdsconnect.m
@@ -15,6 +15,9 @@ function [ status ] = mdsconnect( host )
     else
         if strcmpi(host, 'LOCAL') == 1
             MDSINFO.isConnected = false;
+            if ~MDSINFO.isPythonConnection
+                MDSINFO.connection.mdsdisconnect();
+            end
             MDSINFO.connection = [];
             MDSINFO.connectedHost = host;
             status = 1;


### PR DESCRIPTION
This is a fix for Issue #2925.

To enable MATLAB to access MDSplus, there are two bridges: Python and Java.   The Java bridge was leaving dangling "connection" objects in MATLAB and dangling mdsip connections on the MDSplus archive server.   This is because the `mdsdisconnect` provided to MATLAB was not immediately terminating the mdsip connection to the server.   It was instead releasing a reference to the "connection" object, which was in turn relying on Java's garbage collector to run the `finalize()` method to destroy the connection.   However, the garbage collector runs infrequently and cannot be controlled by the application program.   Which means that MATLAB accumulates dangling "connection" objects and the MDSplus archive server accumulates dangling mdsip connections.   This was causing MATLAB and/or the archive server to eventually choke.   The mdsip connections would only be destroyed when MATLAB's garbage collector ran, MATLAB crashed, or the user shutdown MATLAB.

Note that the Java `finalize()` method was deprecated in Java 9 (in part because of this issue with the garbage collector).   Oracle's most recent advice is to remove the `finalize()` method from classes (see the entry for java.lang.Object.finalize in the following document).
https://docs.oracle.com/en/java/javase/22/docs/api/deprecated-list.html

This PR only fixes the MATLAB Java bridge `mdsdisconnect` issue.   Future PRs should remove `finalize()` from all other Java classes in MDSplus.

This PR was tested manually by using two virtual machines: an archive server and a client.   The client ran a MATLAB program that had a loop that iterated 1,000 times, with each iteration doing a pair of `mdsconnect` and `mdsdisconnect` calls.   When the MATLAB test finished, the archive VM was checked to see how many mdsip connections were present.   Prior to implementing this fix, the test showed that there was a dangling mdsip connection for every iteration of the loop.   With the fix, all mdsip connections were closed.