### PR TITLE
Fix: correct default log file location for local mdsip client

### DIFF
--- a/mdstcpip/mdsip-client-local
+++ b/mdstcpip/mdsip-client-local
@@ -1,2 +1,2 @@
 #!/bin/sh
-exec mdsip -P local 2>> "${MDSIP_CLIENT_LOCAL_LOGFILE:-~/mdsip-local.log}"
+exec mdsip -P local 2>> "${MDSIP_CLIENT_LOCAL_LOGFILE:-$HOME/mdsip-local.log}"


### PR DESCRIPTION
After last commit `~` was enclosed in double quotes which prevented the substitution with the home directory.

Replacing `~` with `$HOME` allows for proper substitution.