### PR TITLE
Build: Default to RelWithDebInfo, Add --debug,--release to build.py

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -153,7 +153,7 @@ mdsplus_option(
     CMAKE_BUILD_TYPE STRING
     "Type of build to configure."
     OPTIONS ${CMAKE_CONFIGURATION_TYPES}
-    DEFAULT "Release"
+    DEFAULT "RelWithDebInfo"
     ${_force_build_type}
 )
 

--- a/deploy/build.py
+++ b/deploy/build.py
@@ -133,6 +133,20 @@ parser.add_argument(
     help='Use with --build, will clean the project in `{--workspace}/build` before building.'
 )
 
+parser.add_argument(
+    '--debug',
+    action='store_true',
+    default=False,
+    help='Shorthand for `-DCMAKE_BUILD_TYPE=Debug`.',
+)
+
+parser.add_argument(
+    '--release',
+    action='store_true',
+    default=False,
+    help='Shorthand for `-DCMAKE_BUILD_TYPE=Release`.',
+)
+
 # Packaging
 
 parser.add_argument(
@@ -290,6 +304,16 @@ if args.os is not None:
         print(f'Using aliased --os={args.os} -> --os={os_alias}')
         
         args.os = os_alias
+
+if args.debug and args.release:
+    print('You cannot use both --debug and --release at the same time')
+    exit(1)
+
+if args.debug:
+    cmake_args.append('-DCMAKE_BUILD_TYPE=Debug')
+
+if args.release:
+    cmake_args.append('-DCMAKE_BUILD_TYPE=Release')
 
 # Defaults
 


### PR DESCRIPTION
Default CMAKE_BUILD_TYPE to "RelWithDebInfo" (Release with Debug Info)
This will build an optimized but debuggable target by default.
The published packages will still be built with "Release"

Add --debug and --release as arguments to build.py to quickly set the CMAKE_BUILD_TYPE to Debug or Release