### PR TITLE
Fix: \TOP node parent state handling in TreeTurnOn

### DIFF
--- a/treeshr/TreeSetNci.c
+++ b/treeshr/TreeSetNci.c
@@ -591,8 +591,11 @@ int _TreeTurnOn(void *dbid, int nid_in)
   if (nci.flags & NciM_STATE)
   {
     bitassign(0, nci.flags, NciM_STATE);
+    if (node_num == 0)
+      bitassign(0, nci.flags, NciM_PARENT_STATE);
     RETURN_IF_NOT_OK(tree_put_nci(info, node_num, &nci, &locked));
-    if (!(nci.flags & NciM_PARENT_STATE))
+    /* if it is \top then do it regardless */
+    if (!(nci.flags & NciM_PARENT_STATE) || ( node_num == 0))
     {
       node = nid_to_node(dblist, nid);
       if (node->child)


### PR DESCRIPTION
When turning on the \TOP node (node_num == 0), clear its PARENT_STATE flag (PARENT_STATE 'on' and ensure its children's PARENT_STATE is set correctly.
.
This fixes an issue where \TOP's children would not be affected when turning on the root node.

Addresses
   https://github.com/MDSplus/mdsplus/issues/2953

Note: There is no completely consistent way to deal with the STATE and PARENT_STATE of nodes in subtrees when treating them both as subtrees and standalone trees.

STATE and PARENT_STATE are bits (**0 -> on**) in the NCI record. There are potentially 2 copies of each.
- One in the parent tree's NCI for the subtree node. This is the one you see and effect if you are edititing the parent, or have opened the parent without the subtree attached
- One in the subtree's NCI for its top node.  This is the one you see and effect when the subtree is attached to a parent tree.

**To rationalize the STATE and PARENT_STATE of the nodes in a subtree when it is opened independently, toggle its TOP node's state off and back on.**
- `TCL> set node \top /off`
- `TCL> set node \top /on` 
or python
- `tree._TOP.on = False`
- `tree._TOP.on = True`