### PR TITLE
Fix: upgrade the mdstest.m MATLAB script to work with newer software

### DIFF
--- a/matlab/mdstest.m
+++ b/matlab/mdstest.m
@@ -32,7 +32,9 @@ function result = mdstest(varargin)
     result = result && mdscheck('$ == $', 'uint8', [1, 1], 1, 2);
     result = result && mdscheck('QUADWORD_UNSIGNED(1:100)', 'uint64', [100, 1]);
     if info.usePython
-        if ismac || ispc
+        % Text can have different classes depending on the software versions
+        x = mdsvalue('"any_string"');
+        if strcmp(class(x), 'py.str')
             result = result && mdscheck('"string test"', 'py.str', [1, 11]);
         else 
             result = result && mdscheck('"string test"', 'char', [1, 11]);

--- a/matlab/mdstest.m
+++ b/matlab/mdstest.m
@@ -5,6 +5,7 @@ function result = mdstest(varargin)
 %   mdstest()   % tests current bridge
 %   mdstest(0)  % tests java bridge
 %   mdstest(1)  % tests python bridge
+%   mdstest(1,1)  % tests mdsthin bridge
 
     info = mdsInfo(varargin{:}); % update MDSINFO
     result = mdscheck('1BU', 'uint8', [1, 1]);
@@ -28,7 +29,7 @@ function result = mdstest(varargin)
     result = result && mdscheck('$ == $', 'uint8', [1, 1], 1, 2);
     result = result && mdscheck('QUADWORD_UNSIGNED(1:100)', 'uint64', [100, 1]);
     if info.usePython
-        if ismac
+        if ismac || ispc
             result = result && mdscheck('"string test"', 'py.str', [1, 11]);
         else 
             result = result && mdscheck('"string test"', 'char', [1, 11]);

--- a/matlab/mdstest.m
+++ b/matlab/mdstest.m
@@ -6,6 +6,7 @@ function result = mdstest(varargin)
 %   mdstest(0)  % tests java bridge
 %   mdstest(1)  % tests python bridge
 
+    global MDSINFO;
     mdsInfo(varargin{:}); % update MDSINFO
     result = mdscheck('1BU', 'uint8', [1, 1]);
     result = result && mdscheck('1WU', 'uint16', [1, 1]);
@@ -13,7 +14,6 @@ function result = mdstest(varargin)
     result = result && mdscheck('100000000000QU', 'uint64', [1, 1]);
     result = result && mdscheck('1.', 'single', [1, 1]);
     result = result && mdscheck('1D0', 'double', [1, 1]);
-    result = result && mdscheck('"string test"', 'char', [1, 11]);
     result = result && mdscheck('BYTE_UNSIGNED(1:100)', 'uint8', [100, 1]);
     result = result && mdscheck('WORD_UNSIGNED(1:100)', 'uint16', [100, 1]);
     result = result && mdscheck('LONG_UNSIGNED(1:100)', 'uint32', [100, 1]);
@@ -28,8 +28,15 @@ function result = mdstest(varargin)
     result = result && mdscheck('$ : $', 'int32', [100, 1], int32(1), int32(100));
     result = result && mdscheck('$ == $', 'uint8', [1, 1], 1, 2);
     result = result && mdscheck('QUADWORD_UNSIGNED(1:100)', 'uint64', [100, 1]);
-    result = result && mdscheck('["a","b","c","d"]', 'cell', [4, 1]);
-    result = result && mdscheck('set_range(2,3,["a","b","c long string","d","e","f"])', 'cell', [2, 3]);
+    if MDSINFO.usePython
+        result = result && mdscheck('"string test"', 'char', [1, 11]);
+        result = result && mdscheck('["a","b","c","d"]', 'cell', [4, 1]);
+        result = result && mdscheck('set_range(2,3,["a","b","c long string","d","e","f"])', 'cell', [2, 3]);
+    else
+        result = result && mdscheck('"string test"', 'string', [1, 1]);
+        result = result && mdscheck('["a","b","c","d"]', 'string', [4, 1]);
+        result = result && mdscheck('set_range(2,3,["a","b","c long string","d","e","f"])', 'string', [2, 3]);
+    end
 end
 
 function result = mdscheck(exp, result_class, result_size, varargin)

--- a/matlab/mdstest.m
+++ b/matlab/mdstest.m
@@ -6,8 +6,7 @@ function result = mdstest(varargin)
 %   mdstest(0)  % tests java bridge
 %   mdstest(1)  % tests python bridge
 
-    global MDSINFO;
-    mdsInfo(varargin{:}); % update MDSINFO
+    info = mdsInfo(varargin{:}); % update MDSINFO
     result = mdscheck('1BU', 'uint8', [1, 1]);
     result = result && mdscheck('1WU', 'uint16', [1, 1]);
     result = result && mdscheck('1LU', 'uint32', [1, 1]);
@@ -28,8 +27,12 @@ function result = mdstest(varargin)
     result = result && mdscheck('$ : $', 'int32', [100, 1], int32(1), int32(100));
     result = result && mdscheck('$ == $', 'uint8', [1, 1], 1, 2);
     result = result && mdscheck('QUADWORD_UNSIGNED(1:100)', 'uint64', [100, 1]);
-    if MDSINFO.usePython
-        result = result && mdscheck('"string test"', 'char', [1, 11]);
+    if info.usePython
+        if ismac
+            result = result && mdscheck('"string test"', 'py.str', [1, 11]);
+        else 
+            result = result && mdscheck('"string test"', 'char', [1, 11]);
+        end
         result = result && mdscheck('["a","b","c","d"]', 'cell', [4, 1]);
         result = result && mdscheck('set_range(2,3,["a","b","c long string","d","e","f"])', 'cell', [2, 3]);
     else
@@ -56,6 +59,9 @@ function result = mdscheck(exp, result_class, result_size, varargin)
         fprintf('Error %s: expected size %s got %s\n', exp, mat2str(result_size), mat2str(size(x)))
         result = 0;
         return
+    end
+    if strcmp(class(x), 'py.str')
+        x = string(x);
     end
     y = mdsvalue('$', x);
     if isa(x, 'cell')

--- a/matlab/mdstest.m
+++ b/matlab/mdstest.m
@@ -2,10 +2,13 @@ function result = mdstest(varargin)
 % MDSTEST  test the MDSplus-MATLAB API (types and shapes)
 %   This routine tests the various functions in the MDSplus
 %   Matlab/Octave interface.
+%   Without a prior "mdsconnect()" call, this function just confirms
+%   that Java or Python can be used to access the MDSplus installed
+%   on the client computer. 
 %   mdstest()   % tests current bridge
 %   mdstest(0)  % tests java bridge
 %   mdstest(1)  % tests python bridge
-%   mdstest(1,1)  % tests mdsthin bridge
+%   mdstest(1,1)  % not a test of the mdsthin bridge, this is equivalent to mdstest(1)
 
     info = mdsInfo(varargin{:}); % update MDSINFO
     result = mdscheck('1BU', 'uint8', [1, 1]);

--- a/matlab/mdsvalue.m
+++ b/matlab/mdsvalue.m
@@ -15,7 +15,9 @@ else
 end
 for k = 1 : n
     argin = varargin(k);
-    if iscell(argin{1})
+    if iscell(argin) && isa(argin{1}, 'string')
+        argout = mdsFromMatlab(argin{1});
+    elseif iscell(argin{1})
         argout = mdsFromMatlab(argin{1});
     else
         argout = mdsFromMatlab(cell2mat(argin));

--- a/matlab/private/pythonFromMatlab.m
+++ b/matlab/private/pythonFromMatlab.m
@@ -3,6 +3,8 @@ dtype = class(value);
 switch dtype
     case 'char'
         result = value;
+    case 'string'
+        result = value;
     otherwise
         switch dtype
             case 'single'


### PR DESCRIPTION
This fixes issue #2987.

Surprisingly, MATLAB does not return the same "class" type across all platforms.   That caused the `mdstest.m` script to fail.

After the script was upgraded, it now passes all three bridges (Java, Python, mdsthin) on the following platforms.

- Ubuntu 24, MATLAB R2025a, OpenJDK 21.0.8, Python 3.12.3, NumPy 1.26.4
- macOS Tahoe, MATLAB R2024b, OpenJDK 21.0.8, Python 3.12.8, NumPy 2.2.2
- Win11, MATLAB R2025b, Java 1.8.0_471, Python 3.12.12, NumPy 2.3.5
