### PR TITLE
Fix: GetMany queries that succeed with a nil result (issue #3070)

### DIFF
--- a/include/mdsobjects.h
+++ b/include/mdsobjects.h
@@ -2892,13 +2892,17 @@ namespace MDSplus
       dtype = DTYPE_DICTIONARY;
     }
 
+    // A NULL value represents missing ("*"): it is what execute() returns
+    // for an expression that evaluates to nil, and convertToApdDsc() emits
+    // it as a null descriptor pointer
     Data *getItem(String *strData)
     {
       for (std::size_t i = 0; i < descs.size(); i += 2)
       {
         if (strData->equals(descs[i]))
         {
-          descs[i + 1]->incRefCount();
+          if (descs[i + 1])
+            descs[i + 1]->incRefCount();
           return descs[i + 1];
         }
       }
@@ -2915,9 +2919,11 @@ namespace MDSplus
           descs[i] = strData;
           strData->incRefCount();
 
-          descs[i + 1]->decRefCount();
+          if (descs[i + 1])
+            descs[i + 1]->decRefCount();
           descs[i + 1] = data;
-          data->incRefCount();
+          if (data)
+            data->incRefCount();
           return;
         }
       }
@@ -2925,7 +2931,8 @@ namespace MDSplus
       descs.push_back(strData);
       descs.push_back(data);
       strData->incRefCount();
-      data->incRefCount();
+      if (data)
+        data->incRefCount();
     }
 
     std::size_t len() { return Apd::len() / 2; }

--- a/mdsobjects/cpp/mdsdataobjects.cpp
+++ b/mdsobjects/cpp/mdsdataobjects.cpp
@@ -330,6 +330,11 @@ Data::~Data()
 
 void MDSplus::deleteData(Data *data)
 {
+  // A NULL Data represents missing ("*"). deleteData() must accept it as a
+  // no-op: RAII wrappers (AutoData) and Apd::propagateDeletion() hand it the
+  // NULL that getItem()/execute() return for a nil result.
+  if (!data)
+    return;
   if (data->refCount <= 1)
   {
     if (data->units)

--- a/mdsobjects/cpp/testing/CMakeLists.txt
+++ b/mdsobjects/cpp/testing/CMakeLists.txt
@@ -59,6 +59,7 @@ set(_test_source_list
     MdsEventSuppression.cpp
     MdsEventTest.cpp
     MdsConnectionTest.cpp
+    MdsGetManyTest.cpp
 
     # SKIP_TEST is not supported
     # MdsCallTest.cpp

--- a/mdsobjects/cpp/testing/MdsGetManyTest.cpp
+++ b/mdsobjects/cpp/testing/MdsGetManyTest.cpp
@@ -1,0 +1,137 @@
+/*
+Copyright (c) 2026, Massachusetts Institute of Technology All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+Redistributions of source code must retain the above copyright notice, this
+list of conditions and the following disclaimer.
+
+Redistributions in binary form must reproduce the above copyright notice, this
+list of conditions and the following disclaimer in the documentation and/or
+other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+#include <stdlib.h>
+
+#include <mdsdescrip.h>
+#include <mdsobjects.h>
+
+#include "testing.h"
+#include "testutils/unique_ptr.h"
+
+using namespace MDSplus;
+using namespace testing;
+
+// The mdsip server entry point for Connection.getMany() batches
+// (tdi/remote/GetManyExecute.fun -> MdsObjectsCppShr->GetManyExecute)
+extern "C" struct descriptor_xd *GetManyExecute(char *serializedIn);
+
+////////////////////////////////////////////////////////////////////////////////
+//  GetMany results that evaluate to missing (issue #3070)  ////////////////////
+////////////////////////////////////////////////////////////////////////////////
+
+int main()
+{
+  BEGIN_TESTING(GetMany);
+
+  { // A Dictionary must accept a missing (NULL) value: getManyObj() stores
+    // one whenever a query succeeds with a nil result. The rest of the Apd
+    // machinery (constructor, propagateDeletion, convertToApdDsc) already
+    // NULL-guards its elements.
+    unique_ptr<Dictionary> dict = new Dictionary();
+    String *key = new String("value"); // freed by the Dictionary destructor
+    String lookup("value");
+
+    dict->setItem(key, NULL);
+    TEST1(dict->len() == 1);
+    TEST1(dict->getItem(&lookup) == NULL);
+
+    // replace the missing value with data...
+    Int32 *num = new Int32(42);
+    dict->setItem(key, num);
+    unique_ptr<Data> value = dict->getItem(&lookup);
+    TEST1(value->getInt() == 42);
+
+    // ...and the data with a missing value again
+    dict->setItem(key, NULL);
+    TEST1(dict->len() == 1);
+    TEST1(dict->getItem(&lookup) == NULL);
+    deleteData(num);
+  }
+
+  { // A missing value must survive the serialize / deserialize round trip
+    // used to transport the GetManyExecute() result dictionary.
+    unique_ptr<Dictionary> dict = new Dictionary();
+    dict->setItem(new String("value"), NULL);
+
+    int size = 0;
+    AutoArray<char> serialized(dict->serialize(&size));
+    TEST1(size > 0);
+
+    unique_ptr<Dictionary> back = (Dictionary *)deserialize(serialized.get());
+    String lookup("value");
+    TEST1(back->len() == 1);
+    TEST1(back->getItem(&lookup) == NULL);
+  }
+
+  { // End to end: a GetMany query that SUCCEEDS with a nil result must come
+    // back as { 'value': missing }, matching what a plain get() of the same
+    // expression returns, instead of crashing the mdsip worker.
+    // The expression mirrors GETNCI(<node>, "RECORD") of a clock whose
+    // record is a Range with a missing begin: * : * : 5E-6
+    Dictionary *nilQuery = new Dictionary(); // freed by the List destructor
+    nilQuery->setItem(new String("name"), new String("nil"));
+    nilQuery->setItem(new String("exp"),
+                      new String("DATA(BEGIN_OF(BUILD_RANGE(*, *, 5E-6)))"));
+
+    Dictionary *numQuery = new Dictionary();
+    numQuery->setItem(new String("name"), new String("num"));
+    numQuery->setItem(new String("exp"), new String("1 + 1"));
+
+    unique_ptr<List> queries = new List();
+    queries->append(nilQuery);
+    queries->append(numQuery);
+
+    int serSize = 0;
+    AutoArray<char> serialized(queries->serialize(&serSize));
+
+    struct descriptor_xd *outXd = GetManyExecute(serialized.get());
+    TEST1(outXd != NULL && outXd->pointer != NULL);
+
+    // GetManyExecute() returns the result dictionary serialized into a
+    // byte array, just as it goes over the wire
+    struct descriptor_a *bytes = (struct descriptor_a *)outXd->pointer;
+    unique_ptr<Dictionary> result =
+        (Dictionary *)deserialize((char *)bytes->pointer);
+
+    String nilName("nil"), numName("num"), valueKey("value"), errorKey("error");
+
+    { // sanity: the numeric query evaluated normally
+      unique_ptr<Dictionary> answer = (Dictionary *)result->getItem(&numName);
+      TEST1((Dictionary *)answer != NULL);
+      unique_ptr<Data> value = answer->getItem(&valueKey);
+      TEST1(value->getInt() == 2);
+    }
+
+    { // the nil query: answered, not an error, and the value is missing
+      unique_ptr<Dictionary> answer = (Dictionary *)result->getItem(&nilName);
+      TEST1((Dictionary *)answer != NULL);
+      TEST1(answer->getItem(&errorKey) == NULL);
+      TEST1(answer->len() == 1); // exactly one entry: 'value'
+      TEST1(answer->getItem(&valueKey) == NULL); // ...holding missing
+    }
+  }
+
+  END_TESTING;
+}

--- a/testing/backends/check/lib/macos_timer.h
+++ b/testing/backends/check/lib/macos_timer.h
@@ -4,6 +4,8 @@
 #include <sys/errno.h>
 #include <stdlib.h>
 #include <time.h>
+#include <signal.h>
+#include <unistd.h>
 
 #include <dispatch/dispatch.h>
 
@@ -56,7 +58,13 @@ _timer_handler(void *arg)
 static inline void _default_timer_expiration(union sigval sv)
 {
   (void) sv;
-  signal(SIGALRM, NULL);
+  /* When timer_create() is called with a NULL sigevent (as the test
+   * harness does), a POSIX timer would deliver SIGALRM to the process on
+   * expiration. Emulate that here so the harness' SIGALRM handler runs and
+   * kills the timed-out child. The previous signal(SIGALRM, NULL) only reset
+   * the SIGALRM disposition and never raised it, so test timeouts silently
+   * never fired on macOS and a hung/crashed child stalled the runner. */
+  kill(getpid(), SIGALRM);
 }
 
 static inline int

--- a/testing/check_backend.c
+++ b/testing/check_backend.c
@@ -39,6 +39,10 @@ extern char *strsignal(int);
 #include <sys/wait.h>
 #endif
 
+#ifdef __APPLE__
+#include <mach/mach.h>
+#endif
+
 #include <check.h>
 #include <check_list.h>
 #include <check_impl.h>
@@ -758,6 +762,21 @@ int __setup_child()
   {
     setpgid(0, 0);
     group_pid = getpgrp();
+
+#ifdef __APPLE__
+    // On macOS a hardware fault (null deref, bad instruction, ...) is caught
+    // by the task-level Mach exception port (the system crash reporter), which
+    // parks the faulting thread instead of terminating the process. The child
+    // then never dies, the parent blocks forever in waitpid(), and the whole
+    // run stalls. Clearing the exception ports lets the fault fall through to
+    // the default action, so a crashing test dies promptly and is reported,
+    // just as on Linux.
+    task_set_exception_ports(mach_task_self(),
+                             EXC_MASK_BAD_ACCESS | EXC_MASK_BAD_INSTRUCTION |
+                                 EXC_MASK_ARITHMETIC,
+                             MACH_PORT_NULL, EXCEPTION_DEFAULT, 0);
+#endif
+
     return 1;
   }
 #endif


### PR DESCRIPTION
# Fix: GetMany queries that succeed with a nil result (issue #3070)

## Problem

A `GetMany` query whose expression evaluates to nil (e.g. `GETNCI(<node>, "RECORD")`
of a clock whose record is `* : * : 5E-6` — a Range with a missing begin) crashed
the mdsip worker instead of returning `{ 'value': missing }`, the way a plain
`get()` of the same expression does.

The crash had several layers; the root cause turned out to be broader than the
`Dictionary` accessors that first showed up in a debugger.

## Root cause

The C++ object layer uses a `NULL` `Data *` to mean **missing** (`*`) — it is what
`execute()` returns for a nil expression, and what `convertToApdDsc()` emits as a
null descriptor pointer. The machinery was inconsistent about tolerating that NULL:

1. **`Dictionary::getItem` / `setItem`** dereferenced the stored value without a
   NULL check, so storing/reading a missing value segfaulted. *(fixed in the header)*

2. **`deleteData(Data *)`** dereferenced `data->refCount` with **no NULL guard**.
   This is the real culprit and the one the fix below targets.

`deleteData(NULL)` is reached on ordinary cleanup paths, because `AutoData<T>` — the
RAII wrapper used throughout the mdsip object code — calls `deleteData(ptr)`
unconditionally in its destructor, and it routinely wraps the (nullable) result of
`getItem()`:

- **Server, `getManyObj`** (`mdsipobjects.cpp`): a query may legitimately omit the
  `args` key — the server explicitly supports that (`if (argsData.get() && argsData->len() > 0)`).
  But `AutoData<List> argsData((List *)currArg->getItem(&argsKey))` then wraps the
  `NULL` that `getItem` returns for the absent key, and destroying it at the end of
  each loop iteration calls `deleteData(NULL)`.
- **Client, `GetMany::get()`** (`mdsipobjects.cpp`): for a query that succeeds with a
  nil result, `AutoData<Data> result(dictionary->getItem(&valueKey))` wraps `NULL`, so
  the same `deleteData(NULL)` fires on the way out — i.e. the crash also reproduces on
  a real client reading back a nil value, not just inside the worker.

**Why it never showed up before:** the production C++ `GetMany` client always attaches
an `args` key (an empty `List` when there are no args), so `getItem(&argsKey)` was never
`NULL` in normal use. The new test exercises the args-less path on purpose.

## The fix, and why it lives in `deleteData`

```c
void MDSplus::deleteData(Data *data)
{
  if (!data)      // NULL == missing ("*"): accept it as a no-op
    return;
  ...
}
```

We considered fixing only `getManyObj`, but that would patch one call site and leave
the same defect live on the client (`GetMany::get()`) and at every other
`AutoData<X>(getItem(...))` in the codebase. The NULL reaching `deleteData` is not
specific to `getManyObj` — it is the general contract that `getItem()`/`execute()`
return NULL for "missing" and that `AutoData` is an RAII wrapper you can hand that NULL
to. `getManyObj` is correct as written; it was simply relying on a `deleteData` that
couldn't hold up its end.

So the fix belongs at the shared choke point. `deleteData` is the right one: it matches
C++'s own `delete nullptr` semantics, matches the already-NULL-tolerant helpers in the
same file (e.g. `getMember`), and covers both the `AutoData` destructor and the raw
`deleteData(descs[i])` calls. (`Apd::propagateDeletion` already guards its own elements,
which is exactly the convention we are now making universal.)

## Tests

`mdsobjects/cpp/testing/MdsGetManyTest.cpp` (new) covers three levels:

1. A `Dictionary` accepts a missing (NULL) value — `setItem`/`getItem`/replace round trips.
2. A missing value survives the serialize / deserialize round trip used to transport the
   result dictionary.
3. End-to-end: `GetManyExecute()` on a batch containing a nil-result query returns
   `{ 'value': missing }` (answered, not an error) instead of crashing.

## macOS test-harness changes (required to even see this failure)

Two changes to the Check-based C test harness were needed so that macOS reports crashes
and timeouts the way Linux does — without them, this bug manifested as a silent hang and
the test appeared to "pass" or stall rather than fail:

- **`testing/check_backend.c`** — On macOS a hardware fault (null deref, illegal
  instruction, …) is delivered to the task-level Mach exception port (the system crash
  reporter), which *parks* the faulting thread instead of terminating the process. The
  forked test child then never dies, the parent blocks forever in `waitpid()`, and the
  whole run stalls. In `__setup_child()` we now clear the child's exception ports
  (`task_set_exception_ports(..., EXC_MASK_BAD_ACCESS | EXC_MASK_BAD_INSTRUCTION |
  EXC_MASK_ARITHMETIC, MACH_PORT_NULL, ...)`), so a fault falls through to the default
  action and a crashing test dies promptly and is reported, just like on Linux.

- **`testing/backends/check/lib/macos_timer.h`** — macOS lacks POSIX `timer_create`
  delivery, so the harness emulates it with a dispatch timer. The default expiration
  handler previously called `signal(SIGALRM, NULL)`, which only reset the SIGALRM
  disposition and never actually raised the signal — so test timeouts silently never
  fired on macOS and a hung child stalled the runner indefinitely. It now does
  `kill(getpid(), SIGALRM)` to emulate real POSIX-timer delivery, so the harness'
  SIGALRM handler runs and kills the timed-out child.

Together these make a segfault/hang in a test surface as a reported failure on macOS
instead of a silent stall — which is how the remaining `deleteData` crash was found
after the header guards were added.

Fixes #3070.
