### PR TITLE
Build: Update notification email for Jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -345,7 +345,7 @@ pipeline {
             // if alpha/stable
             mail subject: 'Build is failing',
                 body: "Build is failing: ${BUILD_URL}",
-                to: 'slwalsh@psfc.mit.edu,heidcamp@mit.edu'
+                to: 'mdsplus-jenkins-alerts@lists.psfc.mit.edu'
         }
     }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -339,7 +339,6 @@ pipeline {
         }
     }
     
-    // TODO: UPDATE ALL DEVELOPERS
     post {
         failure {
             // if alpha/stable


### PR DESCRIPTION
Set the mailing list to send to `mdsplus-jenkins-alerts@lists.psfc.mit.edu`