### PR TITLE
Build: Fix macosx publishing

### DIFF
--- a/deploy/build.py
+++ b/deploy/build.py
@@ -1025,7 +1025,9 @@ def do_package():
         pass
     elif args.platform == 'macosx':
         # TODO: Improved packaging for OSX
-        shutil.copy2(root_package_filename, os.path.join(dist_dir, args.distname))
+        macosx_dist_dir = os.path.join(dist_dir, args.distname)
+        os.makedirs(macosx_dist_dir, exist_ok=True)
+        shutil.copy2(root_package_filename, macosx_dist_dir)
 
     elif args.platform == 'debian':
 

--- a/deploy/platform/macosx/macosx_publish.py
+++ b/deploy/platform/macosx/macosx_publish.py
@@ -48,5 +48,9 @@ args = parser.parse_args()
 # * may be `macports` or `homebrew`
 package_filenames = glob.glob(os.path.join(args.release_dir, f'mdsplus_{args.flavor}_{args.version}_*_{args.arch}.tgz'))
 
+flavor_dir = os.path.join(args.publish_dir, args.flavor)
+os.makedirs(flavor_dir, exist_ok=True)
+
 for filename in package_filenames:
-    shutil.copy2(filename, args.publish_dir)
+    print(f'Copying {filename} to {flavor_dir}')
+    shutil.copy2(filename, flavor_dir)


### PR DESCRIPTION
Add a mkdir to `build.py` to make `dist/homebrew` or `dist/macports`
This will cause `shutil.copy2` to properly place the tgz in the directory
Add flavor as a subdirectory to `macosx_publish.py` so that alpha and stable packages are separated