### PR TITLE
Build: Revert changes for handling multiple tags

### DIFF
--- a/cmake/MDSplusProjectVersion.cmake
+++ b/cmake/MDSplusProjectVersion.cmake
@@ -12,26 +12,12 @@ if(NOT DEFINED RELEASE_TAG OR RELEASE_TAG STREQUAL "")
 
     if(GIT_FOUND AND EXISTS ${CMAKE_SOURCE_DIR}/.git)
 
+        mdsplus_git(GIT_TAG         describe --tag --abbrev=0 HEAD)
         mdsplus_git(GIT_BRANCH      rev-parse --abbrev-ref HEAD)
         mdsplus_git(GIT_REMOTE      config branch.${GIT_BRANCH}.remote)
         mdsplus_git(GIT_REMOTE_URL  config remote.${GIT_REMOTE}.url)
         mdsplus_git(GIT_COMMIT      rev-parse HEAD)
         mdsplus_git(GIT_COMMIT_DATE log -1 --format=%ad)
-
-        # Handle multiple tags for the same commit
-        mdsplus_git(GIT_TAGS tag --points-at HEAD)
-        string(REPLACE "\n" ";" GIT_TAGS "${GIT_TAGS}")
-        foreach(_tag IN LISTS GIT_TAGS)
-            if(_tag MATCHES "^${GIT_BRANCH}")
-                set(GIT_TAG "${_tag}")
-                break()
-            endif()
-        endforeach()
-
-        # Fallback to the previous method
-        if(NOT DEFINED GIT_TAG)
-            mdsplus_git(GIT_TAG describe --tag HEAD)
-        endif()
 
         if(NOT GIT_REMOTE)
             set(GIT_REMOTE "LOCAL")
@@ -72,7 +58,7 @@ list(GET _version_list 1 RELEASE_MINOR)
 list(GET _version_list 2 RELEASE_RELEASE)
 
 if(DEFINED GIT_BRANCH AND NOT RELEASE_BRANCH STREQUAL GIT_BRANCH)
-    message(WARNING "The branch found while parsing the release tag `${RELEASE_BRANCH}` does not match the current git branch `${GIT_BRANCH}`, `${RELEASE_BRANCH}` will be used for RELEASE_BRANCH.")
+    message(WARNING "The branch found while parsing the release tag `${RELEASE_BRANCH}` does not match the current git branch `${GIT_BRANCH}`, `${GIT_BRANCH}` will be used for RELEASE_BRANCH.")
 endif()
 
 # Note: These are used by build.py --package

--- a/deploy/get_new_version.py
+++ b/deploy/get_new_version.py
@@ -18,17 +18,7 @@ def git(command):
     stdout, _ = proc.communicate()
     return stdout.decode().strip()
 
-last_release = None
-branch = git('rev-parse --abbrev-ref HEAD')
-tags = git('tag --points-at HEAD').splitlines()
-for tag in tags:
-    if tag.startswith(branch):
-        last_release = tag
-        break
-
-if last_release is None:
-    last_release = git('describe --tags --abbrev=0')
-
+last_release = git('describe --tag --abbrev=0 HEAD')
 last_release_commit = git(f'rev-list -n 1 {last_release}')
 commit_log = git(f'log {last_release_commit}..HEAD --no-merges --decorate=short --pretty=format:%s')
 


### PR DESCRIPTION
The new approach uses Jenkins to properly label alpha/stable releases, so complicated parsing of multiple version tags isn't actually needed
Use the GIT_BRANCH instead of the RELEASE_BRANCH to always label builds after the branch you're on
Standardize the command for getting the current tag