### PR TITLE
Build: Fix tests on Java >= 24

### DIFF
--- a/java/tests/CMakeLists.txt
+++ b/java/tests/CMakeLists.txt
@@ -32,6 +32,13 @@ if(ENABLE_JAVA AND NOT TEST_WITH_WINE AND NOT ENABLE_SANITIZE)
         -Djava.library.path=${CMAKE_LIBRARY_OUTPUT_DIRECTORY}
     )
 
+    if(Java_VERSION VERSION_GREATER_EQUAL 24)
+        # Starting with Java 24, Java restricts all native code by default, including loadLibrary
+        list(APPEND JAVA_TEST_ARGUMENTS
+            --enable-native-access=ALL-UNNAMED
+        )
+    endif()
+
     if(ENABLE_VALGRIND)
 
         # Disable Java runtime optimizations / Just-In-Time (JIT) compilation


### PR DESCRIPTION
Add new command line option for running tests with Java >= 24 that allows system functions in native modules

This should fix the failing tests for Ubuntu 24.04
```
WARNING: A restricted method in java.lang.System has been called
WARNING: java.lang.System::loadLibrary has been called by MDSplus.Tree in an unnamed module (file:/mdsplus/workspace/build/java/mdsobjects/mdsobjects.jar)
WARNING: Use --enable-native-access=ALL-UNNAMED to avoid a warning for callers in this module
WARNING: Restricted methods will be blocked in a future release unless native access is enabled
```