### PR TITLE
Fix: the mdscts DelCrate now works, plus Add_Entry was cleaned up

### DIFF
--- a/camshr/add_entry.c
+++ b/camshr/add_entry.c
@@ -114,14 +114,9 @@ int add_entry(int dbType, char *newEntry)
     goto AddEntry_Exit;
   }
 
-  // shift current entries by one
-  if (numOfEntries) // ... only if any entries exist
-    for (i = numOfEntries - 1; i >= 0; --i)
-      memcpy((char *)dbptr + ((i + 1) * entrySize),
-             (char *)dbptr + (i * entrySize), entrySize);
-
-  // put new entry at head of list
-  memcpy((char *)dbptr, newEntry, entrySize);
+  // put new entry at end of list
+  // Indices are zero based, numOfEntries is one based so appends to the list.
+  memcpy((char *)(dbptr + numOfEntries * entrySize), newEntry, entrySize);
 
   // insertion sort
   if (numOfEntries > 0) // only insert if more than one entry exists already

--- a/camshr/cam_functions.c
+++ b/camshr/cam_functions.c
@@ -1372,8 +1372,7 @@ EXPORT int CamSetMAXBUF(char *Name, int new)
       char dev_name[12];
       sprintf(dev_name, "GK%c%d%02d", Key.scsi_port, Key.scsi_address,
               Key.crate);
-      if ((scsiDevice = get_scsi_device_number(dev_name, &enhanced, &online)) <
-          0)
+      if ((scsiDevice = get_scsi_device_number(dev_name, &enhanced, &online)) < 0)
       {
         return -1;
       }
@@ -1404,8 +1403,7 @@ EXPORT int CamGetMAXBUF(char *Name)
       char dev_name[12];
       sprintf(dev_name, "GK%c%d%02d", Key.scsi_port, Key.scsi_address,
               Key.crate);
-      if ((scsiDevice = get_scsi_device_number(dev_name, &enhanced, &online)) <
-          0)
+      if ((scsiDevice = get_scsi_device_number(dev_name, &enhanced, &online)) < 0)
       {
         return -1;
       }

--- a/camshr/compare_str.c
+++ b/camshr/compare_str.c
@@ -85,8 +85,7 @@ int compare_str(const void *key1, const void *key2)
            CLR, (char *)key1, CLR, CLR, (char *)key2, CLR);
 
   length = (strlen(key1) >= strlen(key2)) ? strlen(key1) : strlen(key2);
-  if ((retval = strncmp_nocase((const char *)key1, (const char *)key2,
-                               length)) > 0)
+  if ((retval = strncmp_nocase((const char *)key1, (const char *)key2, length)) > 0)
   {
     if (MSGLVL(8))
       printf("comp(): key1 > key2\n");

--- a/camshr/get_file_count.c
+++ b/camshr/get_file_count.c
@@ -74,6 +74,7 @@ int get_file_count(int dbType)
 {
   void *dbptr; // generic pointer to struct's
   char dbFileName[16];
+  char firstChar;
   int dbFileSize, entrySize, i, numOfEntries;
   int *FileIsMapped;
   extern struct MODULE *CTSdb;
@@ -128,7 +129,9 @@ int get_file_count(int dbType)
 
     //              sprintf(&ch, "%.1s", (char *)(dbptr+i));
 
-    if (*(char *)(dbptr + i) == ' ') // we're done, so out'a here
+    // Existing *.db files might be padded with null characters because of a previous bug.
+    firstChar = *(char *)(dbptr + i);
+    if ((firstChar == ' ') || (firstChar == '\0')) // we're done, so out'a here
       break;
 
     ++numOfEntries;

--- a/camshr/get_scsi_device_number.c
+++ b/camshr/get_scsi_device_number.c
@@ -79,8 +79,7 @@ int get_scsi_device_number(char *highway_name, int *enhanced, int *online)
   // lookup name
   sprintf(highway, "%.4s", highway_name); // trim to highway name, only
 
-  if ((i = lookup_entry(CRATE_DB, highway_name)) <
-      0)
+  if ((i = lookup_entry(CRATE_DB, highway_name)) < 0)
   { // lookup actual device num
     if (MSGLVL(IMPORTANT))
       fprintf(stderr, "no such highway in 'crate.db'\n");
@@ -89,6 +88,7 @@ int get_scsi_device_number(char *highway_name, int *enhanced, int *online)
     goto GetScsiDeviceNumber_Exit;
   }
 
+  // The +i increments by CRATE structs, not by bytes.
   parse_crate_db(CRATEdb + i, &crate); // get data from db
   device_num = crate.device;           // extract dev num from db
   *enhanced = crate.enhanced;

--- a/camshr/issort.c
+++ b/camshr/issort.c
@@ -59,6 +59,13 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 // The entry to be inserted is in the first location, subsequent entries
 // are sorted. Only 1 pass through the list is needed, so algorithm is
 // fairly fast.
+//
+// This routine sorts an unordered set of N items.  Conceptually, it 
+// does the following:
+//    sort(list_1_to_N) = sort(list_1_to_N-1), insert(list, item_N)
+// However, instead of recursion it uses a forward loop.
+// If the list is already sorted, the most efficient way to insert a new
+// item is to append it to the end of the list before calling this routine.
 //-------------------------------------------------------------------------
 // input:       see parameter list
 // output:      always 0
@@ -79,6 +86,7 @@ int issort(void *data, int size, int esize,
     return -1;
 
   //  Repeatedly insert a key element among the sorted elements.
+  //  The indices are zero based, size is one based hence the "<".
   for (j = 1; j < size; ++j)
   {
     memcpy(key, &a[j * esize], esize);

--- a/camshr/map_scsi_device.c
+++ b/camshr/map_scsi_device.c
@@ -148,6 +148,7 @@ int map_scsi_device(char *highway_name)
 #if defined __GNUC__ && 800 <= __GNUC__ * 100 + __GNUC_MINOR__
     _Pragma("GCC diagnostic ignored \"-Wstringop-truncation\"")
 #endif
+        // The +i increments by CRATE structs, not by bytes.
         strncpy((CRATEdb + i)->DSFname, dsf, 3); // real device number
 #pragma GCC diagnostic pop
     (CRATEdb + i)->HwyType = hwytype; // highway type

--- a/camshr/remove_entry.c
+++ b/camshr/remove_entry.c
@@ -131,13 +131,14 @@ int remove_entry(int dbType, int index)
   char line[BUFFER_SIZE];
 
   // remove entry -- move appropriate entries one earlier in list
-  for (i = index; i < numOfEntries; ++i)
+  // The index is zero based, but numOfEntries is one based hence the -1.
+  for (i = index; i < (numOfEntries - 1); ++i)
     memcpy((char *)dbptr + (i * entrySize),
             (char *)dbptr + ((i + 1) * entrySize), entrySize);
 
   // 'blank' out last, old entry
   sprintf(line, fmt, " ");
-  memcpy((char *)dbptr + ((i + 1) * entrySize), line, entrySize);
+  memcpy((char *)dbptr + (i * entrySize), line, entrySize);
 
   // commit change to file
   if (commit_entry(dbType) != SUCCESS)

--- a/camshr/remove_entry.c
+++ b/camshr/remove_entry.c
@@ -99,8 +99,7 @@ int remove_entry(int dbType, int index)
     goto RemoveEntry_Exit;
   }
   // get number of current entries
-  if ((numOfEntries = get_file_count(dbType)) ==
-      0)
+  if ((numOfEntries = get_file_count(dbType)) == 0)
   { // no entries in cts db file
     if (MSGLVL(IMPORTANT))
       fprintf(stderr, "db file empty, no entries to remove\n");

--- a/camshr/verbs.c
+++ b/camshr/verbs.c
@@ -351,8 +351,7 @@ EXPORT int Deassign(void *ctx, char **error,
     }
   }
   // get number of current entries
-  if ((numOfEntries = get_file_count(CTS_DB)) ==
-      0)
+  if ((numOfEntries = get_file_count(CTS_DB)) == 0)
   { // no entries in cts db file
     *error = strdup("Error: db file empty, no entries to remove\n");
 
@@ -537,14 +536,13 @@ EXPORT int ShowCrate(void *ctx, char **error, char **output)
   pCr8 = &Cr8; // point to some actual storage
 
   // get number of crates in db file
-  if ((numOfCrates = get_file_count(CRATE_DB)) >
-      0)
+  if ((numOfCrates = get_file_count(CRATE_DB)) > 0)
   { // possibly something to show
-    if ((numOfModules = get_file_count(CTS_DB)) >
-        0)
+    if ((numOfModules = get_file_count(CTS_DB)) > 0)
     { // maybe some crates controllers ..
       for (i = 0; i < numOfCrates; i++)
       {
+        // The +i increments by CRATE structs, not by bytes.
         parse_crate_db(CRATEdb + i, pCr8);
         crate_d.length = strlen(pCr8->name);
         crate_d.pointer = pCr8->name;
@@ -840,8 +838,7 @@ EXPORT int DelCrate(void *ctx, char **error,
     }
   }
   // get number of current entries
-  if ((numOfEntries = get_file_count(CRATE_DB)) ==
-      0)
+  if ((numOfEntries = get_file_count(CRATE_DB)) == 0)
   { // no entries in crate db file
     *error = strdup("Error: db file empty, no entries to remove\n");
     status = FAILURE; // DELCRATE_ERROR;              [2001.07.12]


### PR DESCRIPTION
Fixes issue #3035.

The `mdscts` utility for managing CAMAC crates and modules had an "off by one" issue that caused it to occasionally refuse to delete crates.   (Presumably, the same issue affected deleting modules.)  Records in the `crate.db` and `cts.db` files have zero-based indices; the variable that tracks the number of records in each `*.db` file is one-based.

The `*.db` files are kept in sorted order and are accessed by mapping them into memory.   When records are added, the files grow in chunks of 10 records (one has an entry, the other nine are blank).   If more than 10 records are entered, then an additional chunk of 10 records is added.   (Actually, a bigger file is created, the old file is copied into the new file, and then the old file is deleted.)

Suppose a `*.db` file contains 10 non-empty records.   And then the second record is deleted.   In that case, records 3 through 10 are shifted up in the file, and then the tenth record is overwritten with a blank record.  (Note that the file size never shrinks; as records are deleted the file just fills up with blank records.)

Because of the "off by one" problem, the program incorrectly assumed that there was an extra record in the file, thus attempted to access a region beyond the end of the memory mapped file.  The end result was that instead of the file being padded with blank records after records were deleted, it was being padded with records that contained the NULL character (ASCII code = 0x00).   The `get_file_count()` routine was searching for records that contained a space, never found one, so incorrectly reported more active records in the file than there actually were.   That in turn messed up the binary search that is used to find the record to be deleted.   When the binary search did its midpoint calculation, it could skip over the last active record in the file and end up in the region of the file that only had records filled with NULL characters.   Thus, mdscts would occasionally refuse to delete an entry.

After fixing the deletion issue, the source code was reviewed for other "off by one" issues.   That revealed that the `add_entry()` routine was doing unnecessary record manipulation prior to calling the insertion sort.

Also, some source lines had been split into two lines, so those were reformatted to improve readability.