### PR TITLE
Build: Remove "" from --volume arguments in publish.py

### DIFF
--- a/deploy/publish.py
+++ b/deploy/publish.py
@@ -97,10 +97,10 @@ else:
 
     docker_args = [
         '--rm',
-        f'--volume="{source_dir}":"{source_dir}"',
-        f'--volume="{staging_dist_dir}":"{staging_dist_dir}"', # Formerly /release
-        f'--volume="{publish_dist_dir}":"{publish_dist_dir}"', # Formerly /publish
-        f'--volume="{args.cert_dir}":"{args.cert_dir}":ro', # Formerly /sign_keys
+        f'--volume={source_dir}:{source_dir}',
+        f'--volume={staging_dist_dir}:{staging_dist_dir}', # Formerly /release
+        f'--volume={publish_dist_dir}:{publish_dist_dir}', # Formerly /publish
+        f'--volume={args.cert_dir}:{args.cert_dir}:ro', # Formerly /sign_keys
         f'--workdir="{os.getcwd()}"', # ?
     ]
 


### PR DESCRIPTION
They were added to help with spaces in filenames, but they cause docker to error.