### PR TITLE
Feature: Add $SEEK_SET, $SEEK_CUR, $SEEK_END

### DIFF
--- a/tdishr/TdiIo.c
+++ b/tdishr/TdiIo.c
@@ -182,6 +182,27 @@ int Tdi1Fclose(opcode_t opcode __attribute__((unused)),
   return TdiPutLong((int *)&err, out_ptr);
 }
 
+mdsdsc_t * Tdi3SeekSet()
+{
+    static const int value = SEEK_SET;
+    static const mdsdsc_t constant = { sizeof(value), DTYPE_L, CLASS_S, (char *)&value };
+    return (mdsdsc_t *)&constant;
+}
+
+mdsdsc_t * Tdi3SeekCur()
+{
+    static const int value = SEEK_CUR;
+    static const mdsdsc_t constant = { sizeof(value), DTYPE_L, CLASS_S, (char *)&value };
+    return (mdsdsc_t *)&constant;
+}
+
+mdsdsc_t * Tdi3SeekEnd()
+{
+    static const int value = SEEK_END;
+    static const mdsdsc_t constant = { sizeof(value), DTYPE_L, CLASS_S, (char *)&value };
+    return (mdsdsc_t *)&constant;
+}
+
 /*----------------------------------------------
         Specify position of file pointer.
         err = FSEEK(unit, offset, origin)

--- a/tdishr/opcodes.csv
+++ b/tdishr/opcodes.csv
@@ -460,3 +460,6 @@
 "458","List","LIST","List","undef","undef","XX","YY","XX","YY","0","254","OK+I+S","%f9+ [a..z1:z2:dz..n@[this]]"
 "459","Squeeze","SQUEEZE","Reshape","undef","undef","XX","YY","XX","YY","1","2","OK","%f9+ squeeze(array, [min ndim]) "
 "460","Flatten","FLATTEN","Reshape","undef","undef","XX","YY","XX","YY","1","1","OK","%f9+ flatten(array) "
+"461","SeekSet","$SEEK_SET","Constant","undef","SeekSet","VV","VV","VV","VV","0","0","CONST","SEEK_SET"
+"462","SeekCur","$SEEK_CUR","Constant","undef","SeekCur","VV","VV","VV","VV","0","0","CONST","SEEK_CUR"
+"463","SeekEnd","$SEEK_END","Constant","undef","SeekEnd","VV","VV","VV","VV","0","0","CONST","SEEK_END"

--- a/tditest/testing/test-tdishr.ans
+++ b/tditest/testing/test-tdishr.ans
@@ -6156,6 +6156,9 @@ TUPLE   OPC$TUPLE           457
 LIST   OPC$LIST           458
 SQUEEZE   OPC$SQUEEZE           459
 FLATTEN   OPC$FLATTEN           460
+$SEEK_SET   OPC$$SEEK_SET           461
+$SEEK_CUR   OPC$$SEEK_CUR           462
+$SEEK_END   OPC$$SEEK_END           463
 *
 kind(_u=fopen('tditst.tmp','w'))
 51BU


### PR DESCRIPTION
Since the values of `SEEK_SET`, `SEEK_CUR` and `SEEK_END` aren't standard, this adds a way to access the C macros from TDI. This is for use with the `FSEEK()` builtin, like so:

```
FSEEK(_file, *, $SEEK_END);
```

Each constant required a new opcode, which have been allocated in opcodes.csv