### PR TITLE
Fix: MATLAB no longer errors on mdsconnect('local')

### DIFF
--- a/matlab/mdsconnect.m
+++ b/matlab/mdsconnect.m
@@ -14,10 +14,15 @@ function [ status ] = mdsconnect( host )
         status = 1;
     else
         if strcmpi(host, 'LOCAL') == 1
-            MDSINFO.isConnected = false;
-            if ~MDSINFO.isPythonConnection
-                MDSINFO.connection.mdsdisconnect();
+            if MDSINFO.isConnected
+                if MDSINFO.usePython
+                    MDSINFO.connection.disconnect();
+                    MDSINFO.isPythonConnection = false;
+                else
+                    MDSINFO.connection.mdsdisconnect();
+                end
             end
+            MDSINFO.isConnected = false;
             MDSINFO.connection = [];
             MDSINFO.connectedHost = host;
             status = 1;


### PR DESCRIPTION
This fixes Issue #2944.

A user might have some local trees and remote trees.   In that scenario, the user might want to use `mdsconnect('local')` as the first statement.   This PR enables that workflow to proceed without error.