### PR TITLE
Fix: Remove unused java waitData(milliseconds)

### DIFF
--- a/java/mdsobjects/src/main/java/MDSplus/Event.java
+++ b/java/mdsobjects/src/main/java/MDSplus/Event.java
@@ -97,22 +97,6 @@ public class Event
 		return getData();
 	}
 
-	public synchronized Data waitData(int milliseconds) throws MdsException
-	{
-		timeout = true;
-		try
-		{
-			wait(milliseconds);
-		}
-		catch (final InterruptedException exc)
-		{
-			return null;
-		}
-		if (timeout)
-			throw new MdsException("Timeout occurred in Event wait");
-		return getData();
-	}
-
 	public void dispose()
 	{
 		if (disposed)

--- a/mdsobjects/labview/mdseventobjectswrp.cpp
+++ b/mdsobjects/labview/mdseventobjectswrp.cpp
@@ -95,8 +95,9 @@ EXPORT void mdsplus_event_waitData(const void *lvEventPtr, void **lvDataPtrOut,
     *timeoutOccurred = 0;
     Event *eventPtr = reinterpret_cast<Event *>(const_cast<void *>(lvEventPtr));
     // 1 Second timeout
-    Data *dataPtrOut = eventPtr->waitData(1);
-    *lvDataPtrOut = reinterpret_cast<void *>(dataPtrOut);
+      eventPtr->wait(1);
+      Data *dataPtrOut = eventPtr->getData();
+      *lvDataPtrOut = reinterpret_cast<void *>(dataPtrOut);
   }
   catch (const MdsException &e)
   {


### PR DESCRIPTION
This fixes issue https://github.com/MDSplus/mdsplus/issues/2958.

* Remove unused java waitData(milliseconds) method.
* LabView now directly uses the underlying wait and getData methods

