### PR TITLE
Feature: Actually include HDF5 tools/libraries in debian builds

### DIFF
--- a/deploy/os/debian-11-amd64.opts
+++ b/deploy/os/debian-11-amd64.opts
@@ -1,2 +1,2 @@
 --dockerimage=mdsplus/builder:debian-11-amd64 --distname=DebianBullseye
--DGSI=gcc64
+-DGSI=gcc64 -DENABLE_HDF5=ON

--- a/deploy/os/debian-12-amd64.opts
+++ b/deploy/os/debian-12-amd64.opts
@@ -1,2 +1,2 @@
 --dockerimage=mdsplus/builder:debian-12-amd64 --distname=DebianBookworm
--DGSI=gcc64
+-DGSI=gcc64 -DENABLE_HDF5=ON

--- a/deploy/os/debian-12-arm64.opts
+++ b/deploy/os/debian-12-arm64.opts
@@ -1,2 +1,2 @@
 --dockerimage=mdsplus/builder:debian-12-arm64 --distname=DebianBookworm --platform=debian
--DENABLE_LABVIEW=OFF
+-DENABLE_LABVIEW=OFF -DENABLE_HDF5=ON

--- a/deploy/os/ubuntu-18-amd64.opts
+++ b/deploy/os/ubuntu-18-amd64.opts
@@ -1,2 +1,2 @@
 --dockerimage=mdsplus/builder:ubuntu-18.04-amd64 --distname=Ubuntu18 --platform=debian
--DGSI=gcc64
+-DGSI=gcc64 -DENABLE_HDF5=ON

--- a/deploy/os/ubuntu-20-amd64.opts
+++ b/deploy/os/ubuntu-20-amd64.opts
@@ -1,2 +1,2 @@
 --dockerimage=mdsplus/builder:ubuntu-20.04-amd64 --distname=Ubuntu20 --platform=debian
--DGSI=gcc64
+-DGSI=gcc64 -DENABLE_HDF5=ON

--- a/deploy/os/ubuntu-22-amd64.opts
+++ b/deploy/os/ubuntu-22-amd64.opts
@@ -1,2 +1,2 @@
 --dockerimage=mdsplus/builder:ubuntu-22.04-amd64 --distname=Ubuntu22 --platform=debian
--DGSI=gcc64
+-DGSI=gcc64 -DENABLE_HDF5=ON

--- a/deploy/os/ubuntu-24-amd64.opts
+++ b/deploy/os/ubuntu-24-amd64.opts
@@ -1,2 +1,2 @@
 --dockerimage=mdsplus/builder:ubuntu-24.04-amd64 --distname=Ubuntu24 --platform=debian
--DGSI=gcc64
+-DGSI=gcc64 -DENABLE_HDF5=ON

--- a/deploy/packaging/debian/hdf5_bin.amd64
+++ b/deploy/packaging/debian/hdf5_bin.amd64
@@ -1,0 +1,3 @@
+./usr/local/mdsplus/bin/MDSplus2HDF5
+./usr/local/mdsplus/bin/hdf5ToMds
+./usr/local/mdsplus/lib/libhdf5tdi.so

--- a/deploy/packaging/debian/hdf5_bin.armhf
+++ b/deploy/packaging/debian/hdf5_bin.armhf
@@ -1,0 +1,3 @@
+./usr/local/mdsplus/bin/MDSplus2HDF5
+./usr/local/mdsplus/bin/hdf5ToMds
+./usr/local/mdsplus/lib/libhdf5tdi.so

--- a/deploy/packaging/debian/hdf5_bin.i386
+++ b/deploy/packaging/debian/hdf5_bin.i386
@@ -1,0 +1,3 @@
+./usr/local/mdsplus/bin/MDSplus2HDF5
+./usr/local/mdsplus/bin/hdf5ToMds
+./usr/local/mdsplus/lib/libhdf5tdi.so


### PR DESCRIPTION
Currently the debian hdf5-bin packages contain nothing, and the hdf5 packages contain TDI code that won't work without the libraries

This should be merged after the latest commit to the docker repo is built successfully, which adds libhdf5-dev to all debian images