### PR TITLE
Fix: delete unused functions to support IDL 5.1 and earlier

### DIFF
--- a/deploy/packaging/debian/idl.noarch
+++ b/deploy/packaging/debian/idl.noarch
@@ -14,14 +14,6 @@
 ./usr/local/mdsplus/idl/Logbook/make_entry_display_sav.pro
 ./usr/local/mdsplus/idl/Logbook/rollback.pro
 ./usr/local/mdsplus/idl/Logbook/sql_finish.pro
-./usr/local/mdsplus/idl/PreIDL52/lon64arr.pro
-./usr/local/mdsplus/idl/PreIDL52/long64.pro
-./usr/local/mdsplus/idl/PreIDL52/uint.pro
-./usr/local/mdsplus/idl/PreIDL52/uintarr.pro
-./usr/local/mdsplus/idl/PreIDL52/ulon64arr.pro
-./usr/local/mdsplus/idl/PreIDL52/ulonarr.pro
-./usr/local/mdsplus/idl/PreIDL52/ulong.pro
-./usr/local/mdsplus/idl/PreIDL52/ulong64.pro
 ./usr/local/mdsplus/idl/cw_base.pro
 ./usr/local/mdsplus/idl/cw_wvedit.pro
 ./usr/local/mdsplus/idl/dsql.pro

--- a/deploy/packaging/redhat/idl.noarch
+++ b/deploy/packaging/redhat/idl.noarch
@@ -16,15 +16,6 @@
 ./usr/local/mdsplus/idl/Logbook/make_entry_display_sav.pro
 ./usr/local/mdsplus/idl/Logbook/rollback.pro
 ./usr/local/mdsplus/idl/Logbook/sql_finish.pro
-./usr/local/mdsplus/idl/PreIDL52
-./usr/local/mdsplus/idl/PreIDL52/lon64arr.pro
-./usr/local/mdsplus/idl/PreIDL52/long64.pro
-./usr/local/mdsplus/idl/PreIDL52/uint.pro
-./usr/local/mdsplus/idl/PreIDL52/uintarr.pro
-./usr/local/mdsplus/idl/PreIDL52/ulon64arr.pro
-./usr/local/mdsplus/idl/PreIDL52/ulonarr.pro
-./usr/local/mdsplus/idl/PreIDL52/ulong.pro
-./usr/local/mdsplus/idl/PreIDL52/ulong64.pro
 ./usr/local/mdsplus/idl/cw_base.pro
 ./usr/local/mdsplus/idl/cw_wvedit.pro
 ./usr/local/mdsplus/idl/dsql.pro

--- a/idl/PreIDL52/lon64arr.pro
+++ b/idl/PreIDL52/lon64arr.pro
@@ -1,4 +1,0 @@
-function lon64arr,in
-; Dummy function for pre IDL 5.2
-return,lonarr(in*2)
-end

--- a/idl/PreIDL52/long64.pro
+++ b/idl/PreIDL52/long64.pro
@@ -1,6 +1,0 @@
-function long64,in
-; Dummy function for pre IDL 5.2
-out=intarr(2)
-out(0)=in
-return,out
-end

--- a/idl/PreIDL52/uint.pro
+++ b/idl/PreIDL52/uint.pro
@@ -1,4 +1,0 @@
-function uint,in
-; Dummy function for pre IDL 5.2
-return,fix(in)
-end

--- a/idl/PreIDL52/uintarr.pro
+++ b/idl/PreIDL52/uintarr.pro
@@ -1,4 +1,0 @@
-function uintarr,in
-; Dummy function for pre IDL 5.2
-return,intarr(in)
-end

--- a/idl/PreIDL52/ulon64arr.pro
+++ b/idl/PreIDL52/ulon64arr.pro
@@ -1,4 +1,0 @@
-function ulon64arr,in
-; Dummy function for pre IDL 5.2
-return,lon64arr(in)
-end

--- a/idl/PreIDL52/ulonarr.pro
+++ b/idl/PreIDL52/ulonarr.pro
@@ -1,4 +1,0 @@
-function ulonarr,in
-; Dummy function for pre IDL 5.2
-return,lonarr(in)
-end

--- a/idl/PreIDL52/ulong.pro
+++ b/idl/PreIDL52/ulong.pro
@@ -1,4 +1,0 @@
-function ulong,in
-; Dummy function for pre IDL 5.2
-return,long(in)
-end

--- a/idl/PreIDL52/ulong64.pro
+++ b/idl/PreIDL52/ulong64.pro
@@ -1,4 +1,0 @@
-function ulong64,in
-; Dummy function for pre IDL 5.2
-return,long64(in)
-end


### PR DESCRIPTION
This fixes Issue #3007.

Deletes eight support functions written around 1998 to support backwards compatibility with early versions of the IDL programming language.