### PR TITLE
Build: Keep Jenkins builds for 90 days

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -223,6 +223,7 @@ pipeline {
     options {
         skipDefaultCheckout()
         timeout(time: 1, unit: 'HOURS')
+        buildDiscarder(logRotator(daysToKeepStr: '90', artifactNumToKeepStr: '90'))
     }
     
     triggers {


### PR DESCRIPTION
This will only affect builds in Jenkins, not the kits pushed to GitHub or stored in mdsplus.org/dist/