### PR TITLE
Fix: Convert date string to english locale in java setViewDate method

### DIFF
--- a/java/mdsobjects/src/main/java/MDSplus/Tree.java
+++ b/java/mdsobjects/src/main/java/MDSplus/Tree.java
@@ -320,9 +320,10 @@ public class Tree
 	 *
 	 * @param date
 	 */
-	public void setViewDate(java.util.Date date) throws MdsException
+	public void setViewDate(java.time.LocalDateTime date) throws MdsException
 	{
-		setTreeViewDate(new java.text.SimpleDateFormat("dd-MMM-yyyy HH:mm:ss").format(date));
+		java.time.format.DateTimeFormatter formatter = java.time.format.DateTimeFormatter.ofPattern("dd-MMM-yyyy HH:mm:ss",Locale.ENGLISH);
+		setTreeViewDate(date.format(formatter));
 	}
 
 	/**

--- a/java/mdsobjects/src/test/java/MDSplus/MdsTreeTest.java
+++ b/java/mdsobjects/src/test/java/MDSplus/MdsTreeTest.java
@@ -191,7 +191,7 @@ public class MdsTreeTest
 		// test version
 		node = tree.getNode("versioned");
 		node.putData(new MDSplus.Int32(5552368));
-		final java.util.Date currDate = java.util.Calendar.getInstance().getTime();
+		final java.time.LocalDateTime currDate = java.time.LocalDateTime.now();
 		Thread.sleep(2000);
 		node.putData(new MDSplus.Float64(555.2368));
 		node = tree.getNode("versioned");


### PR DESCRIPTION
The `java/mdsobjects/tests/MDSplus.MdsTreeTest` test would fail on my system due to the locale settings. Converting the locale to `en_US` allowed the test to pass. This PR allows the test to pass with any locale.

- Convert date string to english locale first in java `setViewDate` method since `LibConvertDateString` expects this
- Use `java.time` package tools in place of deprecated `java.util.Date`,... as recommended by JDK.