### PR TITLE
Build: Verify packages in Jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -81,7 +81,7 @@ def packageStage(os) {
     return {
         stage("Build & Package") {
             def threads = getNumThreads()
-            sh "deploy/build.py -j${threads} --os=${os} --build --package -DCMAKE_BUILD_TYPE=Release"
+            sh "deploy/build.py -j${threads} --os=${os} --build --package --verify-packages -DCMAKE_BUILD_TYPE=Release"
             dir("workspace-${os}") {
                 stash name: "packages-${os}", includes: "packages/**/*"
                 stash name: "dist-${os}", includes: "mdsplus-publish.json,dist/**/*"

--- a/deploy/packaging/alpine/alpine_build_apks.py
+++ b/deploy/packaging/alpine/alpine_build_apks.py
@@ -194,6 +194,9 @@ def build():
         os.system("rm -Rf %s" % noarchdir)
         os.system("mkdir -p %s" % noarchdir)
     for package in root.iter('package'):
+        skiparch_list = package.get('skiparch', '').split(',')
+        if info['arch'] in skiparch_list:
+            continue
         pkg = package.attrib['name']
         if pkg in pkg_exclusions:
             continue

--- a/deploy/packaging/debian/debian_build_debs.py
+++ b/deploy/packaging/debian/debian_build_debs.py
@@ -97,6 +97,9 @@ def build():
     root = common.get_root()
     debs = list()
     for package in root.iter('package'):
+        skiparch_list = package.get('skiparch', '').split(',')
+        if info['arch'] in skiparch_list:
+            continue
         pkg = package.attrib['name']
         if pkg == 'MDSplus':
             info['packagename'] = ""

--- a/deploy/packaging/linux.xml
+++ b/deploy/packaging/linux.xml
@@ -220,13 +220,13 @@ fi
 
   </package>
 
-  <package name="labview" arch="noarch" summary="National Instruments Labview extensions" description="National Instruments Labview extensions">
+  <package name="labview" arch="noarch" skiparch="armhf,arm64" summary="National Instruments Labview extensions" description="National Instruments Labview extensions">
     <requires package="labview_bin"/>
     <requires package="kernel"/>
     <include dir="/usr/local/mdsplus/LabView"/>
   </package>
 
-  <package name="labview_bin" arch="bin" summary="Libraries required for LabView interface" description="Libraries required for LabView interface">
+  <package name="labview_bin" arch="bin" skiparch="armhf,arm64" summary="Libraries required for LabView interface" description="Libraries required for LabView interface">
     <include file="/usr/local/mdsplus/lib/*LV*"/>
     <exclude_staticlibs/>
     <postinst>ldconfig -n /etc/ld.so.conf.d/mdsplus.conf</postinst>

--- a/deploy/packaging/redhat/redhat_build_rpms.py
+++ b/deploy/packaging/redhat/redhat_build_rpms.py
@@ -117,6 +117,9 @@ def build():
         info['arch'] = "bin"
         info['arch_t'] = arch['arch_t']
         for package in bin_packages:
+            skiparch_list = package.get('skiparch', '').split(',')
+            if info['arch'] in skiparch_list:
+                continue
             if package.attrib['name'] != "MDSplus":
                 info["packagename"] = "-%s" % package.attrib["name"]
             else:


### PR DESCRIPTION
Enable the package verification feature of `build.py` when building packages
Skips the labview package for arm64
Adds the ability to skip packages based on architecture. 