### PR TITLE
Fix: Dim 1 not calculating properly

### DIFF
--- a/tdishr/TdiMaxVal.c
+++ b/tdishr/TdiMaxVal.c
@@ -283,7 +283,7 @@ operateIloc(char *start, int testit(const char *, const char *), args_t *a)
   int ja, jb, jd;
   char *pid, *pib, *pia;
   char *pmd, *pmb, *pma;
-  for (ja = 0; pia = a->inp, pma = a->maskp, ja < a->cnt_aft;
+  for (ja = 0, pia = a->inp, pma = a->maskp; ja < a->cnt_aft;
        ja++, pia += a->stp_aft, pma += a->stpm_aft)
   { // LOOP_AFTER
     for (jb = 0, pib = pia, pmb = pma; jb++ < a->cnt_bef;
@@ -317,7 +317,7 @@ static inline void OperateFloc(char dtype, double start,
   int ja, jb, jd;
   char *pid, *pib, *pia;
   char *pmd, *pmb, *pma;
-  for (ja = 0; pia = a->inp, pma = a->maskp, ja < a->cnt_aft;
+  for (ja = 0, pia = a->inp, pma = a->maskp; ja < a->cnt_aft;
        ja++, pia += a->stp_aft, pma += a->stpm_aft)
   { // LOOP_AFTER
     for (jb = 0, pib = pia, pmb = pma; jb++ < a->cnt_bef;
@@ -351,7 +351,7 @@ static inline void OperateTloc(int testit(), args_t *a)
   int ja, jb, jd;
   char *pid, *pib, *pia;
   char *pmd, *pmb, *pma;
-  for (ja = 0; pia = a->inp, pma = a->maskp, ja < a->cnt_aft;
+  for (ja = 0, pia = a->inp, pma = a->maskp; ja < a->cnt_aft;
        ja++, pia += a->stp_aft, pma += a->stpm_aft)
   { // LOOP_AFTER
     for (jb = 0, pib = pia, pmb = pma; jb++ < a->cnt_bef;
@@ -538,7 +538,7 @@ operateIval(char *start, int testit(const char *, const char *), args_t *a)
   int ja, jb, jd;
   char *pid, *pib, *pia;
   char *pmd, *pmb, *pma;
-  for (ja = 0; pia = a->inp, pma = a->maskp, ja < a->cnt_aft;
+  for (ja = 0, pia = a->inp, pma = a->maskp; ja < a->cnt_aft;
        ja++, pia += a->stp_aft, pma += a->stpm_aft)
   { // LOOP_AFTER
     for (jb = 0, pib = pia, pmb = pma; jb < a->cnt_bef; jb++, pib += a->stp_bef,
@@ -569,7 +569,7 @@ static inline void OperateFval(char dtype, double start,
   int ja, jb, jd;
   char *pid, *pib, *pia;
   char *pmd, *pmb, *pma;
-  for (ja = 0; pia = a->inp, pma = a->maskp, ja < a->cnt_aft;
+  for (ja = 0, pia = a->inp, pma = a->maskp; ja < a->cnt_aft;
        ja++, pia += a->stp_aft, pma += a->stpm_aft)
   { // LOOP_AFTER
     for (jb = 0, pib = pia, pmb = pma; jb < a->cnt_bef; jb++, pib += a->stp_bef,
@@ -601,7 +601,7 @@ static inline void OperateTval(int testit(), args_t *a)
   int ja, jb, jd;
   char *pid, *pib, *pia;
   char *pmd, *pmb, *pma;
-  for (ja = 0; pia = a->inp, pma = a->maskp, ja < a->cnt_aft;
+  for (ja = 0, pia = a->inp, pma = a->maskp; ja < a->cnt_aft;
        ja++, pia += a->stp_aft, pma += a->stpm_aft)
   { // LOOP_AFTER
     for (jb = 0, pib = pia, pmb = pma; jb < a->cnt_bef; jb++, pib += a->stp_bef,
@@ -757,7 +757,7 @@ static inline void OperateImean(size_t buflen,
   char *pid, *pib, *pia;
   char *pmd, *pmb, *pma;
   char *buf = malloc(buflen);
-  for (ja = 0; pia = a->inp, pma = a->maskp, ja < a->cnt_aft;
+  for (ja = 0, pia = a->inp, pma = a->maskp; ja < a->cnt_aft;
        ja++, pia += a->stp_aft, pma += a->stpm_aft)
   { // LOOP_AFTER
     for (jb = 0, pib = pia, pmb = pma; jb < a->cnt_bef; jb++, pib += a->stp_bef,
@@ -788,7 +788,7 @@ static inline void OperateFmean(char dtype, args_t *a)
   int ja, jb, jd;
   char *pid, *pib, *pia;
   char *pmd, *pmb, *pma;
-  for (ja = 0; pia = a->inp, pma = a->maskp, ja < a->cnt_aft;
+  for (ja = 0, pia = a->inp, pma = a->maskp; ja < a->cnt_aft;
        ja++, pia += a->stp_aft, pma += a->stpm_aft)
   { // LOOP_AFTER
     for (jb = 0, pib = pia, pmb = pma; jb < a->cnt_bef; jb++, pib += a->stp_bef,
@@ -826,7 +826,7 @@ static inline void OperateCmean(char dtype, args_t *a)
   int ja, jb, jd;
   char *pid, *pib, *pia;
   char *pmd, *pmb, *pma;
-  for (ja = 0; pia = a->inp, pma = a->maskp, ja < a->cnt_aft;
+  for (ja = 0, pia = a->inp, pma = a->maskp; ja < a->cnt_aft;
        ja++, pia += a->stp_aft, pma += a->stpm_aft)
   { // LOOP_AFTER
     for (jb = 0, pib = pia, pmb = pma; jb < a->cnt_bef; jb++, pib += a->stp_bef,
@@ -973,7 +973,7 @@ static inline void OperateFfun(double init, char dtype,
   int ja, jb, jd;
   char *pid, *pib, *pia;
   char *pmd, *pmb, *pma;
-  for (ja = 0; pia = a->inp, pma = a->maskp, ja < a->cnt_aft;
+  for (ja = 0, pia = a->inp, pma = a->maskp; ja < a->cnt_aft;
        ja++, pia += a->stp_aft, pma += a->stpm_aft)
   { // LOOP_AFTER
     for (jb = 0, pib = pia, pmb = pma; jb < a->cnt_bef; jb++, pib += a->stp_bef,
@@ -1010,7 +1010,7 @@ static inline void OperateCfun(double init, char dtype,
   int ja, jb, jd;
   char *pid, *pib, *pia;
   char *pmd, *pmb, *pma;
-  for (ja = 0; pia = a->inp, pma = a->maskp, ja < a->cnt_aft;
+  for (ja = 0, pia = a->inp, pma = a->maskp; ja < a->cnt_aft;
        ja++, pia += a->stp_aft, pma += a->stpm_aft)
   { // LOOP_AFTER
     for (jb = 0, pib = pia, pmb = pma; jb < a->cnt_bef; jb++, pib += a->stp_bef,

--- a/tdishr/TdiMaxVal.c
+++ b/tdishr/TdiMaxVal.c
@@ -948,7 +948,7 @@ static inline void OperateIfun(char init,
   int ja, jb, jd;
   char *pid, *pib, *pia;
   char *pmd, *pmb, *pma;
-  for (ja = 0; pia = a->inp, pma = a->maskp, ja < a->cnt_aft;
+  for (ja = 0, pia = a->inp, pma = a->maskp; ja < a->cnt_aft;
        ja++, pia += a->stp_aft, pma += a->stpm_aft)
   { // LOOP_AFTER
     for (jb = 0, pib = pia, pmb = pma; jb < a->cnt_bef; jb++, pib += a->stp_bef,

--- a/tdishr/TdiTrans.c
+++ b/tdishr/TdiTrans.c
@@ -64,14 +64,13 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
         vector offsets from first element.
 
         For logical array V[3,4,5], steps in unit sizes:
-        loop    count @step     no DIM  DIM=0   optim   DIM=1   DIM=2
-        outer   aft             1 @xx   20 @3   1 @xx   5 @12   1 @60   DIM
-   dimension and number of results middle  bef             1 @1    1 @3    20 @3
-   3 @1    12 @1   product of dims after DIM inner   dim             60 @1   3
-   @1    3 @1    4 @3    5 @12   product of dims before DIM Example, ALL(V,0)
-   chooses elements: [0,1,2] [3,4,5] ... Example, ALL(V,1) chooses elements:
-   [0,3,6,9] [1,4,7,10] [2,5,8,11] / [12,15,18,21] ... Example, ALL(V,2) chooses
-   elements: [0,12,24,36,48] [1,13...], ... [11,...]
+        loop	  | count @step	| no DIM	| DIM=0	| optim	| DIM=1	| DIM=2 |
+        outer	  | aft		      | 1 @xx	  | 20 @3	| 1 @xx	| 5 @12	| 1 @60 |	DIM dimension and number of results
+        middle	| bef		      | 1 @1	  | 1 @3	| 20 @3	| 3 @1	| 12 @1 |	product of dims after DIM
+        inner	  | dim		      | 60 @1	  | 3 @1	| 3 @1	| 4 @3	| 5 @12 |	product of dims before DIM
+        Example, ALL(V,0) chooses elements: [0,1,2] [3,4,5] ...
+        Example, ALL(V,1) chooses elements: [0,3,6,9] [1,4,7,10] [2,5,8,11] / [12,15,18,21] ...
+        Example, ALL(V,2) chooses elements: [0,12,24,36,48] [1,13...], ... [11,...]
 
         Ken Klare, LANL P-4     (c)1989,1990,1991
         NEED units for DERIVATIVE INTEGRAL.


### PR DESCRIPTION
Fixed an issue that was noticed with sum and product, where an argument of dim=1 would break and show the wrong answer repeating the first calculations. It, however, affected several other opcodes.

List all affected opcodes:

- `MAXLOC`
- `MINLOC`
- `MAXVAL`
- `MINVAL`
- `MEAN`
- `PRODUCT`
- `SUM`
- `ACCUMULATE`


When doing `sum` or `product` in tdi with multidimensional arrays using the argument dim = 1 would result in an error, doubling the inner array twice.

simply: 
```py
TDI> sum(
    [[[1], [2]],
    [[3],[4]]]
,1)
```
`[[3], [3]]`
summing 1 and 2 twice, when it should produce the sum of 1 and 2 then 3 and 4. 
`[[3], [7]]`
this would even happen with 

```py
TDI> sum([[[1],[2]],[[3],[4]],[[5],[6]]],1)
[[3], [3], [3]]
# Post fix:
[[3], [7], [11]]
```

A more robust example: 
```py
TDI> sum(
[
  [
    [1,2,3,4],
    [5,6,7,8],
    [9,10,11,12]
  ],
  [
    [13,14,15,16],
    [17,18,19,20],
    [21,22,23,24]
  ]
],1)
```
`[[15,18,21,24], [15,18,21,24]]`
After applying the fix it is no longer doubling first inner array. 
`[[15,18,21,24], [51,54,57,60]]`


This was easiest to reproduce with a dim of one but if you could contrive of an example where a higher dimension would need to be duplicated you would be able to get those values to repeat as well.
```py
TDI> sum([[[[1],[2]],[[2],[3]]],[[[3],[4]],[[4],[5]]],[[[5],[6]],[[6],[7]]]],2)
```
`[[[3], [5]], [[3], [5]], [[3], [5]]]`
`[[[3], [5]], [[7], [9]], [[11], [13]]]`

The issue stems from the outer most for loop having a ';' in the wrong location causing the set up for several values to be reset every time the loop was evaluated. 