### PR TITLE
Build: Small fixes for publishing

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -72,6 +72,8 @@ def packageStage(os) {
             dir("workspace-${os}") {
                 stash name: "packages-${os}", includes: "packages/**/*"
                 stash name: "dist-${os}", includes: "mdsplus-publish.json,dist/**/*"
+                
+                archiveArtifacts artifacts: "packages/*.tgz,packages/*.exe", followSymlinks: false
             }
         }
     }
@@ -302,8 +304,6 @@ pipeline {
                             findFiles(glob: "*.tgz,*.exe").each {
                                 file -> release_file_list.add("${prefix}/${file.path}")
                             }
-
-                            archiveArtifacts artifacts: "*.tgz,*.exe", followSymlinks: false
                         }
                         
                         cleanWs disableDeferredWipeout: true, deleteDirs: true

--- a/deploy/platform/macosx/macosx_publish.py
+++ b/deploy/platform/macosx/macosx_publish.py
@@ -46,7 +46,7 @@ args = parser.parse_args()
 
 
 # * may be `macports` or `homebrew`
-package_filenames = glob.glob(os.path.join(args.release_dir, f'mdsplus_{args.flavor}_{args.version}-*-{args.arch}.tgz'))
+package_filenames = glob.glob(os.path.join(args.release_dir, f'mdsplus_{args.flavor}_{args.version}_*_{args.arch}.tgz'))
 
 for filename in package_filenames:
     shutil.copy2(filename, args.publish_dir)

--- a/deploy/publish.py
+++ b/deploy/publish.py
@@ -101,7 +101,7 @@ else:
         f'--volume={staging_dist_dir}:{staging_dist_dir}', # Formerly /release
         f'--volume={publish_dist_dir}:{publish_dist_dir}', # Formerly /publish
         f'--volume={args.cert_dir}:{args.cert_dir}:ro', # Formerly /sign_keys
-        f'--workdir="{os.getcwd()}"', # ?
+        f'--workdir={os.getcwd()}', # ?
     ]
 
     if platform.system() != 'Windows':


### PR DESCRIPTION
Remove additional "" from `publish.py` in `--workdir`
Move `archiveArtifacts` earlier in the Jenkinsfile, so we can test artifacts from builds that didn't publish
Replace - with _ in `macosx_publish.py`