### PR TITLE
Feature: add python wheel to distribution

### DIFF
--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -1,2 +1,28 @@
-
+# Add the MDSplus Python package subdirectory
 add_subdirectory(MDSplus)
+
+# Find Python interpreter for building the wheel
+find_package(Python3 COMPONENTS Interpreter REQUIRED)
+
+# Define where the wheel will be placed
+set(WHEEL_OUTPUT_DIR ${CMAKE_BINARY_DIR}/python)
+
+# Ensure the output directory exists
+file(MAKE_DIRECTORY ${WHEEL_OUTPUT_DIR})
+
+# Custom target that depends on the build command
+add_custom_target(build_wheel ALL
+    ${Python3_EXECUTABLE} -m pip wheel --wheel-dir ${WHEEL_OUTPUT_DIR} --no-deps ${CMAKE_CURRENT_SOURCE_DIR}/MDSplus
+    DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/MDSplus/_version.py
+    COMMENT "Building MDSplus wheel"
+)
+
+# After building the wheel, install it into the python directory of the project
+
+install(DIRECTORY ${WHEEL_OUTPUT_DIR}
+        DESTINATION ${CMAKE_INSTALL_PREFIX}
+        FILES_MATCHING
+            PATTERN "*.whl"
+            PATTERN "MDSplus" EXCLUDE
+            PATTERN "CMakeFiles" EXCLUDE
+)

--- a/python/MDSplus/CMakeLists.txt
+++ b/python/MDSplus/CMakeLists.txt
@@ -23,4 +23,6 @@ install(
     PATTERN "tests" EXCLUDE
     PATTERN "*.pyc" EXCLUDE
     PATTERN "__pycache__" EXCLUDE
+    PATTERN "build" EXCLUDE
+    PATTERN "*.egg-info" EXCLUDE
 )

--- a/python/MDSplus/pyproject.toml
+++ b/python/MDSplus/pyproject.toml
@@ -7,14 +7,13 @@
     authors = [
         {name = "MDSplus Development Team", email = "mdsplusadmin@psfc.mit.edu"},
     ]
-    license = {text = "MIT License"}
     description = "MDSplus Python Object interface"
+    license = "MIT"
     classifiers = [
         "Programming Language :: Python",
         "Intended Audience :: Science/Research",
         "Environment :: Console",
         "Topic :: Scientific/Engineering",
-        "License :: OSI Approved :: MIT License",
     ]
     keywords=['physics', 'mdsplus']
     dynamic = ["version"]
@@ -33,9 +32,8 @@
 [tool.setuptools]
     packages = [
         'MDSplus',
-        'MDSplus.widgets', 
+        'MDSplus.widgets',
         'MDSplus.wsgi',
-        'MDSplus.tests',
     ]
     include-package-data = false  # use package-data below
 
@@ -43,10 +41,9 @@
     'MDSplus' = '.'
     'MDSplus.widgets' = 'widgets'
     'MDSplus.wsgi' = 'wsgi'
-    'MDSplus.tests' = 'tests'
-    
+
 [tool.setuptools.package-data]
-    'MDSplus.wsgi' = [ 
+    'MDSplus.wsgi' = [
         'html/*',
         'conf/*',
         'js/*',


### PR DESCRIPTION
When using with modern package managers and even opinionated newer versions of Ubuntu, it's useful to have MDSplus python as a wheel.  (For example, with uv, one can specify a directory to find wheels.)  This PR adds tooling to build the wheel and copy it into the `python/`directory.  It also adds some cleanup so the byproducts of building the wheel are not installed.  Finally, the pyproject.toml is updated as `python/MDSplus/tests` are not installed with CMake and a small warning of older license info is corrected.