### PR TITLE
Build: add hashbang to scripts that need them for opinionated packaging systems

### DIFF
--- a/scripts/job_finish
+++ b/scripts/job_finish
@@ -1,3 +1,5 @@
+#!/bin/sh
+#
 # file: /usr/local/mdsplus/bin/job_finish
 #
 # shell script to signal completion of async daq task.

--- a/scripts/job_functions
+++ b/scripts/job_functions
@@ -1,3 +1,12 @@
+#!/bin/sh
+#
+# file: /usr/local/mdsplus/bin/job_functions
+#
+# utilities for signal completion of async daq task.
+#
+# called by job_finish.fun
+#
+#
 set_mds_logs()
 {
   if [ "x$MDS_LOGS" = "x" ]; then

--- a/scripts/job_output
+++ b/scripts/job_output
@@ -1,3 +1,5 @@
+#!/bin/sh
+#
 # file: /usr/local/mdsplus/bin/job_output
 #
 # shell script to spawn a batch job for automatic intershot analysis.

--- a/scripts/job_start
+++ b/scripts/job_start
@@ -1,3 +1,5 @@
+#!/bin/sh
+#
 # file: /usr/local/mdsplus/bin/job_start
 #
 # shell script to signal start of async daq task.

--- a/scripts/synchronize_unix
+++ b/scripts/synchronize_unix
@@ -1,3 +1,5 @@
+#!/bin/sh
+#
 if [ "x$MDS_LOGS" = "x" ]; then
     MDS_LOGS="/var/log/mdsplus";
 fi

--- a/tcl/mdstcl
+++ b/tcl/mdstcl
@@ -1,1 +1,3 @@
+#!/bin/sh
+#
 exec mdsdcl -prep "set command tcl_commands -history=.tcl" "$@"


### PR DESCRIPTION
Homebrew is quite opinionated about installing scripts in unix systems that are textual but do not have a hashbang (#!/bin/sh for example) start.  

These are the offending files that won't have their permissions set to executable unless they are amended.  These changes are inline with the other scripts, so making the entire system more self-consistent.