### PR TITLE
Fix:  mdsconnect of IDL API now always updates !MDS_SOCKET

### DIFF
--- a/idl/mdsconnect.pro
+++ b/idl/mdsconnect.pro
@@ -149,7 +149,8 @@ return
 end
 
 
-pro mdsconnect,host,status=status,quiet=quiet,port=port,socket=socket
+; This procedure is used to connect to MDSplus archive servers and to database servers
+pro mdsconnect,host,status=status,quiet=quiet,port=port,socket=socket,database=database
   forward_function mds_keyword_set
   on_error,2
   if (not mds_keyword_set(socket=socket)) then $
@@ -162,12 +163,15 @@ pro mdsconnect,host,status=status,quiet=quiet,port=port,socket=socket
   sockmin=sockmin()
   if (sock ge sockmin) then begin
     status = 1
-    defsysv, '!MDS_SOCKET', exists=conn
-    if not conn then begin
-       defsysv, '!MDS_SOCKET', fix(sock)
-    endif else begin
-      !MDS_SOCKET = fix(sock)
-    endelse
+    ; The !MDS_SOCKET only tracks connections to MDSplus archive servers.   See MDSDbConnect for database connections.
+    if not keyword_set(database) then begin
+      defsysv, '!MDS_SOCKET', exists=conn
+      if not conn then begin
+        defsysv, '!MDS_SOCKET', fix(sock)
+      endif else begin
+        !MDS_SOCKET = fix(sock)
+      endelse
+    endif
     if mds_keyword_set(socket=socket) then $
       socket = sock
   endif else begin

--- a/idl/mdsconnect.pro
+++ b/idl/mdsconnect.pro
@@ -162,7 +162,12 @@ pro mdsconnect,host,status=status,quiet=quiet,port=port,socket=socket
   sockmin=sockmin()
   if (sock ge sockmin) then begin
     status = 1
-    !MDS_SOCKET = sock
+    defsysv, '!MDS_SOCKET', exists=conn
+    if not conn then begin
+       defsysv, !MDS_SOCKET, sock
+    endif else begin
+      !MDS_SOCKET = sock
+    endelse
     if mds_keyword_set(socket=socket) then $
       socket = sock
   endif else begin

--- a/idl/mdsconnect.pro
+++ b/idl/mdsconnect.pro
@@ -164,9 +164,9 @@ pro mdsconnect,host,status=status,quiet=quiet,port=port,socket=socket
     status = 1
     defsysv, '!MDS_SOCKET', exists=conn
     if not conn then begin
-       defsysv, '!MDS_SOCKET', sock
+       defsysv, '!MDS_SOCKET', fix(sock)
     endif else begin
-      !MDS_SOCKET = sock
+      !MDS_SOCKET = fix(sock)
     endelse
     if mds_keyword_set(socket=socket) then $
       socket = sock

--- a/idl/mdsconnect.pro
+++ b/idl/mdsconnect.pro
@@ -164,7 +164,7 @@ pro mdsconnect,host,status=status,quiet=quiet,port=port,socket=socket
     status = 1
     defsysv, '!MDS_SOCKET', exists=conn
     if not conn then begin
-       defsysv, !MDS_SOCKET, sock
+       defsysv, '!MDS_SOCKET', sock
     endif else begin
       !MDS_SOCKET = sock
     endelse

--- a/idl/mdsconnect.pro
+++ b/idl/mdsconnect.pro
@@ -111,6 +111,7 @@ pro Mds$SendArg,sock,n,idx,arg
   return
 end
 
+; This procedure is likely obsolete
 pro mds$connect,host,status=status,quiet=quiet,port=port
   on_error,2
   mds$disconnect,/quiet
@@ -141,13 +142,11 @@ pro mds$disconnect,status=status,quiet=quiet
   return
 end
 
-
+; This procedure is likely obsolete
 pro connect,host,_EXTRA=e
 	mds$connect,host,_EXTRA=e
 return
 end
-
-;*/
 
 
 pro mdsconnect,host,status=status,quiet=quiet,port=port,socket=socket
@@ -163,9 +162,8 @@ pro mdsconnect,host,status=status,quiet=quiet,port=port,socket=socket
   sockmin=sockmin()
   if (sock ge sockmin) then begin
     status = 1
-    if not mds_keyword_set(socket=socket) then $
-      !MDS_SOCKET = sock $
-    else $
+    !MDS_SOCKET = sock
+    if mds_keyword_set(socket=socket) then $
       socket = sock
   endif else begin
     if not keyword_set(quiet) then message,'Error connecting to '+host,/IOERROR

--- a/idl/mdssql.pro
+++ b/idl/mdssql.pro
@@ -70,7 +70,7 @@ pro MDSDbConnect, host
    endif
    if (host ne "" and host ne "local") then begin
        socket=-1
-       MdsConnect, host, socket=socket
+       MdsConnect, host, socket=socket, /database
        !MDSDB_SOCKET = socket
        !MDSDB_HOST=host
    endif

--- a/idl/set_database.pro
+++ b/idl/set_database.pro
@@ -425,7 +425,7 @@ pro MDSDbConnect, host
    endif
    if (host ne "" and host ne "local") then begin
        socket=-1
-       MdsConnect, host, socket=socket
+       MdsConnect, host, socket=socket, /database
        !MDSDB_SOCKET = socket
        !MDSDB_HOST=host
    endif


### PR DESCRIPTION
Fixes issue #2996.

The IDL API has a system variable (i.e., global), `!MDS_SOCKET`, used to store the most recent connection ID.   It is now updated whenever `mdsconnect` establishes a mdsip connection.

Example output follows . . . 

```
IDL> CD, '/usr/local/mdsplus/lib'
IDL> mdsconnect, 'localhost'
% Compiled module: MDSCONNECT.
% Compiled module: MDS_KEYWORD_SET.
% Compiled module: MDSDISCONNECT.
IDL> print, !MDS_SOCKET
       0
IDL> mdsconnect, 'localhost'
IDL> print, !MDS_SOCKET
       1
IDL> mdsconnect, 'localhost'
IDL> print, !MDS_SOCKET
       2
IDL> conn_id = -1
IDL> mdsconnect, 'localhost', socket=conn_id
IDL> print, !MDS_SOCKET, conn_id
       3           3
IDL> mdsconnect, 'localhost', socket=conn_id
IDL> print, !MDS_SOCKET, conn_id
       4           4
IDL> mdsdisconnect, socket=conn_id
IDL> print, !MDS_SOCKET, conn_id
       4           4
IDL> mdsconnect, 'localhost', socket=conn_id
IDL> print, !MDS_SOCKET, conn_id
       5           5
IDL> mdsdisconnect
IDL> print, !MDS_SOCKET, conn_id
      -1           5
IDL> mdsconnect, 'localhost', socket=conn_id
IDL> print, !MDS_SOCKET, conn_id
       6           6
IDL> mdsconnect, 'localhost'
IDL> print, !MDS_SOCKET, conn_id
       7           6
IDL> 
```