### PR TITLE
Fix: Win32 installer now uses correct path for 64-bit Windows

### DIFF
--- a/deploy/packaging/windows/mdsplus.nsi
+++ b/deploy/packaging/windows/mdsplus.nsi
@@ -577,7 +577,11 @@ Function Init
 	${If} for AllUsers ?
 		${If} `$INSTDIR` == ""
 			${If} ${RunningX64} ; 64 bit system
-				StrCpy $INSTDIR $PROGRAMFILES64\MDSplus
+			    ${IF} ${ARCH} == "x64"
+				    StrCpy $INSTDIR $PROGRAMFILES64\MDSplus
+				${Else}
+					StrCpy $INSTDIR $PROGRAMFILES32\MDSplus
+				${Endif}
 			${Else} ; 32 bit system
 				StrCpy $INSTDIR $PROGRAMFILES32\MDSplus
 			${EndIf}


### PR DESCRIPTION
Fixes issue #3040

LabVIEW users often have PCI and PXI hardware that only has 32-bit drivers, thus they must use 32-bit MDSplus even when installing on 64-bit Windows 11.   This change ensures that the 32-bit files are installed in "Program Files (x86)".