### PR TITLE
Build: Replace `date` with `string(TIMESTAMP)`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1143,21 +1143,7 @@ check_include_files("stddef.h;scsi/sg.h" HAVE_SCSI_SG_H)
 ### Get the current timestamp to record when the build happened
 ###
 
-find_program(date_EXECUTABLE date)
-mark_as_advanced(date_EXECUTABLE)
-
-# TODO: Decide that string(TIMESTAMP) is good enough and remove the call to `date`
-if(date_EXECUTABLE)
-    execute_process(
-        COMMAND "${date_EXECUTABLE}"
-        OUTPUT_VARIABLE BUILD_TIMESTAMP
-        OUTPUT_STRIP_TRAILING_WHITESPACE
-    )
-else()
-    # STRING(TIMESTMAP) is missing AM/PM and the Timezone, but it is a sensible fallback
-    string(TIMESTAMP BUILD_TIMESTAMP "%a %d %b %Y %H:%M:%S UTC" UTC)
-endif()
-
+string(TIMESTAMP BUILD_TIMESTAMP "%a %b %d %H:%M:%S UTC %Y" UTC)
 
 ###
 ### Generate _include/_mdsversion.h


### PR DESCRIPTION
So, this one is definitely up for discussion.

The motivation is to replace the call to the `date` executable with a CMake built-in function, which is less code and doesn't rely on an external dependency that may not be there (e.g. on windows). The main differences are the lack of AM/PM (so we switch to 24-hour time) and the lack of time zones. This was originally added as a fallback if `date` isn't found 

This doesn't affect very much, but it does get built into the software alongside the version number, and can be seen from `mdstcl show version` like so:

```
$ mdstcl sho ver

MDSplus version: 7.155.1
----------------------
  Release:  alpha_release-7-155-1
  Date:     Fri Oct 24 22:02:16 UTC 2025
  Browse:   https://github.com/MDSplus/mdsplus/tree/alpha_release-7-155-1
  Download: https://github.com/MDSplus/mdsplus/releases/tag/alpha_release-7-155-1
```

1. For reference, the output of `date` looks like:
"Tue Oct 28 01:15:06 PM EDT 2025"
or
"Fri Oct 24 22:02:16 UTC 2025"
depending on distribution/configuration

2. The output of `string(TIMESTAMP UTC)` looks like:
"Tue Oct 28 17:20:55 UTC 2025"

3. And a third option we could use instead, where we just put "eastern" or something like it in place of the time zone:
"Tue Oct 28 13:21:30 Eastern 2025"
"Tue Oct 28 13:21:30 America/New_York 2025"
"Tue Oct 28 13:21:30 Boston 2025"
.. or anything similar

I've numbered the options so we can easily reference them