### PR TITLE
Fix: buffer size set at compile time eliminates buffer overflow error in mdscts

### DIFF
--- a/camshr/copy.c
+++ b/camshr/copy.c
@@ -109,32 +109,29 @@ int copy(int dbType, char *inFile, char *outFile, int count)
   default:
     return 0;
   }
+    
+  char line[BUFFER_SIZE];
 
-  // local block
+  // read 'n write ...
+  for (i = 0; i < count; ++i)
   {
-    char line[entrySize];
-
-    // read 'n write ...
-    for (i = 0; i < count; ++i)
+    // read ...
+    if (read(Read_fd, line, entrySize) != entrySize)
     {
-      // read ...
-      if (read(Read_fd, line, entrySize) != entrySize)
-      {
-        if (MSGLVL(ALWAYS))
-          perror("read()");
+      if (MSGLVL(ALWAYS))
+        perror("read()");
 
-        status = COPY_ERROR;
-        goto Copy_Exit_3;
-      }
-      // ... then write
-      if (write(Write_fd, line, entrySize) != entrySize)
-      {
-        if (MSGLVL(ALWAYS))
-          perror("write()");
+      status = COPY_ERROR;
+      goto Copy_Exit_3;
+    }
+    // ... then write
+    if (write(Write_fd, line, entrySize) != entrySize)
+    {
+      if (MSGLVL(ALWAYS))
+        perror("write()");
 
-        status = COPY_ERROR;
-        goto Copy_Exit_3;
-      }
+      status = COPY_ERROR;
+      goto Copy_Exit_3;
     }
   }
 

--- a/camshr/create_tmp_file.c
+++ b/camshr/create_tmp_file.c
@@ -105,23 +105,20 @@ int create_tmp_file(int dbType, int count, char *filename)
   // make 'blank-entry' format specifier
   sprintf(fmt, "%%-%ds\n", entrySize - 1);
 
-  // a local block
+  char line[BUFFER_SIZE];
+
+  // 'blank' entry
+  sprintf(line, fmt, " ");
+
+  for (i = 0; i < count; ++i)
   {
-    char line[entrySize];
-
-    // 'blank' entry
-    sprintf(line, fmt, " ");
-
-    for (i = 0; i < count; ++i)
+    if (write(fd, line, entrySize) != entrySize)
     {
-      if (write(fd, line, entrySize) != entrySize)
-      {
-        if (MSGLVL(ALWAYS))
-          perror("write()");
+      if (MSGLVL(ALWAYS))
+        perror("write()");
 
-        status = EXPAND_ERROR;
-        goto CreateTmpFile_Exit;
-      }
+      status = EXPAND_ERROR;
+      goto CreateTmpFile_Exit;
     }
   }
 

--- a/camshr/module.h
+++ b/camshr/module.h
@@ -39,6 +39,11 @@ struct MODULE
 };
 #define MODULE_ENTRY sizeof(struct MODULE)
 
+// A buffer is used when writing records to the *.db files.
+// It must be big enough to hold a module record (which is bigger
+// than a crate record).  Add a few extra bytes for safety.
+#define BUFFER_SIZE MODULE_ENTRY + 10
+
 // internal structure
 typedef struct Module_
 {

--- a/camshr/remove_entry.c
+++ b/camshr/remove_entry.c
@@ -128,19 +128,16 @@ int remove_entry(int dbType, int index)
   // set up 'blank-entry' format string
   sprintf(fmt, "%%-%ds\n", entrySize - 1);
 
-  // local block
-  {
-    char line[entrySize + 1];
+  char line[BUFFER_SIZE];
 
-    // remove entry -- move appropriate entries one earlier in list
-    for (i = index; i < numOfEntries; ++i)
-      memcpy((char *)dbptr + (i * entrySize),
-             (char *)dbptr + ((i + 1) * entrySize), entrySize);
+  // remove entry -- move appropriate entries one earlier in list
+  for (i = index; i < numOfEntries; ++i)
+    memcpy((char *)dbptr + (i * entrySize),
+            (char *)dbptr + ((i + 1) * entrySize), entrySize);
 
-    // 'blank' out last, old entry
-    sprintf(line, fmt, " ");
-    memcpy((char *)dbptr + ((i + 1) * entrySize), line, entrySize);
-  }
+  // 'blank' out last, old entry
+  sprintf(line, fmt, " ");
+  memcpy((char *)dbptr + ((i + 1) * entrySize), line, entrySize);
 
   // commit change to file
   if (commit_entry(dbType) != SUCCESS)


### PR DESCRIPTION
Fixes issue #3031.

The C library `write()` function was throwing a `*** buffer overflow ***` error because `mdscts` was using a buffer created in a `local` block with size unknown until runtime.   The error only occurred with a "release" build and was spotted on Ubuntu 24 (which has improved error checking).   Changing `mdscts` to use a buffer size known at compile time eliminated the error.

More details for the curious . . . 

The `mdscts` utility is used to manage two small databases -- `crate.db` and `cts.db` -- for CAMAC crates and modules.   The `crate.db` records are 17-bytes long; the `cts.db` records are 85-bytes long.   The original code was thus using a C `local` block to create either a 17-byte buffer or an 85-byte buffer.

Defining the buffer to be 95-bytes (`MODULE_SIZE + 10`) creates a buffer large enough to hold either type of record.   Furthermore, the existing code uses the `entrySize` variable to specify the appropriate record size for each database file.   Using a single buffer definition known at compile time means that the C `local` block can also be eliminated.   (The file diff looks complicated, but all that was done was to eliminate a pair of `{` and `}` braces and shift the code left.)

The `remove_entry.c` file has this line: `char line[entrySize + 1];`.   So to be safe, the buffer size was defined to be 10-bytes longer than the module record.

This fix passes manual testing of `mdscts` plus has also been proven to work OK for the Univ. of Washington's Zap-HD device.