### PR TITLE
Fix: can not rename nodes of usages subtree

### DIFF
--- a/treeshr/TreeRenameNode.c
+++ b/treeshr/TreeRenameNode.c
@@ -139,7 +139,7 @@ int _TreeRenameNode(void *dbid, int nid, char const *newname)
    ************************************************/
   if (is_child)
   {
-    if (oldnode_ptr->usage != TreeUSAGE_STRUCTURE)
+    if ((oldnode_ptr->usage != TreeUSAGE_STRUCTURE) && (oldnode_ptr->usage != TreeUSAGE_SUBTREE))
     {
       status = TreeINVPATH;
       goto cleanup;

--- a/treeshr/TreeRenameNode.c
+++ b/treeshr/TreeRenameNode.c
@@ -134,8 +134,8 @@ int _TreeRenameNode(void *dbid, int nid, char const *newname)
   }
 
   /************************************************
-    Make sure that a node with a non-STRUCTURE usage is
-    not being renamed into a son.
+    Make sure that a node with a non-STRUCTURE/SUBTREE 
+    usage is not being renamed into a son.
    ************************************************/
   if (is_child)
   {


### PR DESCRIPTION
This change addresses
    https://github.com/MDSplus/mdsplus/issues/3015

The check that members are not renamed to be children was also preventing subtrees from being renamed as children.