### PR TITLE
Build: Publish to the staging directory

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -300,7 +300,7 @@ pipeline {
                             unstash "packages-${os}"
                             unstash "dist-${os}"
 
-                            sh "deploy/publish.py --dist-dir=/opt/fakedist --cert-dir=/mdsplus/certs --publish-info=mdsplus-publish.json"
+                            sh "deploy/publish.py --dist-dir=/mnt/mdsplus_staging/dist --cert-dir=/mnt/mdsplus_staging/certs --publish-info=mdsplus-publish.json"
                         }
 
                         def release_file_list = [];

--- a/deploy/platform/debian/debian_publish.py
+++ b/deploy/platform/debian/debian_publish.py
@@ -84,7 +84,7 @@ if not os.path.exists(distributions_filename):
         'Label: MDSplus',
         'Codename: MDSplus',
         f"Architectures: {' '.join(all_arches)}",
-        'Components: alpha stable cmake', # TODO: Remove cmake
+        'Components: alpha stable',
         'Description: MDSplus packages',
         'SignWith: MDSplus',
         '',
@@ -92,7 +92,7 @@ if not os.path.exists(distributions_filename):
         'Label: MDSplus-previous',
         'Codename: MDSplus-previous',
         f"Architectures: {' '.join(all_arches)}",
-        'Components: alpha stable cmake', # TODO: Remove cmake
+        'Components: alpha stable',
         'Description: Previous MDSplus packages',
         'SignWith: MDSplus',
         '',


### PR DESCRIPTION
The nightly rsync is currently disabled, but will be enabled once we verify the packages in the staging directory

Also remove "cmake" from the `confi/distributions` file generated by `debian_publish.py`