### PR TITLE
Fix: issue with putRow in MdsTreeNodeTest caused by the optimizer

### DIFF
--- a/treeshr/TreeSegments.c
+++ b/treeshr/TreeSegments.c
@@ -182,7 +182,7 @@ typedef struct vars
 } vars_t;
 #define INIT_VARS                                                         \
   vars_t _vars = {0};                                                     \
-  vars_t *vars = &_vars;                                                  \
+  volatile vars_t *vars = &_vars;                                         \
   _vars.dblist = (PINO_DATABASE *)dbid;                                   \
   _vars.nid_ptr = (NID *)&nid;                                            \
   _vars.xnci = xnci;                                                      \


### PR DESCRIPTION
Mark `vars` (from `INIT_VARS`) as volatile to prevent it from being optimized into an issue

This serves as a partial fix for #2965 