### PR TITLE
Feature: Add TDI TreeShr functions used by mdsthin

### DIFF
--- a/tdi/treeshr/TreeDecompileRecord.fun
+++ b/tdi/treeshr/TreeDecompileRecord.fun
@@ -1,0 +1,7 @@
+/* FOR INTERNAL USE ONLY */
+public fun TreeDecompileRecord(in _nid)
+{
+    _out = 1;
+    _status = TreeShr->TreeGetRecord(val(_nid), xd(_out));
+    return(execute("decompile(`_out)"));
+};

--- a/tdi/treeshr/TreeFindNodeWildRelative.fun
+++ b/tdi/treeshr/TreeFindNodeWildRelative.fun
@@ -1,0 +1,17 @@
+/* FOR INTERNAL USE ONLY */
+public fun TreeFindNodeWildRelative(in _path, in _startnid, optional _usagemask)
+{
+    _ctx = 0q;
+    _nid = 0;
+    _nids = [];
+    if (!present(_usagemask)) _usagemask = -1;
+    while (TreeShr->TreeFindNodeWildRelative(_path, val(_startnid), ref(_nid), ref(_ctx), val(_usagemask)) & 1) {
+        if (size(_nids) > 0) {
+            _nids = [_nids, _nid];
+        } else {
+            _nids = [_nid];
+        }
+    };
+    TreeShr->TreeFindNodeEnd(_ctx);
+    return(_nids);
+};

--- a/tdi/treeshr/TreeGetRecordSerialized.fun
+++ b/tdi/treeshr/TreeGetRecordSerialized.fun
@@ -1,0 +1,7 @@
+/* FOR INTERNAL USE ONLY */
+public fun TreeGetRecordSerialized(in _nid)
+{
+    _out = 1;
+    _status = TreeShr->TreeGetRecord(val(_nid), xd(_out));
+    return(execute("SerializeOut(`_out)"));
+};


### PR DESCRIPTION
When implementing the thin Tree class for mdsthin, I needed these functions from the TDI stdlib. Currently, they're implemented on the fly when called, but they should be added to the stdlib so other things can use them.

* `TreeFindNodeWildRelative` operates much like `TreeFindNodeWild`, but relative to a node
* `TreeGetRecordSerialized` returns the serialized data for a node
* `TreeDecompileRecord` returns the decompiled data for a node

Once these are included, mdsthin can check the server version and only implement them on the fly as needed