### PR TITLE
Build: Fix Java test $CLASSPATH

### DIFF
--- a/cmake/MDSplusAddTest.cmake
+++ b/cmake/MDSplusAddTest.cmake
@@ -41,6 +41,9 @@ set(MDSPLUS_TEST_ENV_MODS
     # Needed for `import MDSplus` in Python
     "PYTHONPATH=set:${CMAKE_SOURCE_DIR}/python"
 
+    # Ensure the system $CLASSPATH doesn't leak in
+    "CLASSPATH=unset:"
+
     # Needed to add Python drivers 
     "MDS_PYDEVICE_PATH=set:${CMAKE_SOURCE_DIR}/pydevices"
 

--- a/java/mdsobjects/tests/CMakeLists.txt
+++ b/java/mdsobjects/tests/CMakeLists.txt
@@ -33,8 +33,8 @@ if(ENABLE_JAVA AND NOT TEST_WITH_WINE AND NOT ENABLE_SANITIZE)
     )
 
     list(APPEND JAVA_TEST_ENV_MODS
-        "CLASSPATH=path_list_append:${CMAKE_CURRENT_BINARY_DIR}/../mdsobjects.jar"
-        "CLASSPATH=path_list_append:${CMAKE_CURRENT_BINARY_DIR}/mdsobjects-tests.jar"
+        "CLASSPATH=path_list_prepend:${CMAKE_CURRENT_BINARY_DIR}/../mdsobjects.jar"
+        "CLASSPATH=path_list_prepend:${CMAKE_CURRENT_BINARY_DIR}/mdsobjects-tests.jar"
     )
 
     foreach(_test_class IN LISTS _test_class_list)

--- a/java/mdsplus-api/tests/CMakeLists.txt
+++ b/java/mdsplus-api/tests/CMakeLists.txt
@@ -30,8 +30,8 @@ if(ENABLE_JAVA AND NOT TEST_WITH_WINE AND NOT ENABLE_SANITIZE)
     )
 
     list(APPEND JAVA_TEST_ENV_MODS
-        "CLASSPATH=path_list_append:${CMAKE_CURRENT_BINARY_DIR}/../mdsplus-api.jar"
-        "CLASSPATH=path_list_append:${CMAKE_CURRENT_BINARY_DIR}/mdsplus-api-tests.jar"
+        "CLASSPATH=path_list_prepend:${CMAKE_CURRENT_BINARY_DIR}/../mdsplus-api.jar"
+        "CLASSPATH=path_list_prepend:${CMAKE_CURRENT_BINARY_DIR}/mdsplus-api-tests.jar"
     )
 
     foreach(_test_class IN LISTS _test_class_list)

--- a/java/tests/CMakeLists.txt
+++ b/java/tests/CMakeLists.txt
@@ -18,12 +18,12 @@ if(ENABLE_JAVA AND NOT TEST_WITH_WINE AND NOT ENABLE_SANITIZE)
     )
 
     set(JAVA_TEST_ENV_MODS
-        "CLASSPATH=path_list_append:${CMAKE_CURRENT_BINARY_DIR}/taptest.jar"
+        "CLASSPATH=path_list_prepend:${CMAKE_CURRENT_BINARY_DIR}/taptest.jar"
     )
 
     foreach(_test_jar IN LISTS _test_jar_list)
         list(APPEND JAVA_TEST_ENV_MODS
-            "CLASSPATH=path_list_append:${_test_jar}"
+            "CLASSPATH=path_list_prepend:${_test_jar}"
         )
     endforeach()
 


### PR DESCRIPTION
Unset `CLASSPATH` for all tests to ensure Java tests use the built JAR files, not the system ones

Swap `path_list_append` to `path_list_prepend`
Note: This would also solve the above problem but I don't want to rely solely on the order of the `$CLASSPATH` environment variable

This issue was found while testing a rebase on #2950 