### PR TITLE
Fix: the CAMAC libraries now accept connection IDs of zero

### DIFF
--- a/camshr/RemCamMulti.c
+++ b/camshr/RemCamMulti.c
@@ -102,7 +102,7 @@ static int DoCamMulti(char *routine, char *name, int a, int f, int count,
   int serverid = RemoteServerId();
   int status = 0;
   int writeData;
-  if (serverid)
+  if (serverid > INVALID_CONNECTION_ID)
   {
     struct descrip data_d = {8, 1, {0}, 0, 0};
     struct descrip ans_d = {0, 0, {0}, 0, 0};
@@ -138,7 +138,7 @@ int RemCamSetMAXBUF(char *name, int new)
 {
   int serverid = RemoteServerId();
   int status = -1;
-  if (serverid)
+  if (serverid > INVALID_CONNECTION_ID)
   {
     struct descrip ans_d = {0, 0, {0}, 0, 0};
     char cmd[512];
@@ -160,7 +160,7 @@ int RemCamGetMAXBUF(char *name)
 {
   int serverid = RemoteServerId();
   int status = -1;
-  if (serverid)
+  if (serverid > INVALID_CONNECTION_ID)
   {
     struct descrip ans_d = {0, 0, {0}, 0, 0};
     char cmd[512];

--- a/camshr/RemCamSingle.c
+++ b/camshr/RemCamSingle.c
@@ -33,8 +33,8 @@ short RemCamLastIosb[4];
 
 int RemoteServerId()
 {
-  static int socket = 0;
-  if (socket == 0)
+  static int socket = INVALID_CONNECTION_ID;
+  if (socket == INVALID_CONNECTION_ID)
   {
     char *server = getenv("camac_server");
     if (server == 0)
@@ -45,8 +45,8 @@ int RemoteServerId()
     else
     {
       socket = ConnectToMds(server);
-      if (socket < 0)
-        socket = 0;
+      if (socket < INVALID_CONNECTION_ID)
+        socket = INVALID_CONNECTION_ID;
     }
   }
   return socket;
@@ -95,7 +95,7 @@ static int CamSingle(char *routine, char *name, int a, int f, void *data,
   int serverid = RemoteServerId();
   int status = 0;
   int writeData;
-  if (serverid)
+  if (serverid > INVALID_CONNECTION_ID)
   {
     struct descrip data_d = {8, 0, {0}, 0, 0};
     struct descrip ans_d = {0, 0, {0}, 0, 0};

--- a/remcam/CamMulti.c
+++ b/remcam/CamMulti.c
@@ -101,7 +101,7 @@ static int DoCamMulti(char *routine, char *name, int a, int f, int count,
   int serverid = RemoteServerId();
   int status = 0;
   int writeData;
-  if (serverid)
+  if (serverid > INVALID_CONNECTION_ID)
   {
     struct descrip data_d = {8, 1, {0}, 0, 0};
     struct descrip ans_d = {0, 0, {0}, 0, 0};
@@ -137,7 +137,7 @@ EXPORT int CamSetMAXBUF(char *name, int new)
 {
   int serverid = RemoteServerId();
   int status = -1;
-  if (serverid)
+  if (serverid > INVALID_CONNECTION_ID)
   {
     struct descrip ans_d = {0, 0, {0}, 0, 0};
     char cmd[512];
@@ -159,7 +159,7 @@ EXPORT int CamGetMAXBUF(char *name)
 {
   int serverid = RemoteServerId();
   int status = -1;
-  if (serverid)
+  if (serverid > INVALID_CONNECTION_ID)
   {
     struct descrip ans_d = {0, 0, {0}, 0, 0};
     char cmd[512];

--- a/remcam/CamSingle.c
+++ b/remcam/CamSingle.c
@@ -33,8 +33,8 @@ short RemCamLastIosb[4];
 
 int RemoteServerId()
 {
-  static int socket = 0;
-  if (socket == 0)
+  static int socket = INVALID_CONNECTION_ID;
+  if (socket == INVALID_CONNECTION_ID)
   {
     char *server = getenv("camac_server");
     if (server == 0)
@@ -45,8 +45,8 @@ int RemoteServerId()
     else
     {
       socket = ConnectToMds(server);
-      if (socket < 0)
-        socket = 0;
+      if (socket < INVALID_CONNECTION_ID)
+        socket = INVALID_CONNECTION_ID;
     }
   }
   return socket;
@@ -96,7 +96,7 @@ static int CamSingle(char *routine, char *name, int a, int f, void *data,
   int serverid = RemoteServerId();
   int status = 0;
   int writeData;
-  if (serverid)
+  if (serverid > INVALID_CONNECTION_ID)
   {
     struct descrip data_d = {8, 0, {0}, 0, 0};
     struct descrip ans_d = {0, 0, {0}, 0, 0};


### PR DESCRIPTION
This fixes Issue #3024.

PR #2288 redefined `INVALID_CONNECTION_ID` to be `-1` (it used to be zero).   This fix changes two CAMAC libraries, `libCamShr.so` and `libRemCamShr.so`, to accept zero as a valid connection ID.   Developer builds of the libraries were tested by the user and confirmed to fix the problem.   This fix needs to be included in a new "stable" release.