### PR TITLE
Fix: eliminates buffer overflow in mds_value_remote_expression()

### DIFF
--- a/mdslib/MdsLib.c
+++ b/mdslib/MdsLib.c
@@ -1433,7 +1433,7 @@ static char *mds_value_remote_expression(char *expression,
 
   char *native_float_str, *native_double_str, *native_complex_str,
       *native_double_complex_str;
-  char *newexpression = (char *)malloc(strlen(expression) + 24);
+  char *newexpression = (char *)calloc(strlen(expression) + 24, sizeof(char));
 
   /*  Determine the native floating/double/complex type of the client, so as to
    * pass the correct conversion function to the server and thus save extra


### PR DESCRIPTION
Fixes issue #3042.

The `mds_value_remote_expression()` is only designed to work with data types defined in `include/ipdesc.h`.   However, that constraint is only documented in the source code, so users will occasionally instead use a data type from `include/mdsdescrip.h` (which in turn uses `include/dtypedef.h`).

When the function receives a data type it doesn't recognize, it skips the `switch()` statements that specify explicit data conversions, and instead falls directly to a `strcat()` at the end of the function.   If the `newexpression` buffer is full of random junk, the `strcat()` can overflow the buffer.   And even if it doesn't overflow, having junk at the beginning of `newexpression` can cause TDI on the archive server to fail or crash.

This fix clears the `newexpression` buffer on creation (fills it with zeros, i.e., NULL characters), thus the `strcat()` will always stay within the buffer.


**NOTES:**

1. When an unrecognized data type is used, the resulting `newexpression` will not have an explicit data conversion function applied, thus errors can still arise.   For example, specifying `DTYPE_G` (VAX double precision) from `dtypedef.h` fails when accessing a node with IEEE floats; one should instead use `DTYPE_DOUBLE` from `ipdesc.h`.
2. The documentation for `MdsValue()` should explain that when using thin-client, only data types from `ipdesc.h` should be used.
3. `DTYPE_FLOAT` has two definitions: one in `ipdesc.h` (=10), the other in `mdsdescrip.h` (= DTYPE_FS = 52).   The same is true of `DTYPE_DOUBLE` (i.e., 11 versus 53).
4. Experiments with the debugger show that `mds_value_remote_expression()` is only called by thin-client.