### PR TITLE
Fix: Fix clang-format issues for tdishr C codebase

### DIFF
--- a/tdishr/CvtConvertFloat.c
+++ b/tdishr/CvtConvertFloat.c
@@ -567,10 +567,6 @@ static void unpack_ibm_s(CVT_IBM_SHORT input_value,
 static void unpack_cray(CVT_CRAY input_value, UNPACKED_REAL intermediate_value,
                         uint32_t options __attribute__((unused)));
 
-extern EXPORT CVT_STATUS CvtConvertFloat(void *input_value, uint32_t input_type,
-                                         void *output_value,
-                                         uint32_t output_type)
-
 /*
 **=============================================================================
 **
@@ -635,6 +631,9 @@ extern EXPORT CVT_STATUS CvtConvertFloat(void *input_value, uint32_t input_type,
 **
 **=============================================================================
 */
+extern EXPORT CVT_STATUS CvtConvertFloat(void *input_value, uint32_t input_type,
+                                         void *output_value,
+                                         uint32_t output_type)
 {
   /*
    ** Local variable definitions.

--- a/tdishr/DummyRoutines.c
+++ b/tdishr/DummyRoutines.c
@@ -30,4 +30,5 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
     return 0;                                       \
   }
 /* dummy(LibConvertDateString) */
-dummy(LibFindVmZone) dummy(LibShowVmZone)
+dummy(LibFindVmZone);
+dummy(LibShowVmZone);

--- a/tdishr/TdiAbs.c
+++ b/tdishr/TdiAbs.c
@@ -340,30 +340,45 @@ int Tdi3AbsSq(struct descriptor *in_ptr, struct descriptor *out_ptr)
 
   switch (in_ptr->dtype)
   {
-  case DTYPE_BU:
-  case DTYPE_WU:
-  case DTYPE_LU:
-  case DTYPE_QU:
-  case DTYPE_OU:
-  case DTYPE_B:
-  case DTYPE_W:
-  case DTYPE_L:
-  case DTYPE_Q:
-  case DTYPE_O:
-  case DTYPE_F:
-  case DTYPE_FS:
-  case DTYPE_G:
-  case DTYPE_D:
-  case DTYPE_FT:
-    status = Tdi3Multiply(in_ptr, in_ptr, out_ptr);
-    break;
-  case DTYPE_FC:
-    start_operate(float) AbssqComplex(DTYPE_F);
-    end_operate case DTYPE_FSC : start_operate(float) AbssqComplex(DTYPE_FS);
-    end_operate case DTYPE_GC : start_operate(double) AbssqComplex(DTYPE_G);
-    end_operate case DTYPE_DC : start_operate(double) AbssqComplex(DTYPE_D);
-    end_operate case DTYPE_FTC : start_operate(double) AbssqComplex(DTYPE_FT);
-    end_operate default : status = TdiINVDTYDSC;
+    case DTYPE_BU:
+    case DTYPE_WU:
+    case DTYPE_LU:
+    case DTYPE_QU:
+    case DTYPE_OU:
+    case DTYPE_B:
+    case DTYPE_W:
+    case DTYPE_L:
+    case DTYPE_Q:
+    case DTYPE_O:
+    case DTYPE_F:
+    case DTYPE_FS:
+    case DTYPE_G:
+    case DTYPE_D:
+    case DTYPE_FT:
+      status = Tdi3Multiply(in_ptr, in_ptr, out_ptr);
+      break;
+    case DTYPE_FC:
+      start_operate(float); 
+      AbssqComplex(DTYPE_F);
+      end_operate; 
+    case DTYPE_FSC: 
+      start_operate(float);
+      AbssqComplex(DTYPE_FS);
+      end_operate; 
+    case DTYPE_GC: 
+      start_operate(double);
+      AbssqComplex(DTYPE_G);
+      end_operate;
+    case DTYPE_DC: 
+      start_operate(double);
+      AbssqComplex(DTYPE_D);
+      end_operate;
+    case DTYPE_FTC: 
+      start_operate(double);
+      AbssqComplex(DTYPE_FT);
+      end_operate;
+    default: 
+      status = TdiINVDTYDSC;
   }
 
   return status;
@@ -381,34 +396,67 @@ int Tdi3Aimag(struct descriptor *in_ptr, struct descriptor *out_ptr)
 
   switch (in_ptr->dtype)
   {
-  case DTYPE_B:
-  case DTYPE_BU:
-    start_operate2(int8_t) out[i] = 0;
-    end_operate case DTYPE_W : case DTYPE_WU : start_operate2(int16_t) out[i] =
-                                                   0;
-    end_operate case DTYPE_L : case DTYPE_LU : start_operate2(int32_t) out[i] =
-                                                   0;
-    end_operate case DTYPE_Q : case DTYPE_QU : start_operate2(int64_t) out[i] =
-                                                   0;
-    end_operate case DTYPE_O : case DTYPE_OU : start_operate2(int128_t) out[i]
-                                                   .low = 0;
-    out[i].high = 0;
-    ;
-    end_operate case DTYPE_F : start_operate2(float) float ans = (float)0.0;
-    CvtConvertFloat(&ans, DTYPE_NATIVE_FLOAT, &out[i], DTYPE_F, 0);
-    end_operate case DTYPE_FS : start_operate2(float) float ans = (float)0.0;
-    CvtConvertFloat(&ans, DTYPE_NATIVE_FLOAT, &out[i], DTYPE_FS, 0);
-    end_operate case DTYPE_G : start_operate2(double) double ans = 0.0;
-    CvtConvertFloat(&ans, DTYPE_NATIVE_DOUBLE, &out[i], DTYPE_G, 0);
-    end_operate case DTYPE_D : start_operate2(double) double ans = 0.0;
-    CvtConvertFloat(&ans, DTYPE_NATIVE_DOUBLE, &out[i], DTYPE_D, 0);
-    end_operate case DTYPE_FT : start_operate2(double) double ans = 0.0;
-    CvtConvertFloat(&ans, DTYPE_NATIVE_DOUBLE, &out[i], DTYPE_FT, 0);
-    end_operate case DTYPE_FC : case DTYPE_FSC : start_operate(int) out[i] =
-                                                     in[i * 2 + 1];
-    end_operate case DTYPE_GC : case DTYPE_DC : case DTYPE_FTC
-        : start_operate(double) memcpy(&out[i], &in[i * 2 + 1], sizeof(double));
-    end_operate default : status = TdiINVDTYDSC;
+    case DTYPE_B:
+    case DTYPE_BU:
+      start_operate2(int8_t) out[i] = 0;
+      end_operate;
+    case DTYPE_W:
+    case DTYPE_WU:
+      start_operate2(int16_t);
+      out[i] = 0;
+      end_operate;
+    case DTYPE_L: 
+    case DTYPE_LU:
+      start_operate2(int32_t)
+      out[i] = 0;
+      end_operate; 
+    case DTYPE_Q: 
+    case DTYPE_QU:
+      start_operate2(int64_t);
+      out[i] = 0;
+      end_operate;
+    case DTYPE_O: 
+    case DTYPE_OU:
+      start_operate2(int128_t);
+      out[i].low = 0;
+      out[i].high = 0;
+      end_operate;
+    case DTYPE_F: 
+      start_operate2(float);
+      float ans = (float)0.0;
+      CvtConvertFloat(&ans, DTYPE_NATIVE_FLOAT, &out[i], DTYPE_F, 0);
+      end_operate;
+    case DTYPE_FS: 
+      start_operate2(float);
+      float ans = (float)0.0;
+      CvtConvertFloat(&ans, DTYPE_NATIVE_FLOAT, &out[i], DTYPE_FS, 0);
+      end_operate;
+    case DTYPE_G: 
+      start_operate2(double);
+      double ans = 0.0;
+      CvtConvertFloat(&ans, DTYPE_NATIVE_DOUBLE, &out[i], DTYPE_G, 0);
+      end_operate;
+    case DTYPE_D: start_operate2(double) double ans = 0.0;
+      CvtConvertFloat(&ans, DTYPE_NATIVE_DOUBLE, &out[i], DTYPE_D, 0);
+      end_operate; 
+    case DTYPE_FT: 
+      start_operate2(double);
+      double ans = 0.0;
+      CvtConvertFloat(&ans, DTYPE_NATIVE_DOUBLE, &out[i], DTYPE_FT, 0);
+      end_operate; 
+    case DTYPE_FC: 
+    case DTYPE_FSC:
+      start_operate(int);
+      out[i] = in[i * 2 + 1];
+      end_operate;
+    case DTYPE_GC: 
+    case DTYPE_DC: 
+    case DTYPE_FTC:
+      start_operate(double);
+      memcpy(&out[i], &in[i * 2 + 1], sizeof(double));
+      end_operate; 
+    default: 
+      status = TdiINVDTYDSC;
   }
   return status;
 }
@@ -423,28 +471,64 @@ int Tdi3Conjg(struct descriptor *in_ptr, struct descriptor *out_ptr)
     return status;
   switch (in_ptr->dtype)
   {
-  case DTYPE_BU:
-  case DTYPE_B:
-    start_operate(uint8_t) out[i] = in[i];
-    end_operate case DTYPE_WU : case DTYPE_W : start_operate(uint16_t) out[i] =
-                                                   in[i];
-    end_operate case DTYPE_LU : case DTYPE_L : start_operate(uint32_t) out[i] =
-                                                   in[i];
-    end_operate case DTYPE_QU : case DTYPE_Q : start_operate(uint64_t) out[i] =
-                                                   in[i];
-    end_operate case DTYPE_OU : case DTYPE_O
-        : start_operate(uint128_t) memcpy(&out[i], &in[i], sizeof(int128_t));
-    end_operate case DTYPE_F : case DTYPE_FS : start_operate(float) out[i] =
-                                                   in[i];
-    end_operate case DTYPE_G : case DTYPE_D : case DTYPE_FT
-        : start_operate(double) out[i] = in[i];
-    end_operate case DTYPE_FC : start_operate(float) ConjgComplex(DTYPE_F)
-                                    end_operate case DTYPE_FSC
-        : start_operate(float) ConjgComplex(DTYPE_FS) end_operate case DTYPE_GC
-        : start_operate(double) ConjgComplex(DTYPE_G) end_operate case DTYPE_DC
-        : start_operate(double) ConjgComplex(DTYPE_D) end_operate case DTYPE_FTC
-        : start_operate(double) ConjgComplex(DTYPE_FT) end_operate default
-        : status = TdiINVDTYDSC;
+    case DTYPE_BU:
+    case DTYPE_B:
+      start_operate(uint8_t);
+      out[i] = in[i];
+      end_operate;
+    case DTYPE_WU:
+    case DTYPE_W:
+      start_operate(uint16_t);
+      out[i] = in[i];
+      end_operate;
+    case DTYPE_LU:
+    case DTYPE_L:
+      start_operate(uint32_t);
+      out[i] = in[i];
+      end_operate;
+    case DTYPE_QU:
+    case DTYPE_Q: 
+      start_operate(uint64_t);
+      out[i] = in[i];
+      end_operate;
+    case DTYPE_OU:
+    case DTYPE_O:
+      start_operate(uint128_t);
+      memcpy(&out[i], &in[i], sizeof(int128_t));
+      end_operate;
+    case DTYPE_F:
+    case DTYPE_FS:
+      start_operate(float);
+      out[i] = in[i];
+      end_operate;
+    case DTYPE_G:
+    case DTYPE_D:
+    case DTYPE_FT:
+      start_operate(double);
+      out[i] = in[i];
+      end_operate;
+    case DTYPE_FC:
+      start_operate(float);
+      ConjgComplex(DTYPE_F);
+      end_operate;
+    case DTYPE_FSC:
+      start_operate(float);
+      ConjgComplex(DTYPE_FS);
+      end_operate;
+    case DTYPE_GC:
+      start_operate(double);
+      ConjgComplex(DTYPE_G);
+      end_operate;
+    case DTYPE_DC:
+      start_operate(double);
+      ConjgComplex(DTYPE_D);
+      end_operate;
+    case DTYPE_FTC:
+      start_operate(double);
+      ConjgComplex(DTYPE_FT);
+      end_operate;
+    default: 
+      status = TdiINVDTYDSC;
   }
   return status;
 }
@@ -459,19 +543,34 @@ int Tdi3Inot(struct descriptor *in_ptr, struct descriptor *out_ptr)
     return status;
   switch (in_ptr->dtype)
   {
-  case DTYPE_B:
-  case DTYPE_BU:
-    start_operate(uint8_t) out[i] = ~in[i];
-    end_operate case DTYPE_W : case DTYPE_WU : start_operate(uint16_t) out[i] =
-                                                   ~in[i];
-    end_operate case DTYPE_L : case DTYPE_LU : start_operate(uint32_t) out[i] =
-                                                   ~in[i];
-    end_operate case DTYPE_Q : case DTYPE_QU : start_operate(uint64_t) out[i] =
-                                                   ~in[i];
-    end_operate case DTYPE_O : case DTYPE_OU : start_operate(uint128_t) out[i]
-                                                   .low = ~in[i].low;
-    out[i].high = ~in[i].high;
-    end_operate default : status = TdiINVDTYDSC;
+    case DTYPE_B:
+    case DTYPE_BU:
+        start_operate(uint8_t);
+        out[i] = ~in[i];
+        end_operate;
+      case DTYPE_W:
+      case DTYPE_WU:
+        start_operate(uint16_t);
+        out[i] = ~in[i];
+        end_operate;
+      case DTYPE_L:
+      case DTYPE_LU:
+        start_operate(uint32_t);
+        out[i] = ~in[i];
+        end_operate;
+      case DTYPE_Q:
+      case DTYPE_QU:
+        start_operate(uint64_t);
+        out[i] = ~in[i];
+        end_operate;
+      case DTYPE_O:
+      case DTYPE_OU:
+        start_operate(uint128_t);
+        out[i].low = ~in[i].low;
+        out[i].high = ~in[i].high;
+        end_operate;
+      default:
+        status = TdiINVDTYDSC;
   }
   return status;
 }
@@ -488,18 +587,33 @@ int Tdi3Logical(struct descriptor *in_ptr,
     return status;
   switch (in_ptr->dtype)
   {
-  case DTYPE_B:
-  case DTYPE_BU:
-    start_operate1(uint8_t, uint8_t) out[i] = (uint8_t)(1 & in[i]);
-    end_operate case DTYPE_W : case DTYPE_WU
-        : start_operate1(uint16_t, uint8_t) out[i] = (uint8_t)(1 & in[i]);
-    end_operate case DTYPE_L : case DTYPE_LU
-        : start_operate1(uint32_t, uint8_t) out[i] = (uint8_t)(1 & in[i]);
-    end_operate case DTYPE_Q : case DTYPE_QU
-        : start_operate1(uint64_t, uint8_t) out[i] = (uint8_t)(1 & in[i]);
-    end_operate case DTYPE_O : case DTYPE_OU
-        : start_operate1(uint128_t, uint8_t) out[i] = (uint8_t)(1 & in[i].low);
-    end_operate default : status = TdiINVDTYDSC;
+    case DTYPE_B:
+    case DTYPE_BU:
+      start_operate1(uint8_t, uint8_t); 
+      out[i] = (uint8_t)(1 & in[i]);
+      end_operate; 
+    case DTYPE_W : 
+    case DTYPE_WU: 
+      start_operate1(uint16_t, uint8_t); 
+      out[i] = (uint8_t)(1 & in[i]);
+      end_operate; 
+    case DTYPE_L : 
+    case DTYPE_LU: 
+      start_operate1(uint32_t, uint8_t); 
+      out[i] = (uint8_t)(1 & in[i]);
+      end_operate; 
+    case DTYPE_Q : 
+    case DTYPE_QU: 
+      start_operate1(uint64_t, uint8_t); 
+      out[i] = (uint8_t)(1 & in[i]);
+      end_operate; 
+    case DTYPE_O : 
+    case DTYPE_OU: 
+      start_operate1(uint128_t, uint8_t); 
+      out[i] = (uint8_t)(1 & in[i].low);
+      end_operate; 
+    default : 
+      status = TdiINVDTYDSC;
   }
   return status;
 }
@@ -513,24 +627,40 @@ int Tdi3Not(struct descriptor *in_ptr, struct descriptor *out_ptr)
   if (STATUS_NOT_OK)
     return status;
   switch (in_ptr->dtype)
+
   {
   case DTYPE_B:
   case DTYPE_BU:
-    start_operate1(uint8_t, uint8_t) out[i] = (uint8_t) !(in[i] & 1);
-    end_operate case DTYPE_W : case DTYPE_WU
-        : start_operate1(uint16_t, uint8_t) out[i] = (uint8_t) !(in[i] & 1);
-    end_operate case DTYPE_L : case DTYPE_LU
-        : start_operate1(uint32_t, uint8_t) out[i] = (uint8_t) !(in[i] & 1);
-    end_operate case DTYPE_Q : case DTYPE_QU
-        : start_operate1(uint64_t, uint8_t) out[i] = (uint8_t) !(in[i] & 1);
-    end_operate case DTYPE_O : case DTYPE_OU
-        : start_operate1(uint128_t, uint8_t) out[i] =
-              (uint8_t) !(1 & in[i].low);
-    end_operate default : status = TdiINVDTYDSC;
+    start_operate1(uint8_t, uint8_t); 
+    out[i] = (uint8_t) !(in[i] & 1);
+    end_operate; 
+  case DTYPE_W : 
+  case DTYPE_WU: 
+    start_operate1(uint16_t, uint8_t); 
+    out[i] = (uint8_t) !(in[i] & 1);
+    end_operate 
+  case DTYPE_L : 
+  case DTYPE_LU: 
+    start_operate1(uint32_t, uint8_t); 
+    out[i] = (uint8_t) !(in[i] & 1);
+    end_operate ;
+  case DTYPE_Q : 
+  case DTYPE_QU: 
+    start_operate1(uint64_t, uint8_t); 
+    out[i] = (uint8_t) !(in[i] & 1);
+    end_operate; 
+  case DTYPE_O : 
+  case DTYPE_OU: 
+    start_operate1(uint128_t, uint8_t); 
+    out[i] = (uint8_t) !(1 & in[i].low);
+    end_operate; 
+  default : 
+    status = TdiINVDTYDSC;
   }
 
   return status;
 }
+
 
 int Tdi3Nint(struct descriptor *in_ptr,
              struct descriptor *kind __attribute__((unused)),
@@ -546,34 +676,87 @@ int Tdi3Nint(struct descriptor *in_ptr,
 
   switch (in_ptr->dtype)
   {
-  case DTYPE_BU:
-    start_operate(uint8_t) out[i] = in[i];
-    end_operate case DTYPE_WU : start_operate(uint16_t) out[i] = in[i];
-    end_operate case DTYPE_LU : start_operate(uint32_t) out[i] = in[i];
-    end_operate case DTYPE_QU : start_operate(uint64_t) out[i] = in[i];
-    end_operate case DTYPE_OU : start_operate(uint128_t)
-                                    memcpy(&out[i], &in[i], sizeof(uint128_t));
-    end_operate case DTYPE_B : start_operate(int8_t) out[i] = in[i];
-    end_operate case DTYPE_W : start_operate(int16_t) out[i] = in[i];
-    end_operate case DTYPE_L : start_operate(int32_t) out[i] = in[i];
-    end_operate case DTYPE_Q : start_operate(int64_t) out[i] = in[i];
-    end_operate case DTYPE_O : start_operate(int128_t)
-                                   memcpy(&out[i], &in[i], sizeof(int128_t));
-    end_operate case DTYPE_F : start_operate1(float, int) NintFloat(DTYPE_F);
-    end_operate case DTYPE_FS : start_operate1(float, int) NintFloat(DTYPE_FS);
-    end_operate case DTYPE_G : start_operate1(double, int) NintFloat(DTYPE_G);
-    end_operate case DTYPE_D : start_operate1(double, int) NintFloat(DTYPE_D);
-    end_operate case DTYPE_FT : start_operate1(double, int) NintFloat(DTYPE_FT);
-    end_operate case DTYPE_FC : start_operate1(float, int) NintComplex(DTYPE_F);
-    end_operate case DTYPE_FSC : start_operate1(float, int)
-                                     NintComplex(DTYPE_FS);
-    end_operate case DTYPE_GC : start_operate1(double, int)
-                                    NintComplex(DTYPE_G);
-    end_operate case DTYPE_DC : start_operate1(double, int)
-                                    NintComplex(DTYPE_D);
-    end_operate case DTYPE_FTC : start_operate1(double, int)
-                                     NintComplex(DTYPE_FT);
-    end_operate default : status = TdiINVDTYDSC;
+    case DTYPE_BU:
+      start_operate(uint8_t) out[i] = in[i];
+      end_operate 
+    case DTYPE_WU : 
+      start_operate(uint16_t); 
+      out[i] = in[i];
+      end_operate; 
+    case DTYPE_LU : 
+      start_operate(uint32_t); 
+      out[i] = in[i];
+      end_operate; 
+    case DTYPE_QU : 
+      start_operate(uint64_t); 
+      out[i] = in[i];
+      end_operate; 
+    case DTYPE_OU : 
+      start_operate(uint128_t);
+      memcpy(&out[i], &in[i], sizeof(uint128_t));
+      end_operate; 
+    case DTYPE_B : 
+      start_operate(int8_t); 
+      out[i] = in[i];
+      end_operate; 
+    case DTYPE_W : 
+      start_operate(int16_t); 
+      out[i] = in[i];
+      end_operate; 
+    case DTYPE_L : 
+      start_operate(int32_t); 
+      out[i] = in[i];
+      end_operate; 
+    case DTYPE_Q : 
+      start_operate(int64_t); 
+      out[i] = in[i];
+      end_operate; 
+    case DTYPE_O : 
+      start_operate(int128_t);
+      memcpy(&out[i], &in[i], sizeof(int128_t));
+      end_operate; 
+    case DTYPE_F : 
+      start_operate1(float, int); 
+      NintFloat(DTYPE_F);
+      end_operate; 
+    case DTYPE_FS : 
+      start_operate1(float, int); 
+      NintFloat(DTYPE_FS);
+      end_operate; 
+    case DTYPE_G : 
+      start_operate1(double, int); 
+      NintFloat(DTYPE_G);
+      end_operate; 
+    case DTYPE_D : 
+      start_operate1(double, int); 
+      NintFloat(DTYPE_D);
+      end_operate; 
+    case DTYPE_FT : 
+      start_operate1(double, int); 
+      NintFloat(DTYPE_FT);
+      end_operate; 
+    case DTYPE_FC : 
+      start_operate1(float, int); 
+      NintComplex(DTYPE_F);
+      end_operate; 
+    case DTYPE_FSC : 
+      start_operate1(float, int);
+      NintComplex(DTYPE_FS);
+      end_operate; 
+    case DTYPE_GC : 
+      start_operate1(double, int);
+      NintComplex(DTYPE_G);
+      end_operate;
+    case DTYPE_DC : 
+      start_operate1(double, int);
+      NintComplex(DTYPE_D);
+      end_operate; 
+    case DTYPE_FTC : 
+      start_operate1(double, int);
+      NintComplex(DTYPE_FT);
+      end_operate; 
+    default : 
+      status = TdiINVDTYDSC;
   }
 
   return status;
@@ -591,39 +774,89 @@ int Tdi3UnaryMinus(struct descriptor *in_ptr, struct descriptor *out_ptr)
 
   switch (in_ptr->dtype)
   {
-  case DTYPE_BU:
-    start_operate(int8_t) out[i] = -in[i];
-    end_operate case DTYPE_WU : start_operate(int16_t) out[i] = -in[i];
-    end_operate case DTYPE_LU : start_operate(int32_t) out[i] = -in[i];
-    end_operate case DTYPE_QU : start_operate(int64_t) out[i] = -in[i];
-    end_operate case DTYPE_OU : start_operate(int128_t)
-                                    int128_minus((int128_t *)&in[i], &out[i]);
-    end_operate case DTYPE_B : start_operate(int8_t) out[i] = -in[i];
-    end_operate case DTYPE_W : start_operate(int16_t) out[i] = -in[i];
-    end_operate case DTYPE_L : start_operate(int32_t) out[i] = -in[i];
-    end_operate case DTYPE_Q : start_operate(int64_t) out[i] = -in[i];
-    end_operate case DTYPE_O : start_operate(int128_t)
-                                   int128_minus((int128_t *)&in[i], &out[i]);
-    end_operate case DTYPE_F : start_operate(float) UnaryMinusFloat(DTYPE_F)
-                                   end_operate case DTYPE_FS
-        : start_operate(float) UnaryMinusFloat(DTYPE_FS)
-              end_operate case DTYPE_G : start_operate(double)
-                                             UnaryMinusFloat(DTYPE_G)
-                                                 end_operate case DTYPE_D
-        : start_operate(double) UnaryMinusFloat(DTYPE_D)
-              end_operate case DTYPE_FT : start_operate(double)
-                                              UnaryMinusFloat(DTYPE_FT)
-                                                  end_operate case DTYPE_FC
-        : start_operate(float) UnaryMinusComplex(DTYPE_F)
-              end_operate case DTYPE_FSC : start_operate(float)
-                                               UnaryMinusComplex(DTYPE_FS)
-                                                   end_operate case DTYPE_GC
-        : start_operate(double) UnaryMinusComplex(DTYPE_G)
-              end_operate case DTYPE_DC : start_operate(double)
-                                              UnaryMinusComplex(DTYPE_D)
-                                                  end_operate case DTYPE_FTC
-        : start_operate(double) UnaryMinusComplex(DTYPE_FT) end_operate default
-        : status = TdiINVDTYDSC;
+    case DTYPE_BU:
+      start_operate(int8_t);
+      out[i] = -in[i];
+      end_operate; 
+    case DTYPE_WU: 
+      start_operate(int16_t); 
+      out[i] = -in[i];
+      end_operate; 
+    case DTYPE_LU: 
+      start_operate(int32_t); 
+      out[i] = -in[i];
+      end_operate;
+    case DTYPE_QU: 
+      start_operate(int64_t); 
+      out[i] = -in[i];
+      end_operate; 
+    case DTYPE_OU: 
+      start_operate(int128_t);
+      int128_minus((int128_t *)&in[i], &out[i]);
+      end_operate; 
+    case DTYPE_B: 
+      start_operate(int8_t); 
+      out[i] = -in[i];
+      end_operate; 
+    case DTYPE_W: 
+      start_operate(int16_t); 
+      out[i] = -in[i];
+      end_operate; 
+    case DTYPE_L: 
+      start_operate(int32_t); 
+      out[i] = -in[i];
+      end_operate; 
+    case DTYPE_Q: 
+      start_operate(int64_t); 
+      out[i] = -in[i];
+      end_operate; 
+    case DTYPE_O: 
+      start_operate(int128_t);
+      int128_minus((int128_t *)&in[i], &out[i]);
+      end_operate; 
+    case DTYPE_F: 
+      start_operate(float); 
+      UnaryMinusFloat(DTYPE_F);
+      end_operate; 
+    case DTYPE_FS: 
+      start_operate(float); 
+      UnaryMinusFloat(DTYPE_FS);
+      end_operate; 
+    case DTYPE_G: 
+      start_operate(double);
+      UnaryMinusFloat(DTYPE_G);
+      end_operate;
+    case DTYPE_D: 
+      start_operate(double); 
+      UnaryMinusFloat(DTYPE_D);
+      end_operate; 
+    case DTYPE_FT: 
+      start_operate(double);
+      UnaryMinusFloat(DTYPE_FT);
+      end_operate; 
+    case DTYPE_FC: 
+      start_operate(float);
+      UnaryMinusComplex(DTYPE_F);
+      end_operate; 
+    case DTYPE_FSC: 
+      start_operate(float);
+      UnaryMinusComplex(DTYPE_FS);
+      end_operate;
+    case DTYPE_GC: 
+      start_operate(double); 
+      UnaryMinusComplex(DTYPE_G);
+      end_operate; 
+    case DTYPE_DC: 
+      start_operate(double);
+      UnaryMinusComplex(DTYPE_D);
+      end_operate; 
+    case DTYPE_FTC: 
+      start_operate(double);
+      UnaryMinusComplex(DTYPE_FT); 
+      end_operate;
+    default: 
+      status = TdiINVDTYDSC;
   }
+  
   return status;
 }

--- a/tdishr/TdiAdd.c
+++ b/tdishr/TdiAdd.c
@@ -304,24 +304,48 @@ int Tdi3Add(struct descriptor *in1, struct descriptor *in2,
 {
   SetupArgs switch (in1->dtype)
   {
-  case DTYPE_B:
-    Operate(int8_t, +) case DTYPE_BU : Operate(uint8_t, +) case DTYPE_W
-        : Operate(uint16_t, +) case DTYPE_WU : Operate(uint16_t, +) case DTYPE_L
-        : Operate(uint32_t, +) case DTYPE_LU : Operate(uint32_t, +) case DTYPE_Q
-        : Operate(int64_t, +) case DTYPE_QU : Operate(uint64_t, +) case DTYPE_O
-        : Operate128(int128, add) case DTYPE_OU
-        : Operate128(uint128, add) case DTYPE_F
-        : OperateFloat(float, DTYPE_F, DTYPE_NATIVE_FLOAT, +) case DTYPE_FS
-        : OperateFloat(float, DTYPE_FS, DTYPE_NATIVE_FLOAT, +) case DTYPE_D
-        : OperateFloat(double, DTYPE_D, DTYPE_NATIVE_DOUBLE, +) case DTYPE_G
-        : OperateFloat(double, DTYPE_G, DTYPE_NATIVE_DOUBLE, +) case DTYPE_FT
-        : OperateFloat(double, DTYPE_FT, DTYPE_NATIVE_DOUBLE, +) case DTYPE_FC
-        : OperateComplex(float, DTYPE_F, DTYPE_NATIVE_FLOAT, +) case DTYPE_FSC
-        : OperateComplex(float, DTYPE_FS, DTYPE_NATIVE_FLOAT, +) case DTYPE_GC
-        : OperateComplex(double, DTYPE_G, DTYPE_NATIVE_DOUBLE, +) case DTYPE_DC
-        : OperateComplex(double, DTYPE_D, DTYPE_NATIVE_DOUBLE, +) case DTYPE_FTC
-        : OperateComplex(double, DTYPE_FT, DTYPE_NATIVE_DOUBLE, +) default
-        : return TdiINVDTYDSC;
+    case DTYPE_B:
+      Operate(int8_t, +); 
+    case DTYPE_BU : 
+      Operate(uint8_t, +); 
+    case DTYPE_W: 
+      Operate(uint16_t, +); 
+    case DTYPE_WU : 
+      Operate(uint16_t, +); 
+    case DTYPE_L: 
+      Operate(uint32_t, +); 
+    case DTYPE_LU : 
+      Operate(uint32_t, +); 
+    case DTYPE_Q: 
+      Operate(int64_t, +); 
+    case DTYPE_QU : 
+      Operate(uint64_t, +); 
+    case DTYPE_O: 
+      Operate128(int128, add); 
+    case DTYPE_OU: 
+      Operate128(uint128, add); 
+    case DTYPE_F: 
+      OperateFloat(float, DTYPE_F, DTYPE_NATIVE_FLOAT, +); 
+    case DTYPE_FS: 
+      OperateFloat(float, DTYPE_FS, DTYPE_NATIVE_FLOAT, +); 
+    case DTYPE_D: 
+      OperateFloat(double, DTYPE_D, DTYPE_NATIVE_DOUBLE, +); 
+    case DTYPE_G: 
+      OperateFloat(double, DTYPE_G, DTYPE_NATIVE_DOUBLE, +); 
+    case DTYPE_FT: 
+      OperateFloat(double, DTYPE_FT, DTYPE_NATIVE_DOUBLE, +); 
+    case DTYPE_FC: 
+      OperateComplex(float, DTYPE_F, DTYPE_NATIVE_FLOAT, +); 
+    case DTYPE_FSC: 
+      OperateComplex(float, DTYPE_FS, DTYPE_NATIVE_FLOAT, +); 
+    case DTYPE_GC: 
+      OperateComplex(double, DTYPE_G, DTYPE_NATIVE_DOUBLE, +); 
+    case DTYPE_DC: 
+      OperateComplex(double, DTYPE_D, DTYPE_NATIVE_DOUBLE, +); 
+    case DTYPE_FTC: 
+      OperateComplex(double, DTYPE_FT, DTYPE_NATIVE_DOUBLE, +); 
+    default: 
+      return TdiINVDTYDSC;
   }
   return 1;
 }
@@ -331,24 +355,48 @@ int Tdi3Subtract(struct descriptor *in1, struct descriptor *in2,
 {
   SetupArgs switch (in1->dtype)
   {
-  case DTYPE_B:
-    Operate(int8_t, -) case DTYPE_BU : Operate(uint8_t, -) case DTYPE_W
-        : Operate(uint16_t, -) case DTYPE_WU : Operate(uint16_t, -) case DTYPE_L
-        : Operate(uint32_t, -) case DTYPE_LU : Operate(uint32_t, -) case DTYPE_Q
-        : Operate(int64_t, -) case DTYPE_QU : Operate(uint64_t, -) case DTYPE_O
-        : Operate128(int128, sub) case DTYPE_OU
-        : Operate128(uint128, sub) case DTYPE_F
-        : OperateFloat(float, DTYPE_F, DTYPE_NATIVE_FLOAT, -) case DTYPE_FS
-        : OperateFloat(float, DTYPE_FS, DTYPE_NATIVE_FLOAT, -) case DTYPE_D
-        : OperateFloat(double, DTYPE_D, DTYPE_NATIVE_DOUBLE, -) case DTYPE_G
-        : OperateFloat(double, DTYPE_G, DTYPE_NATIVE_DOUBLE, -) case DTYPE_FT
-        : OperateFloat(double, DTYPE_FT, DTYPE_NATIVE_DOUBLE, -) case DTYPE_FC
-        : OperateComplex(float, DTYPE_F, DTYPE_NATIVE_FLOAT, -) case DTYPE_FSC
-        : OperateComplex(float, DTYPE_FS, DTYPE_NATIVE_FLOAT, -) case DTYPE_GC
-        : OperateComplex(double, DTYPE_G, DTYPE_NATIVE_DOUBLE, -) case DTYPE_DC
-        : OperateComplex(double, DTYPE_D, DTYPE_NATIVE_DOUBLE, -) case DTYPE_FTC
-        : OperateComplex(double, DTYPE_FT, DTYPE_NATIVE_DOUBLE, -) default
-        : return TdiINVDTYDSC;
+    case DTYPE_B:
+      Operate(int8_t, -); 
+    case DTYPE_BU : 
+      Operate(uint8_t, -); 
+    case DTYPE_W: 
+      Operate(uint16_t, -); 
+    case DTYPE_WU : 
+      Operate(uint16_t, -); 
+    case DTYPE_L: 
+      Operate(uint32_t, -); 
+    case DTYPE_LU : 
+      Operate(uint32_t, -); 
+    case DTYPE_Q: 
+      Operate(int64_t, -); 
+    case DTYPE_QU : 
+      Operate(uint64_t, -); 
+    case DTYPE_O: 
+      Operate128(int128, sub); 
+    case DTYPE_OU: 
+      Operate128(uint128, sub); 
+    case DTYPE_F: 
+      OperateFloat(float, DTYPE_F, DTYPE_NATIVE_FLOAT, -); 
+    case DTYPE_FS: 
+      OperateFloat(float, DTYPE_FS, DTYPE_NATIVE_FLOAT, -); 
+    case DTYPE_D: 
+      OperateFloat(double, DTYPE_D, DTYPE_NATIVE_DOUBLE, -); 
+    case DTYPE_G: 
+      OperateFloat(double, DTYPE_G, DTYPE_NATIVE_DOUBLE, -); 
+    case DTYPE_FT: 
+      OperateFloat(double, DTYPE_FT, DTYPE_NATIVE_DOUBLE, -); 
+    case DTYPE_FC: 
+      OperateComplex(float, DTYPE_F, DTYPE_NATIVE_FLOAT, -); 
+    case DTYPE_FSC: 
+      OperateComplex(float, DTYPE_FS, DTYPE_NATIVE_FLOAT, -); 
+    case DTYPE_GC: 
+      OperateComplex(double, DTYPE_G, DTYPE_NATIVE_DOUBLE, -); 
+    case DTYPE_DC: 
+      OperateComplex(double, DTYPE_D, DTYPE_NATIVE_DOUBLE, -); 
+    case DTYPE_FTC: 
+      OperateComplex(double, DTYPE_FT, DTYPE_NATIVE_DOUBLE, -); 
+    default: 
+      return TdiINVDTYDSC;
   }
   return 1;
 }
@@ -358,24 +406,48 @@ int Tdi3Multiply(struct descriptor *in1, struct descriptor *in2,
 {
   SetupArgs switch (in1->dtype)
   {
-  case DTYPE_B:
-    Operate(int8_t, *) case DTYPE_BU : Operate(uint8_t, *) case DTYPE_W
-        : Operate(uint16_t, *) case DTYPE_WU : Operate(uint16_t, *) case DTYPE_L
-        : Operate(uint32_t, *) case DTYPE_LU : Operate(uint32_t, *) case DTYPE_Q
-        : Operate(int64_t, *) case DTYPE_QU : Operate(uint64_t, *) case DTYPE_O
-        : Operate128(int128, mul) case DTYPE_OU
-        : Operate128(uint128, mul) case DTYPE_F
-        : OperateFloat(float, DTYPE_F, DTYPE_NATIVE_FLOAT, *) case DTYPE_FS
-        : OperateFloat(float, DTYPE_FS, DTYPE_NATIVE_FLOAT, *) case DTYPE_D
-        : OperateFloat(double, DTYPE_D, DTYPE_NATIVE_DOUBLE, *) case DTYPE_G
-        : OperateFloat(double, DTYPE_G, DTYPE_NATIVE_DOUBLE, *) case DTYPE_FT
-        : OperateFloat(double, DTYPE_FT, DTYPE_NATIVE_DOUBLE, *) case DTYPE_FC
-        : MultiplyComplex(float, DTYPE_F, DTYPE_NATIVE_FLOAT) case DTYPE_FSC
-        : MultiplyComplex(float, DTYPE_FS, DTYPE_NATIVE_FLOAT) case DTYPE_GC
-        : MultiplyComplex(double, DTYPE_G, DTYPE_NATIVE_DOUBLE) case DTYPE_DC
-        : MultiplyComplex(double, DTYPE_D, DTYPE_NATIVE_DOUBLE) case DTYPE_FTC
-        : MultiplyComplex(double, DTYPE_FT, DTYPE_NATIVE_DOUBLE) default
-        : return TdiINVDTYDSC;
+    case DTYPE_B:
+      Operate(int8_t, *); 
+    case DTYPE_BU : 
+      Operate(uint8_t, *); 
+    case DTYPE_W: 
+      Operate(uint16_t, *); 
+    case DTYPE_WU : 
+      Operate(uint16_t, *); 
+    case DTYPE_L: 
+      Operate(uint32_t, *); 
+    case DTYPE_LU : 
+      Operate(uint32_t, *); 
+    case DTYPE_Q: 
+      Operate(int64_t, *); 
+    case DTYPE_QU : 
+      Operate(uint64_t, *); 
+    case DTYPE_O: 
+      Operate128(int128, mul); 
+    case DTYPE_OU: 
+      Operate128(uint128, mul); 
+    case DTYPE_F: 
+      OperateFloat(float, DTYPE_F, DTYPE_NATIVE_FLOAT, *); 
+    case DTYPE_FS: 
+      OperateFloat(float, DTYPE_FS, DTYPE_NATIVE_FLOAT, *); 
+    case DTYPE_D: 
+      OperateFloat(double, DTYPE_D, DTYPE_NATIVE_DOUBLE, *); 
+    case DTYPE_G: 
+      OperateFloat(double, DTYPE_G, DTYPE_NATIVE_DOUBLE, *); 
+    case DTYPE_FT: 
+      OperateFloat(double, DTYPE_FT, DTYPE_NATIVE_DOUBLE, *); 
+    case DTYPE_FC: 
+      MultiplyComplex(float, DTYPE_F, DTYPE_NATIVE_FLOAT); 
+    case DTYPE_FSC: 
+      MultiplyComplex(float, DTYPE_FS, DTYPE_NATIVE_FLOAT); 
+    case DTYPE_GC: 
+      MultiplyComplex(double, DTYPE_G, DTYPE_NATIVE_DOUBLE); 
+    case DTYPE_DC: 
+      MultiplyComplex(double, DTYPE_D, DTYPE_NATIVE_DOUBLE); 
+    case DTYPE_FTC: 
+      MultiplyComplex(double, DTYPE_FT, DTYPE_NATIVE_DOUBLE); 
+    default: 
+      return TdiINVDTYDSC;
   }
   return 1;
 }

--- a/tdishr/TdiApd.c
+++ b/tdishr/TdiApd.c
@@ -96,15 +96,7 @@ int UnwrapComma(int narg, struct descriptor *list[], int *nout_p,
 int Tdi1Apd(int dtype, int narg, struct descriptor *list[],
             struct descriptor_xd *out_ptr)
 {
-  struct descriptor_a arr = {sizeof(void *),
-                             (unsigned char)(dtype & 0xff),
-                             CLASS_APD,
-                             (void *)0,
-                             0,
-                             0,
-                             {0},
-                             1,
-                             0};
+  struct descriptor_a arr = {sizeof(void *), (unsigned char)(dtype & 0xff), CLASS_APD, (void *)0, 0, 0, {0}, 1, 0};
   if (narg == 0)
     return MdsCopyDxXd((struct descriptor *)&arr, out_ptr);
   struct descriptor **alist, **olist;

--- a/tdishr/TdiArray.c
+++ b/tdishr/TdiArray.c
@@ -117,8 +117,7 @@ extern int Tdi1Array(opcode_t opcode, int narg, struct descriptor *list[],
   INIT_STATUS;
   array_coeff arr = {1, DTYPE_B, CLASS_A, (char *)0, 0, 0, {0, 1, 1, 1, 0}, MAX_DIMS, 0, 0, {0}};
   array_int cvt = {sizeof(int), DTYPE_L, CLASS_A, (int *)0, 0, 0, {0, 1, 1, 0, 0}, 1, 0};
-  struct TdiFunctionStruct *fun_ptr =
-      (struct TdiFunctionStruct *)&TdiRefFunction[opcode];
+  struct TdiFunctionStruct *fun_ptr = (struct TdiFunctionStruct *)&TdiRefFunction[opcode];
   struct descriptor_xd tmp = EMPTY_XD;
   length_t length;
   dtype_t dtype;
@@ -231,10 +230,9 @@ int Tdi3Ramp(struct descriptor *out_ptr)
 {
   INIT_STATUS;
   static const int i0 = 0, i1 = 1;
-  static const struct descriptor con0 = {sizeof(int), DTYPE_L, CLASS_S,
-                                         (char *)&i0};
+  static const struct descriptor con0 = {sizeof(int), DTYPE_L, CLASS_S,(char *)&i0};
   static const struct descriptor con1 = {sizeof(int), DTYPE_L, CLASS_S,
-                                         (char *)&i1};
+    (char *)&i1};
   int i, n;
 
 #define LoadRamp(type)                    \
@@ -262,21 +260,37 @@ int Tdi3Ramp(struct descriptor *out_ptr)
   N_ELEMENTS(out_ptr, n);
   switch (out_ptr->dtype)
   {
-  case DTYPE_B:
-    LoadRamp(int8_t) case DTYPE_BU : LoadRamp(uint8_t) case DTYPE_W
-        : LoadRamp(int16_t) case DTYPE_WU : LoadRamp(uint16_t) case DTYPE_L
-        : LoadRamp(int32_t) case DTYPE_LU : LoadRamp(uint32_t) case DTYPE_Q
-        : LoadRamp(int64_t) case DTYPE_QU : LoadRamp(uint64_t) case DTYPE_F
-        : LoadRampF(float, DTYPE_F, DTYPE_NATIVE_FLOAT) case DTYPE_FS
-        : LoadRampF(float, DTYPE_FS, DTYPE_NATIVE_FLOAT) case DTYPE_D
-        : LoadRampF(double, DTYPE_D, DTYPE_NATIVE_DOUBLE) case DTYPE_G
-        : LoadRampF(double, DTYPE_G, DTYPE_NATIVE_DOUBLE) case DTYPE_FT
-        : LoadRampF(double, DTYPE_FT, DTYPE_NATIVE_DOUBLE)
+    case DTYPE_B:
+      LoadRamp(int8_t); 
+    case DTYPE_BU : 
+      LoadRamp(uint8_t); 
+    case DTYPE_W: 
+      LoadRamp(int16_t); 
+    case DTYPE_WU : 
+      LoadRamp(uint16_t); 
+    case DTYPE_L: 
+      LoadRamp(int32_t); 
+    case DTYPE_LU : 
+      LoadRamp(uint32_t); 
+    case DTYPE_Q: 
+      LoadRamp(int64_t); 
+    case DTYPE_QU : 
+      LoadRamp(uint64_t); 
+    case DTYPE_F: 
+      LoadRampF(float, DTYPE_F, DTYPE_NATIVE_FLOAT); 
+    case DTYPE_FS: 
+      LoadRampF(float, DTYPE_FS, DTYPE_NATIVE_FLOAT); 
+    case DTYPE_D: 
+      LoadRampF(double, DTYPE_D, DTYPE_NATIVE_DOUBLE); 
+    case DTYPE_G: 
+      LoadRampF(double, DTYPE_G, DTYPE_NATIVE_DOUBLE); 
+    case DTYPE_FT: 
+      LoadRampF(double, DTYPE_FT, DTYPE_NATIVE_DOUBLE);
           /**********************************************************
           WARNING this depends on order of operations in ADD routine.
           Make a zero and a one. Add 1 to this starter, but offset.
           **********************************************************/
-          default:
+    default:
     {
       struct descriptor new = *out_ptr;
       new.class = CLASS_S;
@@ -300,7 +314,7 @@ int Tdi3Ramp(struct descriptor *out_ptr)
     }
     break;
   }
-  return status;
+  return status;;
 }
 
 /*---------------------------------------------------------------------
@@ -432,7 +446,6 @@ int Tdi3Random(struct descriptor_a *out_ptr)
 int Tdi3Zero(struct descriptor_a *out_ptr)
 {
   static const int i0 = 0;
-  static const struct descriptor con0 = {sizeof(int), DTYPE_L, CLASS_S,
-                                         (char *)&i0};
+  static const struct descriptor con0 = {sizeof(int), DTYPE_L, CLASS_S, (char *)&i0};
   return TdiConvert(&con0, out_ptr);
 }

--- a/tdishr/TdiConvert.c
+++ b/tdishr/TdiConvert.c
@@ -1266,28 +1266,28 @@ static void DOUBLEC_TO_TEXT(int itype, char *pa, char *pb, int numb, int lenb, c
   case MAXTYPE *DTYPE_##a + DTYPE_##b: \
     a##_##b(lena, pa, lenb, pb, numb); \
     break;
-#define defset(a)                                                                             \
-  defcase(a, BU)                                                                              \
-      defcase(a, WU)                                                                          \
-          defcase(a, LU)                                                                      \
-              defcase(a, QU)                                                                  \
-                  defcase(a, OU)                                                              \
-                      defcase(a, B)                                                           \
-                          defcase(a, W)                                                       \
-                              defcase(a, L)                                                   \
-                                  defcase(a, Q)                                               \
-                                      defcase(a, O)                                           \
-                                          defcase(a, F)                                       \
-                                              defcase(a, D)                                   \
-                                                  defcase(a, G)                               \
-                                                      defcase(a, FC)                          \
-                                                          defcase(a, DC)                      \
-                                                              defcase(a, GC)                  \
-                                                                  defcase(a, T)               \
-                                                                      defcase(a, FS)          \
-                                                                          defcase(a, FT)      \
-                                                                              defcase(a, FSC) \
-                                                                                  defcase(a, FTC)
+#define defset(a)   \
+    defcase(a, BU);  \
+    defcase(a, WU);  \
+    defcase(a, LU);  \
+    defcase(a, QU);  \
+    defcase(a, OU);  \
+    defcase(a, B);   \
+    defcase(a, W);   \
+    defcase(a, L);   \
+    defcase(a, Q);   \
+    defcase(a, O);   \
+    defcase(a, F);   \
+    defcase(a, D);   \
+    defcase(a, G);   \
+    defcase(a, FC);  \
+    defcase(a, DC);  \
+    defcase(a, GC);  \
+    defcase(a, T);   \
+    defcase(a, FS);  \
+    defcase(a, FT);  \
+    defcase(a, FSC); \
+    defcase(a, FTC);
 
 EXPORT int TdiConvert(struct descriptor_a *pdin, struct descriptor_a *pdout)
 {
@@ -1367,27 +1367,29 @@ EXPORT int TdiConvert(struct descriptor_a *pdin, struct descriptor_a *pdout)
     n = MAXTYPE * dtypea + dtypeb;
     switch (n)
     {
-      defset(BU)
-          defset(WU)
-              defset(LU)
-                  defset(QU)
-                      defset(OU)
-                          defset(B)
-                              defset(W)
-                                  defset(L)
-                                      defset(Q)
-                                          defset(O)
-                                              defset(F)
-                                                  defset(D)
-                                                      defset(G)
-                                                          defset(FC)
-                                                              defset(DC)
-                                                                  defset(GC)
-                                                                      defset(T)
-                                                                          defset(FS)
-                                                                              defset(FT)
-                                                                                  defset(FSC)
-                                                                                      defset(FTC) default : return TdiINVDTYDSC;
+      defset(BU);
+      defset(WU);
+      defset(LU);
+      defset(QU);
+      defset(OU);
+      defset(B);
+      defset(W);
+      defset(L);
+      defset(Q);
+      defset(O);
+      defset(F);
+      defset(D);
+      defset(G);
+      defset(FC);
+      defset(DC);
+      defset(GC);
+      defset(T);
+      defset(FS);
+      defset(FT);
+      defset(FSC);
+      defset(FTC); 
+      default: 
+        return TdiINVDTYDSC;
     }
   }
   return status;

--- a/tdishr/TdiDim.c
+++ b/tdishr/TdiDim.c
@@ -621,25 +621,40 @@ int Tdi3Max(struct descriptor *in1, struct descriptor *in2,
 {
   SetupArgs switch (in1->dtype)
   {
-  case DTYPE_T:
-    return TdiINVDTYDSC;
-  case DTYPE_B:
-    Operate(int8_t, *in1p > *in2p) case DTYPE_BU
-        : Operate(uint8_t, *in1p > *in2p) case DTYPE_W
-        : Operate(int16_t, *in1p > *in2p) case DTYPE_WU
-        : Operate(uint16_t, *in1p > *in2p) case DTYPE_L
-        : Operate(int32_t, *in1p > *in2p) case DTYPE_LU
-        : Operate(uint32_t, *in1p > *in2p) case DTYPE_Q
-        : Operate(int64_t, *in1p > *in2p) case DTYPE_QU
-        : Operate(uint64_t, *in1p > *in2p) case DTYPE_O
-        : Operate(octaword, TdiGtO(in1p, in2p, 1)) case DTYPE_OU
-        : Operate(octaword, TdiGtO(in1p, in2p, 0)) case DTYPE_F
-        : OperateF(float, DTYPE_F, DTYPE_NATIVE_FLOAT, a > b) case DTYPE_FS
-        : OperateF(float, DTYPE_FS, DTYPE_NATIVE_FLOAT, a > b) case DTYPE_G
-        : OperateF(double, DTYPE_G, DTYPE_NATIVE_DOUBLE, a > b) case DTYPE_D
-        : OperateF(double, DTYPE_D, DTYPE_NATIVE_DOUBLE, a > b) case DTYPE_FT
-        : OperateF(double, DTYPE_FT, DTYPE_NATIVE_DOUBLE, a > b) default
-        : return TdiINVDTYDSC;
+    case DTYPE_T:
+      return TdiINVDTYDSC;
+    case DTYPE_B:
+      Operate(int8_t, *in1p > *in2p);
+    case DTYPE_BU:
+      Operate(uint8_t, *in1p > *in2p);
+    case DTYPE_W:
+      Operate(int16_t, *in1p > *in2p);
+    case DTYPE_WU:
+      Operate(uint16_t, *in1p > *in2p);
+    case DTYPE_L:
+      Operate(int32_t, *in1p > *in2p);
+    case DTYPE_LU:
+      Operate(uint32_t, *in1p > *in2p);
+    case DTYPE_Q:
+      Operate(int64_t, *in1p > *in2p);
+    case DTYPE_QU:
+      Operate(uint64_t, *in1p > *in2p);
+    case DTYPE_O:
+      Operate(octaword, TdiGtO(in1p, in2p, 1));
+    case DTYPE_OU:
+      Operate(octaword, TdiGtO(in1p, in2p, 0));
+    case DTYPE_F:
+      OperateF(float, DTYPE_F, DTYPE_NATIVE_FLOAT, a > b);
+    case DTYPE_FS:
+      OperateF(float, DTYPE_FS, DTYPE_NATIVE_FLOAT, a > b);
+    case DTYPE_G:
+      OperateF(double, DTYPE_G, DTYPE_NATIVE_DOUBLE, a > b);
+    case DTYPE_D:
+      OperateF(double, DTYPE_D, DTYPE_NATIVE_DOUBLE, a > b);
+    case DTYPE_FT:
+      OperateF(double, DTYPE_FT, DTYPE_NATIVE_DOUBLE, a > b);
+    default:
+      return TdiINVDTYDSC;
   }
   return 1;
 }
@@ -649,25 +664,40 @@ int Tdi3Min(struct descriptor *in1, struct descriptor *in2,
 {
   SetupArgs switch (in1->dtype)
   {
-  case DTYPE_T:
-    return TdiINVDTYDSC;
-  case DTYPE_B:
-    Operate(int8_t, *in1p < *in2p) case DTYPE_BU
-        : Operate(uint8_t, *in1p < *in2p) case DTYPE_W
-        : Operate(int16_t, *in1p < *in2p) case DTYPE_WU
-        : Operate(uint16_t, *in1p < *in2p) case DTYPE_L
-        : Operate(int32_t, *in1p < *in2p) case DTYPE_LU
-        : Operate(uint32_t, *in1p < *in2p) case DTYPE_Q
-        : Operate(int64_t, *in1p < *in2p) case DTYPE_QU
-        : Operate(uint64_t, *in1p < *in2p) case DTYPE_O
-        : Operate(octaword, TdiLtO(in1p, in2p, 1)) case DTYPE_OU
-        : Operate(octaword, TdiLtO(in1p, in2p, 0)) case DTYPE_F
-        : OperateF(float, DTYPE_F, DTYPE_NATIVE_FLOAT, a < b) case DTYPE_FS
-        : OperateF(float, DTYPE_FS, DTYPE_NATIVE_FLOAT, a < b) case DTYPE_G
-        : OperateF(double, DTYPE_G, DTYPE_NATIVE_DOUBLE, a < b) case DTYPE_D
-        : OperateF(double, DTYPE_D, DTYPE_NATIVE_DOUBLE, a < b) case DTYPE_FT
-        : OperateF(double, DTYPE_FT, DTYPE_NATIVE_DOUBLE, a < b) default
-        : return TdiINVDTYDSC;
+    case DTYPE_T:
+      return TdiINVDTYDSC;
+    case DTYPE_B:
+      Operate(int8_t, *in1p < *in2p);
+    case DTYPE_BU:
+      Operate(uint8_t, *in1p < *in2p);
+    case DTYPE_W:
+      Operate(int16_t, *in1p < *in2p);
+    case DTYPE_WU:
+      Operate(uint16_t, *in1p < *in2p);
+    case DTYPE_L:
+      Operate(int32_t, *in1p < *in2p);
+    case DTYPE_LU:
+      Operate(uint32_t, *in1p < *in2p);
+    case DTYPE_Q:
+      Operate(int64_t, *in1p < *in2p);
+    case DTYPE_QU:
+      Operate(uint64_t, *in1p < *in2p);
+    case DTYPE_O:
+      Operate(octaword, TdiLtO(in1p, in2p, 1));
+    case DTYPE_OU:
+      Operate(octaword, TdiLtO(in1p, in2p, 0));
+    case DTYPE_F:
+      OperateF(float, DTYPE_F, DTYPE_NATIVE_FLOAT, a < b);
+    case DTYPE_FS:
+      OperateF(float, DTYPE_FS, DTYPE_NATIVE_FLOAT, a < b);
+    case DTYPE_G:
+      OperateF(double, DTYPE_G, DTYPE_NATIVE_DOUBLE, a < b);
+    case DTYPE_D:
+      OperateF(double, DTYPE_D, DTYPE_NATIVE_DOUBLE, a < b);
+    case DTYPE_FT:
+      OperateF(double, DTYPE_FT, DTYPE_NATIVE_DOUBLE, a < b);
+    default:
+      return TdiINVDTYDSC;
   }
   return 1;
 }
@@ -804,13 +834,23 @@ int Tdi3Ishft(struct descriptor *in1, struct descriptor *in2,
 {
   SetupArgs switch (in1->dtype)
   {
-  case DTYPE_BU:
-  case DTYPE_B:
-    Operate(uint8_t, int8_t) case DTYPE_WU : case DTYPE_W
-        : Operate(uint16_t, int16_t) case DTYPE_LU : case DTYPE_L
-        : Operate(uint32_t, int32_t) case DTYPE_QU : case DTYPE_Q
-        : Operate(uint64_t, int64_t) case DTYPE_OU : case DTYPE_O
-        : Operate128(uint128, ishft) default : return TdiINVDTYDSC;
+    case DTYPE_BU:
+    case DTYPE_B:
+      Operate(uint8_t, int8_t); 
+    case DTYPE_WU: 
+    case DTYPE_W:
+      Operate(uint16_t, int16_t);
+    case DTYPE_LU: 
+    case DTYPE_L:
+      Operate(uint32_t, int32_t);
+    case DTYPE_QU: 
+    case DTYPE_Q:
+      Operate(uint64_t, int64_t);
+    case DTYPE_OU: 
+    case DTYPE_O:
+      Operate128(uint128, ishft);
+    default: 
+    return TdiINVDTYDSC;
   }
   return 1;
 }
@@ -865,17 +905,28 @@ int Tdi3ShiftRight(struct descriptor *in1, struct descriptor *in2,
 {
   SetupArgs switch (in1->dtype)
   {
-  case DTYPE_B:
-    Operate(int8_t, int8_t, >>) case DTYPE_BU
-        : Operate(uint8_t, int8_t, >>) case DTYPE_W
-        : Operate(int16_t, int16_t, >>) case DTYPE_WU
-        : Operate(uint16_t, int16_t, >>) case DTYPE_L
-        : Operate(int32_t, int32_t, >>) case DTYPE_LU
-        : Operate(uint32_t, int32_t, >>) case DTYPE_Q
-        : Operate(int64_t, int64_t, >>) case DTYPE_QU
-        : Operate(uint64_t, int64_t, >>) case DTYPE_O
-        : Operate128(int128, rshft) case DTYPE_OU
-        : Operate128(uint128, rshft) default : return TdiINVDTYDSC;
+    case DTYPE_B:
+      Operate(int8_t, int8_t, >>); 
+    case DTYPE_BU:
+      Operate(uint8_t, int8_t, >>);
+    case DTYPE_W:
+      Operate(int16_t, int16_t, >>);
+    case DTYPE_WU:
+      Operate(uint16_t, int16_t, >>);
+    case DTYPE_L:
+      Operate(int32_t, int32_t, >>);
+    case DTYPE_LU:
+      Operate(uint32_t, int32_t, >>);
+    case DTYPE_Q:
+      Operate(int64_t, int64_t, >>);
+    case DTYPE_QU:
+      Operate(uint64_t, int64_t, >>);
+    case DTYPE_O:
+      Operate128(int128, rshft);
+    case DTYPE_OU:
+      Operate128(uint128, rshft);
+    default : 
+      return TdiINVDTYDSC;
   }
   return 1;
 }
@@ -885,17 +936,28 @@ int Tdi3ShiftLeft(struct descriptor *in1, struct descriptor *in2,
 {
   SetupArgs switch (in1->dtype)
   {
-  case DTYPE_B:
-    Operate(int8_t, int8_t, <<) case DTYPE_BU
-        : Operate(uint8_t, int8_t, <<) case DTYPE_W
-        : Operate(int16_t, int16_t, <<) case DTYPE_WU
-        : Operate(uint16_t, int16_t, <<) case DTYPE_L
-        : Operate(int32_t, int32_t, <<) case DTYPE_LU
-        : Operate(uint32_t, int32_t, <<) case DTYPE_Q
-        : Operate(int64_t, int64_t, <<) case DTYPE_QU
-        : Operate(uint64_t, int64_t, <<) case DTYPE_O
-        : Operate128(int128, lshft) case DTYPE_OU
-        : Operate128(uint128, lshft) default : return TdiINVDTYDSC;
+    case DTYPE_B:
+      Operate(int8_t, int8_t, <<);
+    case DTYPE_BU:
+      Operate(uint8_t, int8_t, <<);
+    case DTYPE_W:
+      Operate(int16_t, int16_t, <<);
+    case DTYPE_WU:
+      Operate(uint16_t, int16_t, <<);
+    case DTYPE_L:
+      Operate(int32_t, int32_t, <<);
+    case DTYPE_LU:
+      Operate(uint32_t, int32_t, <<);
+    case DTYPE_Q:
+      Operate(int64_t, int64_t, <<);
+    case DTYPE_QU:
+      Operate(uint64_t, int64_t, <<);
+    case DTYPE_O:
+      Operate128(int128, lshft);
+    case DTYPE_OU:
+      Operate128(uint128, lshft);
+    default : 
+      return TdiINVDTYDSC;
   }
   return 1;
 }

--- a/tdishr/TdiDivide.c
+++ b/tdishr/TdiDivide.c
@@ -281,28 +281,39 @@ int Tdi3Divide(struct descriptor *in1, struct descriptor *in2,
 {
   SetupArgs switch (in1->dtype)
   {
-  case DTYPE_B:
-    Operate(char) case DTYPE_BU : Operate(unsigned char) case DTYPE_W
-        : Operate(short) case DTYPE_WU : Operate(unsigned short) case DTYPE_L
-        : Operate(int) case DTYPE_LU : Operate(unsigned int) case DTYPE_Q
-        : Operate(int64_t);
-  case DTYPE_QU:
-    Operate(uint64_t);
-  case DTYPE_O:
-    Operate128(int128);
-  case DTYPE_OU:
-    Operate128(uint128);
-  case DTYPE_F:
-    OperateF(float, DTYPE_F, DTYPE_NATIVE_FLOAT) case DTYPE_FS
-        : OperateF(float, DTYPE_FS, DTYPE_NATIVE_FLOAT) case DTYPE_G
-        : OperateF(double, DTYPE_G, DTYPE_NATIVE_DOUBLE) case DTYPE_D
-        : OperateF(double, DTYPE_D, DTYPE_NATIVE_DOUBLE) case DTYPE_FT
-        : OperateF(double, DTYPE_FT, DTYPE_NATIVE_DOUBLE) case DTYPE_FC
-        : OperateC(float, DTYPE_F) case DTYPE_FSC
-        : OperateC(float, DTYPE_FS) case DTYPE_GC
-        : OperateC(double, DTYPE_G) case DTYPE_DC
-        : OperateC(double, DTYPE_D) case DTYPE_FTC
-        : OperateC(double, DTYPE_FT) default : return TdiINVDTYDSC;
+    case DTYPE_B:
+      Operate(char) case DTYPE_BU : Operate(unsigned char) case DTYPE_W
+          : Operate(short) case DTYPE_WU : Operate(unsigned short) case DTYPE_L
+          : Operate(int) case DTYPE_LU : Operate(unsigned int) case DTYPE_Q
+          : Operate(int64_t);
+    case DTYPE_QU:
+      Operate(uint64_t);
+    case DTYPE_O:
+      Operate128(int128);
+    case DTYPE_OU:
+      Operate128(uint128);
+    case DTYPE_F:
+      OperateF(float, DTYPE_F, DTYPE_NATIVE_FLOAT) 
+    case DTYPE_FS:
+      OperateF(float, DTYPE_FS, DTYPE_NATIVE_FLOAT);
+    case DTYPE_G:
+      OperateF(double, DTYPE_G, DTYPE_NATIVE_DOUBLE);
+    case DTYPE_D:
+      OperateF(double, DTYPE_D, DTYPE_NATIVE_DOUBLE);
+    case DTYPE_FT:
+      OperateF(double, DTYPE_FT, DTYPE_NATIVE_DOUBLE);
+    case DTYPE_FC:
+      OperateC(float, DTYPE_F);
+    case DTYPE_FSC:
+      OperateC(float, DTYPE_FS);
+    case DTYPE_GC:
+      OperateC(double, DTYPE_G);
+    case DTYPE_DC:
+      OperateC(double, DTYPE_D);
+    case DTYPE_FTC:
+      OperateC(double, DTYPE_FT);
+    default : 
+    return TdiINVDTYDSC;
   }
   return 1;
 }

--- a/tdishr/TdiEq.c
+++ b/tdishr/TdiEq.c
@@ -288,23 +288,45 @@ int Tdi3_Eq(struct descriptor *in1_ptr, struct descriptor *in2_ptr,
 
   switch (in1_ptr->dtype)
   {
-  case DTYPE_T:
-    testc(unsigned char) case DTYPE_BU : test(uint8_t) case DTYPE_WU
-        : test(uint16_t) case DTYPE_LU : test(uint32_t) case DTYPE_QU
-        : test(uint64_t) case DTYPE_OU : testn(unsigned int, 4, 0) case DTYPE_B
-        : test(int8_t) case DTYPE_W : test(int16_t) case DTYPE_L
-        : test(int32_t) case DTYPE_Q : test(int64_t) case DTYPE_O
-        : testn(int, 4, 1) case DTYPE_F
-        : testf(float, DTYPE_F, DTYPE_NATIVE_FLOAT) case DTYPE_FS
-        : testf(float, DTYPE_FS, DTYPE_NATIVE_FLOAT) case DTYPE_G
-        : testf(double, DTYPE_G, DTYPE_NATIVE_DOUBLE) case DTYPE_D
-        : testf(double, DTYPE_D, DTYPE_NATIVE_DOUBLE) case DTYPE_FT
-        : testf(double, DTYPE_FT, DTYPE_NATIVE_DOUBLE) case DTYPE_FC
-        : case DTYPE_FSC : if (op != OP_EQ && op != OP_NE)
-    {
-      status = TdiINVDTYDSC;
-      break;
-    }
+    case DTYPE_T:
+      testc(unsigned char);
+    case DTYPE_BU:
+      test(uint8_t);
+    case DTYPE_WU:
+      test(uint16_t);
+    case DTYPE_LU:
+      test(uint32_t);
+    case DTYPE_QU:
+      test(uint64_t);
+    case DTYPE_OU:
+      testn(unsigned int, 4, 0);
+    case DTYPE_B:
+      test(int8_t);
+    case DTYPE_W:
+      test(int16_t);
+    case DTYPE_L:
+      test(int32_t);
+    case DTYPE_Q:
+      test(int64_t);
+    case DTYPE_O:
+      testn(int, 4, 1);
+    case DTYPE_F:
+      testf(float, DTYPE_F, DTYPE_NATIVE_FLOAT);
+    case DTYPE_FS:
+      testf(float, DTYPE_FS, DTYPE_NATIVE_FLOAT);
+    case DTYPE_G:
+      testf(double, DTYPE_G, DTYPE_NATIVE_DOUBLE);
+    case DTYPE_D:
+      testf(double, DTYPE_D, DTYPE_NATIVE_DOUBLE);
+    case DTYPE_FT:
+      testf(double, DTYPE_FT, DTYPE_NATIVE_DOUBLE);
+    case DTYPE_FC:
+    case DTYPE_FSC:
+      if (op != OP_EQ && op != OP_NE)
+      {
+        status = TdiINVDTYDSC;
+        break;
+      }
     testn(int, 2, 0) case DTYPE_GC : case DTYPE_DC : case DTYPE_FTC
         : if (op != OP_EQ && op != OP_NE)
     {

--- a/tdishr/TdiExponent.c
+++ b/tdishr/TdiExponent.c
@@ -1,3 +1,4 @@
+
 /*
 Copyright (c) 2017, Massachusetts Institute of Technology All rights reserved.
 
@@ -92,9 +93,17 @@ int Tdi3Exponent(struct descriptor *in_ptr, struct descriptor *out_ptr)
       status = TdiNO_CMPLX;
       break;
     case DTYPE_F:
-      compute_exponent(F) case DTYPE_FS : compute_exponent(FS) case DTYPE_D
-          : compute_exponent(D) case DTYPE_G : compute_exponent(G) case DTYPE_FT
-          : compute_exponent(FT) default : status = TdiINVDTYDSC;
+      compute_exponent(F);
+    case DTYPE_FS:
+      compute_exponent(FS);
+    case DTYPE_D:
+      compute_exponent(D);
+    case DTYPE_G:
+      compute_exponent(G);
+    case DTYPE_FT:
+      compute_exponent(FT);
+    default:
+      status = TdiINVDTYDSC;
       break;
     }
   return status;
@@ -409,12 +418,14 @@ int Tdi3SetExponent(struct descriptor *in1_ptr, struct descriptor *in2_ptr,
   if (STATUS_OK)
     switch (in1_ptr->dtype)
     {
-      do_setexponent(F, ;) do_setexponent(FS, ;)
-          do_setexponent(G, ((int *)outp)[1] = ((int *)inp)[1];)
-              do_setexponent(D, ((int *)outp)[1] = ((int *)inp)[1];)
-                  do_setexponent(FT, ((int *)outp)[1] = ((int *)inp)[1];) default
-          : status = TdiINVDTYDSC;
-      break;
+      do_setexponent(F, ;);
+      do_setexponent(FS, ;);
+      do_setexponent(G, ((int *)outp)[1] = ((int *)inp)[1];);
+      do_setexponent(D, ((int *)outp)[1] = ((int *)inp)[1];);
+      do_setexponent(FT, ((int *)outp)[1] = ((int *)inp)[1];); 
+      default:
+        status = TdiINVDTYDSC;
+        break;
     }
   return status;
 }
@@ -450,11 +461,14 @@ int Tdi3Spacing(struct descriptor *in_ptr, struct descriptor *out_ptr)
   N_ELEMENTS(out_ptr, n);
   if (STATUS_OK)
     switch (in_ptr->dtype)
-    {
-      do_spacing(F, ;) do_spacing(FS, ;) do_spacing(G, ((int *)outp)[1] = 0;)
-          do_spacing(D, ((int *)outp)[1] = 0;)
-              do_spacing(FT, ((int *)outp)[1] = 0;) default : status =
-                                                                  TdiINVDTYDSC;
+   {
+      do_spacing(F, ;); 
+      do_spacing(FS, ;); 
+      do_spacing(G, ((int *)outp)[1] = 0;);
+      do_spacing(D, ((int *)outp)[1] = 0;);
+      do_spacing(FT, ((int *)outp)[1] = 0;); 
+      default : 
+        status = TdiINVDTYDSC;
       break;
     }
   return status;

--- a/tdishr/TdiGetData.c
+++ b/tdishr/TdiGetData.c
@@ -431,25 +431,25 @@ extern EXPORT int TdiGetFloat(mdsdsc_t *in_ptr, float *val_ptr)
     case CLASS_D:
       switch (in_ptr->dtype)
       {
-      case DTYPE_BU:
-        *val_ptr = (float)*(unsigned char *)in_ptr->pointer;
-        break;
-      case DTYPE_B:
-        *val_ptr = (float)*(char *)in_ptr->pointer;
-        break;
-      case DTYPE_WU:
-        *val_ptr = (float)*(unsigned short *)in_ptr->pointer;
-        break;
-      case DTYPE_W:
-        *val_ptr = (float)*(short *)in_ptr->pointer;
-        break;
-      case DTYPE_LU:
-        *val_ptr = (float)*(unsigned int *)in_ptr->pointer;
-        break;
-      case DTYPE_L:
-        *val_ptr = (float)*(int *)in_ptr->pointer;
-        break;
-      default:
+        case DTYPE_BU:
+          *val_ptr = (float)*(unsigned char *)in_ptr->pointer;
+          break;
+        case DTYPE_B:
+          *val_ptr = (float)*(char *)in_ptr->pointer;
+          break;
+        case DTYPE_WU:
+          *val_ptr = (float)*(unsigned short *)in_ptr->pointer;
+          break;
+        case DTYPE_W:
+          *val_ptr = (float)*(short *)in_ptr->pointer;
+          break;
+        case DTYPE_LU:
+          *val_ptr = (float)*(unsigned int *)in_ptr->pointer;
+          break;
+        case DTYPE_L:
+          *val_ptr = (float)*(int *)in_ptr->pointer;
+          break;
+        default:
       {
         mdsdsc_t val_dsc = {sizeof(float), DTYPE_NATIVE_FLOAT, CLASS_S, 0};
         val_dsc.pointer = (char *)val_ptr;
@@ -508,29 +508,29 @@ extern EXPORT int TdiGetLong(mdsdsc_t *in_ptr, int *val_ptr)
     case CLASS_D:
       switch (in_ptr->dtype)
       {
-      case DTYPE_BU:
-        *val_ptr = (int)*(unsigned char *)in_ptr->pointer;
+        case DTYPE_BU:
+          *val_ptr = (int)*(unsigned char *)in_ptr->pointer;
+          break;
+        case DTYPE_B:
+          *val_ptr = (int)*(char *)in_ptr->pointer;
+          break;
+        case DTYPE_WU:
+          *val_ptr = (int)*(unsigned short *)in_ptr->pointer;
+          break;
+        case DTYPE_W:
+          *val_ptr = (int)*(short *)in_ptr->pointer;
+          break;
+        case DTYPE_L:
+        case DTYPE_LU:
+          *val_ptr = *(int *)in_ptr->pointer;
+          break;
+        default:
+        {
+          mdsdsc_t val_dsc = {sizeof(int), DTYPE_L, CLASS_S, 0};
+          val_dsc.pointer = (char *)val_ptr;
+          status = TdiConvert(in_ptr, &val_dsc MDS_END_ARG);
+        }
         break;
-      case DTYPE_B:
-        *val_ptr = (int)*(char *)in_ptr->pointer;
-        break;
-      case DTYPE_WU:
-        *val_ptr = (int)*(unsigned short *)in_ptr->pointer;
-        break;
-      case DTYPE_W:
-        *val_ptr = (int)*(short *)in_ptr->pointer;
-        break;
-      case DTYPE_L:
-      case DTYPE_LU:
-        *val_ptr = *(int *)in_ptr->pointer;
-        break;
-      default:
-      {
-        mdsdsc_t val_dsc = {sizeof(int), DTYPE_L, CLASS_S, 0};
-        val_dsc.pointer = (char *)val_ptr;
-        status = TdiConvert(in_ptr, &val_dsc MDS_END_ARG);
-      }
-      break;
       }
       break;
     default:
@@ -544,14 +544,14 @@ extern EXPORT int TdiGetLong(mdsdsc_t *in_ptr, int *val_ptr)
     if (STATUS_OK)
       switch (tmp.pointer->class)
       {
-      case CLASS_S:
-      case CLASS_D:
-      case CLASS_A:
-        status = TdiGetLong(tmp.pointer, val_ptr);
-        break;
-      default:
-        status = TdiINVCLADSC;
-        break;
+        case CLASS_S:
+        case CLASS_D:
+        case CLASS_A:
+          status = TdiGetLong(tmp.pointer, val_ptr);
+          break;
+        default:
+          status = TdiINVCLADSC;
+          break;
       }
     MdsFree1Dx(&tmp, NULL);
   }
@@ -572,20 +572,20 @@ extern EXPORT int TdiGetNid(mdsdsc_t *in_ptr, int *nid_ptr)
   {
     switch (tmp.pointer->dtype)
     {
-    case DTYPE_T:
-    case DTYPE_PATH:
-    {
-      char *path = MdsDescrToCstring(tmp.pointer);
-      status = TreeFindNode(path, nid_ptr);
-      MdsFree(path);
-    }
-    break;
-    case DTYPE_NID:
-      *nid_ptr = *(unsigned int *)tmp.pointer->pointer;
+      case DTYPE_T:
+      case DTYPE_PATH:
+      {
+        char *path = MdsDescrToCstring(tmp.pointer);
+        status = TreeFindNode(path, nid_ptr);
+        MdsFree(path);
+      }
       break;
-    default:
-      status = TdiINVDTYDSC;
-      break;
+      case DTYPE_NID:
+        *nid_ptr = *(unsigned int *)tmp.pointer->pointer;
+        break;
+      default:
+        status = TdiINVDTYDSC;
+        break;
     }
     MdsFree1Dx(&tmp, NULL);
   }
@@ -627,12 +627,12 @@ int Tdi1Value(opcode_t opcode __attribute__((unused)),
   if (TDI_SELF_PTR)
     switch (TDI_SELF_PTR->dtype)
     {
-    case DTYPE_SIGNAL:
-      return MdsCopyDxXd(((mds_signal_t *)TDI_SELF_PTR)->raw, out_ptr);
-    case DTYPE_PARAM:
-      return MdsCopyDxXd(((mds_param_t *)TDI_SELF_PTR)->value, out_ptr);
-    default:
-      return TdiINVDTYDSC;
+      case DTYPE_SIGNAL:
+        return MdsCopyDxXd(((mds_signal_t *)TDI_SELF_PTR)->raw, out_ptr);
+      case DTYPE_PARAM:
+        return MdsCopyDxXd(((mds_param_t *)TDI_SELF_PTR)->value, out_ptr);
+      default:
+        return TdiINVDTYDSC;
     }
   else
     return TdiNO_SELF_PTR;
@@ -676,42 +676,42 @@ int Tdi1Units(opcode_t opcode __attribute__((unused)), int narg,
   if (STATUS_OK)
     switch (rptr->dtype)
     {
-    case DTYPE_DIMENSION:
-      status = TdiUnits(((mds_dimension_t *)rptr)->axis, out_ptr MDS_END_ARG);
-      break;
-    case DTYPE_RANGE:
-    case DTYPE_SLOPE:
-      uni[1] = uni[0] = EMPTY_XD;
-      for (j = rptr->ndesc; --j >= 0 && STATUS_OK;)
-      {
-        if (rptr->dscptrs[j])
-          status = TdiUnits(rptr->dscptrs[j], &uni[1] MDS_END_ARG);
-        if (uni[1].pointer && STATUS_OK)
-          status = Tdi2Add(narg, uni, 0, cats, 0);
-      }
-      MdsFree1Dx(&uni[1], NULL);
-      if (uni[0].pointer)
-      {
-        MdsFree1Dx(out_ptr, NULL);
-        *out_ptr = uni[0];
-      }
-      else if (STATUS_OK)
-        status = MdsCopyDxXd((mdsdsc_t *)&blank_dsc, out_ptr);
-      break;
-    case DTYPE_WINDOW:
-      status = TdiUnits(((struct descriptor_window *)rptr)->value_at_idx0,
+      case DTYPE_DIMENSION:
+        status = TdiUnits(((mds_dimension_t *)rptr)->axis, out_ptr MDS_END_ARG);
+        break;
+      case DTYPE_RANGE:
+      case DTYPE_SLOPE:
+        uni[1] = uni[0] = EMPTY_XD;
+        for (j = rptr->ndesc; --j >= 0 && STATUS_OK;)
+        {
+          if (rptr->dscptrs[j])
+            status = TdiUnits(rptr->dscptrs[j], &uni[1] MDS_END_ARG);
+          if (uni[1].pointer && STATUS_OK)
+            status = Tdi2Add(narg, uni, 0, cats, 0);
+        }
+        MdsFree1Dx(&uni[1], NULL);
+        if (uni[0].pointer)
+        {
+          MdsFree1Dx(out_ptr, NULL);
+          *out_ptr = uni[0];
+        }
+        else if (STATUS_OK)
+          status = MdsCopyDxXd((mdsdsc_t *)&blank_dsc, out_ptr);
+        break;
+      case DTYPE_WINDOW:
+        status = TdiUnits(((struct descriptor_window *)rptr)->value_at_idx0,
+                          out_ptr MDS_END_ARG);
+        break;
+      case DTYPE_WITH_UNITS:
+        status = TdiData(((struct descriptor_with_units *)rptr)->units,
                         out_ptr MDS_END_ARG);
-      break;
-    case DTYPE_WITH_UNITS:
-      status = TdiData(((struct descriptor_with_units *)rptr)->units,
-                       out_ptr MDS_END_ARG);
-      break;
-    case DTYPE_WITH_ERROR:
-      status = TdiData(((mds_with_error_t *)rptr)->data, out_ptr MDS_END_ARG);
-      break;
-    default:
-      status = MdsCopyDxXd((mdsdsc_t *)&blank_dsc, out_ptr);
-      break;
+        break;
+      case DTYPE_WITH_ERROR:
+        status = TdiData(((mds_with_error_t *)rptr)->data, out_ptr MDS_END_ARG);
+        break;
+      default:
+        status = MdsCopyDxXd((mdsdsc_t *)&blank_dsc, out_ptr);
+        break;
     }
   MdsFree1Dx(&tmp, NULL);
   return status;
@@ -788,8 +788,7 @@ int Tdi1Validation(opcode_t opcode __attribute__((unused)),
      ******************************************/
       keep = TDI_SELF_PTR;
       TDI_SELF_PTR = (mdsdsc_xd_t *)rptr;
-      status = get_data(no_omits, ((mds_param_t *)rptr)->validation, out_ptr,
-                        TDITHREADSTATIC_VAR);
+      status = get_data(no_omits, ((mds_param_t *)rptr)->validation, out_ptr, TDITHREADSTATIC_VAR);
       TDI_SELF_PTR = keep;
       break;
     default:

--- a/tdishr/TdiIand.c
+++ b/tdishr/TdiIand.c
@@ -387,23 +387,43 @@ extern void DoubleToWideInt();
     {                                                                         \
     case DTYPE_B:                                                             \
     case DTYPE_BU:                                                            \
-      Operate(unsigned char, operator) case DTYPE_W : case DTYPE_WU           \
-          : Operate(unsigned short, operator) case DTYPE_L : case DTYPE_LU    \
-          : Operate(unsigned int, operator) case DTYPE_Q                      \
-          : OperateSpecial(2, operator) case DTYPE_QU                         \
-          : OperateSpecial(2, operator) case DTYPE_O                          \
-          : OperateSpecial(4, operator) case DTYPE_OU                         \
-          : OperateSpecial(4, operator) case DTYPE_F                          \
-          : OperateFloat(DTYPE_F, operator) case DTYPE_FS                     \
-          : OperateFloat(DTYPE_FS, operator) case DTYPE_G                     \
-          : OperateDouble(DTYPE_G, operator) case DTYPE_D                     \
-          : OperateDouble(DTYPE_D, operator) case DTYPE_FT                    \
-          : OperateDouble(DTYPE_FT, operator) case DTYPE_FC                   \
-          : OperateFloatC(DTYPE_F, operator) case DTYPE_FSC                   \
-          : OperateFloatC(DTYPE_FS, operator) case DTYPE_GC                   \
-          : OperateDoubleC(DTYPE_G, operator) case DTYPE_DC                   \
-          : OperateDoubleC(DTYPE_D, operator) case DTYPE_FTC                  \
-          : OperateDoubleC(DTYPE_FT, operator) default : return TdiINVDTYDSC; \
+      Operate(unsigned char, operator);                                       \
+    case DTYPE_W:                                                             \
+    case DTYPE_WU:                                                            \
+      Operate(unsigned short, operator);                                      \
+    case DTYPE_L:                                                             \
+    case DTYPE_LU:                                                            \
+      Operate(unsigned int, operator);                                        \
+    case DTYPE_Q:                                                             \
+      OperateSpecial(2, operator);                                            \
+    case DTYPE_QU:                                                            \
+      OperateSpecial(2, operator);                                            \
+    case DTYPE_O:                                                             \
+      OperateSpecial(4, operator);                                            \
+    case DTYPE_OU:                                                            \
+      OperateSpecial(4, operator);                                            \
+    case DTYPE_F:                                                             \
+      OperateFloat(DTYPE_F, operator);                                        \
+    case DTYPE_FS:                                                            \
+      OperateFloat(DTYPE_FS, operator);                                       \
+    case DTYPE_G:                                                             \
+      OperateDouble(DTYPE_G, operator);                                       \
+    case DTYPE_D:                                                             \
+      OperateDouble(DTYPE_D, operator);                                       \
+    case DTYPE_FT:                                                            \
+      OperateDouble(DTYPE_FT, operator);                                      \
+    case DTYPE_FC:                                                            \
+      OperateFloatC(DTYPE_F, operator);                                       \
+    case DTYPE_FSC:                                                           \
+      OperateFloatC(DTYPE_FS, operator);                                      \
+    case DTYPE_GC:                                                            \
+      OperateDoubleC(DTYPE_G, operator);                                      \
+    case DTYPE_DC:                                                            \
+      OperateDoubleC(DTYPE_D, operator);                                      \
+    case DTYPE_FTC:                                                           \
+      OperateDoubleC(DTYPE_FT, operator);                                     \
+    default :                                                                 \
+      return TdiINVDTYDSC;                                                    \
     }                                                                         \
     return 1;                                                                 \
   }

--- a/tdishr/TdiMath1.c
+++ b/tdishr/TdiMath1.c
@@ -182,12 +182,18 @@ static const int roprand = 0x8000;
   {                                                                            \
     SetupArgs switch (in->dtype)                                               \
     {                                                                          \
-    case DTYPE_F:                                                              \
-      Operate(float, DTYPE_F, function) case DTYPE_FS                          \
-          : Operate(float, DTYPE_FS, function) case DTYPE_G                    \
-          : Operate(double, DTYPE_G, function) case DTYPE_D                    \
-          : Operate(double, DTYPE_D, function) case DTYPE_FT                   \
-          : Operate(double, DTYPE_FT, function) default : return TdiINVDTYDSC; \
+      case DTYPE_F:                                                            \
+        Operate(float, DTYPE_F, function);                                     \
+      case DTYPE_FS:                                                           \
+        Operate(float, DTYPE_FS, function);                                    \
+      case DTYPE_G :                                                           \
+        Operate(double, DTYPE_G, function);                                    \
+      case DTYPE_D :                                                           \
+        Operate(double, DTYPE_D, function);                                    \
+      case DTYPE_FT:                                                           \
+        Operate(double, DTYPE_FT, function);                                   \
+      default :                                                                \
+        return TdiINVDTYDSC;                                                   \
     }                                                                          \
     return 1;                                                                  \
   }
@@ -198,35 +204,51 @@ static const int roprand = 0x8000;
   {                                                                            \
     SetupArgs switch (in->dtype)                                               \
     {                                                                          \
-    case DTYPE_F:                                                              \
-      Operate(float, DTYPE_F, function) case DTYPE_FS                          \
-          : Operate(float, DTYPE_FS, function) case DTYPE_G                    \
-          : Operate(double, DTYPE_G, function) case DTYPE_D                    \
-          : Operate(double, DTYPE_D, function) case DTYPE_FT                   \
-          : Operate(double, DTYPE_FT, function) default : return TdiINVDTYDSC; \
+      case DTYPE_F:                                                            \
+        Operate(float, DTYPE_F, function);                                     \
+      case DTYPE_FS:                                                           \
+        Operate(float, DTYPE_FS, function);                                    \
+      case DTYPE_G:                                                            \
+        Operate(double, DTYPE_G, function);                                    \
+      case DTYPE_D:                                                            \
+        Operate(double, DTYPE_D, function);                                    \
+      case DTYPE_FT:                                                           \
+        Operate(double, DTYPE_FT, function);                                   \
+      default :                                                                \
+        return TdiINVDTYDSC;                                                   \
     }                                                                          \
     return kind ? 1 : 1;                                                       \
   }
 
-#define mathboth(name, function)                                           \
-  int Tdi3##name(struct descriptor *in, struct descriptor *out)            \
-  {                                                                        \
-    SetupArgs switch (in->dtype)                                           \
-    {                                                                      \
-    case DTYPE_F:                                                          \
-      Operate(float, DTYPE_F, function) case DTYPE_FS                      \
-          : Operate(float, DTYPE_FS, function) case DTYPE_G                \
-          : Operate(double, DTYPE_G, function) case DTYPE_D                \
-          : Operate(double, DTYPE_D, function) case DTYPE_FT               \
-          : Operate(double, DTYPE_FT, function) case DTYPE_FC              \
-          : Operate(float, DTYPE_F, function) case DTYPE_FSC               \
-          : OperateC2C(float, DTYPE_FS, function##_complex) case DTYPE_GC  \
-          : OperateC2C(double, DTYPE_G, function##_complex) case DTYPE_DC  \
-          : OperateC2C(double, DTYPE_D, function##_complex) case DTYPE_FTC \
-          : OperateC2C(double, DTYPE_FT, function##_complex) default       \
-          : return TdiINVDTYDSC;                                           \
-    }                                                                      \
-    return 1;                                                              \
+#define mathboth(name, function)                                               \
+  int Tdi3##name(struct descriptor *in, struct descriptor *out)                \
+  {                                                                            \
+    SetupArgs switch (in->dtype)                                               \
+    {                                                                          \
+      case DTYPE_F:                                                            \
+        Operate(float, DTYPE_F, function);                                     \
+      case DTYPE_FS:                                                           \
+        Operate(float, DTYPE_FS, function);                                    \
+      case DTYPE_G:                                                            \
+        Operate(double, DTYPE_G, function);                                    \
+      case DTYPE_D:                                                            \
+        Operate(double, DTYPE_D, function);                                    \
+      case DTYPE_FT:                                                           \
+        Operate(double, DTYPE_FT, function);                                   \
+      case DTYPE_FC:                                                           \
+        Operate(float, DTYPE_F, function);                                     \
+      case DTYPE_FSC:                                                          \
+        OperateC2C(float, DTYPE_FS, function##_complex);                       \
+      case DTYPE_GC:                                                           \
+        OperateC2C(double, DTYPE_G, function##_complex);                       \
+      case DTYPE_DC:                                                           \
+        OperateC2C(double, DTYPE_D, function##_complex);                       \
+      case DTYPE_FTC:                                                          \
+        OperateC2C(double, DTYPE_FT, function##_complex);                      \
+      default:                                                                 \
+        return TdiINVDTYDSC;                                                   \
+    }                                                                          \
+    return 1;                                                                  \
   }
 
 #define mathcomplex(name, function)                              \
@@ -234,13 +256,18 @@ static const int roprand = 0x8000;
   {                                                              \
     SetupArgs switch (in->dtype)                                 \
     {                                                            \
-    case DTYPE_FC:                                               \
-      OperateC2S(float, DTYPE_F, function) case DTYPE_FSC        \
-          : OperateC2S(float, DTYPE_FS, function) case DTYPE_GC  \
-          : OperateC2S(double, DTYPE_G, function) case DTYPE_DC  \
-          : OperateC2S(double, DTYPE_D, function) case DTYPE_FTC \
-          : OperateC2S(double, DTYPE_FT, function) default       \
-          : return TdiINVDTYDSC;                                 \
+      case DTYPE_FC:                                             \
+        OperateC2S(float, DTYPE_F, function);                    \
+      case DTYPE_FSC:                                            \
+        OperateC2S(float, DTYPE_FS, function);                   \
+      case DTYPE_GC:                                             \
+        OperateC2S(double, DTYPE_G, function);                   \
+      case DTYPE_DC:                                             \
+        OperateC2S(double, DTYPE_D, function);                   \
+      case DTYPE_FTC:                                            \
+        OperateC2S(double, DTYPE_FT, function);                  \
+      default:                                                   \
+        return TdiINVDTYDSC;                                     \
     }                                                            \
     return 1;                                                    \
   }
@@ -373,23 +400,33 @@ static double atanh_Static(double in)
   return ans;
 }
 
-mathsingle(Atanh, atanh_Static) mathsingle(Cosh, cosh)
-    mathsingle(Log2, log2_Static) mathsingle(Sinh, sinh) mathsingle(Tanh, tanh)
-        mathsingle(Acos, acos) mathsingle(Acosd, acosd_Static)
-            mathsingle(Asin, asin) mathsingle(Asind, asind_Static)
-                mathsingle(Atan, atan) mathsingle(Atand, atand_Static)
-                    mathsingle(Cosd, cosd_Static) mathsingle(Floor, floor)
-                        mathsingle(Log10, log10) mathsingle(Sind, sind_Static)
-                            mathsingle(Tan, tan) mathsingle(Tand, tand_Static)
-                                mathsinglewithkind(Aint, trunc_Static)
-                                    mathsinglewithkind(Anint,
-                                                       anint) mathboth(Cos, cos)
-                                        mathboth(Exp, exp) mathboth(Log, log)
-                                            mathboth(Sin, sin) mathboth(Sqrt,
-                                                                        sqrt)
-                                                mathcomplex(Arg, atan2)
-                                                    mathcomplex(Argd,
-                                                                atand2_Static)
+mathsingle(Atanh, atanh_Static); 
+mathsingle(Cosh, cosh);
+mathsingle(Log2, log2_Static); 
+mathsingle(Sinh, sinh);
+mathsingle(Tanh, tanh);
+mathsingle(Acos, acos);
+mathsingle(Acosd, acosd_Static);
+mathsingle(Asin, asin);
+mathsingle(Asind, asind_Static);
+mathsingle(Atan, atan);
+mathsingle(Atand, atand_Static);
+mathsingle(Cosd, cosd_Static);
+mathsingle(Floor, floor);
+mathsingle(Log10, log10);
+mathsingle(Sind, sind_Static);
+mathsingle(Tan, tan);
+mathsingle(Tand, tand_Static);
+mathsinglewithkind(Aint, trunc_Static);
+mathsinglewithkind(Anint,anint);
+mathboth(Cos, cos);
+mathboth(Exp, exp);
+mathboth(Log, log);
+mathboth(Sin, sin);
+mathboth(Sqrt,sqrt);
+mathcomplex(Arg, atan2);
+mathcomplex(Argd,atand2_Static);
+  
     /*  CMS REPLACEMENT HISTORY, Element Tdi3MATH1.C */
     /*  *51   27-AUG-1996 07:42:11 TWF "Fix compile warnings" */
     /*  *50   21-AUG-1996 11:56:00 TWF "fix arg" */

--- a/tdishr/TdiMath2.c
+++ b/tdishr/TdiMath2.c
@@ -248,24 +248,38 @@ int Tdi3Mod(struct descriptor *in1, struct descriptor *in2,
 {
   SetupArgs switch (in1->dtype)
   {
-  case DTYPE_B:
-    Operate(int8_t, %) case DTYPE_BU : Operate(uint8_t, %) case DTYPE_W
-        : Operate(int16_t, %) case DTYPE_WU : Operate(uint16_t, %) case DTYPE_L
-        : Operate(int32_t, %) case DTYPE_LU : Operate(uint32_t, %) case DTYPE_Q
-        : Operate(int64_t, %) case DTYPE_QU : Operate(uint64_t, %) case DTYPE_O
-        : OperateBin(in1->length, 1, mod_bin) case DTYPE_OU
-        : OperateBin(in1->length, 0, mod_bin) case DTYPE_F
-        : OperateFloat(float, DTYPE_F, mod_float);
-  case DTYPE_FS:
-    OperateFloat(float, DTYPE_FS, mod_float);
-  case DTYPE_D:
-    OperateFloat(double, DTYPE_D, mod_float);
-  case DTYPE_G:
-    OperateFloat(double, DTYPE_G, mod_float);
-  case DTYPE_FT:
-    OperateFloat(double, DTYPE_FT, mod_float);
-  default:
-    return TdiINVDTYDSC;
+    case DTYPE_B:
+      Operate(int8_t, %);
+    case DTYPE_BU :
+      Operate(uint8_t, %);
+    case DTYPE_W:
+      Operate(int16_t, %);
+    case DTYPE_WU :
+      Operate(uint16_t, %);
+    case DTYPE_L:
+      Operate(int32_t, %);
+    case DTYPE_LU :
+      Operate(uint32_t, %);
+    case DTYPE_Q:
+      Operate(int64_t, %);
+    case DTYPE_QU :
+      Operate(uint64_t, %);
+    case DTYPE_O:
+      OperateBin(in1->length, 1, mod_bin);
+    case DTYPE_OU:
+      OperateBin(in1->length, 0, mod_bin);
+    case DTYPE_F:
+      OperateFloat(float, DTYPE_F, mod_float);
+    case DTYPE_FS:
+      OperateFloat(float, DTYPE_FS, mod_float);
+    case DTYPE_D:
+      OperateFloat(double, DTYPE_D, mod_float);
+    case DTYPE_G:
+      OperateFloat(double, DTYPE_G, mod_float);
+    case DTYPE_FT:
+      OperateFloat(double, DTYPE_FT, mod_float);
+    default:
+      return TdiINVDTYDSC;
   }
   return 1;
 }


### PR DESCRIPTION
* clang-format introduced weird formatting issues for certain section of the tdishr codebase. Those issues were fixed manually.
* Some refactor of the code was needed for those fixes.