### PR TITLE
Fix: READ() removing last character of file

### DIFF
--- a/tdishr/TdiIo.c
+++ b/tdishr/TdiIo.c
@@ -436,7 +436,10 @@ int Tdi1Read(opcode_t opcode __attribute__((unused)),
     ans = fgets(line, sizeof(line), unit);
     if (ans)
     {
-      line_d.length = strlen(line) - 1;
+      line_d.length = strlen(line);
+      if (line_d.length > 0 && line[line_d.length - 1] == '\n') {
+        --line_d.length;
+      }
       line_d.pointer = line;
       status = MdsCopyDxXd(&line_d, out_ptr);
     }


### PR DESCRIPTION
When a file does not end with a newline, `READ()` erroneously strips off the last character of the last line.
This simply checks that it is a newline before removing it.

`example.txt`
```
This line has a newline
This line doesn't
```

```tdi
_file = fopen('example.txt', 'r')
read(_file) # "This line has a newline"
read(_file) # "This line doesn't"
```

Previously, the last read() would have returned `"This line doesn'"`
