### PR TITLE
Fix: fix brother of subtree nodes.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -76,8 +76,7 @@ def packageStage(os) {
     return {
         stage("Build & Package") {
             def threads = getNumThreads()
-            // (SLW) This has been changed to Debug while we investigate Issue #2972
-            sh "deploy/build.py -j${threads} --os=${os} --build --package -DCMAKE_BUILD_TYPE=Debug" // -DCMAKE_BUILD_TYPE=Release
+            sh "deploy/build.py -j${threads} --os=${os} --build --package -DCMAKE_BUILD_TYPE=Release"
             dir("workspace-${os}") {
                 stash name: "packages-${os}", includes: "packages/**/*"
                 stash name: "dist-${os}", includes: "mdsplus-publish.json,dist/**/*"

--- a/treeshr/TreeOpen.c
+++ b/treeshr/TreeOpen.c
@@ -1187,7 +1187,7 @@ static void SubtreeNodeConnect(PINO_DATABASE *dblist, NODE *parent,
   node_to_nid(dblist, parent_of(dblist, parent), &parent_nid);
   parent->child = *(int *)&child_nid;
   if (brother) {
-    node_to_nid(dblist, brother_of(dblist, parent), (NID *)&brother_nid);
+    node_to_nid(dblist, brother_of(dblist, parent), &brother_nid);
   }
   subtreetop->brother = *(int *)&brother_nid;
   subtreetop->parent = *(int *)&parent_nid;

--- a/treeshr/TreeOpen.c
+++ b/treeshr/TreeOpen.c
@@ -1184,7 +1184,7 @@ static void SubtreeNodeConnect(PINO_DATABASE *dblist, NODE *parent,
   parent->usage = TreeUSAGE_SUBTREE_REF;
   subtreetop->usage = TreeUSAGE_SUBTREE_TOP;
   node_to_nid(dblist, subtreetop, &child_nid);
-  node_to_nid(dblist, parent_of(dblist, parent), (NID *)&parent_nid);
+  node_to_nid(dblist, parent_of(dblist, parent), &parent_nid);
   parent->child = *(int *)&child_nid;
   if (brother) {
     node_to_nid(dblist, brother_of(dblist, parent), (NID *)&brother_nid);

--- a/treeshr/TreeOpen.c
+++ b/treeshr/TreeOpen.c
@@ -1174,17 +1174,23 @@ static int GetVmForTree(TREE_INFO *info, int nomap)
 static void SubtreeNodeConnect(PINO_DATABASE *dblist, NODE *parent,
                                NODE *subtreetop)
 {
-  NID child_nid, parent_nid, brother_nid = {0, 0};
+  NID child_nid, parent_nid = {0, 0};
+  /*
+   * make brother_nid volatile so that the optimizer does not
+   * decide to optimize it out and replace it with a zero.
+   */
+  volatile brother_nid = {0,0};
   NODE *brother = brother_of(dblist, parent);
   parent->usage = TreeUSAGE_SUBTREE_REF;
   subtreetop->usage = TreeUSAGE_SUBTREE_TOP;
   node_to_nid(dblist, subtreetop, &child_nid);
-  node_to_nid(dblist, parent_of(dblist, parent), &parent_nid);
-  if (brother)
-    node_to_nid(dblist, brother_of(dblist, parent), &brother_nid);
+  node_to_nid(dblist, parent_of(dblist, parent), (NID *)&parent_nid);
   parent->child = *(int *)&child_nid;
-  subtreetop->parent = *(int *)&parent_nid;
+  if (brother) {
+    node_to_nid(dblist, brother_of(dblist, parent), (NID *)&brother_nid);
+  }
   subtreetop->brother = *(int *)&brother_nid;
+  subtreetop->parent = *(int *)&parent_nid;
   memcpy(subtreetop->name, parent->name, sizeof(subtreetop->name));
   return;
 }

--- a/treeshr/TreeOpen.c
+++ b/treeshr/TreeOpen.c
@@ -1179,7 +1179,7 @@ static void SubtreeNodeConnect(PINO_DATABASE *dblist, NODE *parent,
    * make brother_nid volatile so that the optimizer does not
    * decide to optimize it out and replace it with a zero.
    */
-  volatile brother_nid = {0,0};
+  volatile NID brother_nid = {0,0};
   NODE *brother = brother_of(dblist, parent);
   parent->usage = TreeUSAGE_SUBTREE_REF;
   subtreetop->usage = TreeUSAGE_SUBTREE_TOP;


### PR DESCRIPTION
The optimizer is deciding that it does not need to fill in the brother nid of nodes that are subtree attachment points. Making the variable that holds it volatile forces the optimizer to do the right thing.

Fixes: https://github.com/MDSplus/mdsplus/issues/2972